### PR TITLE
CHFT1-681 Event Search clear all

### DIFF
--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Grid } from '@trussworks/react-uswds';
 import { useContext, useEffect, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams, useParams } from 'react-router-dom';
 import { Config } from '../../config';
 
 import {
@@ -48,11 +48,12 @@ enum ACTIVE_TAB {
 }
 
 export const AdvancedSearch = () => {
+    const { searchType } = useParams();
     // shared variables
     const NBS_URL = Config.nbsUrl;
     const { state } = useContext(UserContext);
     const navigate = useNavigate();
-    const [activeTab, setActiveTab] = useState<'person' | 'event'>('person');
+    const [activeTab, setActiveTab] = useState(searchType === 'event' ? 'event' : 'person');
     const [lastSearchType, setLastSearchType] = useState<SEARCH_TYPE | undefined>();
     const [searchParams] = useSearchParams();
     const [submitted, setSubmitted] = useState(false);
@@ -106,6 +107,11 @@ export const AdvancedSearch = () => {
         }
     ] = useFindLabReportsByFilterLazyQuery();
 
+    const handleActiveTab = (searchType: string) => {
+        setActiveTab(searchType);
+        navigate(`/advanced-search/${searchType}`, { replace: true });
+    };
+
     useEffect(() => {
         function handleClickOutside(event: any) {
             if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
@@ -131,9 +137,9 @@ export const AdvancedSearch = () => {
     useEffect(() => {
         const queryParam = searchParams?.get('q');
         const type = searchParams?.get('type');
-        if (!queryParam || !state.isLoggedIn) {
+        if (!queryParam) {
             // no query parameters specified or user is not logged in
-            setActiveTab('person');
+            // setActiveTab('person');
             setResultsChip([]);
             return;
         }
@@ -362,7 +368,7 @@ export const AdvancedSearch = () => {
         setLabReportFilter({});
         setSubmitted(false);
         setLastSearchType(undefined);
-        navigate('/advanced-search');
+        navigate(`/advanced-search${activeTab ? '/' + activeTab : ''}`);
     };
 
     const handleChipClose = (name: string, value: string) => {
@@ -734,14 +740,14 @@ export const AdvancedSearch = () => {
                                 className={`${
                                     activeTab === ACTIVE_TAB.PERSON && 'active'
                                 } text-normal type font-sans-md padding-bottom-1 margin-x-2 cursor-pointer margin-top-2 margin-bottom-0`}
-                                onClick={() => setActiveTab(ACTIVE_TAB.PERSON)}>
+                                onClick={() => handleActiveTab(ACTIVE_TAB.PERSON)}>
                                 Patient search
                             </h6>
                             <h6
                                 className={`${
                                     activeTab === ACTIVE_TAB.EVENT && 'active'
                                 } padding-bottom-1 type text-normal font-sans-md cursor-pointer margin-top-2 margin-bottom-0`}
-                                onClick={() => setActiveTab(ACTIVE_TAB.EVENT)}>
+                                onClick={() => handleActiveTab(ACTIVE_TAB.EVENT)}>
                                 Event search
                             </h6>
                         </div>
@@ -758,6 +764,7 @@ export const AdvancedSearch = () => {
                                 onSearch={handleSubmit}
                                 investigationFilter={investigationFilter}
                                 labReportFilter={labReportFilter}
+                                clearAll={handleClearAll}
                             />
                         )}
                     </div>

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.spec.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.spec.tsx
@@ -8,10 +8,11 @@ import { EventSearch } from './EventSearch';
 describe('EventSearch component tests', () => {
     it('should render event search form', () => {
         const mockOnSearch = (filter: InvestigationFilter | LabReportFilter, type: SEARCH_TYPE) => {};
+        const mockClearAll = () => {};
         const { container, getByLabelText, getByTestId, getAllByTestId } = render(
             <MockedProvider>
                 <BrowserRouter>
-                    <EventSearch onSearch={mockOnSearch} />
+                    <EventSearch onSearch={mockOnSearch} clearAll={mockClearAll} />
                 </BrowserRouter>
             </MockedProvider>
         );

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.tsx
@@ -2,7 +2,7 @@ import { Accordion, Button, Form, Grid } from '@trussworks/react-uswds';
 import { AccordionItemProps } from '@trussworks/react-uswds/lib/components/Accordion/Accordion';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+// import { useNavigate } from 'react-router-dom';
 import {
     InvestigationFilter,
     LabReportFilter,
@@ -22,10 +22,11 @@ type EventSearchProps = {
     onSearch: (filter: InvestigationFilter | LabReportFilter, type: SEARCH_TYPE) => void;
     investigationFilter?: InvestigationFilter;
     labReportFilter?: LabReportFilter;
+    clearAll: () => void;
 };
 
-export const EventSearch = ({ onSearch, investigationFilter, labReportFilter }: EventSearchProps) => {
-    const navigate = useNavigate();
+export const EventSearch = ({ onSearch, investigationFilter, labReportFilter, clearAll }: EventSearchProps) => {
+    // const navigate = useNavigate();
     const methods = useForm();
     const [eventSearchType, setEventSearchType] = useState<SEARCH_TYPE | ''>();
     const { handleSubmit, control, reset } = methods;
@@ -297,24 +298,8 @@ export const EventSearch = ({ onSearch, investigationFilter, labReportFilter }: 
                         className="width-full clear-btn"
                         type={'button'}
                         onClick={() => {
-                            reset({
-                                firstName: '',
-                                lastName: '',
-                                address: '',
-                                city: '',
-                                state: '-Select-',
-                                zip: '',
-                                patientId: '',
-                                dob: '',
-                                gender: '-Select-',
-                                phoneNumber: '',
-                                email: '',
-                                identificationNumber: '',
-                                identificationType: '-Select-',
-                                ethnicity: '-Select-',
-                                race: '-Select-'
-                            });
-                            navigate({ pathname: '/INVESTIGATION' });
+                            reset();
+                            clearAll();
                         }}
                         outline>
                         Clear all

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/GeneralSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/GeneralSearch.tsx
@@ -21,7 +21,6 @@ type GeneralSearchProps = {
 
 export const GeneralSearch = ({ control, filter }: GeneralSearchProps) => {
     const [facilityType, setFacilityType] = useState(false);
-
     return (
         <>
             <SearchCriteriaContext.Consumer>

--- a/apps/modernization-ui/src/routes/AppRoutes.tsx
+++ b/apps/modernization-ui/src/routes/AppRoutes.tsx
@@ -9,7 +9,7 @@ export const AppRoutes = () => {
         <Routes>
             <Route path="/">
                 <Route path="/login" element={<Login />} />
-                <Route path="/advanced-search" element={<AdvancedSearch />} />
+                <Route path="/advanced-search/:searchType?" element={<AdvancedSearch />} />
                 <Route path="/patient-profile/:id" element={<PatientProfile />} />
                 <Route path="/add-patient" element={<AddPatient />} />
                 <Route path="*" element={<Navigate to="/advanced-search" />} />


### PR DESCRIPTION
Clear all now stays on the Event Search tab by adding separate routes for 'person' and 'event' in advanced-search.

A bug that I discovered is that the current `Multiselect` component will only clear after Submit (other fields will clear).
Research has suggested that the `multiselect-react-dropdown` cannot reset and there's another component that can accomodate clearing multi-select options.
https://stackoverflow.com/questions/64971726/how-to-reset-selected-values-in-multiselect-react-dropdown
https://www.npmjs.com/package/react-multi-select-component

This change to a different component will require signoff from design so we should loop them in on this potential change.
