### PR TITLE
CNFT1 156/search pages skipping

### DIFF
--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/elasticsearch/ElasticsearchPerson.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/elasticsearch/ElasticsearchPerson.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javax.persistence.Id;
 
+import gov.cdc.nbs.patient.search.ElasticsearchSuffixConverter;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -301,6 +302,7 @@ public class ElasticsearchPerson {
     private String nmPrefix;
 
     @Field(name = NM_SUFFIX, type = FieldType.Text)
+    @ValueConverter(ElasticsearchSuffixConverter.class)
     private Suffix nmSuffix;
 
     @Field(name = PREFERRED_NM, type = FieldType.Text)

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/SuffixConverter.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/SuffixConverter.java
@@ -8,62 +8,14 @@ import gov.cdc.nbs.message.enums.Suffix;
 @Converter
 public class SuffixConverter implements AttributeConverter<Suffix, String> {
 
-    @Override
-    public String convertToDatabaseColumn(Suffix attribute) {
-        return getValueFromType(attribute);
-    }
+  @Override
+  public String convertToDatabaseColumn(Suffix attribute) {
+    return SuffixStringConverter.toString(attribute);
+  }
 
-    @Override
-    public Suffix convertToEntityAttribute(String dbData) {
-        return getTypeFromValue(dbData);
-    }
-
-    private Suffix getTypeFromValue(String dbData) {
-        if (dbData == null) {
-            return null;
-        }
-        switch (dbData) {
-            case "ESQ":
-                return Suffix.ESQ;
-            case "II":
-                return Suffix.II;
-            case "III":
-                return Suffix.III;
-            case "IV":
-                return Suffix.IV;
-            case "JR":
-                return Suffix.JR;
-            case "SR":
-                return Suffix.SR;
-            case "V":
-                return Suffix.V;
-            default:
-                return null;
-        }
-    }
-
-    private String getValueFromType(Suffix attribute) {
-        if (attribute == null) {
-            return null;
-        }
-        switch (attribute) {
-            case ESQ:
-                return "ESQ";
-            case II:
-                return "II";
-            case III:
-                return "III";
-            case IV:
-                return "IV";
-            case JR:
-                return "JR";
-            case SR:
-                return "SR";
-            case V:
-                return "V";
-            default:
-                return null;
-        }
-    }
+  @Override
+  public Suffix convertToEntityAttribute(String dbData) {
+    return SuffixStringConverter.fromString(dbData);
+  }
 
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/SuffixConverter.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/SuffixConverter.java
@@ -4,6 +4,7 @@ import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 
 import gov.cdc.nbs.message.enums.Suffix;
+import gov.cdc.nbs.patient.SuffixStringConverter;
 
 @Converter
 public class SuffixConverter implements AttributeConverter<Suffix, String> {

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/SuffixStringConverter.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/converter/SuffixStringConverter.java
@@ -1,0 +1,41 @@
+package gov.cdc.nbs.entity.enums.converter;
+
+import gov.cdc.nbs.message.enums.Suffix;
+
+public class SuffixStringConverter {
+
+  public static Suffix fromString(final String dbData) {
+    if (dbData == null) {
+      return null;
+    }
+    return switch (dbData) {
+      case "ESQ" -> Suffix.ESQ;
+      case "II" -> Suffix.II;
+      case "III" -> Suffix.III;
+      case "IV" -> Suffix.IV;
+      case "JR" -> Suffix.JR;
+      case "SR" -> Suffix.SR;
+      case "V" -> Suffix.V;
+      default -> null;
+    };
+  }
+
+  public static String toString(final Suffix attribute) {
+    if (attribute == null) {
+      return null;
+    }
+    return switch (attribute) {
+      case ESQ -> "ESQ";
+      case II -> "II";
+      case III -> "III";
+      case IV -> "IV";
+      case JR -> "JR";
+      case SR -> "SR";
+      case V -> "V";
+    };
+  }
+
+  private SuffixStringConverter() {
+
+  }
+}

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/NBSEntity.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/NBSEntity.java
@@ -67,7 +67,7 @@ public class NBSEntity {
 
         List<EntityLocatorParticipation> locators = ensureLocators();
 
-        EntityLocatorParticipationId identifier = new EntityLocatorParticipationId(this.id, (long) locators.size());
+        EntityLocatorParticipationId identifier = new EntityLocatorParticipationId(this.id, address.id());
 
         EntityLocatorParticipation participation = new PostalEntityLocatorParticipation(
                 this,
@@ -84,7 +84,7 @@ public class NBSEntity {
     public EntityLocatorParticipation add(final PatientCommand.AddPhoneNumber phoneNumber) {
         List<EntityLocatorParticipation> locators = ensureLocators();
 
-        EntityLocatorParticipationId identifier = new EntityLocatorParticipationId(this.id, (long) locators.size());
+        EntityLocatorParticipationId identifier = new EntityLocatorParticipationId(this.id, phoneNumber.id());
 
         EntityLocatorParticipation participation = new TeleEntityLocatorParticipation(
                 this,
@@ -101,7 +101,7 @@ public class NBSEntity {
     public EntityLocatorParticipation add(final PatientCommand.AddEmailAddress emailAddress) {
         List<EntityLocatorParticipation> locators = ensureLocators();
 
-        EntityLocatorParticipationId identifier = new EntityLocatorParticipationId(this.id, (long) locators.size());
+        EntityLocatorParticipationId identifier = new EntityLocatorParticipationId(this.id, emailAddress.id());
 
         EntityLocatorParticipation participation = new TeleEntityLocatorParticipation(
                 this,

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/SuffixStringConverter.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/SuffixStringConverter.java
@@ -1,14 +1,14 @@
-package gov.cdc.nbs.entity.enums.converter;
+package gov.cdc.nbs.patient;
 
 import gov.cdc.nbs.message.enums.Suffix;
 
 public class SuffixStringConverter {
 
-  public static Suffix fromString(final String dbData) {
-    if (dbData == null) {
+  public static Suffix fromString(final String value) {
+    if (value == null) {
       return null;
     }
-    return switch (dbData) {
+    return switch (value) {
       case "ESQ" -> Suffix.ESQ;
       case "II" -> Suffix.II;
       case "III" -> Suffix.III;
@@ -20,11 +20,11 @@ public class SuffixStringConverter {
     };
   }
 
-  public static String toString(final Suffix attribute) {
-    if (attribute == null) {
+  public static String toString(final Suffix value) {
+    if (value == null) {
       return null;
     }
-    return switch (attribute) {
+    return switch (value) {
       case ESQ -> "ESQ";
       case II -> "II";
       case III -> "III";

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/search/ElasticsearchSuffixConverter.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/search/ElasticsearchSuffixConverter.java
@@ -1,0 +1,21 @@
+package gov.cdc.nbs.patient.search;
+
+import gov.cdc.nbs.message.enums.Suffix;
+import gov.cdc.nbs.patient.SuffixStringConverter;
+import org.springframework.data.elasticsearch.core.mapping.PropertyValueConverter;
+
+public class ElasticsearchSuffixConverter implements PropertyValueConverter {
+  @Override
+  public Object write(final Object value) {
+    return (value instanceof Suffix suffix)
+        ? SuffixStringConverter.toString(suffix)
+        : null;
+  }
+
+  @Override
+  public Object read(final Object value) {
+    return (value instanceof String suffix)
+        ? SuffixStringConverter.fromString(suffix)
+        : null;
+  }
+}

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -19,307 +19,308 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PersonTest {
 
-    @Test
-    @SuppressWarnings("squid:S5961")
-        // Allow more than 25 assertions
-    void should_create_new_person_when_patient_added() {
+  @Test
+  @SuppressWarnings("squid:S5961")
+    // Allow more than 25 assertions
+  void should_create_new_person_when_patient_added() {
 
-        PatientCommand.AddPatient request = new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                "ssn-value",
-                Instant.parse("2000-09-03T15:17:39.00Z"),
-                Gender.M,
-                Gender.F,
-                Deceased.N,
-                null,
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30.00Z"),
-                "comments",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
+    PatientCommand.AddPatient request = new PatientCommand.AddPatient(
+        117L,
+        "patient-local-id",
+        "ssn-value",
+        Instant.parse("2000-09-03T15:17:39.00Z"),
+        Gender.M,
+        Gender.F,
+        Deceased.N,
+        null,
+        "Marital Status",
+        "EthCode",
+        Instant.parse("2019-03-03T10:15:30.00Z"),
+        "comments",
+        131L,
+        Instant.parse("2020-03-03T10:15:30.00Z")
+    );
+
+    Person actual = new Person(request);
+
+    assertThat(actual.getId()).isEqualTo(117L);
+    assertThat(actual.getLocalId()).isEqualTo("patient-local-id");
+
+    assertThat(actual.getVersionCtrlNbr()).isEqualTo((short) 1);
+    assertThat(actual.getCd()).isEqualTo("PAT");
+    assertThat(actual.getElectronicInd()).isEqualTo('N');
+    assertThat(actual.getEdxInd()).isEqualTo("Y");
+    assertThat(actual.getDedupMatchInd()).isEqualTo('F');
+
+    assertThat(actual.getAddUserId()).isEqualTo(131L);
+    assertThat(actual.getAddTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+    assertThat(actual.getLastChgUserId()).isEqualTo(131L);
+    assertThat(actual.getLastChgTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+
+    assertThat(actual.getStatusCd()).isEqualTo('A');
+    assertThat(actual.getStatusTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+
+    assertThat(actual.getRecordStatusCd()).isEqualTo(RecordStatus.ACTIVE);
+    assertThat(actual.getRecordStatusTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+
+    assertThat(actual.getSsn()).isEqualTo("ssn-value");
+    assertThat(actual.getBirthTime()).isEqualTo("2000-09-03T15:17:39.00Z");
+    assertThat(actual.getBirthGenderCd()).isEqualTo(Gender.M);
+    assertThat(actual.getCurrSexCd()).isEqualTo(Gender.F);
+    assertThat(actual.getDeceasedIndCd()).isEqualTo(Deceased.N);
+    assertThat(actual.getMaritalStatusCd()).isEqualTo("Marital Status");
+    assertThat(actual.getEthnicGroupInd()).isEqualTo("EthCode");
+    assertThat(actual.getAsOfDateGeneral()).isEqualTo("2019-03-03T10:15:30.00Z");
+    assertThat(actual.getAsOfDateAdmin()).isEqualTo("2019-03-03T10:15:30.00Z");
+    assertThat(actual.getAsOfDateSex()).isEqualTo("2019-03-03T10:15:30.00Z");
+    assertThat(actual.getDescription()).isEqualTo("comments");
+
+    assertThat(actual.getPersonParentUid())
+        .as("Master Patient Record set itself as parent")
+        .isSameAs(actual);
+
+  }
+
+  @Test
+  void should_add_race() {
+
+    Person actual = new Person(117L, "local-id-value");
+    actual.add(
+        new PatientCommand.AddRace(
+            117L,
+            "race-code-value",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual.getRaces()).satisfiesExactly(
+        actual_race -> assertThat(actual_race)
+            .returns("race-code-value", PersonRace::getRaceCd)
+    );
+
+  }
+
+  @Test
+  void should_add_primary_name() {
+
+    PatientInput patient = new PatientInput();
+
+    patient.setNames(
+        Arrays.asList(
+            new PatientInput.Name(
+                "First",
+                "Middle",
+                "Last",
+                Suffix.JR,
+                PatientInput.NameUseCd.L
+            ),
+            new PatientInput.Name(
+                "Second",
+                "SecondMiddle",
+                "SecondLast",
+                Suffix.SR,
+                PatientInput.NameUseCd.AL
+            )
+        )
+    );
+
+    Person actual = new Person(117L, "local-id-value");
+
+    actual.add(
+        new PatientCommand.AddName(
+            117L,
+            "First",
+            "Middle",
+            "Last",
+            Suffix.JR,
+            PatientInput.NameUseCd.L,
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual.getFirstNm()).isEqualTo("First");
+    assertThat(actual.getMiddleNm()).isEqualTo("Middle");
+    assertThat(actual.getLastNm()).isEqualTo("Last");
+    assertThat(actual.getNmSuffix()).isEqualTo(Suffix.JR);
+
+    assertThat(actual.getNames()).satisfiesExactly(
+        actual_primary -> assertThat(actual_primary)
+            .returns("First", PersonName::getFirstNm)
+            .returns("Middle", PersonName::getMiddleNm)
+            .returns("Last", PersonName::getLastNm)
+            .returns(Suffix.JR, PersonName::getNmSuffix)
+            .returns("L", PersonName::getNmUseCd)
+    );
+
+  }
+
+  @Test
+  void should_add_secondary_name() {
+
+    Person actual = new Person(117L, "local-id-value");
+
+    actual.add(
+        new PatientCommand.AddName(
+            117L,
+            "First",
+            "Middle",
+            "Last",
+            Suffix.JR,
+            PatientInput.NameUseCd.L,
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    actual.add(
+        new PatientCommand.AddName(
+            117L,
+            "Second",
+            "SecondMiddle",
+            "SecondLast",
+            Suffix.SR,
+            PatientInput.NameUseCd.AL,
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual.getFirstNm()).isEqualTo("First");
+    assertThat(actual.getMiddleNm()).isEqualTo("Middle");
+    assertThat(actual.getLastNm()).isEqualTo("Last");
+    assertThat(actual.getNmSuffix()).isEqualTo(Suffix.JR);
+
+    assertThat(actual.getNames()).satisfiesExactly(
+        actual_primary -> assertThat(actual_primary)
+            .returns("First", PersonName::getFirstNm)
+            .returns("Middle", PersonName::getMiddleNm)
+            .returns("Last", PersonName::getLastNm)
+            .returns(Suffix.JR, PersonName::getNmSuffix)
+            .returns("L", PersonName::getNmUseCd),
+        actual_alias -> assertThat(actual_alias)
+            .returns("Second", PersonName::getFirstNm)
+            .returns("SecondMiddle", PersonName::getMiddleNm)
+            .returns("SecondLast", PersonName::getLastNm)
+            .returns(Suffix.SR, PersonName::getNmSuffix)
+            .returns("AL", PersonName::getNmUseCd)
+    );
+
+  }
+
+
+  @Test
+  void should_add_postal_address() {
+
+    Person actual = new Person(117L, "local-id-value");
+
+    actual.add(
+        new PatientCommand.AddAddress(
+            117L,
+            4861L,
+            "SA1",
+            "SA2",
+            new City("city-code", "city-description"),
+            "State",
+            "Zip",
+            new County("county-code", "county-description"),
+            new Country("country-code", "country-description"),
+            "Census Tract",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
+        .satisfiesExactly(
+            actual_postal_locator -> assertThat(actual_postal_locator)
+                .isInstanceOf(PostalEntityLocatorParticipation.class)
+                .asInstanceOf(InstanceOfAssertFactories.type(PostalEntityLocatorParticipation.class))
+                .returns(4861L, p -> p.getId().getLocatorUid())
+                .returns("H", EntityLocatorParticipation::getCd)
+                .extracting(PostalEntityLocatorParticipation::getLocator)
+                .returns(4861L, PostalLocator::getId)
+                .returns("SA1", PostalLocator::getStreetAddr1)
+                .returns("SA2", PostalLocator::getStreetAddr2)
+                //  should this be getCityDescTxt or getCityCd?
+                .returns("city-code", PostalLocator::getCityCd)
+                .returns("city-description", PostalLocator::getCityDescTxt)
+                .returns("State", PostalLocator::getStateCd)
+                .returns("county-code", PostalLocator::getCntyCd)
+                .returns("county-description", PostalLocator::getCntyDescTxt)
+                .returns("Zip", PostalLocator::getZipCd)
+                .returns("country-code", PostalLocator::getCntryCd)
+                .returns("country-description", PostalLocator::getCntryDescTxt)
+
         );
 
-        Person actual = new Person(request);
 
-        assertThat(actual.getId()).isEqualTo(117L);
-        assertThat(actual.getLocalId()).isEqualTo("patient-local-id");
+  }
 
-        assertThat(actual.getVersionCtrlNbr()).isEqualTo((short) 1);
-        assertThat(actual.getCd()).isEqualTo("PAT");
-        assertThat(actual.getElectronicInd()).isEqualTo('N');
-        assertThat(actual.getEdxInd()).isEqualTo("Y");
-        assertThat(actual.getDedupMatchInd()).isEqualTo('F');
+  @Test
+  void should_add_email_address() {
 
-        assertThat(actual.getAddUserId()).isEqualTo(131L);
-        assertThat(actual.getAddTime()).isEqualTo("2020-03-03T10:15:30.00Z");
-        assertThat(actual.getLastChgUserId()).isEqualTo(131L);
-        assertThat(actual.getLastChgTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+    Person actual = new Person(117L, "local-id-value");
 
-        assertThat(actual.getStatusCd()).isEqualTo('A');
-        assertThat(actual.getStatusTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+    actual.add(
+        new PatientCommand.AddEmailAddress(
+            117L,
+            5333L,
+            "AnEmail@email.com",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        assertThat(actual.getRecordStatusCd()).isEqualTo(RecordStatus.ACTIVE);
-        assertThat(actual.getRecordStatusTime()).isEqualTo("2020-03-03T10:15:30.00Z");
+    assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
+        .satisfiesExactly(
+            actual_email_locator ->
+                assertThat(actual_email_locator)
+                    .isInstanceOf(TeleEntityLocatorParticipation.class)
+                    .asInstanceOf(InstanceOfAssertFactories.type(TeleEntityLocatorParticipation.class))
+                    .returns(5333L, p -> p.getId().getLocatorUid())
+                    .returns("NET", EntityLocatorParticipation::getCd)
+                    .extracting(TeleEntityLocatorParticipation::getLocator)
+                    .returns(5333L, TeleLocator::getId)
+                    .returns("AnEmail@email.com", TeleLocator::getEmailAddress)
 
-        assertThat(actual.getSsn()).isEqualTo("ssn-value");
-        assertThat(actual.getBirthTime()).isEqualTo("2000-09-03T15:17:39.00Z");
-        assertThat(actual.getBirthGenderCd()).isEqualTo(Gender.M);
-        assertThat(actual.getCurrSexCd()).isEqualTo(Gender.F);
-        assertThat(actual.getDeceasedIndCd()).isEqualTo(Deceased.N);
-        assertThat(actual.getMaritalStatusCd()).isEqualTo("Marital Status");
-        assertThat(actual.getEthnicGroupInd()).isEqualTo("EthCode");
-        assertThat(actual.getAsOfDateGeneral()).isEqualTo("2019-03-03T10:15:30.00Z");
-        assertThat(actual.getAsOfDateAdmin()).isEqualTo("2019-03-03T10:15:30.00Z");
-        assertThat(actual.getAsOfDateSex()).isEqualTo("2019-03-03T10:15:30.00Z");
-        assertThat(actual.getDescription()).isEqualTo("comments");
-
-        assertThat(actual.getPersonParentUid())
-                .as("Master Patient Record set itself as parent")
-                .isSameAs(actual);
-
-    }
-
-    @Test
-    void should_add_race() {
-
-        Person actual = new Person(117L, "local-id-value");
-        actual.add(
-                new PatientCommand.AddRace(
-                        117L,
-                        "race-code-value",
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
         );
 
-        assertThat(actual.getRaces()).satisfiesExactly(
-                actual_race -> assertThat(actual_race)
-                        .returns("race-code-value", PersonRace::getRaceCd)
+
+  }
+
+  @Test
+  void should_add_cell_phone_number() {
+
+    Person actual = new Person(117L, "local-id-value");
+
+    actual.add(
+        new PatientCommand.AddPhoneNumber(
+            117L,
+            5347L,
+            "Phone Number",
+            "Extension",
+            PatientInput.PhoneType.CELL,
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
+        .satisfiesExactly(
+            actual_phone_locator ->
+                assertThat(actual_phone_locator)
+                    .isInstanceOf(TeleEntityLocatorParticipation.class)
+                    .asInstanceOf(InstanceOfAssertFactories.type(TeleEntityLocatorParticipation.class))
+                    .returns(5347L, p -> p.getId().getLocatorUid())
+                    .returns("CP", EntityLocatorParticipation::getCd)
+                    .extracting(TeleEntityLocatorParticipation::getLocator)
+                    .returns(5347L, TeleLocator::getId)
+                    .returns("Phone Number", TeleLocator::getPhoneNbrTxt)
+                    .returns("Extension", TeleLocator::getExtensionTxt)
         );
 
-    }
-
-    @Test
-    void should_add_primary_name() {
-
-        PatientInput patient = new PatientInput();
-
-        patient.setNames(
-                Arrays.asList(
-                        new PatientInput.Name(
-                                "First",
-                                "Middle",
-                                "Last",
-                                Suffix.JR,
-                                PatientInput.NameUseCd.L
-                        ),
-                        new PatientInput.Name(
-                                "Second",
-                                "SecondMiddle",
-                                "SecondLast",
-                                Suffix.SR,
-                                PatientInput.NameUseCd.AL
-                        )
-                )
-        );
-
-        Person actual = new Person(117L, "local-id-value");
-
-        actual.add(
-                new PatientCommand.AddName(
-                        117L,
-                        "First",
-                        "Middle",
-                        "Last",
-                        Suffix.JR,
-                        PatientInput.NameUseCd.L,
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
-        );
-
-        assertThat(actual.getFirstNm()).isEqualTo("First");
-        assertThat(actual.getMiddleNm()).isEqualTo("Middle");
-        assertThat(actual.getLastNm()).isEqualTo("Last");
-        assertThat(actual.getNmSuffix()).isEqualTo(Suffix.JR);
-
-        assertThat(actual.getNames()).satisfiesExactly(
-                actual_primary -> assertThat(actual_primary)
-                        .returns("First", PersonName::getFirstNm)
-                        .returns("Middle", PersonName::getMiddleNm)
-                        .returns("Last", PersonName::getLastNm)
-                        .returns(Suffix.JR, PersonName::getNmSuffix)
-                        .returns("L", PersonName::getNmUseCd)
-        );
-
-    }
-
-    @Test
-    void should_add_secondary_name() {
-
-        Person actual = new Person(117L, "local-id-value");
-
-        actual.add(
-                new PatientCommand.AddName(
-                        117L,
-                        "First",
-                        "Middle",
-                        "Last",
-                        Suffix.JR,
-                        PatientInput.NameUseCd.L,
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
-        );
-
-        actual.add(
-                new PatientCommand.AddName(
-                        117L,
-                        "Second",
-                        "SecondMiddle",
-                        "SecondLast",
-                        Suffix.SR,
-                        PatientInput.NameUseCd.AL,
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
-        );
-
-        assertThat(actual.getFirstNm()).isEqualTo("First");
-        assertThat(actual.getMiddleNm()).isEqualTo("Middle");
-        assertThat(actual.getLastNm()).isEqualTo("Last");
-        assertThat(actual.getNmSuffix()).isEqualTo(Suffix.JR);
-
-        assertThat(actual.getNames()).satisfiesExactly(
-                actual_primary -> assertThat(actual_primary)
-                        .returns("First", PersonName::getFirstNm)
-                        .returns("Middle", PersonName::getMiddleNm)
-                        .returns("Last", PersonName::getLastNm)
-                        .returns(Suffix.JR, PersonName::getNmSuffix)
-                        .returns("L", PersonName::getNmUseCd),
-                actual_alias -> assertThat(actual_alias)
-                        .returns("Second", PersonName::getFirstNm)
-                        .returns("SecondMiddle", PersonName::getMiddleNm)
-                        .returns("SecondLast", PersonName::getLastNm)
-                        .returns(Suffix.SR, PersonName::getNmSuffix)
-                        .returns("AL", PersonName::getNmUseCd)
-        );
-
-    }
-
-
-    @Test
-    void should_add_postal_address() {
-
-        Person actual = new Person(117L, "local-id-value");
-
-        actual.add(
-                new PatientCommand.AddAddress(
-                        117L,
-                        4861L,
-                        "SA1",
-                        "SA2",
-                        new City("city-code", "city-description"),
-                        "State",
-                        "Zip",
-                        new County("county-code", "county-description"),
-                        new Country("country-code", "country-description"),
-                        "Census Tract",
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
-        );
-
-        assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
-                .satisfiesExactly(
-                        actual_postal_locator -> assertThat(actual_postal_locator)
-                                .isInstanceOf(PostalEntityLocatorParticipation.class)
-                                .asInstanceOf(InstanceOfAssertFactories.type(PostalEntityLocatorParticipation.class))
-                                .returns("H", EntityLocatorParticipation::getCd)
-                                .extracting(PostalEntityLocatorParticipation::getLocator)
-                                .returns(4861L, PostalLocator::getId)
-                                .returns("SA1", PostalLocator::getStreetAddr1)
-                                .returns("SA2", PostalLocator::getStreetAddr2)
-                                //  should this be getCityDescTxt or getCityCd?
-                                .returns("city-code", PostalLocator::getCityCd)
-                                .returns("city-description", PostalLocator::getCityDescTxt)
-                                .returns("State", PostalLocator::getStateCd)
-                                .returns("county-code", PostalLocator::getCntyCd)
-                                .returns("county-description", PostalLocator::getCntyDescTxt)
-                                .returns("Zip", PostalLocator::getZipCd)
-                                .returns("country-code", PostalLocator::getCntryCd)
-                                .returns("country-description", PostalLocator::getCntryDescTxt)
-
-                );
-
-
-    }
-
-    @Test
-    void should_add_email_address() {
-
-        Person actual = new Person(117L, "local-id-value");
-
-        actual.add(
-                new PatientCommand.AddEmailAddress(
-                        117L,
-                        5333L,
-                        "AnEmail@email.com",
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
-        );
-
-        assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
-                .satisfiesExactly(
-                        actual_email_locator ->
-                                assertThat(actual_email_locator)
-                                        .isInstanceOf(TeleEntityLocatorParticipation.class)
-                                        .asInstanceOf(
-                                                InstanceOfAssertFactories.type(TeleEntityLocatorParticipation.class))
-                                        .returns("NET", EntityLocatorParticipation::getCd)
-                                        .extracting(TeleEntityLocatorParticipation::getLocator)
-                                        .returns(5333L, TeleLocator::getId)
-                                        .returns("AnEmail@email.com", TeleLocator::getEmailAddress)
-
-                );
-
-
-    }
-
-    @Test
-    void should_add_cell_phone_number() {
-
-        Person actual = new Person(117L, "local-id-value");
-
-        actual.add(
-                new PatientCommand.AddPhoneNumber(
-                        117L,
-                        5347L,
-                        "Phone Number",
-                        "Extension",
-                        PatientInput.PhoneType.CELL,
-                        131L,
-                        Instant.parse("2020-03-03T10:15:30.00Z")
-                )
-        );
-
-        assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
-                .satisfiesExactly(
-                        actual_phone_locator ->
-                                assertThat(actual_phone_locator)
-                                        .isInstanceOf(TeleEntityLocatorParticipation.class)
-                                        .asInstanceOf(
-                                                InstanceOfAssertFactories.type(TeleEntityLocatorParticipation.class))
-                                        .returns("CP", EntityLocatorParticipation::getCd)
-                                        .extracting(TeleEntityLocatorParticipation::getLocator)
-                                        .returns(5347L, TeleLocator::getId)
-                                        .returns("Phone Number", TeleLocator::getPhoneNbrTxt)
-                                        .returns("Extension", TeleLocator::getExtensionTxt)
-                );
-
-    }
+  }
 
 }

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/SuffixStringConverterTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/SuffixStringConverterTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.nbs.patient;
+
+import gov.cdc.nbs.message.enums.Suffix;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class SuffixStringConverterTest {
+
+  @Test
+  void should_convert_null_Suffix_as_null_String() {
+    String actual = SuffixStringConverter.toString(null);
+
+    assertThat(actual).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("suffixToString")
+  void should_convert_known_Suffix_as_String(final Suffix in, final String expected) {
+
+    String actual = SuffixStringConverter.toString(in);
+
+    assertThat(actual).isEqualTo(expected);
+
+  }
+
+  static Stream<Arguments> suffixToString() {
+    return Arrays.stream(Suffix.values())
+        .map(e -> arguments(e, e.name()));
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("stringToSuffix")
+  void should_convert_known_String_values_as_Suffix(final String in, final Suffix expected) {
+
+    Suffix actual = SuffixStringConverter.fromString(in);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> stringToSuffix() {
+    return Arrays.stream(Suffix.values())
+        .map(e -> arguments(e.name(), e));
+  }
+
+  @Test
+  void should_convert_null_String_as_null_Suffix() {
+    Suffix actual = SuffixStringConverter.fromString(null);
+
+    assertThat(actual).isNull();
+  }
+  
+  @Test
+  void should_convert_unknown_String_as_null_Suffix() {
+    Suffix actual = SuffixStringConverter.fromString("unknown-value");
+
+    assertThat(actual).isNull();
+  }
+
+}

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/search/ElasticsearchSuffixConverterTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/search/ElasticsearchSuffixConverterTest.java
@@ -1,7 +1,6 @@
 package gov.cdc.nbs.patient.search;
 
 import gov.cdc.nbs.message.enums.Suffix;
-import gov.cdc.nbs.patient.SuffixStringConverter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/search/ElasticsearchSuffixConverterTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/search/ElasticsearchSuffixConverterTest.java
@@ -1,0 +1,76 @@
+package gov.cdc.nbs.patient.search;
+
+import gov.cdc.nbs.message.enums.Suffix;
+import gov.cdc.nbs.patient.SuffixStringConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ElasticsearchSuffixConverterTest {
+
+  @Test
+  void should_write_null_Suffix_as_null_String() {
+    ElasticsearchSuffixConverter converter = new ElasticsearchSuffixConverter();
+
+    Object actual = converter.write(null);
+
+    assertThat(actual).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("suffixToString")
+  void should_write_known_Suffix_as_string(final Suffix in, final String expected) {
+
+    ElasticsearchSuffixConverter converter = new ElasticsearchSuffixConverter();
+
+    Object actual = converter.write(in);
+
+    assertThat(actual).isEqualTo(expected);
+
+  }
+
+  static Stream<Arguments> suffixToString() {
+    return Arrays.stream(Suffix.values())
+        .map(e -> arguments(e, e.name()));
+  }
+
+  @Test
+  void should_read_null_String_as_null_Suffix() {
+    ElasticsearchSuffixConverter converter = new ElasticsearchSuffixConverter();
+
+    Object actual = converter.read(null);
+
+    assertThat(actual).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("stringToSuffix")
+  void should_read_known_string_values_as_Suffix(final String in, final Suffix expected) {
+    ElasticsearchSuffixConverter converter = new ElasticsearchSuffixConverter();
+
+    Object actual = converter.read(in);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> stringToSuffix() {
+    return Arrays.stream(Suffix.values())
+        .map(e -> arguments(e.name(), e));
+  }
+
+  @Test
+  void should_read_unknown_string_as_null_Suffix() {
+    ElasticsearchSuffixConverter converter = new ElasticsearchSuffixConverter();
+
+    Object actual = converter.read("unknown-value");
+
+    assertThat(actual).isNull();
+  }
+}


### PR DESCRIPTION
There were at least two issues found that could cause an error in the `findPatientsByFilter` Query resulting in search pages being "skipped" when clicked.

- Corrects how the locator id was being set for Entity Locators Participations
- Adds a Suffix converter for Elasticseach results that will disregard unknown suffix values instead of throwing an error.

The invalid Suffix values were most likely introduce by anonymization of the data.