### PR TITLE
CNFT1-721/ensures that classCd is returned to the client

### DIFF
--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/EntityLocatorParticipation.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/EntityLocatorParticipation.java
@@ -131,4 +131,6 @@ public abstract class EntityLocatorParticipation {
     }
 
     public abstract Locator getLocator();
+
+    public abstract String getClassCd();
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
@@ -11,8 +11,10 @@ import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 
 @Entity
-@DiscriminatorValue("PST")
+@DiscriminatorValue(PostalEntityLocatorParticipation.POSTAL_CLASS_CODE)
 public class PostalEntityLocatorParticipation extends EntityLocatorParticipation {
+
+    static final String POSTAL_CLASS_CODE = "PST";
 
     @MapsId("locatorUid")
     @OneToOne(
@@ -56,6 +58,11 @@ public class PostalEntityLocatorParticipation extends EntityLocatorParticipation
 
     public void setLocator(final PostalLocator locator) {
         this.locator = locator;
+    }
+
+    @Override
+    public String getClassCd() {
+        return POSTAL_CLASS_CODE;
     }
 
     @Override

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/TeleEntityLocatorParticipation.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/TeleEntityLocatorParticipation.java
@@ -12,8 +12,10 @@ import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 
 @Entity
-@DiscriminatorValue("TELE")
+@DiscriminatorValue(TeleEntityLocatorParticipation.TELECOM_CLASS_CODE)
 public class TeleEntityLocatorParticipation extends EntityLocatorParticipation {
+
+    static final String TELECOM_CLASS_CODE = "TELE";
 
     @MapsId("locatorUid")
     @OneToOne(
@@ -85,6 +87,11 @@ public class TeleEntityLocatorParticipation extends EntityLocatorParticipation {
 
     public void setLocator(final TeleLocator locator) {
         this.locator = locator;
+    }
+
+    @Override
+    public String getClassCd() {
+        return TELECOM_CLASS_CODE;
     }
 
     @Override


### PR DESCRIPTION
Addresses were not displaying on patient search results due to the `classCd` property always being null.  Previously, entityLocatorParticipations with address would have a `classCd` with a value of `PST`.

The `EntityLocatorParticipation` was changed to use Single Table Inheritance with the `classCd` being the property that determines which implementation is returned.  When this change was made the `classCd` getter was removed.  This adds a getter for `classCd` that returns the same value used to determine the implementation.