### PR TITLE
Fix test case

### DIFF
--- a/patient-search/api/src/main/java/gov/cdc/nbs/entity/odse/Person.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/entity/odse/Person.java
@@ -31,7 +31,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -39,7 +38,6 @@ import lombok.ToString;
 @Getter
 @Setter
 @Entity
-@ToString
 public class Person {
     @Id
     @Column(name = "person_uid", nullable = false)

--- a/patient-search/api/src/main/java/gov/cdc/nbs/message/KafkaMessageSerializer.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/message/KafkaMessageSerializer.java
@@ -7,11 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serializer;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 @Slf4j
 public class KafkaMessageSerializer implements Serializer<Object> {
-	
+
 	@Override
 	public byte[] serialize(String s, Object o) {
 		byte[] retVal = null;
@@ -24,5 +23,5 @@ public class KafkaMessageSerializer implements Serializer<Object> {
 		}
 		return retVal;
 	}
-	
+
 }

--- a/patient-search/api/src/main/java/gov/cdc/nbs/service/KafkaRequestProducerService.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/service/KafkaRequestProducerService.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class KafkaRequestProducerService {
 
 	@Autowired
-	private KafkaTemplate<String, EnvelopeRequest> kafkaEnvelopTemplate;
+	private KafkaTemplate<String, EnvelopeRequest> kafkaEnvelopeTemplate;
 
 	@Autowired
 	private KafkaTemplate<String, PatientUpdateRequest> kafkaPatientUpdateTemplate;
@@ -29,7 +29,7 @@ public class KafkaRequestProducerService {
 	private String patientUpdateTopic;
 
 	public void requestEnvelope(EnvelopeRequest kafkaMessage) {
-		send(kafkaEnvelopTemplate, patientSearchTopic, kafkaMessage.getRequestId(), kafkaMessage);
+		send(kafkaEnvelopeTemplate, patientSearchTopic, kafkaMessage.getRequestId(), kafkaMessage);
 
 	}
 

--- a/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/patient-search/api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -1,6 +1,5 @@
 package gov.cdc.nbs.service;
 
-import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -71,11 +70,9 @@ import gov.cdc.nbs.repository.PostalLocatorRepository;
 import gov.cdc.nbs.repository.TeleLocatorRepository;
 import gov.cdc.nbs.service.util.Constants;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class PatientService {
     private static final String ACTIVE = "ACTIVE";
 

--- a/patient-search/api/src/test/java/gov/cdc/nbs/RedirectSteps.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/RedirectSteps.java
@@ -83,7 +83,7 @@ public class RedirectSteps {
     public void i_send_a_request_to_the_nbs_simple_search() throws Exception {
         response = mvc
                 .perform(
-                        MockMvcRequestBuilders.post("/nbs/HomePage.do")
+                        MockMvcRequestBuilders.post("/nbs/redirect/simpleSearch")
                                 .cookie(new Cookie("JSESSIONID", sessionId)))
                 .andReturn().getResponse();
     }
@@ -99,7 +99,7 @@ public class RedirectSteps {
     @Given("I send a search request to the NBS simple search")
     public void I_send_a_search_request_to_the_nbs_simple_search() throws Exception {
         response = mvc.perform(MockMvcRequestBuilders
-                .post("/nbs/HomePage.do")
+                .post("/nbs/redirect/simpleSearch")
                 .param("patientSearchVO.lastName", "Doe")
                 .param("patientSearchVO.firstName", "John")
                 .param("patientSearchVO.birthTime", "01/01/2000")
@@ -130,7 +130,7 @@ public class RedirectSteps {
     @Given("I navigate to the NBS advanced search page")
     public void i_navigate_to_the_NBS_advanced_search_page() throws Exception {
         response = mvc.perform(
-                MockMvcRequestBuilders.get("/nbs/MyTaskList1.do")
+                MockMvcRequestBuilders.get("/nbs/redirect/advancedSearch")
                         .cookie(new Cookie("JSESSIONID", sessionId)))
                 .andReturn().getResponse();
     }

--- a/patient-search/api/src/test/java/gov/cdc/nbs/services/KafkaProducerTest.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/services/KafkaProducerTest.java
@@ -37,19 +37,19 @@ import gov.cdc.nbs.service.KafkaRequestProducerService;
 class KafkaProducerTest {
 
 	@Mock
-	private KafkaTemplate<String, EnvelopeRequest> kafkaTemplate;
-	
+	private KafkaTemplate<String, EnvelopeRequest> kafkaEnvelopeTemplate;
+
 	@Mock
 	private KafkaTemplate<String, PatientUpdateRequest> KafkaPatientUpdateTemplate;
 
 	@InjectMocks
 	private KafkaRequestProducerService producer;
 
-     public KafkaProducerTest() {
-    	 MockitoAnnotations.openMocks(this);
-    	 producer = new KafkaRequestProducerService();
-    	 
-     }
+	public KafkaProducerTest() {
+		MockitoAnnotations.openMocks(this);
+		producer = new KafkaRequestProducerService();
+	}
+
 	@Test
 	void testPatientSearchEvent() {
 		List<TemplateInput> msgVariables = new ArrayList<TemplateInput>();
@@ -60,17 +60,17 @@ class KafkaProducerTest {
 
 		EnvelopeRequest message = new EnvelopeRequest("Request-ID", msgVariables);
 		ListenableFuture<SendResult<String, EnvelopeRequest>> future = new SettableListenableFuture<SendResult<String, EnvelopeRequest>>();
-		Mockito.when(kafkaTemplate.send(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(future);
+		Mockito.when(kafkaEnvelopeTemplate.send(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(future);
 
 		producer.requestEnvelope(message);
 
 		ArgumentCaptor<EnvelopeRequest> envelopeEventArgumentCaptor = ArgumentCaptor.forClass(EnvelopeRequest.class);
-		verify(kafkaTemplate).send(eq(null), eq("Request-ID"), envelopeEventArgumentCaptor.capture());
+		verify(kafkaEnvelopeTemplate).send(eq(null), eq("Request-ID"), envelopeEventArgumentCaptor.capture());
 
 		EnvelopeRequest actualRecord = envelopeEventArgumentCaptor.getValue();
 		assertThat(actualRecord.getRequestId()).isEqualTo("Request-ID");
 		assertThat(actualRecord.getVars().get(0).getValue()).isEqualTo("Hello World.");
 
-		verifyNoMoreInteractions(kafkaTemplate);
+		verifyNoMoreInteractions(kafkaEnvelopeTemplate);
 	}
 }

--- a/patient-search/api/src/test/java/gov/cdc/nbs/services/PatientUpdateTest.java
+++ b/patient-search/api/src/test/java/gov/cdc/nbs/services/PatientUpdateTest.java
@@ -63,6 +63,7 @@ class PatientUpdateTest {
 	Person person;
 	Long ID;
 
+	@SuppressWarnings("deprecation")
 	public PatientUpdateTest() {
 		MockitoAnnotations.openMocks(this);
 		patientService = new PatientService(null, personRepository, teleLocatorRepository, postalLocatorRepository,
@@ -77,10 +78,10 @@ class PatientUpdateTest {
 
 		Authentication auth = Mockito.mock(Authentication.class);
 		SecurityContext secCont = Mockito.mock(SecurityContext.class);
-		securitContextHolder.setContext(secCont);
+		SecurityContextHolder.setContext(secCont);
 
 		when(teleLocatorRepository.getMaxId()).thenReturn(ID + 1);
-		when(securitContextHolder.getContext().getAuthentication()).thenReturn(auth);
+		when(SecurityContextHolder.getContext().getAuthentication()).thenReturn(auth);
 
 		NbsUserDetails principal = new NbsUserDetails(id, "testUserName", "testFirstName", null, false, false, null,
 				null, null, null, false);
@@ -107,7 +108,7 @@ class PatientUpdateTest {
 		assertEquals(person.getMiddleNm(), updatedPerson.getMiddleNm());
 		assertEquals(person.getLastNm(), updatedPerson.getLastNm());
 		assertEquals(person.getNames(), updatedPerson.getNames());
-		assertEquals(person.getNbsEntity() , updatedPerson.getNbsEntity());	
+		assertEquals(person.getNbsEntity(), updatedPerson.getNbsEntity());
 		assertEquals(person.getRaces(), updatedPerson.getRaces());
 		assertEquals(person.getRaces(), updatedPerson.getRaces());
 		assertEquals(person.getDeceasedIndCd(), updatedPerson.getDeceasedIndCd());


### PR DESCRIPTION
In this PR:
1. In the updates I made to get some of the redirects to work better with Kubernetes, I neglected to updated the redirect test cases. So this updates those test cases with the correct paths.
2. This also removes the `@ToString` annotation from the Person class. This broke the patient search as the toString was triggering recursively due to self referencing fields in the entity.
3. Resolves some small java warnings (unused imports, mock of deprecated method).
4. Fixes a spelling error in the `KafkaRequestProducerService`