### PR TITLE
CNPT-121 wildcard search testing

### DIFF
--- a/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -151,7 +151,7 @@ public class PatientService {
         }
 
         if (filter.getLastName() != null && !filter.getLastName().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("name", QueryBuilders.regexpQuery("name.lastNm",addWildcards(filter.getLastName())), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("name", QueryBuilders.wildcardQuery("name.lastNm",addWildcards(filter.getLastName())), ScoreMode.Avg));
         }
 
         if (filter.getSsn() != null && !filter.getSsn().isEmpty()) {
@@ -163,7 +163,7 @@ public class PatientService {
         }
 
         if (filter.getAddress() != null && !filter.getAddress().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.matchQuery("address.streetAddr1",filter.getAddress()), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.wildcardQuery("address.streetAddr1",addWildcards(filter.getAddress())), ScoreMode.Avg));
         }
 
         if (filter.getGender() != null) {
@@ -585,6 +585,6 @@ public class PatientService {
     }
 
     private String addWildcards(String searchString) {
-        return  ".*" + searchString + ".*" ;
+        return  "*" + searchString + "*" ;
     }
 }

--- a/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -175,7 +175,7 @@ public class PatientService {
         }
 
         if (filter.getCity() != null && !filter.getCity().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.matchQuery("address.city",filter.getCity()), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.wildcardQuery("address.city",addWildcards(filter.getCity())), ScoreMode.Avg));
         }
 
         if (filter.getZip() != null && !filter.getZip().isEmpty()) {

--- a/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -585,6 +585,7 @@ public class PatientService {
     }
 
     private String addWildcards(String searchString) {
-        return  "*" + searchString + "*" ;
+        // wildcard does not default to case insensitive searching
+        return  '*' + searchString.toLowerCase() + "*" ;
     }
 }

--- a/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -147,11 +147,11 @@ public class PatientService {
         }
 
         if (filter.getFirstName() != null && !filter.getFirstName().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("name", QueryBuilders.wildcardQuery("name.firstNm",addWildcards(filter.getFirstName())), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("name", QueryBuilders.queryStringQuery(addWildcards(filter.getFirstName())).defaultField("name.firstNm"), ScoreMode.Avg));
         }
 
         if (filter.getLastName() != null && !filter.getLastName().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("name", QueryBuilders.wildcardQuery("name.lastNm",addWildcards(filter.getLastName())), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("name", QueryBuilders.queryStringQuery(addWildcards(filter.getLastName())).defaultField("name.lastNm"), ScoreMode.Avg));
         }
 
         if (filter.getSsn() != null && !filter.getSsn().isEmpty()) {
@@ -163,7 +163,7 @@ public class PatientService {
         }
 
         if (filter.getAddress() != null && !filter.getAddress().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.wildcardQuery("address.streetAddr1",addWildcards(filter.getAddress())), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.queryStringQuery(addWildcards(filter.getAddress())).defaultField("address.streetAddr1"), ScoreMode.Avg));
         }
 
         if (filter.getGender() != null) {
@@ -175,7 +175,7 @@ public class PatientService {
         }
 
         if (filter.getCity() != null && !filter.getCity().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.wildcardQuery("address.city",addWildcards(filter.getCity())), ScoreMode.Avg));
+            builder.must(QueryBuilders.nestedQuery("address", QueryBuilders.queryStringQuery(addWildcards(filter.getCity())).defaultField("address.city"), ScoreMode.Avg));
         }
 
         if (filter.getZip() != null && !filter.getZip().isEmpty()) {
@@ -586,6 +586,6 @@ public class PatientService {
 
     private String addWildcards(String searchString) {
         // wildcard does not default to case insensitive searching
-        return  '*' + searchString.toLowerCase() + "*" ;
+        return  searchString.toLowerCase() + "*" ;
     }
 }

--- a/patient-search/api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
@@ -433,6 +433,10 @@ public class PatientSearchSteps {
                 var addressLocator = PersonUtil.getPostalLocators(searchPatient).get(0);
                 filter.setAddress(RandomUtil.randomPartialDataSearchString(addressLocator.getStreetAddr1()));
                 break;
+            case "city":
+                var cityLocator = PersonUtil.getPostalLocators(searchPatient).get(0);
+                filter.setCity(RandomUtil.randomPartialDataSearchString(cityLocator.getCityDescTxt()));
+                break;
             default:
                 throw new IllegalArgumentException("Invalid field specified: " + field);
         }

--- a/patient-search/api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
@@ -162,6 +162,13 @@ public class PatientSearchSteps {
         searchResults = patientController.findPatientsByFilter(filter, new GraphQLPage(1000, 0)).getContent();
     }
 
+    @When("I search patients using partial data {string} {string} {string} {string}")
+    public void i_search_patients_using_partial_data(String field, String qualifier, String field2, String qualifier2) {
+        PatientFilter filter = getPatientPartialDataFilter(field, qualifier);
+        updatePatientPartialDataFilter(filter, field2, qualifier2);
+        searchResults = patientController.findPatientsByFilter(filter, new GraphQLPage(1000, 0)).getContent();
+    }
+
     @When("I search investigation events by {string} {string}")
     public void i_search_patients_by_investigation_events(String field, String qualifier) {
         EventFilter filter = getInvestigationFilter(field, qualifier);
@@ -411,9 +418,35 @@ public class PatientSearchSteps {
         return filter;
     }
 
+    private PatientFilter updatePatientPartialDataFilter(PatientFilter filter, String field, String qualifier) {
+        if (field == null || field.isEmpty()) {
+            return filter;
+        }
+        switch (field) {
+            case "last name":
+                filter.setLastName(RandomUtil.randomPartialDataSearchString(searchPatient.getLastNm()));
+                break;
+            case "first name":
+                filter.setFirstName(RandomUtil.randomPartialDataSearchString(searchPatient.getFirstNm()));
+                break;
+            case "address":
+                var addressLocator = PersonUtil.getPostalLocators(searchPatient).get(0);
+                filter.setAddress(RandomUtil.randomPartialDataSearchString(addressLocator.getStreetAddr1()));
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid field specified: " + field);
+        }
+        return filter;
+    }
+
     private PatientFilter getPatientDataFilter(String field, String qualifier) {
         var filter = new PatientFilter();
         return updatePatientDataFilter(filter, field, qualifier);
+    }
+
+    private PatientFilter getPatientPartialDataFilter(String field, String qualifier) {
+        var filter = new PatientFilter();
+        return updatePatientPartialDataFilter(filter, field, qualifier);
     }
 
     private Instant getDobByQualifier(Person search, String qualifier) {

--- a/patient-search/api/src/test/java/gov/cdc/nbs/support/PersonMother.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/support/PersonMother.java
@@ -132,7 +132,7 @@ public class PersonMother {
         postalLocator.setStreetAddr1(faker.address().streetAddress());
         postalLocator.setCntryCd(
                 RandomUtil.getRandomFromArray(CountryCodeUtil.countryCodeMap.values().toArray(new String[0])));
-        postalLocator.setCityDescTxt(RandomUtil.getRandomString(8));
+        postalLocator.setCityDescTxt(faker.address().city());
         postalLocator.setStateCd(RandomUtil.getRandomStateCode());
         postalLocator.setZipCd(RandomUtil.getRandomNumericString(5));
         postalLocator.setRecordStatusCd("ACTIVE");

--- a/patient-search/api/src/test/java/gov/cdc/nbs/support/PersonMother.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/support/PersonMother.java
@@ -129,7 +129,7 @@ public class PersonMother {
         locatorId = id + 80000L;
         var postalLocator = new PostalLocator();
         postalLocator.setId(locatorId);
-        postalLocator.setStreetAddr1(RandomUtil.getRandomString(8));
+        postalLocator.setStreetAddr1(faker.address().streetAddress());
         postalLocator.setCntryCd(
                 RandomUtil.getRandomFromArray(CountryCodeUtil.countryCodeMap.values().toArray(new String[0])));
         postalLocator.setCityDescTxt(RandomUtil.getRandomString(8));

--- a/patient-search/api/src/test/java/gov/cdc/nbs/support/util/RandomUtil.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/support/util/RandomUtil.java
@@ -80,20 +80,10 @@ public class RandomUtil {
     }
 
     public static String randomPartialDataSearchString(String data) {
-        int random = new Random().nextInt(3);
         int len = data.length();
         if (len<=1) {
             return data;
         }
-        // make sure prefix, suffix, and interior substring are tested evenly
-        switch(random) {
-            case 0: // prefix
-                return data.substring(0, 1);
-            case 1: // suffix
-                return data.substring(len-1, len);
-            case 2: // interior substring
-                return data.substring(1, len-1);
-        }
-        return data;
+        return data.substring(0, new Random().nextInt(len - 1) + 1);
     }
 }

--- a/patient-search/api/src/test/java/gov/cdc/nbs/support/util/RandomUtil.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/support/util/RandomUtil.java
@@ -78,4 +78,22 @@ public class RandomUtil {
         var index = random.nextInt(StateCodeUtil.stateCodeMap.size());
         return StateCodeUtil.stateCodeMap.values().toArray(new String[0])[index];
     }
+
+    public static String randomPartialDataSearchString(String data) {
+        int random = new Random().nextInt(3);
+        int len = data.length();
+        if (len<=1) {
+            return data;
+        }
+        // make sure prefix, suffix, and interior substring are tested evenly
+        switch(random) {
+            case 0: // prefix
+                return data.substring(0, 1);
+            case 1: // suffix
+                return data.substring(len-1, len);
+            case 2: // interior substring
+                return data.substring(1, len-1);
+        }
+        return data;
+    }
 }

--- a/patient-search/api/src/test/resources/features/PatientSearch.feature
+++ b/patient-search/api/src/test/resources/features/PatientSearch.feature
@@ -68,10 +68,12 @@ Feature: Patient search
       | field         | qualifier | field2     | qualifier2 |
       | last name     |           |            |            |
       | first name    |           |            |            |
-      | last name     |           | first name |            |
       | address       |           |            |            |
+      | city          |           |            |            |
+      | last name     |           | first name |            |
       | first name    |           | address    |            |
       | last name     |           | address    |            |
+      | last name     |           | city       |            |
 
   @patient_investigation_search
   Scenario: I can find a patient by one field in the investigation data

--- a/patient-search/api/src/test/resources/features/PatientSearch.feature
+++ b/patient-search/api/src/test/resources/features/PatientSearch.feature
@@ -73,6 +73,7 @@ Feature: Patient search
       | last name     |           | first name |            |
       | first name    |           | address    |            |
       | last name     |           | address    |            |
+      | city          |           |            |            |
       | last name     |           | city       |            |
 
   @patient_investigation_search

--- a/patient-search/api/src/test/resources/features/PatientSearch.feature
+++ b/patient-search/api/src/test/resources/features/PatientSearch.feature
@@ -59,6 +59,20 @@ Feature: Patient search
       | ethnicity     |           | first name |            | race    |            |
       | record status |           | first name |            | city    |            |
 
+  @patient_multi_data_partial_search
+  Scenario: I can find a Patient by patient data using multiple partial fields
+    When I search patients using partial data "<field>" "<qualifier>" "<field2>" "<qualifier2>"
+    Then I find the patient
+
+    Examples:
+      | field         | qualifier | field2     | qualifier2 |
+      | last name     |           |            |            |
+      | first name    |           |            |            |
+      | last name     |           | first name |            |
+      | address       |           |            |            |
+      | first name    |           | address    |            |
+      | last name     |           | address    |            |
+
   @patient_investigation_search
   Scenario: I can find a patient by one field in the investigation data
     Given Investigations exist


### PR DESCRIPTION
Feature specs for testing with partial searches of the form `'string*'` using first name and/or last name and/or address and/or city.  The legacy code code did a `like 'searchstring%'` in the database.  

To achieve this we use https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html with a wildcard query `'string*'` 

NOTE: defaulting to `'*string*' `wildcard search is counterintuitive.  Ie searching for 'it' yielding 'Smith'.  If we want to support wildcard searches we can intercept wildcards in the search string and support them accordingly.  For now defaulting to matching the first characters including spaces (and also full match) with no added input text will be on parity with legacy.


```
gradlew clean -i -Dcucumber.filter.tags="@patient_multi_data_partial_search" test

api:test results: SUCCESS (147 tests, 17 successes, 0 failures, 130 skipped) in 1 minutes, 8.894 seconds
```

Example request body searching for patients from the city 'East Jorge' with the query 'East Jo':

```
{
  "from": 0,
  "size": 1000,
  "query": {
    "bool": {
      "must": [
        {
          "match": {
            "cd": {
              "query": "PAT",
              "operator": "OR",
              "prefix_length": 0,
              "max_expansions": 50,
              "fuzzy_transpositions": true,
              "lenient": false,
              "zero_terms_query": "NONE",
              "auto_generate_synonyms_phrase_query": true,
              "boost": 1.0
            }
          }
        },
        {
          "nested": {
            "query": {
              "query_string": {
                "query": "East Jo*",
                "default_field": "address.city",
                "fields": [],
                "type": "best_fields",
                "default_operator": "or",
                "max_determinized_states": 10000,
                "enable_position_increments": true,
                "fuzziness": "AUTO",
                "fuzzy_prefix_length": 0,
                "fuzzy_max_expansions": 50,
                "phrase_slop": 0,
                "escape": false,
                "auto_generate_synonyms_phrase_query": true,
                "fuzzy_transpositions": true,
                "boost": 1.0
              }
            },
            "path": "address",
            "ignore_unmapped": false,
            "score_mode": "avg",
            "boost": 1.0
          }
        }
      ],
      "adjust_pure_negative": true,
      "boost": 1.0
    }
  },
  "version": true,
  "explain": false
}
```