### PR TITLE
Patient search/multiple record status

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/graphql/filter/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/graphql/filter/PatientFilter.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.graphql.filter;
 
 import java.time.Instant;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -39,7 +40,7 @@ public class PatientFilter {
     private String zip;
     private String mortalityStatus;
     private String ethnicity;
-    private RecordStatus recordStatus;
+    private List<RecordStatus> recordStatus;
     private String treatmentId;
     private String vaccinationId;
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -64,7 +64,7 @@ import gov.cdc.nbs.patient.create.PatientCreateRequestResolver;
 import gov.cdc.nbs.repository.PersonRepository;
 import gov.cdc.nbs.service.util.Constants;
 import graphql.com.google.common.collect.Ordering;
-import lombok.RequiredArgsConstructor;;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/PatientService.java
@@ -1,8 +1,44 @@
 package gov.cdc.nbs.service;
 
+import static gov.cdc.nbs.config.security.SecurityUtil.BusinessObjects.PATIENT;
+import static gov.cdc.nbs.config.security.SecurityUtil.Operations.FINDINACTIVE;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.apache.commons.codec.language.Soundex;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
 import com.blazebit.persistence.CriteriaBuilderFactory;
 import com.blazebit.persistence.querydsl.BlazeJPAQuery;
 import com.querydsl.core.types.dsl.BooleanExpression;
+
 import gov.cdc.nbs.config.security.NbsUserDetails;
 import gov.cdc.nbs.config.security.SecurityUtil;
 import gov.cdc.nbs.entity.elasticsearch.ElasticsearchPerson;
@@ -28,37 +64,7 @@ import gov.cdc.nbs.patient.create.PatientCreateRequestResolver;
 import gov.cdc.nbs.repository.PersonRepository;
 import gov.cdc.nbs.service.util.Constants;
 import graphql.com.google.common.collect.Ordering;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.codec.language.Soundex;
-import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.Operator;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.sort.SortBuilder;
-import org.elasticsearch.search.sort.SortBuilders;
-import org.elasticsearch.search.sort.SortOrder;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Function;
+import lombok.RequiredArgsConstructor;;
 
 @Service
 @RequiredArgsConstructor
@@ -75,6 +81,7 @@ public class PatientService {
     private final InstantConverter instantConverter = new InstantConverter();
     private final KafkaRequestProducerService producer;
     private final PatientCreateRequestResolver createRequestResolver;
+    private final UserService userService;
 
     private <T> BlazeJPAQuery<T> applySort(BlazeJPAQuery<T> query, Sort sort) {
         var person = QPerson.person;
@@ -147,7 +154,7 @@ public class PatientService {
             firstNameBuilder.should(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
                     QueryBuilders.queryStringQuery(firstNmSndx).defaultField("name.firstNmSndx"),
                     ScoreMode.Avg));
-        
+
             builder.must(firstNameBuilder);
         }
 
@@ -173,22 +180,22 @@ public class PatientService {
         if (filter.getPhoneNumber() != null && !filter.getPhoneNumber().isEmpty()) {
             builder.must(QueryBuilders.nestedQuery(ElasticsearchPerson.PHONE_FIELD,
                     QueryBuilders.queryStringQuery(filter.getPhoneNumber())
-                    .defaultField("phone.telephoneNbr")
-                    .defaultOperator(Operator.AND),
+                            .defaultField("phone.telephoneNbr")
+                            .defaultOperator(Operator.AND),
                     ScoreMode.Avg));
         }
 
         if (filter.getEmail() != null && !filter.getEmail().isEmpty()) {
             builder.must(QueryBuilders.nestedQuery(ElasticsearchPerson.EMAIL_FIELD,
                     QueryBuilders.queryStringQuery(filter.getEmail())
-                    .defaultField("email.emailAddress")
-                    .defaultOperator(Operator.AND),
+                            .defaultField("email.emailAddress")
+                            .defaultOperator(Operator.AND),
                     ScoreMode.Avg));
         }
 
         if (filter.getAddress() != null && !filter.getAddress().isEmpty()) {
             builder.must(QueryBuilders.nestedQuery(ElasticsearchPerson.ADDRESS_FIELD, QueryBuilders
-                            .queryStringQuery(addWildcards(filter.getAddress())).defaultField("address.streetAddr1"),
+                    .queryStringQuery(addWildcards(filter.getAddress())).defaultField("address.streetAddr1"),
                     ScoreMode.Avg));
         }
 
@@ -300,7 +307,7 @@ public class PatientService {
     // checks to see if the filter provided is null, if not add the filter to the
     // 'query.where' based on the expression supplied
     private <T, I> BlazeJPAQuery<T> addParameter(BlazeJPAQuery<T> query,
-                                                 Function<I, BooleanExpression> expression, I filter) {
+            Function<I, BooleanExpression> expression, I filter) {
         if (filter != null) {
             if (filter instanceof String s && s.trim().length() == 0) {
                 return query;
@@ -311,26 +318,25 @@ public class PatientService {
         }
     }
 
+    /**
+     * Adds the record status to the query builder. If no record status is
+     * specified, throw a QueryException.
+     */
     private void addRecordStatusQuery(Collection<RecordStatus> recordStatus, BoolQueryBuilder builder) {
         if (recordStatus == null || recordStatus.isEmpty()) {
-            return;
+            throw new QueryException("At least one RecordStatus is required");
         }
-        // If LOG_DEL or SUPERCEDED are specified, user must have
-        // FINDINACTIVE-PATIENT authority
+        // If LOG_DEL or SUPERCEDED are specified, user must have FINDINACTIVE-PATIENT
+        // authority
         if (recordStatus.contains(RecordStatus.SUPERCEDED) || recordStatus.contains(RecordStatus.LOG_DEL)) {
-            var user = (NbsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-            var findInactivePatientAuthority = SecurityUtil.Operations.FINDINACTIVE + "-"
-                    + SecurityUtil.BusinessObjects.PATIENT;
-            var hasPermission = user.getAuthorities().stream()
-                    .filter(a -> a.getAuthority().equals(findInactivePatientAuthority))
-                    .findAny()
-                    .isPresent();
+            var currentUser = SecurityUtil.getUserDetails();
             // If user lacks permission, remove these from the search criteria
-            if (!hasPermission) {
+            if (!userService.isAuthorized(currentUser, FINDINACTIVE + "-" + PATIENT)) {
                 recordStatus = recordStatus.stream()
                         .filter(s -> !s.equals(RecordStatus.SUPERCEDED) && !s.equals(RecordStatus.LOG_DEL))
                         .toList();
             }
+
         }
 
         if (recordStatus.isEmpty()) {
@@ -354,8 +360,7 @@ public class PatientService {
         producer.requestPatientCreateEnvelope(createRequest);
         return new PatientCreateResponse(
                 createRequest.request(),
-                createRequest.patient()
-        );
+                createRequest.patient());
     }
 
     /**

--- a/apps/modernization-api/src/main/resources/graphql/patient.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient.graphqls
@@ -44,7 +44,7 @@ input PersonFilter {
     ethnicity: String
     vaccinationId: String
     treatmentId: String
-    recordStatus: RecordStatus
+    recordStatus: [RecordStatus!]
 }
 
 type Person {

--- a/apps/modernization-api/src/main/resources/graphql/patient.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient.graphqls
@@ -44,7 +44,7 @@ input PersonFilter {
     ethnicity: String
     vaccinationId: String
     treatmentId: String
-    recordStatus: [RecordStatus!]
+    recordStatus: [RecordStatus!]!
 }
 
 type Person {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/PermissionSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/PermissionSteps.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.runner.RunWith;
@@ -26,6 +27,7 @@ import gov.cdc.nbs.config.security.NbsUserDetails;
 import gov.cdc.nbs.config.security.SecurityProperties;
 import gov.cdc.nbs.controller.EventController;
 import gov.cdc.nbs.controller.PatientController;
+import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.graphql.filter.InvestigationFilter;
 import gov.cdc.nbs.graphql.filter.LabReportFilter;
@@ -126,6 +128,7 @@ public class PermissionSteps {
             switch (searchType) {
                 case "findPatientsByFilter":
                     var patientFilter = new PatientFilter();
+                    patientFilter.setRecordStatus(Arrays.asList(RecordStatus.ACTIVE));
                     patientFilter.setFirstName("John");
                     response = patientController.findPatientsByFilter(patientFilter, page);
                     break;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/services/PatientUpdateTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/services/PatientUpdateTest.java
@@ -46,7 +46,7 @@ class PatientUpdateTest {
 	public PatientUpdateTest() {
 		MockitoAnnotations.openMocks(this);
 		patientService = new PatientService(null, personRepository, null, null,
-				null, null);
+				null, null, null);
 		Long id = UUID.randomUUID().getMostSignificantBits();
 		Person old = buildPersonFromInput();
 		person = old;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/PersonMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/PersonMother.java
@@ -44,6 +44,8 @@ public class PersonMother {
         final String lastName = faker.name().lastName();
 
         Person person = new Person(id, "PSN" + id + 10000000L);
+        person.setCd("PAT");
+        person.setRecordStatusCd(RecordStatus.ACTIVE);
         person.setFirstNm(firstName);
         person.setMiddleNm(middleName);
         person.setLastNm(lastName);
@@ -145,6 +147,7 @@ public class PersonMother {
         person.setCurrSexCd(Gender.M);
         person.setDeceasedIndCd(Deceased.N);
         person.setSsn("999-888-7777");
+        person.setCd("PAT");
 
         // name
         person.add(
@@ -228,6 +231,72 @@ public class PersonMother {
                         now
                 )
         );
+
+        return person;
+    }
+
+    public static Person janeDoe_deleted() {
+        final long id = 19000001L;
+        Instant now = Instant.now();
+        Person person = new Person(id, "PSN" + 19000001L + "GA01");
+
+        person.setBirthTime(Instant.parse("1980-11-30T18:35:24.00Z"));
+        person.setBirthGenderCd(Gender.F);
+        person.setCurrSexCd(Gender.F);
+        person.setDeceasedIndCd(Deceased.N);
+        person.setSsn("666-777-8888");
+        person.setCd("PAT");
+
+        // name
+        person.add(
+                new PatientCommand.AddName(
+                        id,
+                        "Jane",
+                        "S",
+                        "Doe",
+                        null,
+                        PatientInput.NameUseCd.L,
+                        CREATED_BY_ID,
+                        now));
+
+        // phone numbers
+        person.add(
+                new PatientCommand.AddPhoneNumber(
+                        id,
+                        id + 40000L,
+                        "111-222-3333",
+                        null,
+                        PhoneType.HOME,
+                        CREATED_BY_ID,
+                        now));
+
+        // addresses
+        person.add(
+                new PatientCommand.AddAddress(
+                        id,
+                        id + 80000L,
+                        "123 Main St",
+                        null,
+                        new City("1304000", "Atlanta"),
+                        StateCodeUtil.stateCodeMap.get("Georgia"),
+                        "30301",
+                        new County("13089"),
+                        new Country("840", "United States"),
+                        null,
+                        CREATED_BY_ID,
+                        now));
+
+        person.setEthnicGroupInd(EthnicityMother.HISPANIC_OR_LATINO_CODE);
+        person.setRecordStatusCd(RecordStatus.LOG_DEL);
+        person.setVersionCtrlNbr((short) 1);
+
+        // race
+        person.add(
+                new PatientCommand.AddRace(
+                        id,
+                        RaceMother.WHITE_CODE,
+                        id,
+                        now));
 
         return person;
     }

--- a/apps/modernization-api/src/test/resources/features/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/PatientSearch.feature
@@ -13,28 +13,28 @@ Feature: Patient search
     Then I find the patient
 
     Examples: 
-      | field         | qualifier |
-      | last name     |           |
-      | last name soundex |           |
-      | first name    |           |
+      | field              | qualifier |
+      | last name          |           |
+      | last name soundex  |           |
+      | first name         |           |
       | first name soundex |           |
-      | race          |           |
-      | patient id    |           |
-      | ssn           |           |
-      | phone number  |           |
-      | date of birth | before    |
-      | date of birth | after     |
-      | date of birth | equal     |
-      | gender        |           |
-      | deceased      |           |
-      | address       |           |
-      | city          |           |
-      | state         |           |
-      | country       |           |
-      | zip code      |           |
-      | ethnicity     |           |
-      | record status |           |
-      | email         |           |
+      | race               |           |
+      | patient id         |           |
+      | ssn                |           |
+      | phone number       |           |
+      | date of birth      | before    |
+      | date of birth      | after     |
+      | date of birth      | equal     |
+      | gender             |           |
+      | deceased           |           |
+      | address            |           |
+      | city               |           |
+      | state              |           |
+      | country            |           |
+      | zip code           |           |
+      | ethnicity          |           |
+      | record status      |           |
+      | email              |           |
 
   @patient_multi_data_search
   Scenario: I can find a Patient by patient data using multiple fields
@@ -84,9 +84,27 @@ Feature: Patient search
     When I search for patients sorted by "<search field>" "<qualifier>" "<sort field>" "<direction>"
     Then I find the patients sorted
 
-    Examples:
-      | search field  | qualifier | sort field  | direction|
-      | record status |           | lastNm      | asc      |
-      | record status |           | lastNm      | desc     |
-      | record status |           | birthTime   | asc      |
-      | record status |           | birthTime   | desc     |
+    Examples: 
+      | search field  | qualifier | sort field | direction |
+      | record status |           | lastNm     | asc       |
+      | record status |           | lastNm     | desc      |
+      | record status |           | birthTime  | asc       |
+      | record status |           | birthTime  | desc      |
+
+  @patient_search_record_status_deleted
+  Scenario: I can find patients with deleted record status
+    Given I have the authorities: "FINDINACTIVE-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+    And A deleted patient exists
+    When I search for a record status of "LOG_DEL"
+    Then I find patients with "LOG_DEL" record status
+
+  @patient_search_record_status_active
+  Scenario: I can find patients with active record status
+    When I search for a record status of "ACTIVE"
+    Then I find patients with "ACTIVE" record status
+
+  @patient_search_record_status_deleted_invalid_permission
+  Scenario: I cant search for deleted records without the correct permission
+    Given A deleted patient exists
+    When I search for a record status of "LOG_DEL"
+    Then I dont have permissions to execute the search

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -778,7 +778,7 @@ export type PersonFilter = {
   mortalityStatus?: InputMaybe<Scalars['String']>;
   phoneNumber?: InputMaybe<Scalars['String']>;
   race?: InputMaybe<Scalars['String']>;
-  recordStatus?: InputMaybe<RecordStatus>;
+  recordStatus?: InputMaybe<Array<RecordStatus>>;
   ssn?: InputMaybe<Scalars['String']>;
   state?: InputMaybe<Scalars['String']>;
   treatmentId?: InputMaybe<Scalars['String']>;

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -778,7 +778,7 @@ export type PersonFilter = {
   mortalityStatus?: InputMaybe<Scalars['String']>;
   phoneNumber?: InputMaybe<Scalars['String']>;
   race?: InputMaybe<Scalars['String']>;
-  recordStatus?: InputMaybe<Array<RecordStatus>>;
+  recordStatus: Array<RecordStatus>;
   ssn?: InputMaybe<Scalars['String']>;
   state?: InputMaybe<Scalars['String']>;
   treatmentId?: InputMaybe<Scalars['String']>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -588,7 +588,7 @@ input PersonFilter {
     ethnicity: String
     vaccinationId: String
     treatmentId: String
-    recordStatus: RecordStatus
+    recordStatus: [RecordStatus!]
 }
 
 type Person {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -588,7 +588,7 @@ input PersonFilter {
     ethnicity: String
     vaccinationId: String
     treatmentId: String
-    recordStatus: [RecordStatus!]
+    recordStatus: [RecordStatus!]!
 }
 
 type Person {

--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
@@ -184,6 +184,10 @@ export const AdvancedSearch = () => {
         const chips: any = [];
         if (filter) {
             Object.entries(filter as any).map((re: any) => {
+                // Do not display record status chip, as indicated in Figma design
+                if (re[0] === 'recordStatus') {
+                    return;
+                }
                 if (re[0] !== 'identification') {
                     let name = re[0];
                     switch (re[0]) {

--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
@@ -13,6 +13,7 @@ import {
     LabReportFilter,
     PersonFilter,
     SortDirection,
+    RecordStatus,
     SortField,
     useFindInvestigationsByFilterLazyQuery,
     useFindLabReportsByFilterLazyQuery,
@@ -65,7 +66,7 @@ export const AdvancedSearch = () => {
     const PAGE_SIZE = 25;
 
     // patient search variables
-    const [personFilter, setPersonFilter] = useState<PersonFilter>();
+    const [personFilter, setPersonFilter] = useState<PersonFilter>({ recordStatus: [RecordStatus.Active] });
     const addPatiendRef = useRef<any>(null);
     const [resultsChip, setResultsChip] = useState<{ name: string; value: string }[]>([]);
     const [showSorting, setShowSorting] = useState<boolean>(false);
@@ -306,7 +307,7 @@ export const AdvancedSearch = () => {
 
     function isEmpty(obj: any) {
         for (const key in obj) {
-            if (obj[key] !== undefined && obj[key] != '') return false;
+            if (obj[key] !== undefined && obj[key] != '' && key !== 'recordStatus') return false;
         }
         return true;
     }
@@ -374,7 +375,7 @@ export const AdvancedSearch = () => {
 
     const handleClearAll = () => {
         setPatientData(undefined);
-        setPersonFilter({});
+        setPersonFilter({ recordStatus: [RecordStatus.Active] });
         setInvestigationData(undefined);
         setInvestigationFilter({});
         setLabReportData(undefined);

--- a/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.spec.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useForm } from 'react-hook-form';
-import { PersonFilter } from '../../../../generated/graphql/schema';
+import { PersonFilter, RecordStatus } from '../../../../generated/graphql/schema';
 import { PatientSearch } from './PatientSearch';
 
 describe('PatientSearch component tests', () => {
@@ -11,11 +11,7 @@ describe('PatientSearch component tests', () => {
         const sampleClearFunction = () => {};
         let sampleData;
         const { container, getByLabelText } = render(
-            <PatientSearch 
-                handleSubmission={sampleSearchFunction}
-                data={sampleData}
-                clearAll={sampleClearFunction}
-            />
+            <PatientSearch handleSubmission={sampleSearchFunction} data={sampleData} clearAll={sampleClearFunction} />
         );
         const accordionH4Elements = container.querySelectorAll('h4.accordian-item');
         expect(accordionH4Elements.length).toBe(5);
@@ -32,17 +28,66 @@ describe('PatientSearch component tests', () => {
         const sampleClearFunction = () => {};
         let sampleData;
         const { container, getByLabelText } = render(
-            <PatientSearch 
-                handleSubmission={sampleSearchFunction}
-                data={sampleData}
-                clearAll={sampleClearFunction}
-            />
+            <PatientSearch handleSubmission={sampleSearchFunction} data={sampleData} clearAll={sampleClearFunction} />
         );
         const accordionButtonElements = container.querySelectorAll('h4.accordian-item button');
-        expect(accordionButtonElements[0].getAttribute('aria-expanded')).toBe("true");
-        expect(accordionButtonElements[1].getAttribute('aria-expanded')).toBe("false");
-        expect(accordionButtonElements[2].getAttribute('aria-expanded')).toBe("false");
-        expect(accordionButtonElements[3].getAttribute('aria-expanded')).toBe("false");
-        expect(accordionButtonElements[4].getAttribute('aria-expanded')).toBe("false");
+        expect(accordionButtonElements[0].getAttribute('aria-expanded')).toBe('true');
+        expect(accordionButtonElements[1].getAttribute('aria-expanded')).toBe('false');
+        expect(accordionButtonElements[2].getAttribute('aria-expanded')).toBe('false');
+        expect(accordionButtonElements[3].getAttribute('aria-expanded')).toBe('false');
+        expect(accordionButtonElements[4].getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should only have the "Active" record status checked by default', () => {
+        const sampleSearchFunction = (data: PersonFilter) => {};
+        const sampleClearFunction = () => {};
+        let sampleData;
+        const { container, getByLabelText } = render(
+            <PatientSearch handleSubmission={sampleSearchFunction} data={sampleData} clearAll={sampleClearFunction} />
+        );
+        const activeCheckbox = container.querySelector('#record-status-active') as HTMLInputElement;
+        const deletedCheckbox = container.querySelector('#record-status-deleted') as HTMLInputElement;
+        const superCededCheckbox = container.querySelector('#record-status-superceded') as HTMLInputElement;
+        expect(activeCheckbox.checked).toBe(true);
+        expect(deletedCheckbox.checked).toBe(false);
+        expect(superCededCheckbox.checked).toBe(false);
+    });
+
+    it('should set record status checkboxes from incoming data', () => {
+        const sampleSearchFunction = (data: PersonFilter) => {};
+        const sampleClearFunction = () => {};
+        let sampleData: PersonFilter = { recordStatus: [RecordStatus.LogDel, RecordStatus.Superceded] };
+        const { container, getByLabelText } = render(
+            <PatientSearch handleSubmission={sampleSearchFunction} data={sampleData} clearAll={sampleClearFunction} />
+        );
+        const activeCheckbox = container.querySelector('#record-status-active') as HTMLInputElement;
+        const deletedCheckbox = container.querySelector('#record-status-deleted') as HTMLInputElement;
+        const superCededCheckbox = container.querySelector('#record-status-superceded') as HTMLInputElement;
+        expect(activeCheckbox.checked).toBe(false);
+        expect(deletedCheckbox.checked).toBe(true);
+        expect(superCededCheckbox.checked).toBe(true);
+    });
+
+    it('should return the selected record status on submit', () => {
+        const sampleSearchFunction = (data: PersonFilter) => {
+            // Verify all 3 record status returned
+            expect(data.recordStatus).toMatchObject([
+                RecordStatus.LogDel,
+                RecordStatus.Superceded,
+                RecordStatus.Active
+            ]);
+        };
+        const sampleClearFunction = () => {};
+        // Load page with Deleted and Superceded checked
+        let sampleData: PersonFilter = { recordStatus: [RecordStatus.LogDel, RecordStatus.Superceded] };
+        const { container, getByLabelText } = render(
+            <PatientSearch handleSubmission={sampleSearchFunction} data={sampleData} clearAll={sampleClearFunction} />
+        );
+        // Click on Active to select it
+        const activeCheckbox = container.querySelector('#record-status-active') as HTMLInputElement;
+        activeCheckbox.click();
+        // Click submit
+        const submitButton = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+        submitButton.click();
     });
 });

--- a/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.spec.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.spec.tsx
@@ -90,4 +90,31 @@ describe('PatientSearch component tests', () => {
         const submitButton = container.querySelector('button[type="submit"]') as HTMLButtonElement;
         submitButton.click();
     });
+
+    it('should display an error when no record status is selected', () => {
+        const sampleSearchFunction = (data: PersonFilter) => {};
+        const sampleClearFunction = () => {};
+        let sampleData: PersonFilter = { recordStatus: [RecordStatus.Active] };
+        const { container, getByLabelText } = render(
+            <PatientSearch handleSubmission={sampleSearchFunction} data={sampleData} clearAll={sampleClearFunction} />
+        );
+        // Error message should be hidden
+        let errorMessage = container.querySelector('#record-status-error-message') as HTMLSpanElement;
+        expect(errorMessage).toBeFalsy();
+
+        // Click on Active to de-select it (no RecordStatus selected)
+        const activeCheckbox = container.querySelector('#record-status-active') as HTMLInputElement;
+        activeCheckbox.click();
+
+        // Error message should be visible
+        errorMessage = container.querySelector('#record-status-error-message') as HTMLSpanElement;
+        expect(errorMessage).toBeVisible();
+
+        // Click Active to select it
+        activeCheckbox.click();
+
+        // Error message should be hidden
+        errorMessage = container.querySelector('#record-status-error-message') as HTMLSpanElement;
+        expect(errorMessage).toBeFalsy();
+    });
 });

--- a/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Button, Checkbox, Form, Grid, Label } from '@trussworks/react-uswds';
+import { Accordion, Button, Checkbox, ErrorMessage, Form, FormGroup, Grid, Label } from '@trussworks/react-uswds';
 import { AccordionItemProps } from '@trussworks/react-uswds/lib/components/Accordion/Accordion';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -132,38 +132,49 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
                         />
                     </Grid>
                     <Grid col={12}>
-                        <Label htmlFor={''}>Include records that are</Label>
-                        <Grid row>
-                            <Grid col={6}>
-                                <Checkbox
-                                    id={'record-status-active'}
-                                    onChange={(v) => handleRecordStatusChange(RecordStatus.Active, v.target.checked)}
-                                    name={'name'}
-                                    label={'Active'}
-                                    checked={selectedRecordStatus.includes(RecordStatus.Active)}
-                                />
+                        <FormGroup error={selectedRecordStatus.length === 0}>
+                            <Label htmlFor={''}>Include records that are</Label>
+                            {selectedRecordStatus.length === 0 && (
+                                <ErrorMessage id="record-status-error-message">
+                                    At least one status is required
+                                </ErrorMessage>
+                            )}
+                            <Grid row>
+                                <Grid col={6}>
+                                    <Checkbox
+                                        id={'record-status-active'}
+                                        onChange={(v) =>
+                                            handleRecordStatusChange(RecordStatus.Active, v.target.checked)
+                                        }
+                                        name={'name'}
+                                        label={'Active'}
+                                        checked={selectedRecordStatus.includes(RecordStatus.Active)}
+                                    />
+                                </Grid>
+                                <Grid col={6}>
+                                    <Checkbox
+                                        id={'record-status-deleted'}
+                                        onChange={(v) =>
+                                            handleRecordStatusChange(RecordStatus.LogDel, v.target.checked)
+                                        }
+                                        name={'name'}
+                                        label={'Deleted'}
+                                        checked={selectedRecordStatus.includes(RecordStatus.LogDel)}
+                                    />
+                                </Grid>
+                                <Grid col={6}>
+                                    <Checkbox
+                                        id={'record-status-superceded'}
+                                        onChange={(v) =>
+                                            handleRecordStatusChange(RecordStatus.Superceded, v.target.checked)
+                                        }
+                                        name={'name'}
+                                        label={'Superceded'}
+                                        checked={selectedRecordStatus.includes(RecordStatus.Superceded)}
+                                    />
+                                </Grid>
                             </Grid>
-                            <Grid col={6}>
-                                <Checkbox
-                                    id={'record-status-deleted'}
-                                    onChange={(v) => handleRecordStatusChange(RecordStatus.LogDel, v.target.checked)}
-                                    name={'name'}
-                                    label={'Deleted'}
-                                    checked={selectedRecordStatus.includes(RecordStatus.LogDel)}
-                                />
-                            </Grid>
-                            <Grid col={6}>
-                                <Checkbox
-                                    id={'record-status-superceded'}
-                                    onChange={(v) =>
-                                        handleRecordStatusChange(RecordStatus.Superceded, v.target.checked)
-                                    }
-                                    name={'name'}
-                                    label={'Superceded'}
-                                    checked={selectedRecordStatus.includes(RecordStatus.Superceded)}
-                                />
-                            </Grid>
-                        </Grid>
+                        </FormGroup>
                     </Grid>
                 </>
             ),
@@ -216,9 +227,14 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
     };
 
     const onSubmit: any = (body: any) => {
+        // at least 1 record status must be selected
+        if (selectedRecordStatus.length === 0) {
+            return;
+        }
         const rowData: PersonFilter = {
             firstName: body.firstName,
-            lastName: body.lastName
+            lastName: body.lastName,
+            recordStatus: selectedRecordStatus
         };
         body.dob && validateDate(body.dob) && (rowData.dateOfBirth = body.dob);
         body.gender !== '- Select -' && (rowData.gender = body.gender);
@@ -233,7 +249,6 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
 
         body.race !== '- Select -' && (rowData.race = body.race);
         body.ethnicity !== '- Select -' && (rowData.ethnicity = body.ethnicity);
-        rowData.recordStatus = selectedRecordStatus;
 
         if (body.identificationNumber && body.identificationType !== '- Select -') {
             rowData.identification = {

--- a/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/patientSearch/PatientSearch.tsx
@@ -1,6 +1,6 @@
-import { Accordion, Button, Form, Grid, Label } from '@trussworks/react-uswds';
+import { Accordion, Button, Checkbox, Form, Grid, Label } from '@trussworks/react-uswds';
 import { AccordionItemProps } from '@trussworks/react-uswds/lib/components/Accordion/Accordion';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Gender, PersonFilter, RecordStatus } from '../../../../generated/graphql/schema';
 import { DatePickerInput } from '../../../../components/FormInputs/DatePickerInput';
@@ -10,8 +10,6 @@ import { AddressForm } from './AddressForm';
 import { ContactForm } from './ContactForm';
 import { EthnicityForm } from './EthnicityForm';
 import { IDForm } from './IdForm';
-import { CheckBoxControl } from '../../../../components/FormInputs/CheckBoxControl';
-import { formatInterfaceString } from '../../../../utils/util';
 import { validatePhoneNumber } from '../../../../utils/PhoneValidation';
 import { validateDate } from '../../../../utils/DateValidation';
 
@@ -22,6 +20,7 @@ type PatientSearchProps = {
 };
 
 export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearchProps) => {
+    const [selectedRecordStatus, setSelectedRecordStatus] = useState([] as RecordStatus[]);
     const methods = useForm();
     const {
         handleSubmit,
@@ -50,6 +49,10 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
                 race: data.race
             });
         }
+        // Default to Active checked
+        data?.recordStatus
+            ? setSelectedRecordStatus(data.recordStatus)
+            : setSelectedRecordStatus([RecordStatus.Active]);
     }, [data]);
 
     const simpleSearchItems: AccordionItemProps[] = [
@@ -131,16 +134,35 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
                     <Grid col={12}>
                         <Label htmlFor={''}>Include records that are</Label>
                         <Grid row>
-                            {Object.values(RecordStatus).map((status, index) => (
-                                <Grid col={6} key={index}>
-                                    <CheckBoxControl
-                                        name={status}
-                                        label={formatInterfaceString(status)}
-                                        id={status}
-                                        control={control}
-                                    />
-                                </Grid>
-                            ))}
+                            <Grid col={6}>
+                                <Checkbox
+                                    id={'record-status-active'}
+                                    onChange={(v) => handleRecordStatusChange(RecordStatus.Active, v.target.checked)}
+                                    name={'name'}
+                                    label={'Active'}
+                                    checked={selectedRecordStatus.includes(RecordStatus.Active)}
+                                />
+                            </Grid>
+                            <Grid col={6}>
+                                <Checkbox
+                                    id={'record-status-deleted'}
+                                    onChange={(v) => handleRecordStatusChange(RecordStatus.LogDel, v.target.checked)}
+                                    name={'name'}
+                                    label={'Deleted'}
+                                    checked={selectedRecordStatus.includes(RecordStatus.LogDel)}
+                                />
+                            </Grid>
+                            <Grid col={6}>
+                                <Checkbox
+                                    id={'record-status-superceded'}
+                                    onChange={(v) =>
+                                        handleRecordStatusChange(RecordStatus.Superceded, v.target.checked)
+                                    }
+                                    name={'name'}
+                                    label={'Superceded'}
+                                    checked={selectedRecordStatus.includes(RecordStatus.Superceded)}
+                                />
+                            </Grid>
                         </Grid>
                     </Grid>
                 </>
@@ -184,6 +206,15 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
         }
     ];
 
+    const handleRecordStatusChange = (status: RecordStatus, isChecked: boolean) => {
+        // Add or remove record status from state
+        if (isChecked) {
+            setSelectedRecordStatus([...selectedRecordStatus, status]);
+        } else {
+            setSelectedRecordStatus(selectedRecordStatus.filter((r) => r !== status));
+        }
+    };
+
     const onSubmit: any = (body: any) => {
         const rowData: PersonFilter = {
             firstName: body.firstName,
@@ -202,6 +233,7 @@ export const PatientSearch = ({ handleSubmission, data, clearAll }: PatientSearc
 
         body.race !== '- Select -' && (rowData.race = body.race);
         body.ethnicity !== '- Select -' && (rowData.ethnicity = body.ethnicity);
+        rowData.recordStatus = selectedRecordStatus;
 
         if (body.identificationNumber && body.identificationType !== '- Select -') {
             rowData.identification = {

--- a/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
@@ -14,6 +14,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import {
     FindPatientsByFilterQuery,
+    RecordStatus,
     useFindInvestigationsByFilterLazyQuery,
     useFindLabReportsByFilterLazyQuery,
     useFindPatientsByFilterLazyQuery
@@ -48,7 +49,8 @@ export const PatientProfile = () => {
             getPatientProfileData({
                 variables: {
                     filter: {
-                        id: id
+                        id: id,
+                        recordStatus: [RecordStatus.Active, RecordStatus.LogDel, RecordStatus.Superceded]
                     }
                 }
             });

--- a/apps/modernization-ui/src/pages/simpleSearch/SimpleSearch.tsx
+++ b/apps/modernization-ui/src/pages/simpleSearch/SimpleSearch.tsx
@@ -8,7 +8,7 @@ import { DatePickerInput } from '../../components/FormInputs/DatePickerInput';
 import { Input } from '../../components/FormInputs/Input';
 import { SelectInput } from '../../components/FormInputs/SelectInput';
 import { TableContent } from '../../components/TableContent/TableContent';
-import { Gender, PersonFilter, useFindPatientsByFilterLazyQuery } from '../../generated/graphql/schema';
+import { Gender, PersonFilter, RecordStatus, useFindPatientsByFilterLazyQuery } from '../../generated/graphql/schema';
 import { EncryptionControllerService } from '../../generated/services/EncryptionControllerService';
 import { UserContext } from '../../providers/UserContext';
 import './SimpleSearch.scss';
@@ -88,7 +88,8 @@ export const SimpleSearch = () => {
         // build filter from user input
         const filter: PersonFilter = {
             firstName: body.firstName,
-            lastName: body.lastName
+            lastName: body.lastName,
+            recordStatus: [RecordStatus.Active]
         };
         body.city && (filter.city = body.city);
         body.zip && (filter.zip = body.zip);
@@ -127,7 +128,7 @@ export const SimpleSearch = () => {
                                     e.preventDefault();
                                     // build search filter from text
                                     const formatName = e.target[0].value.split(' ');
-                                    const filter: PersonFilter = {};
+                                    const filter: PersonFilter = { recordStatus: [RecordStatus.Active] };
                                     filter.firstName = formatName[0];
                                     filter.lastName = formatName.length > 1 ? formatName[1] : '';
                                     // send filter for encryption

--- a/libs/authentication/src/main/java/gov/cdc/nbs/service/UserService.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/service/UserService.java
@@ -68,6 +68,12 @@ public class UserService implements UserDetailsService {
                 .orElse(false);
     }
 
+    public boolean isAuthorized(final NbsUserDetails userDetails, final String... permissions) {
+        return userDetails.getAuthorities()
+                .stream()
+                .anyMatch(allowsAny(permissions));
+    }
+
     private Predicate<NbsAuthority> allows(final String permission) {
         return authority -> Objects.equals(authority.getAuthority(), permission);
     }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/RecordStatus.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/RecordStatus.java
@@ -1,8 +1,0 @@
-package gov.cdc.nbs.entity.enums.converter;
-
-public enum RecordStatus {
-    ACTIVE,
-    INACTIVE,
-    LOG_DEL,
-    SUPERCEDED
-}


### PR DESCRIPTION
The current Patient Search API only allows a single `RecordStatus`. The new UI designs allow multi select for `RecordStatus`
![image](https://user-images.githubusercontent.com/109251240/222570202-8bc662d1-cea8-4aa4-8078-673841f3c289.png)

This PR adds support for multiple `RecordStatus`, at least 1 is required for all queries.

![image](https://user-images.githubusercontent.com/109251240/222570330-b488a1aa-fc62-4c52-abde-8e3bf5155628.png)
