### PR TITLE
updates Maven 3.8.6 to 3.8.7

### DIFF
--- a/cdc-sandbox/Dockerfile-antbuild
+++ b/cdc-sandbox/Dockerfile-antbuild
@@ -1,16 +1,19 @@
 FROM amazoncorretto:8-al2-jdk
 
+ARG ant_version=1.10.12
+ARG maven_version=3.8.7
+
 RUN yum update -y
 RUN yum install -y tar gzip hostname
 WORKDIR /home
-ADD https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz .
-RUN tar -zxvf apache-ant-1.10.12-bin.tar.gz
-RUN rm apache-ant-1.10.12*.gz
-ENV ANT_HOME=/home/apache-ant-1.10.12
-ADD https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz .
-RUN tar -zxvf apache-maven-3.8.6-bin.tar.gz
-RUN rm apache-maven-3.8.6-bin.tar.gz
-ENV MAVEN_HOME=/home/apache-maven-3.8.6
+ADD https://dlcdn.apache.org/ant/binaries/apache-ant-$ant_version-bin.tar.gz .
+RUN tar -zxvf apache-ant-$ant_version-bin.tar.gz
+RUN rm apache-ant-$ant_version*.gz
+ENV ANT_HOME=/home/apache-ant-$ant_version
+ADD https://dlcdn.apache.org/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz .
+RUN tar -zxvf apache-maven-$maven_version-bin.tar.gz
+RUN rm apache-maven-$maven_version-bin.tar.gz
+ENV MAVEN_HOME=/home/apache-maven-$maven_version
 ENV JBOSS_HOME=build
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=ISO-8859-1
 ADD docker-entrypoint-ant.sh .


### PR DESCRIPTION
There was a patch release of maven `3.8` increasing the  version from `3.8.6` to `3.8.7`.  The binaries for `3.8.6` were no longer available causing the building of NBC Classic via `cdc-sandbox/build.sh` to fail.  Build arguments were introduced to reduce having to keep the version numbers the same through the script.