### PR TITLE
Fix broken test

### DIFF
--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
@@ -18,6 +18,7 @@ import gov.cdc.nbs.entity.odse.TeleLocator;
 import org.apache.commons.codec.language.Soundex;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
@@ -1,5 +1,12 @@
 package gov.cdc.nbs.support.util;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.codec.language.Soundex;
 import gov.cdc.nbs.entity.elasticsearch.ElasticsearchPerson;
 import gov.cdc.nbs.entity.elasticsearch.NestedAddress;
 import gov.cdc.nbs.entity.elasticsearch.NestedEmail;
@@ -15,14 +22,6 @@ import gov.cdc.nbs.entity.odse.PostalEntityLocatorParticipation;
 import gov.cdc.nbs.entity.odse.PostalLocator;
 import gov.cdc.nbs.entity.odse.TeleEntityLocatorParticipation;
 import gov.cdc.nbs.entity.odse.TeleLocator;
-import org.apache.commons.codec.language.Soundex;
-
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class ElasticsearchPersonMapper {
 
@@ -47,11 +46,16 @@ public class ElasticsearchPersonMapper {
         race.setRaceCd(person.getRaceCd());
         race.setRaceDescTxt(person.getRaceCd());
 
-        var nestedEntityId = new NestedEntityId();
-        EntityId entityId = person.getEntityIds().get(0);
-        nestedEntityId.setRecordStatusCd(entityId.getRecordStatusCd());
-        nestedEntityId.setRootExtensionTxt(entityId.getRootExtensionTxt());
-        nestedEntityId.setTypeCd(entityId.getTypeCd());
+        var nestedEntityIds = new ArrayList<NestedEntityId>();
+        if (person.getEntityIds() != null && !person.getEntityIds().isEmpty()) {
+            EntityId entityId = person.getEntityIds().get(0);
+            var nestedEntityId = new NestedEntityId();
+            nestedEntityId.setRecordStatusCd(entityId.getRecordStatusCd());
+            nestedEntityId.setRootExtensionTxt(entityId.getRootExtensionTxt());
+            nestedEntityId.setTypeCd(entityId.getTypeCd());
+            nestedEntityIds.add(nestedEntityId);
+        }
+
 
         var address = new NestedAddress();
         PostalLocator pl = PersonUtil.getPostalLocators(person).get(0);
@@ -77,7 +81,7 @@ public class ElasticsearchPersonMapper {
                 .phone(asNestedPhones(person))
                 .localId(person.getLocalId())
                 .address(asNestedAddresses(person))
-                .entityId(Arrays.asList(nestedEntityId))
+                .entityId(nestedEntityIds)
                 .recordStatusCd(person.getRecordStatusCd())
                 .ethnicGroupInd(person.getEthnicGroupInd())
                 .birthTime((Instant) instantConverter.read(person.getBirthTime()))


### PR DESCRIPTION
Add a null / empty list check for EntityIds. Was causing a test failure when no EntityId was present on the Person object.

After fix:
`modernization-api:test results: SUCCESS (241 tests, 241 successes, 0 failures, 0 skipped)`