### PR TITLE
CNPT-723 CNPT-641 Replace ElasticSearch with OpenSearch

### DIFF
--- a/.github/workflows/dockerfile-to-ecr.yaml
+++ b/.github/workflows/dockerfile-to-ecr.yaml
@@ -65,7 +65,7 @@ jobs:
         IMAGE_NAME: elasticsearch
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ secrets.ECR_REPO_NAME }}
-        IMAGE_TAG: "${{ env.github_repo_name }}-elasticsearch-${{ env.github_branch }}-${{ env.github_sha_short }}"
+        IMAGE_TAG: "${{ env.github_repo_name }}-opensearch-${{ env.github_branch }}-${{ env.github_sha_short }}"
       run: |
         # Build a docker container and push it to ECR 
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./cdc-sandbox/opensearch/

--- a/.github/workflows/dockerfile-to-ecr.yaml
+++ b/.github/workflows/dockerfile-to-ecr.yaml
@@ -68,7 +68,7 @@ jobs:
         IMAGE_TAG: "${{ env.github_repo_name }}-elasticsearch-${{ env.github_branch }}-${{ env.github_sha_short }}"
       run: |
         # Build a docker container and push it to ECR 
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./cdc-sandbox/elasticsearch/
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./cdc-sandbox/opensearch/
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     #   - ./proxy/:/etc/traefik/    
   elasticsearch:
     container_name: elasticsearch
-    build:  ./elasticsearch
+    build:  ./opensearch
     networks:
       - nbs
     ports:

--- a/cdc-sandbox/opensearch/Dockerfile
+++ b/cdc-sandbox/opensearch/Dockerfile
@@ -4,3 +4,5 @@ FROM opensearchproject/opensearch:2.4.1
 # Relaxes security and sets node to single
 ENV plugins.security.disabled=true
 ENV discovery.type=single-node
+
+RUN /usr/share/opensearch/bin/opensearch-plugin install analysis-phonetic

--- a/cdc-sandbox/opensearch/Dockerfile
+++ b/cdc-sandbox/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile to build elasticsearch image
+# Dockerfile to build opensearch image
 FROM opensearchproject/opensearch:2.4.1
 
 # Relaxes security and sets node to single

--- a/cdc-sandbox/opensearch/Dockerfile
+++ b/cdc-sandbox/opensearch/Dockerfile
@@ -1,0 +1,6 @@
+# Dockerfile to build elasticsearch image
+FROM opensearchproject/opensearch:2.4.1
+
+# Relaxes security and sets node to single
+ENV plugins.security.disabled=true
+ENV discovery.type=single-node

--- a/patient-search/api/build.gradle
+++ b/patient-search/api/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 	implementation "com.blazebit:blaze-persistence-integration-hibernate-5.6:${blazePersistenceVersion}"
 
 	// elasticsearch
-	implementation 'org.springframework.data:spring-data-elasticsearch:4.4.6'
+	implementation 'org.springframework.data:spring-data-elasticsearch:4.2.12'
 
 	// swagger
 	implementation "io.springfox:springfox-boot-starter:3.0.0"
@@ -91,6 +91,7 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers:1.17.6"
 	testImplementation "org.testcontainers:junit-jupiter:1.17.6"
 	testImplementation "org.testcontainers:elasticsearch:1.17.6"
+	testImplementation "org.opensearch:opensearch-testcontainers:2.0.0"
 	testImplementation 'com.github.javafaker:javafaker:1.0.2'
 	testImplementation 'org.yaml:snakeyaml:1.33'
 	

--- a/patient-search/api/src/test/java/gov/cdc/nbs/containers/NbsElasticsearchContainer.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/containers/NbsElasticsearchContainer.java
@@ -2,26 +2,26 @@ package gov.cdc.nbs.containers;
 
 import java.io.IOException;
 
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.opensearch.testcontainers.OpensearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class NbsElasticsearchContainer extends ElasticsearchContainer {
-    private static final String ELASTIC_SEARCH_DOCKER = "elasticsearch:7.17.7";
+public class NbsElasticsearchContainer extends OpensearchContainer {
+    private static final String OPENSEARCH_DOCKER = "opensearchproject/opensearch:2.4.1";
 
     private static final String CLUSTER_NAME = "cluster.name";
 
-    private static final String ELASTIC_SEARCH = "elasticsearch";
+    private static final String OPENSEARCH = "opensearch";
 
     public NbsElasticsearchContainer() {
-        super(DockerImageName.parse(ELASTIC_SEARCH_DOCKER)
-                .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"));
-        this.addEnv(CLUSTER_NAME, ELASTIC_SEARCH);
+        super(DockerImageName.parse(OPENSEARCH_DOCKER)
+                .asCompatibleSubstituteFor("opensearchproject/opensearch"));
+        this.addEnv(CLUSTER_NAME, OPENSEARCH);
     }
 
     public void startWithPlugins() throws UnsupportedOperationException, IOException, InterruptedException {
         start();
         execInContainer(
-            "/usr/share/elasticsearch/bin/elasticsearch-plugin",
+            "/usr/share/opensearch/bin/opensearch-plugin",
             "install",
             "analysis-phonetic"
         );


### PR DESCRIPTION
Leave the elasticsearch/Dockerfile and create a new opensearch/Dockerfile so we can compare the differences and switch between them if issues arise.  Right now the only difference is that opensearch has it's own security plugin and does not use xpack.

Up for feedback on whether we should rename all references to `elasticsearch` in the containers and documentation to `opensearch`.  As it's currently implemented here it retains the `elasticsearch` container name.

Here we validate opensearch is running and working with nifi:
![Screenshot 2023-01-19 at 12 59 40 AM](https://user-images.githubusercontent.com/34244063/213376380-d10ffb26-cf58-4bf9-afcb-241622fdc192.jpg)

![Screenshot 2023-01-19 at 12 38 04 PM](https://user-images.githubusercontent.com/34244063/213532023-2cd2b383-f493-4aac-b9da-552b10b68e1b.jpg)

TODO:
spring-data-elasticsearch 4.3.x and up do version checks on elasticsearch and won't work with elasticsearch so we need to remove the annotations that are from 4.3.x for example `org.springframework.data.elasticsearch.annotations.ValueConverter`
(small amount of rewrite)
or switch to opensearch libraries (big rewrite)