### PR TITLE
CNFT1 601 Patient documents graphql api

### DIFF
--- a/apps/modernization-api/build.gradle
+++ b/apps/modernization-api/build.gradle
@@ -16,7 +16,7 @@ plugins {
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.enabled true
+        xml.required
     }
 }
 
@@ -26,7 +26,7 @@ version = '1.0.0-SNAPSHOT'
 
 bootJar {
     manifest {
-        attributes 'API-Version': version
+        attributes 'API-Version': archiveVersion
     }
 }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/contact/ContactNamedByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/contact/ContactNamedByPatientResolver.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.patient.contact;
+
+import gov.cdc.nbs.entity.odse.Person;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+class ContactNamedByPatientResolver {
+  private final ContactNamedByPatientFinder finder;
+
+  ContactNamedByPatientResolver(final ContactNamedByPatientFinder finder) {
+    this.finder = finder;
+  }
+
+  @SchemaMapping("namedByPatient")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-INVESTIGATION')")
+  List<PatientContacts.NamedByPatient> resolve(final Person patient) {
+    return this.finder.find(patient.getId());
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/contact/PatientContactsByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/contact/PatientContactsByPatientResolver.java
@@ -9,26 +9,27 @@ import java.util.List;
 
 @Controller
 class PatientContactsByPatientResolver {
-    private final ContactNamedByPatientFinder namedByPatientFinder;
-    private final PatientNamedByContactFinder namedByContactFinder;
+  private final ContactNamedByPatientFinder namedByPatientFinder;
+  private final PatientNamedByContactFinder namedByContactFinder;
 
-    PatientContactsByPatientResolver(
-            final ContactNamedByPatientFinder namedByPatientFinder,
-            final PatientNamedByContactFinder namedByContactFinder
-    ) {
-        this.namedByPatientFinder = namedByPatientFinder;
-        this.namedByContactFinder = namedByContactFinder;
-    }
+  PatientContactsByPatientResolver(
+      final ContactNamedByPatientFinder namedByPatientFinder,
+      final PatientNamedByContactFinder namedByContactFinder
+  ) {
+    this.namedByPatientFinder = namedByPatientFinder;
+    this.namedByContactFinder = namedByContactFinder;
+  }
 
-    @QueryMapping(name = "findContactsForPatient")
-    @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-INVESTIGATION')")
-    PatientContacts find(@Argument("patient") final long patient) {
-        List<PatientContacts.NamedByPatient> namedByPatients = this.namedByPatientFinder.find(patient);
-        List<PatientContacts.NamedByContact> namedByContacts = this.namedByContactFinder.find(patient);
-        return new PatientContacts(
-                patient,
-                namedByPatients,
-                namedByContacts
-        );
-    }
+  @QueryMapping(name = "findContactsForPatient")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-INVESTIGATION')")
+  PatientContacts find(@Argument("patient") final long patient) {
+    List<PatientContacts.NamedByPatient> namedByPatients = this.namedByPatientFinder.find(patient);
+    List<PatientContacts.NamedByContact> namedByContacts = this.namedByContactFinder.find(patient);
+    return new PatientContacts(
+        patient,
+        namedByPatients,
+        namedByContacts
+    );
+  }
+
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/contact/PatientNamedByContactResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/contact/PatientNamedByContactResolver.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.patient.contact;
+
+import gov.cdc.nbs.entity.odse.Person;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+class PatientNamedByContactResolver {
+  private final PatientNamedByContactFinder finder;
+
+  PatientNamedByContactResolver(final PatientNamedByContactFinder finder) {
+    this.finder = finder;
+  }
+
+  @SchemaMapping("namedByContact")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-INVESTIGATION')")
+  List<PatientContacts.NamedByContact> resolve(final Person patient) {
+    return this.finder.find(patient.getId());
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocument.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocument.java
@@ -1,0 +1,22 @@
+package gov.cdc.nbs.patient.document;
+
+import java.time.Instant;
+
+public record PatientDocument (
+    long document,
+    Instant receivedOn,
+    String type,
+    String sendingFacility,
+    Instant reportedOn,
+    String condition,
+    String event,
+    Investigation associatedWith
+) {
+
+  public record Investigation(
+      long id,
+      String local
+  ) {
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentByPatientResolver.java
@@ -1,0 +1,32 @@
+package gov.cdc.nbs.patient.document;
+
+import gov.cdc.nbs.entity.odse.Person;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+class PatientDocumentByPatientResolver {
+
+  private final PatientDocumentFinder finder;
+
+  PatientDocumentByPatientResolver(final PatientDocumentFinder finder) {
+    this.finder = finder;
+  }
+
+  @QueryMapping(name = "findDocumentsForPatient")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-DOCUMENT')")
+  List<PatientDocument> find(@Argument("patient") final long patient) {
+    return this.finder.find(patient);
+  }
+
+  @SchemaMapping("documents")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-DOCUMENT')")
+  List<PatientDocument> resolve(final Person patient) {
+    return this.finder.find(patient.getId());
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentFinder.java
@@ -1,0 +1,123 @@
+package gov.cdc.nbs.patient.document;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.enums.RecordStatus;
+import gov.cdc.nbs.entity.odse.*;
+import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+class PatientDocumentFinder {
+
+  private static final QPublicHealthCase INVESTIGATION = new QPublicHealthCase("investigation");
+  private static final QPerson PATIENT = QPerson.person;
+  private static final QParticipation PARTICIPATION = QParticipation.participation;
+  private static final QNbsDocument DOCUMENT = QNbsDocument.nbsDocument;
+  private static final QCodeValueGeneral DOCUMENT_TYPE = QCodeValueGeneral.codeValueGeneral;
+  private static final QActRelationship RELATIONSHIP = QActRelationship.actRelationship;
+  private static final String DELETED = "LOG_DEL";
+  private static final String SUBJECT_OF_DOCUMENT = "SubjOfDoc";
+  private static final String DOCUMENT_TYPE_CODE_NAME_SET = "PUBLIC_HEALTH_EVENT";
+  private static final String PERSON_CLASS = "PSN";
+  private static final String DOCUMENT_CLASS = "DOC";
+  private static final String INVESTIGATION_CLASS = "CASE";
+  public static final String UPDATED_MODIFIER = "(Updated)";
+
+  private final JPAQueryFactory factory;
+
+
+  PatientDocumentFinder(final JPAQueryFactory factory) {
+    this.factory = factory;
+  }
+
+  List<PatientDocument> find(final long patient) {
+    return this.factory.selectDistinct(
+            DOCUMENT.id,
+            DOCUMENT.addTime,
+            DOCUMENT_TYPE.codeShortDescTxt,
+            DOCUMENT.sendingFacilityNm,
+            DOCUMENT.cdDescTxt,
+            DOCUMENT.localId,
+            DOCUMENT.externalVersionCtrlNbr,
+            INVESTIGATION.id,
+            INVESTIGATION.localId
+        ).from(PATIENT)
+        .join(PARTICIPATION).on(
+            PARTICIPATION.id.subjectEntityUid.eq(PATIENT.id),
+            PARTICIPATION.id.typeCd.eq(SUBJECT_OF_DOCUMENT),
+            PARTICIPATION.actClassCd.eq(DOCUMENT_CLASS),
+            PARTICIPATION.subjectClassCd.eq(PERSON_CLASS),
+            PARTICIPATION.recordStatusCd.eq(RecordStatus.ACTIVE)
+        )
+        .join(DOCUMENT).on(
+            DOCUMENT.id.eq(PARTICIPATION.id.actUid),
+            DOCUMENT.recordStatusCd.ne(DELETED)
+        )
+        .join(DOCUMENT_TYPE).on(
+            DOCUMENT_TYPE.id.codeSetNm.eq(DOCUMENT_TYPE_CODE_NAME_SET),
+            DOCUMENT_TYPE.id.code.eq(DOCUMENT.docTypeCd)
+        )
+        .leftJoin(RELATIONSHIP).on(
+            RELATIONSHIP.targetClassCd.eq(INVESTIGATION_CLASS),
+            RELATIONSHIP.sourceClassCd.eq(DOCUMENT_CLASS)
+        )
+        .leftJoin(INVESTIGATION).on(
+            INVESTIGATION.id.eq(RELATIONSHIP.id.targetActUid),
+            INVESTIGATION.recordStatusCd.ne(DELETED)
+        )
+        .where(PATIENT.personParentUid.id.eq(patient))
+        .fetch()
+        .stream()
+        .map(this::map)
+        .toList()
+        ;
+  }
+
+  private PatientDocument map(final Tuple tuple) {
+    Long identifier = Objects.requireNonNull(tuple.get(DOCUMENT.id), "A document id is required.");
+    Instant added = tuple.get(DOCUMENT.addTime);
+    String type = tuple.get(DOCUMENT_TYPE.codeShortDescTxt);
+    String sendingFacility = tuple.get(DOCUMENT.sendingFacilityNm);
+    String condition = tuple.get(DOCUMENT.cdDescTxt);
+    String localId = tuple.get(DOCUMENT.localId);
+    Short version = tuple.get(DOCUMENT.externalVersionCtrlNbr);
+
+    String event = resolveEvent(localId, version);
+
+    PatientDocument.Investigation investigation = maybeMapInvestigation(tuple);
+
+    return new PatientDocument(
+        identifier,
+        added,
+        type,
+        sendingFacility,
+        added,
+        condition,
+        event,
+        investigation
+    );
+  }
+
+  private String resolveEvent(final String localId, final Short version) {
+    return version != null && version > 1
+        ? localId + UPDATED_MODIFIER
+        : localId;
+  }
+
+  private PatientDocument.Investigation maybeMapInvestigation(final Tuple tuple) {
+    Long identifier = tuple.get(INVESTIGATION.id);
+    String local = tuple.get(INVESTIGATION.localId);
+
+    return identifier == null
+        ? null
+        : new PatientDocument.Investigation(
+        identifier,
+        local
+    );
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentByPatientResolver.java
@@ -1,7 +1,9 @@
 package gov.cdc.nbs.patient.treatment;
 
+import gov.cdc.nbs.entity.odse.Person;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 
@@ -22,4 +24,9 @@ class PatientTreatmentByPatientResolver {
         return this.finder.find(patient);
     }
 
+    @SchemaMapping("treatments")
+    @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-TREATMENT')")
+    List<PatientTreatment> resolve(final Person patient) {
+        return this.finder.find(patient.getId());
+    }
 }

--- a/apps/modernization-api/src/main/resources/graphql/patient-contact.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-contact.graphqls
@@ -36,6 +36,11 @@ type PatientContactInvestigation {
     condition: String!
 }
 
+extend type Person {
+    namedByPatient: [NamedByPatient]
+    namedByContact: [NamedByContact]
+}
+
 extend type Query {
     findContactsForPatient(patient: ID!): PatientContacts
 }

--- a/apps/modernization-api/src/main/resources/graphql/patient-contact.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-contact.graphqls
@@ -36,11 +36,6 @@ type PatientContactInvestigation {
     condition: String!
 }
 
-extend type Person {
-    namedByPatient: [NamedByPatient]
-    namedByContact: [NamedByContact]
-}
-
 extend type Query {
     findContactsForPatient(patient: ID!): PatientContacts
 }

--- a/apps/modernization-api/src/main/resources/graphql/patient-document.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-document.graphqls
@@ -1,0 +1,23 @@
+type PatientDocument {
+    document: ID!,
+    receivedOn: Date!
+    type : String!
+    sendingFacility: String!
+    reportedOn: Date!
+    condition: String
+    event: String!
+    associatedWith: PatientDocumentInvestigation
+}
+
+type PatientDocumentInvestigation {
+    id: ID!,
+    local: String!
+}
+
+extend type Query {
+    findDocumentsForPatient(patient: ID!): [PatientDocument]
+}
+
+extend type Person {
+    documents: [PatientDocument]
+}

--- a/apps/modernization-api/src/main/resources/graphql/patient-document.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-document.graphqls
@@ -18,6 +18,3 @@ extend type Query {
     findDocumentsForPatient(patient: ID!): [PatientDocument]
 }
 
-extend type Person {
-    documents: [PatientDocument]
-}

--- a/apps/modernization-api/src/main/resources/graphql/patient-treatment.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-treatment.graphqls
@@ -14,10 +14,6 @@ type PatientTreatmentInvestigation {
     condition: String!
 }
 
-extend type Person {
-    treatments: [PatientTreatment]
-}
-
 extend type Query {
     findTreatmentsForPatient(patient: ID!): [PatientTreatment]
 }

--- a/apps/modernization-api/src/main/resources/graphql/patient-treatment.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-treatment.graphqls
@@ -14,6 +14,10 @@ type PatientTreatmentInvestigation {
     condition: String!
 }
 
+extend type Person {
+    treatments: [PatientTreatment]
+}
+
 extend type Query {
     findTreatmentsForPatient(patient: ID!): [PatientTreatment]
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/identity/TestIdentityModule.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/identity/TestIdentityModule.java
@@ -1,0 +1,15 @@
+package gov.cdc.nbs.identity;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class TestIdentityModule {
+
+  @Bean
+  TestUniqueIdGenerator uniqueIdGenerator(final @Value("${testing.id-generation.starting}") long starting) {
+    return new TestUniqueIdGenerator(starting);
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/identity/TestUniqueIdGenerator.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/identity/TestUniqueIdGenerator.java
@@ -1,0 +1,27 @@
+package gov.cdc.nbs.identity;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TestUniqueIdGenerator {
+
+  private final AtomicLong next;
+  private final long starting;
+
+  public TestUniqueIdGenerator(long starting) {
+    this.starting = starting;
+    this.next = new AtomicLong(starting + 1);
+  }
+
+  public long starting() {
+    return starting;
+  }
+
+  public long next() {
+    return this.next.incrementAndGet();
+  }
+
+  public String nextLocal(final String type) {
+    return type + next() + "TEST";
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientProfileSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientProfileSteps.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.patient;
+
+import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.identity.TestUniqueIdGenerator;
+import gov.cdc.nbs.repository.PersonRepository;
+import gov.cdc.nbs.support.PersonMother;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class PatientProfileSteps {
+
+  @Autowired
+  PersonRepository repository;
+
+  @Autowired
+  TestPatients testPatients;
+
+  @Autowired
+  TestUniqueIdGenerator idGenerator;
+
+  @Autowired
+  TestPatientCleaner cleaner;
+
+  @Before
+  public void clean() {
+    cleaner.clean(idGenerator.starting());
+    testPatients.reset();
+  }
+
+  @Given("I have a patient")
+  public void i_have_a_patient() {
+    Person patient = PersonMother.generateRandomPerson(idGenerator.next());
+    repository.save(patient);
+    testPatients.available(patient.getId());
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/TestPatientCleaner.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/TestPatientCleaner.java
@@ -1,0 +1,41 @@
+package gov.cdc.nbs.patient;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.odse.QPerson;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+@Component
+public class TestPatientCleaner {
+
+  public static final QPerson PATIENT = QPerson.person;
+  private final EntityManager entityManager;
+
+  private final JPAQueryFactory factory;
+
+
+  public TestPatientCleaner(final EntityManager entityManager, final JPAQueryFactory factory) {
+    this.entityManager = entityManager;
+    this.factory = factory;
+  }
+
+  @Transactional
+  public void clean(final long starting) {
+    this.factory.select(PATIENT)
+        .from(PATIENT)
+        .where(criteria(starting))
+        .fetch()
+        .forEach(this.entityManager::remove);
+  }
+
+  private BooleanExpression criteria(final long starting) {
+    BooleanExpression threshold = PATIENT.id.goe(starting);
+    return starting < 0
+        ? threshold.and(PATIENT.id.lt(0))
+        : threshold;
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/TestPatients.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/TestPatients.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.patient;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class TestPatients {
+
+  private final Collection<Long> identifiers;
+
+  public TestPatients() {
+    identifiers = new ArrayList<>();
+  }
+
+  void available(final long patient) {
+    this.identifiers.add(patient);
+  }
+
+  void unavailable(final long patient) {
+    this.identifiers.remove(patient);
+  }
+
+  void reset() {
+    this.identifiers.clear();
+  }
+
+  public Collection<Long> available() {
+    return List.copyOf(this.identifiers);
+  }
+
+  public Optional<Long> one() {
+    return this.identifiers.stream().findFirst();
+  }
+
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/DocumentMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/DocumentMother.java
@@ -1,0 +1,104 @@
+package gov.cdc.nbs.patient.document;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.enums.RecordStatus;
+import gov.cdc.nbs.entity.odse.*;
+import gov.cdc.nbs.identity.TestUniqueIdGenerator;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import java.time.Instant;
+
+@Component
+class DocumentMother {
+
+  public static final String DOCUMENT_CLASS = "DOC";
+  public static final String PERSON_CLASS = "PSN";
+  private final TestUniqueIdGenerator idGenerator;
+
+  private final EntityManager entityManager;
+  private final JPAQueryFactory factory;
+
+  DocumentMother(
+      final TestUniqueIdGenerator idGenerator,
+      final EntityManager entityManager,
+      final JPAQueryFactory factory
+  ) {
+    this.idGenerator = idGenerator;
+    this.entityManager = entityManager;
+    this.factory = factory;
+  }
+
+  /**
+   * Creates a Case Report associated with the given {@code patient}
+   *
+   * @param patient The identifier of the patient.
+   * @return A {@link NbsDocument} representing a Case Report associated with a patient.
+   */
+  NbsDocument caseReport(final long patient) {
+    //  create a document
+    NbsDocument document = new NbsDocument();
+    long identifier = idGenerator.next();
+
+    document.setId(identifier);
+    document.setDocPayload("<?xml version=\"1.0\"?>");
+    document.setDocTypeCd("PHC236");
+    document.setLocalId(idGenerator.nextLocal(DOCUMENT_CLASS));
+
+    document.setNbsInterfaceUid(227L);  // not sure what this refers to
+
+    document.setSharedInd('F');
+    document.setVersionCtrlNbr((short) 1);
+
+    Instant now = Instant.now();
+    document.setRecordStatusCd("ACTIVE");
+    document.setRecordStatusTime(now);
+    document.setAddTime(now);
+    document.setAddUserId(9999L);
+
+    document.setNbsDocumentMetadataUid(metadatum());
+
+    entityManager.persist(document);
+
+    subjectOfDocument(patient, identifier);
+
+    return document;
+  }
+
+  private Participation subjectOfDocument(final long patient, final long document) {
+
+    //  create the act
+    Act act = new Act();
+    act.setId(document);
+    act.setClassCd(DOCUMENT_CLASS);
+    act.setMoodCd("EVN");
+
+    // create the participation
+    ParticipationId identifier = new ParticipationId(patient, document, "SubjOfDoc");
+
+    Participation participation = new Participation();
+    participation.setId(identifier);
+    participation.setActClassCd(DOCUMENT_CLASS);
+    participation.setSubjectClassCd(PERSON_CLASS);
+
+    Instant now = Instant.now();
+    participation.setRecordStatusCd(RecordStatus.ACTIVE);
+    participation.setRecordStatusTime(now);
+    participation.setAddTime(now);
+    participation.setAddUserId(9999L);
+    participation.setActUid(act);
+
+    act.addParticipation(participation);
+
+    entityManager.persist(act);
+
+    return participation;
+  }
+
+  private NbsDocumentMetadatum metadatum() {
+    return this.factory.select(QNbsDocumentMetadatum.nbsDocumentMetadatum)
+        .from(QNbsDocumentMetadatum.nbsDocumentMetadatum)
+        .where(QNbsDocumentMetadatum.nbsDocumentMetadatum.id.eq((long) 1003))
+        .fetchOne();
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
@@ -1,0 +1,69 @@
+package gov.cdc.nbs.patient.document;
+
+import gov.cdc.nbs.identity.TestUniqueIdGenerator;
+import gov.cdc.nbs.patient.TestPatients;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+public class PatientDocumentSteps {
+
+  @Autowired
+  TestPatients patients;
+
+  @Autowired
+  PatientDocumentByPatientResolver resolver;
+
+  @Autowired
+  TestUniqueIdGenerator idGenerator;
+
+  @Autowired
+  TestDocumentCleaner documentCleaner;
+
+  @Autowired
+  DocumentMother documentMother;
+
+  @Before
+  public void clean() {
+    documentCleaner.clean(idGenerator.starting());
+  }
+
+  @When("the patient has a Case Report")
+  public void the_patient_has_a_Case_Report() {
+    this.patients.one().ifPresent(this.documentMother::caseReport);
+  }
+
+
+  @Then("the profile has an associated document")
+  public void the_profile_has_an_associated_document() {
+    Long patient = patients.one().orElseThrow(() -> new IllegalStateException("No patient exists"));
+
+    List<PatientDocument> actual = this.resolver.find(patient);
+    assertThat(actual).isNotEmpty();
+  }
+
+  @Then("the profile documents are not returned")
+  public void the_profile_documents_are_not_returned() {
+    Long patient = patients.one().orElseThrow(() -> new IllegalStateException("No patient exists"));
+
+    assertThatThrownBy(() -> this.resolver.find(patient))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Then("the profile has no associated document")
+  public void the_profile_has_no_associated_document() {
+    Long patient = patients.one().orElseThrow(() -> new IllegalStateException("No patient exists"));
+
+    List<PatientDocument> actual = this.resolver.find(patient);
+    assertThat(actual).isEmpty();
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/TestDocumentCleaner.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/TestDocumentCleaner.java
@@ -1,0 +1,60 @@
+package gov.cdc.nbs.patient.document;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.odse.Act;
+import gov.cdc.nbs.entity.odse.NbsDocument;
+import gov.cdc.nbs.entity.odse.QNbsDocument;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+@Component
+class TestDocumentCleaner {
+
+  public static final QNbsDocument DOCUMENT = QNbsDocument.nbsDocument;
+  private final EntityManager entityManager;
+  private final JPAQueryFactory factory;
+
+  TestDocumentCleaner(final EntityManager entityManager, final JPAQueryFactory factory) {
+    this.entityManager = entityManager;
+    this.factory = factory;
+  }
+
+  /**
+   * Removes any Documents from the database with an id greater than the given {@code starting} value
+   * @param starting
+   */
+  @Transactional
+  void clean(final long starting) {
+    this.factory.select(DOCUMENT)
+        .from(DOCUMENT)
+        .where(criteria(starting))
+        .fetch()
+        .forEach(this::remove);
+  }
+
+  private BooleanExpression criteria(final long starting) {
+    BooleanExpression threshold = DOCUMENT.id.goe(starting);
+    return starting < 0
+        ? threshold.and(DOCUMENT.id.lt(0))
+        : threshold;
+  }
+
+  private void remove(final NbsDocument document) {
+    removeParticipations(document);
+
+    this.entityManager.remove(document);
+  }
+
+  private void removeParticipations(final NbsDocument document) {
+    //  The all document participation instances are associated with the Act entity.  Removing the Act will remove any
+    //  associations.
+    Act existing = this.entityManager.find(Act.class, document.getId());
+
+    if (existing != null) {
+      this.entityManager.remove(existing);
+    }
+  }
+}

--- a/apps/modernization-api/src/test/resources/application-test.yml
+++ b/apps/modernization-api/src/test/resources/application-test.yml
@@ -53,3 +53,7 @@ kafkadef:
         patientupdate: request-patient-search.patientupdate
         patientdelete: request-patient-search.patientdelete
         patientcreate: patient-create-test
+
+testing:
+  id-generation:
+    starting: -20000000 # a negative id should reduce conflicts of ids in a live system

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
@@ -1,0 +1,19 @@
+@patient-profile-documents
+Feature: Patient Profile Documents
+
+  Background:
+    Given I have a patient
+
+  Scenario: I can retrieve documents for a patient
+    Given I have the authorities: "FIND-PATIENT,VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"
+    When the patient has a Case Report
+    Then the profile has an associated document
+
+  Scenario: I cannot retrieve documents for a patient without documents
+    Given I have the authorities: "FIND-PATIENT,VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"
+    Then the profile has no associated document
+
+
+  Scenario: I cannot retrieve documents without proper authorities
+    Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+    Then the profile documents are not returned

--- a/apps/modernization-ui/src/generated/gql/queries/findDocumentsForPatient.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findDocumentsForPatient.gql
@@ -1,0 +1,15 @@
+query findDocumentsForPatient($patient: ID!){
+    findDocumentsForPatient(patient: $patient){
+        document
+        receivedOn
+        type
+        sendingFacility
+        reportedOn
+        condition
+        event
+        associatedWith{
+            id
+            local
+        }
+    }
+}

--- a/apps/modernization-ui/src/generated/gql/queries/index.js
+++ b/apps/modernization-ui/src/generated/gql/queries/index.js
@@ -24,6 +24,7 @@ module.exports.findAllOrganizations = fs.readFileSync(path.join(__dirname, 'find
 module.exports.findOrganizationsByFilter = fs.readFileSync(path.join(__dirname, 'findOrganizationsByFilter.gql'), 'utf8');
 module.exports.findAllOutbreaks = fs.readFileSync(path.join(__dirname, 'findAllOutbreaks.gql'), 'utf8');
 module.exports.findContactsForPatient = fs.readFileSync(path.join(__dirname, 'findContactsForPatient.gql'), 'utf8');
+module.exports.findDocumentsForPatient = fs.readFileSync(path.join(__dirname, 'findDocumentsForPatient.gql'), 'utf8');
 module.exports.findTreatmentsForPatient = fs.readFileSync(path.join(__dirname, 'findTreatmentsForPatient.gql'), 'utf8');
 module.exports.findPlaceById = fs.readFileSync(path.join(__dirname, 'findPlaceById.gql'), 'utf8');
 module.exports.findAllPlaces = fs.readFileSync(path.join(__dirname, 'findAllPlaces.gql'), 'utf8');

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -756,6 +756,24 @@ export type PatientContacts = {
   patient: Scalars['ID'];
 };
 
+export type PatientDocument = {
+  __typename?: 'PatientDocument';
+  associatedWith?: Maybe<PatientDocumentInvestigation>;
+  condition?: Maybe<Scalars['String']>;
+  document: Scalars['ID'];
+  event: Scalars['String'];
+  receivedOn: Scalars['Date'];
+  reportedOn: Scalars['Date'];
+  sendingFacility: Scalars['String'];
+  type: Scalars['String'];
+};
+
+export type PatientDocumentInvestigation = {
+  __typename?: 'PatientDocumentInvestigation';
+  id: Scalars['ID'];
+  local: Scalars['String'];
+};
+
 export type PatientIdentificationTypeResults = {
   __typename?: 'PatientIdentificationTypeResults';
   content: Array<Maybe<IdentificationType>>;
@@ -1112,6 +1130,7 @@ export type Query = {
   findAllStateCodes: Array<Maybe<StateCode>>;
   findAllUsers: UserResults;
   findContactsForPatient?: Maybe<PatientContacts>;
+  findDocumentsForPatient?: Maybe<Array<Maybe<PatientDocument>>>;
   findDocumentsRequiringReviewForPatient: LabReportResults;
   findInvestigationsByFilter: InvestigationResults;
   findLabReportsByFilter: LabReportResults;
@@ -1204,6 +1223,11 @@ export type QueryFindAllUsersArgs = {
 
 
 export type QueryFindContactsForPatientArgs = {
+  patient: Scalars['ID'];
+};
+
+
+export type QueryFindDocumentsForPatientArgs = {
   patient: Scalars['ID'];
 };
 
@@ -1548,6 +1572,13 @@ export type FindContactsForPatientQueryVariables = Exact<{
 
 
 export type FindContactsForPatientQuery = { __typename?: 'Query', findContactsForPatient?: { __typename?: 'PatientContacts', patient: string, namedByPatient?: Array<{ __typename?: 'NamedByPatient', contactRecord: string, createdOn: any, condition?: string | null, namedOn: any, priority?: string | null, disposition?: string | null, event: string, contact: { __typename?: 'NamedContact', id: string, name: string } } | null> | null, namedByContact?: Array<{ __typename?: 'NamedByContact', contactRecord: string, createdOn: any, namedOn: any, condition?: string | null, event: string, contact: { __typename?: 'NamedContact', id: string, name: string }, associatedWith?: { __typename?: 'PatientContactInvestigation', id: string, local: string, condition: string } | null } | null> | null } | null };
+
+export type FindDocumentsForPatientQueryVariables = Exact<{
+  patient: Scalars['ID'];
+}>;
+
+
+export type FindDocumentsForPatientQuery = { __typename?: 'Query', findDocumentsForPatient?: Array<{ __typename?: 'PatientDocument', document: string, receivedOn: any, type: string, sendingFacility: string, reportedOn: any, condition?: string | null, event: string, associatedWith?: { __typename?: 'PatientDocumentInvestigation', id: string, local: string } | null } | null> | null };
 
 export type FindDocumentsRequiringReviewForPatientQueryVariables = Exact<{
   patientId: Scalars['Int'];
@@ -2776,6 +2807,51 @@ export function useFindContactsForPatientLazyQuery(baseOptions?: Apollo.LazyQuer
 export type FindContactsForPatientQueryHookResult = ReturnType<typeof useFindContactsForPatientQuery>;
 export type FindContactsForPatientLazyQueryHookResult = ReturnType<typeof useFindContactsForPatientLazyQuery>;
 export type FindContactsForPatientQueryResult = Apollo.QueryResult<FindContactsForPatientQuery, FindContactsForPatientQueryVariables>;
+export const FindDocumentsForPatientDocument = gql`
+    query findDocumentsForPatient($patient: ID!) {
+  findDocumentsForPatient(patient: $patient) {
+    document
+    receivedOn
+    type
+    sendingFacility
+    reportedOn
+    condition
+    event
+    associatedWith {
+      id
+      local
+    }
+  }
+}
+    `;
+
+/**
+ * __useFindDocumentsForPatientQuery__
+ *
+ * To run a query within a React component, call `useFindDocumentsForPatientQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindDocumentsForPatientQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindDocumentsForPatientQuery({
+ *   variables: {
+ *      patient: // value for 'patient'
+ *   },
+ * });
+ */
+export function useFindDocumentsForPatientQuery(baseOptions: Apollo.QueryHookOptions<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>(FindDocumentsForPatientDocument, options);
+      }
+export function useFindDocumentsForPatientLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>(FindDocumentsForPatientDocument, options);
+        }
+export type FindDocumentsForPatientQueryHookResult = ReturnType<typeof useFindDocumentsForPatientQuery>;
+export type FindDocumentsForPatientLazyQueryHookResult = ReturnType<typeof useFindDocumentsForPatientLazyQuery>;
+export type FindDocumentsForPatientQueryResult = Apollo.QueryResult<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>;
 export const FindDocumentsRequiringReviewForPatientDocument = gql`
     query findDocumentsRequiringReviewForPatient($patientId: Int!, $page: Page) {
   findDocumentsRequiringReviewForPatient(patientId: $patientId, page: $page) {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -658,6 +658,26 @@ type PatientContactInvestigation {
 extend type Query {
     findContactsForPatient(patient: ID!): PatientContacts
 }
+type PatientDocument {
+    document: ID!,
+    receivedOn: Date!
+    type : String!
+    sendingFacility: String!
+    reportedOn: Date!
+    condition: String
+    event: String!
+    associatedWith: PatientDocumentInvestigation
+}
+
+type PatientDocumentInvestigation {
+    id: ID!,
+    local: String!
+}
+
+extend type Query {
+    findDocumentsForPatient(patient: ID!): [PatientDocument]
+}
+
 type PatientTreatment {
     treatment: ID!,
     createdOn: Date!
@@ -676,7 +696,8 @@ type PatientTreatmentInvestigation {
 
 extend type Query {
     findTreatmentsForPatient(patient: ID!): [PatientTreatment]
-}type Query {
+}
+type Query {
     findPatientById(id: ID!): Person
     findAllPatients(page: SortablePage): PersonResults!
     findPatientsByFilter(filter: PersonFilter!, page: SortablePage): PersonResults!

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Act.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Act.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.entity.odse;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
@@ -50,4 +51,17 @@ public class Act {
 
     @OneToMany(mappedBy = "sourceActUid", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ActRelationship> actRelationships;
+
+    public void addParticipation(final Participation participation) {
+        participation.setActUid(this);
+        ensureParticipation().add(participation);
+    }
+
+    private List<Participation> ensureParticipation() {
+        if(this.participations == null) {
+            this.participations = new ArrayList<>();
+        }
+
+        return this.participations;
+    }
 }


### PR DESCRIPTION
Adds the GraphQL query 'findDocumentsForPatient' to return documents associated with a patient. 

```graphql
query documents($patient :ID!) {
  findDocumentsForPatient(patient: $patient) {
    document
    receivedOn
    type
    sendingFacility
    reportedOn
    condition
    event    
    associatedWith {
      id
      local 
    }
  }

}
```

The caller of the query must have the FIND-PATIENT and VIEW-DOCUMENT authorities.
