### PR TITLE
CNPT-948 CNPT-946 CNFT1-187 fix phone,email search,add soundex

### DIFF
--- a/apps/modernization-api/build.gradle
+++ b/apps/modernization-api/build.gradle
@@ -82,6 +82,8 @@ dependencies {
 	// itext pdf generation
 	implementation "com.itextpdf:itextpdf:5.5.13.3"
 
+	implementation group: 'commons-codec', name: 'commons-codec', version: '1.15'
+
 	// test
 	testImplementation "org.projectlombok:lombok"
 	testAnnotationProcessor "org.projectlombok:lombok"

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -504,9 +504,7 @@ public class PatientService {
         personName.setAddReasonCd("Add");
         personName.setAddTime(now);
         personName.setFirstNm(name.getFirstName());
-        // personName.setFirstNmSndx(); TODO how to generate sndx
         personName.setLastNm(name.getLastName());
-        // personName.setLastNmSndx(); TODO
         personName.setMiddleNm(name.getMiddleName());
         personName.setNmSuffix(name.getSuffix());
         personName.setNmUseCd("L"); // L = legal, AL = alias. per NEDSSConstants

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -161,9 +161,18 @@ public class PatientService {
         }
 
         if (filter.getFirstName() != null && !filter.getFirstName().isEmpty()) {
-            builder.must(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
+            BoolQueryBuilder firstNameBuilder = QueryBuilders.boolQuery();
+            firstNameBuilder.should(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
                     QueryBuilders.queryStringQuery(addWildcards(filter.getFirstName())).defaultField("name.firstNm"),
                     ScoreMode.Avg));
+
+            Soundex soundex = new Soundex();
+            String firstNmSndx = soundex.encode(filter.getFirstName());
+            firstNameBuilder.should(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
+                    QueryBuilders.queryStringQuery(firstNmSndx).defaultField("name.firstNmSndx"),
+                    ScoreMode.Avg));
+        
+            builder.must(firstNameBuilder);
         }
 
         if (filter.getLastName() != null && !filter.getLastName().isEmpty()) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -16,6 +16,7 @@ import javax.persistence.PersistenceContext;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.Operator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -176,13 +177,17 @@ public class PatientService {
 
         if (filter.getPhoneNumber() != null && !filter.getPhoneNumber().isEmpty()) {
             builder.must(QueryBuilders.nestedQuery(ElasticsearchPerson.PHONE_FIELD,
-                    QueryBuilders.queryStringQuery(filter.getPhoneNumber()).defaultField("phone.telephoneNbr"),
+                    QueryBuilders.queryStringQuery(filter.getPhoneNumber())
+                    .defaultField("phone.telephoneNbr")
+                    .defaultOperator(Operator.AND),
                     ScoreMode.Avg));
         }
 
         if (filter.getEmail() != null && !filter.getEmail().isEmpty()) {
             builder.must(QueryBuilders.nestedQuery(ElasticsearchPerson.EMAIL_FIELD,
-                    QueryBuilders.queryStringQuery(filter.getEmail()).defaultField("email.emailAddress"),
+                    QueryBuilders.queryStringQuery(filter.getEmail())
+                    .defaultField("email.emailAddress")
+                    .defaultOperator(Operator.AND),
                     ScoreMode.Avg));
         }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
@@ -37,6 +37,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.springframework.data.domain.Sort.Direction;
 import java.util.Comparator;
+import org.apache.commons.codec.language.Soundex;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
@@ -72,6 +73,11 @@ public class PatientSearchSteps {
     public void there_are_patients(int patientCount) {
         // person data is randomly generated but the Ids are always the same.
         generatedPersons = PersonMother.getRandomPersons(patientCount);
+        
+        // make first person soundex testable
+        Person soundexPerson = generatedPersons.get(0);
+        soundexPerson.setFirstNm("Jon");  // soundex equivalent to John
+        soundexPerson.setLastNm("Smyth");  // soundex equivalent to Smith
 
         var generatedIds = generatedPersons.stream()
                 .map(p -> p.getId()).collect(Collectors.toList());
@@ -151,11 +157,17 @@ public class PatientSearchSteps {
             case "email":
                 filter.setEmail(PersonUtil.getTeleLocators(searchPatient).get(0).getEmailAddress());
                 break;
+            case "last name soundex":
+              filter.setLastName("Smith");  // finds Smyth
+              break;
             case "last name":
                 filter.setLastName(searchPatient.getLastNm());
                 break;
             case "first name":
                 filter.setFirstName(searchPatient.getFirstNm());
+                break;
+            case "first name soundex":
+                filter.setFirstName("John"); // finds Jon
                 break;
             case "race":
                 filter.setRace(searchPatient.getRaces().get(0).getId().getRaceCd());

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
@@ -158,8 +158,9 @@ public class PatientSearchSteps {
                 filter.setEmail(PersonUtil.getTeleLocators(searchPatient).get(0).getEmailAddress());
                 break;
             case "last name soundex":
-              filter.setLastName("Smith");  // finds Smyth
-              break;
+                searchPatient = generatedPersons.get(0);
+                filter.setLastName("Smith");  // finds Smyth
+                break;
             case "last name":
                 filter.setLastName(searchPatient.getLastNm());
                 break;
@@ -167,6 +168,7 @@ public class PatientSearchSteps {
                 filter.setFirstName(searchPatient.getFirstNm());
                 break;
             case "first name soundex":
+                searchPatient = generatedPersons.get(0);
                 filter.setFirstName("John"); // finds Jon
                 break;
             case "race":

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/PatientSearchSteps.java
@@ -37,7 +37,6 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.springframework.data.domain.Sort.Direction;
 import java.util.Comparator;
-import org.apache.commons.codec.language.Soundex;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/PersonUtil.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/PersonUtil.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.codec.language.Soundex;
+
 import gov.cdc.nbs.entity.elasticsearch.ElasticsearchPerson;
 import gov.cdc.nbs.entity.elasticsearch.NestedAddress;
 import gov.cdc.nbs.entity.elasticsearch.NestedEmail;
@@ -33,10 +35,13 @@ public class PersonUtil {
     public static ElasticsearchPerson getElasticSearchPerson(Person person) {
         Long id = person.getId();
 
+        Soundex soundex = new Soundex();
         var name = new NestedName();
         name.setFirstNm(person.getFirstNm());
+        name.setFirstNmSndx(soundex.encode(person.getFirstNm()));
         name.setLastNm(person.getLastNm());
-
+        name.setLastNmSndx(soundex.encode(person.getLastNm()));
+ 
         var race = new NestedRace();
         race.setRaceCd(person.getRaceCd());
         race.setRaceDescTxt(person.getRaceDescTxt());

--- a/apps/modernization-api/src/test/resources/features/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/PatientSearch.feature
@@ -15,7 +15,9 @@ Feature: Patient search
     Examples: 
       | field         | qualifier |
       | last name     |           |
+      | last name soundex |           |
       | first name    |           |
+      | first name soundex |           |
       | race          |           |
       | patient id    |           |
       | ssn           |           |


### PR DESCRIPTION
Make the default operator `and` instead of `or` to require all the `-` and `@` separated values.  ie searching for 123-456-7890 could return phones with just 123 before (and appeared to be returning all phones when in actuality it was just phones in that area code).  This also allows searching by say area code 123 if that is the query string.

Added soundex search API capability.  Decided new analyzer wasn't needed in elasticsearch.  Legacy already has a populated soundex field.  Pass that through and key off of it in the api.  In the api require that the fname/lname searches satisfy at least one of a traditional or soundex match (logical OR ie `should`)
