### PR TITLE
Modernization-api externalized configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+cdc-sandbox
+node_modules
+build
+log

--- a/.github/workflows/dockerfile-to-ecr.yaml
+++ b/.github/workflows/dockerfile-to-ecr.yaml
@@ -109,7 +109,7 @@ jobs:
         IMAGE_TAG: "${{ env.github_repo_name }}-modernization-api-${{ env.github_branch }}-${{ env.github_sha_short }}"
       run: |
         # Build a docker container and push it to ECR 
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./apps/modernization-api
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f ./apps/modernization-api/Dockerfile .
         echo "Pushing image to ECR..."
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/apps/modernization-api/Dockerfile
+++ b/apps/modernization-api/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /usr/src/nbs
 # Build the UI
 RUN ./gradlew :modernization-ui:build -x test --no-daemon 
 
-# Build just the modernization-api and it's dependents
-RUN ./gradlew :modernization-api:buildDependents -x test --no-daemon
+# Build just the modernization-api and any required library
+RUN ./gradlew :modernization-api:buildNeeded --no-daemon
 
 FROM amazoncorretto:17
 

--- a/apps/modernization-api/Dockerfile
+++ b/apps/modernization-api/Dockerfile
@@ -24,6 +24,9 @@ RUN npm install
 
 WORKDIR /usr/src/nbs
 
+# Build the UI
+RUN ./gradlew :modernization-ui:build -x test --no-daemon 
+
 # Build just the modernization-api and it's dependents
 RUN ./gradlew :modernization-api:buildDependents -x test --no-daemon
 

--- a/apps/modernization-api/Dockerfile
+++ b/apps/modernization-api/Dockerfile
@@ -1,29 +1,39 @@
-FROM amazoncorretto:17
+FROM amazoncorretto:17 as builder
+
+# Copy project configuration
+COPY gradle /usr/src/nbs/gradle
+COPY gradlew /usr/src/nbs/gradlew
+COPY build.gradle /usr/src/nbs/build.gradle
+COPY settings.gradle /usr/src/nbs/settings.gradle
+
+# Copy required sources
+COPY apps /usr/src/nbs/apps
+COPY libs /usr/src/nbs/libs
 
 COPY . /usr/src/nbs
 
+# Preparation for the modernization-ui build
 # Install node
-WORKDIR /usr/src/nbs/apps/modernization-ui
-RUN yum update -y
-RUN curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -
-RUN yum install tar gzip nodejs -y
+RUN yum update -y \
+    && curl --silent --location https://rpm.nodesource.com/setup_16.x | bash - \
+    && yum install tar gzip nodejs -y
 
 # Install node modules
+WORKDIR /usr/src/nbs/apps/modernization-ui
 RUN npm install
 
-# Update database connections
 WORKDIR /usr/src/nbs
-RUN sed -i 's/localhost:1433/nbs-mssql:1433/' apps/modernization-api/src/main/resources/application.yml
-RUN sed -i 's/localhost:1433/nbs-mssql:1433/' apps/modernization-api/src/test/resources/application-test.yml
-RUN sed -i 's/localhost:7001/wildfly:7001/' apps/modernization-api/src/main/resources/application.yml
-RUN sed -i 's/localhost:9200/elasticsearch:9200/' apps/modernization-api/src/main/resources/application.yml
 
+# Build just the modernization-api and it's dependents
+RUN ./gradlew :modernization-api:buildDependents -x test --no-daemon
 
-# Build app
-RUN ./gradlew clean build -x test --no-daemon
+FROM amazoncorretto:17
 
-RUN mv apps/modernization-api/build/libs/modernization-api*-plain.jar apps/modernization-api/build/libs/plain.jar 
-RUN mv apps/modernization-api/build/libs/modernization-api*.jar apps/modernization-api/build/libs/api.jar 
+COPY --from=builder /usr/src/nbs/apps/modernization-api/build/libs/modernization-api*.jar api.jar 
+
+ENV NBS_DATASOURCE_SERVER=nbs-mssql
+ENV NBS_ELASTICSEARCH_SERVER=elasticsearch
+ENV NBS_WILDFLY_SERVER=wildfly
 
 # Run jar
-CMD ["java", "-jar", "apps/modernization-api/build/libs/api.jar"]
+CMD ["java", "-jar", "api.jar"]

--- a/apps/modernization-api/README.md
+++ b/apps/modernization-api/README.md
@@ -12,6 +12,7 @@
 
 1. In the ui directory run `npm install`
 1. In the modernization-api directory run `./gradlew build`
+    - Alternatively, from the root directory run `./gradlew :modernization-api:buildDependents`
 1. Press `Cmd+Shift+P` and run `Java: Clean Language Server Workspace`
 1. VSCode should now recognize the QueryDSL generated Q classes and be able to launch the debugger
 
@@ -28,6 +29,17 @@ To execute specific test tags:
 ```bash
 ./gradlew test -Dcucumber.filter.tags="@patient_create" --tests "RunCucumberTest"
 ```
+
+## Running
+
+The Modernization API can be started from the root directory by runninng:
+
+```bash
+./gradlew :modernization-api:bootRun
+```
+
+It assumes that ElasticSeach and MSSQL Server are running on `localhost`.  Preconfigured containers are avaiable in the [CDC Sandbox](../../cdc-sandbox/README.md), `cdc-sandbox/elasticsearch` and `cdc-sandbox/db`
+
 
 ## GraphQL
 
@@ -53,3 +65,16 @@ public List<Patient> findPatientsNamedJohn() {
 ## Swagger
 
 A swagger page is available at [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+
+
+## Configuration
+
+Spring Config allows configuration values to be overwritten at runtime.  Values can be set through Java System Variables, Environment Variable, and [other useful means](https://docs.spring.io/spring-boot/docs/2.7.5/reference/html/features.html#features.external-config).  The default profile contains the following properties configuration most likely to change.
+
+| Name                     | Default   | Description                                       |
+|--------------------------|-----------|---------------------------------------------------|
+| nbs.elasticsearch.server | localhost | The host name of the server running ElasticSearch |
+| nbs.elasticsearch.port   | 9200      | The port in which ElasticSearch is listening      |
+| nbs.wildfly.server       | localhost | The host name of the server running NBS Classic   |
+| nbs.wildfly.port         | 7001      | The port in which NBS Classic is listening        |
+| nbs.datasource.server    | localhost | The host name of the server running MS SQL Server |

--- a/apps/modernization-api/build.gradle
+++ b/apps/modernization-api/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	annotationProcessor("org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}")
 
 	// common
+	implementation project(':modernization-ui')
 	implementation project(':database-entities')
 
 	// jwt

--- a/apps/modernization-api/src/main/resources/application.yml
+++ b/apps/modernization-api/src/main/resources/application.yml
@@ -6,12 +6,18 @@ nbs:
         parameterSecret: Yq4vh+mbi4B4QYThc/M+33VtPJ5O2Adc
     max-page-size: 50
     elasticsearch:
-        url: http://localhost:9200
-    wildfly:
-        url: http://localhost:7001
+        server: localhost
+        port: 9200
+        url: http://${nbs.elasticsearch.server}:${nbs.elasticsearch.port}
+    wildfly:        
+        server: localhost
+        port: 7001
+        url: http://${nbs.wildfly.server}:${nbs.wildfly.port}
     uid:
         suffix: GA01
         seed: 10000000
+    datasource:
+        server: localhost
 
 logging:
     file.path: ./log/
@@ -36,7 +42,7 @@ spring:
                 dialect: org.hibernate.dialect.SQLServer2012Dialect
                 hbm2ddl.jdbc_metadata_extraction_strategy: individually
     datasource:
-        url: jdbc:sqlserver://localhost:1433;database=nbs_odse;encrypt=true;trustServerCertificate=true;
+        url: jdbc:sqlserver://${nbs.datasource.server}:1433;database=nbs_odse;encrypt=true;trustServerCertificate=true;
         username: sa
         password: fake.fake.fake.1234
     mvc:

--- a/apps/modernization-api/src/test/resources/application-test.yml
+++ b/apps/modernization-api/src/test/resources/application-test.yml
@@ -5,6 +5,9 @@ nbs:
         tokenExpirationMillis: 60000
         parameterSecret: Yq4vh+mbi4B4QYThc/M+33VtPJ5O2Adc
     max-page-size: 1000
+    datasource:
+        server: localhost
+
 logging:
     file.path: ./log/
     level:
@@ -29,7 +32,7 @@ spring:
                 hbm2ddl:
                     jdbc_metadata_extraction_strategy: individually
     datasource:
-        url: jdbc:sqlserver://localhost:1433;database=nbs_odse;encrypt=true;trustServerCertificate=true;
+        url: jdbc:sqlserver://${nbs.datasource.server}:1433;database=nbs_odse;encrypt=true;trustServerCertificate=true;
         username: sa
         password: fake.fake.fake.1234
     mvc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,13 @@ services:
       context: ./
       dockerfile: ./apps/modernization-api/Dockerfile
     container_name: modernization-api
+    environment:
+      - NBS_DATASOURCE_SERVER=nbs-mssql
+      - NBS_ELASTICSEARCH_SERVER=elasticsearch
+      - NBS_WILDFLY_SERVER=wildfly
     networks:
       - nbs
 networks:
   nbs:
     name: nbs
-    driver: bridge
+    external: true      


### PR DESCRIPTION
Changed the `modernization-api` container to pull the `elasticsearch`, 'nbs-mssql`, and 'wildfly` configuration from Spring Config sources (i.e environment variables, java system properties).  

Reduces the build context of the `modernization-api` by excluding the `cdc-sandbox` directory.  This can be removed in the future if the gradle project is moved into a sibling folder of `cdc-sandbox`.

Reduces the size of the resulting `modernization-api` image by only including the files required to run the application.  This can further reduced if needed with a more precise base image for the application container.