### PR TITLE
Use nedssEntryId instead of userId to query for created by / updated by

### DIFF
--- a/apps/modernization-api/src/main/resources/graphql/user.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/user.graphqls
@@ -1,4 +1,5 @@
 type User {
+    nedssEntryId: ID!
     userId: String!
     userFirstNm: String!
     userLastNm: String!

--- a/apps/modernization-ui/src/generated/gql/queries/findAllUsers.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findAllUsers.gql
@@ -1,6 +1,7 @@
 query findAllUsers($page: Page) {
     findAllUsers(page: $page){
         content{
+            nedssEntryId
             userId
             userFirstNm
             userLastNm

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -1235,6 +1235,7 @@ export type UpdateResult = {
 
 export type User = {
   __typename?: 'User';
+  nedssEntryId: Scalars['ID'];
   recordStatusCd?: Maybe<RecordStatus>;
   userFirstNm: Scalars['String'];
   userId: Scalars['String'];
@@ -1369,7 +1370,7 @@ export type FindAllUsersQueryVariables = Exact<{
 }>;
 
 
-export type FindAllUsersQuery = { __typename?: 'Query', findAllUsers: { __typename?: 'UserResults', total: number, content: Array<{ __typename?: 'User', userId: string, userFirstNm: string, userLastNm: string, recordStatusCd?: RecordStatus | null } | null> } };
+export type FindAllUsersQuery = { __typename?: 'Query', findAllUsers: { __typename?: 'UserResults', total: number, content: Array<{ __typename?: 'User', nedssEntryId: string, userId: string, userFirstNm: string, userLastNm: string, recordStatusCd?: RecordStatus | null } | null> } };
 
 export type FindDocumentsRequiringReviewForPatientQueryVariables = Exact<{
   patientId: Scalars['Int'];
@@ -2481,6 +2482,7 @@ export const FindAllUsersDocument = gql`
     query findAllUsers($page: Page) {
   findAllUsers(page: $page) {
     content {
+      nedssEntryId
       userId
       userFirstNm
       userLastNm

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -983,6 +983,7 @@ type StateCode {
     codeSystemDescTxt: String
 }
 type User {
+    nedssEntryId: ID!
     userId: String!
     userFirstNm: String!
     userLastNm: String!

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/GeneralSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/GeneralSearch.tsx
@@ -145,7 +145,7 @@ export const GeneralSearch = ({ control, filter }: GeneralSearchProps) => {
                             options={searchCriteria.userResults.map((user) => {
                                 return {
                                     name: `${user.userLastNm}, ${user.userFirstNm}`,
-                                    value: user.userId
+                                    value: user.nedssEntryId
                                 };
                             })}
                         />
@@ -157,7 +157,7 @@ export const GeneralSearch = ({ control, filter }: GeneralSearchProps) => {
                             options={searchCriteria.userResults.map((user) => {
                                 return {
                                     name: `${user.userLastNm}, ${user.userFirstNm}`,
-                                    value: user.userId
+                                    value: user.nedssEntryId
                                 };
                             })}
                         />

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/LabGeneralSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/LabGeneralSearch.tsx
@@ -291,7 +291,7 @@ export const LabGeneralSearch = ({ control, filter }: GeneralSearchProps) => {
                             options={searchCriteria.userResults.map((user) => {
                                 return {
                                     name: `${user.userLastNm}, ${user.userFirstNm}`,
-                                    value: user.userId
+                                    value: user.nedssEntryId
                                 };
                             })}
                         />
@@ -303,7 +303,7 @@ export const LabGeneralSearch = ({ control, filter }: GeneralSearchProps) => {
                             options={searchCriteria.userResults.map((user) => {
                                 return {
                                     name: `${user.userLastNm}, ${user.userFirstNm}`,
-                                    value: user.userId
+                                    value: user.nedssEntryId
                                 };
                             })}
                         />


### PR DESCRIPTION
When querying for Events that were created by or last updated by a user, the `nedssEntryId` needs to be used instead of the `userId`.

Successful search after update.
![image](https://user-images.githubusercontent.com/109251240/222022879-a680ad7a-1dc7-4bc0-ba4e-d41daac9956c.png)
