### PR TITLE
Update personParticipation search criteria to find subject of lab report

### DIFF
--- a/patient-search/ui/src/pages/advancedSearch/components/LabReportResults.tsx
+++ b/patient-search/ui/src/pages/advancedSearch/components/LabReportResults.tsx
@@ -50,7 +50,9 @@ export const LabReportResults = ({
     };
 
     const getPatient = (labReport: LabReport): PersonParticipation | undefined | null => {
-        return labReport.personParticipations?.find((p) => p?.typeDescTxt === 'Patient subject');
+        return labReport.personParticipations?.find(
+            (p) => p?.typeDescTxt === 'Patient subject' || p?.typeCd === 'PATSBJ'
+        );
     };
 
     const getOrderingProvidorName = (labReport: LabReport): string | undefined => {


### PR DESCRIPTION
Demo environment is not displaying patient information for lab reports;
![image](https://user-images.githubusercontent.com/109251240/217083552-92d6e9b1-0c3d-49cf-b6e7-fb075da5d591.png)

The issue is the UI is searching for a `personParticipation` where `typeDescTxt` = 'Patient subject', but the data does not have that field as our dev environment does. 

![image](https://user-images.githubusercontent.com/109251240/217083743-4c876698-b089-4d0b-a7c3-f7441d8556bf.png)


This PR updates the search to look for where `typeCd` = 'PATSBJ'