### PR TITLE
Remove 'rhap_parse_nbs_ind' and 'rhap_action_value' columns from Cond…

### DIFF
--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/srte/ConditionCode.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/srte/ConditionCode.java
@@ -120,12 +120,6 @@ public class ConditionCode implements Serializable {
     @Column(name = "coinfection_grp_cd", length = 20)
     private String coinfectionGrpCd;
 
-    @Column(name = "rhap_parse_nbs_ind", length = 1)
-    private String rhapParseNbsInd;
-
-    @Column(name = "rhap_action_value", length = 200)
-    private String rhapActionValue;
-
     @OneToMany(mappedBy = "conditionCd")
     private Set<LdfPageSet> ldfPageSets = new LinkedHashSet<>();
 


### PR DESCRIPTION
[CNFT1-650](https://cdc-nbs.atlassian.net/browse/CNFT1-650)
The condition codes dropdown was failing to populate with data. 

The problem is that the `rhap_parse_nbs_ind` and `rhap_action_value` columns do not exist in the demo database. Removing these column definitions from the `ConditionCode` class fixes the problem.

I was unable to find a reference to either of these columns in the [NEDSSDB Repo](https://github.com/cdcent/NEDSSDB)