### PR TITLE
CNFT1 711/ api integration treatments provider entry

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentByPatientResolver.java
@@ -1,6 +1,10 @@
 package gov.cdc.nbs.patient.treatment;
 
 import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.graphql.GraphQLPage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
@@ -11,22 +15,34 @@ import java.util.List;
 
 @Controller
 class PatientTreatmentByPatientResolver {
+  
+  private final Integer maxPageSize;
+  private final PatientTreatmentFinder finder;
 
-    private final PatientTreatmentFinder finder;
+  PatientTreatmentByPatientResolver(
+      @Value("${nbs.max-page-size}") final int maxPageSize,
+      final PatientTreatmentFinder finder
+  ) {
+    this.maxPageSize = maxPageSize;
+    this.finder = finder;
+  }
 
-    PatientTreatmentByPatientResolver(final PatientTreatmentFinder finder) {
-        this.finder = finder;
-    }
+  @QueryMapping(name = "findTreatmentsForPatient")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-TREATMENT')")
+  Page<PatientTreatment> find(
+      @Argument("patient") final long patient,
+      @Argument final GraphQLPage page
+  ) {
+    Pageable pageable = GraphQLPage.toPageable(page, maxPageSize);
+    return this.finder.find(
+        patient,
+        pageable
+    );
+  }
 
-    @QueryMapping(name = "findTreatmentsForPatient")
-    @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-TREATMENT')")
-    List<PatientTreatment> find(@Argument("patient") final long patient) {
-        return this.finder.find(patient);
-    }
-
-    @SchemaMapping("treatments")
-    @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-TREATMENT')")
-    List<PatientTreatment> resolve(final Person patient) {
-        return this.finder.find(patient.getId());
-    }
+  @SchemaMapping("treatments")
+  @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-TREATMENT')")
+  List<PatientTreatment> resolve(final Person patient) {
+    return this.finder.find(patient.getId());
+  }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentFinder.java
@@ -13,163 +13,195 @@ import gov.cdc.nbs.entity.odse.QTreatment;
 import gov.cdc.nbs.entity.odse.QTreatmentAdministered;
 import gov.cdc.nbs.entity.srte.QConditionCode;
 import gov.cdc.nbs.message.enums.Suffix;
+import gov.cdc.nbs.patient.NameRenderer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Component
 class PatientTreatmentFinder {
 
-    private static final String NAME_SEPARATOR = " ";
-    private static final String SUBJECT_OF_TREATMENT = "SubjOfTrmt";
-    private static final String TREATMENT = "TRMT";
-    private static final String PERSON = "PSN";
-    private static final String TREATMENT_TO_PUBLIC_HEALTH_CASE = "TreatmentToPHC";
-    private static final String CASE = "CASE";
-    private static final String PROVIDER_OF_TREATMENT = "ProviderOfTrmt";
-    private static final String ACTIVE = "ACTIVE";
-    private static final String OPEN = "O";
-    private static final String CLOSED = "C";
-    private static final String DELETED = "LOG_DEL";
+  private static final QPerson PATIENTS = QPerson.person;
+  private static final String SUBJECT_OF_TREATMENT_CODE = "SubjOfTrmt";
+  private static final String TREATMENT_CODE = "TRMT";
+  private static final String PERSON_CODE = "PSN";
+  private static final String TREATMENT_TO_PUBLIC_HEALTH_CASE_CODE = "TreatmentToPHC";
+  private static final String CASE_CODE = "CASE";
+  private static final String PROVIDER_OF_TREATMENT_CODE = "ProviderOfTrmt";
+  private static final String ACTIVE = "ACTIVE";
+  private static final String OPEN = "O";
+  private static final String CLOSED = "C";
+  private static final String DELETED = "LOG_DEL";
+  private static final QTreatment TREATMENT = QTreatment.treatment;
+  private static final QParticipation SUBJECT_OF_TREATMENT = new QParticipation("subject_of_treatment");
+  private static final QTreatmentAdministered ADMINISTERED = QTreatmentAdministered.treatmentAdministered;
+  private static final QActRelationship RELATIONSHIP = QActRelationship.actRelationship;
+  private static final QParticipation TREATMENT_PROVIDER = new QParticipation("treatment_provider");
+  private static final QPersonName PROVIDER = QPersonName.personName;
+  private static final QPublicHealthCase INVESTIGATION = QPublicHealthCase.publicHealthCase;
+  private static final QConditionCode CONDITION = QConditionCode.conditionCode;
 
-    private final JPAQueryFactory factory;
+  private final JPAQueryFactory factory;
 
-    PatientTreatmentFinder(final JPAQueryFactory factory) {
-        this.factory = factory;
-    }
+  PatientTreatmentFinder(final JPAQueryFactory factory) {
+    this.factory = factory;
+  }
 
-    List<PatientTreatment> find(long patient) {
+  List<PatientTreatment> find(long patient) {
+    return resolveResults(patient);
+  }
 
-        QPerson patients = QPerson.person;
-        QParticipation subjectOfTreatment = new QParticipation("subject_of_treatment");
-        QTreatment treatment = QTreatment.treatment;
-        QTreatmentAdministered administered = QTreatmentAdministered.treatmentAdministered;
-        QActRelationship relationship = QActRelationship.actRelationship;
-        QParticipation treatmentProvider = new QParticipation("treatment_provider");
-        QPersonName provider = QPersonName.personName;
-        QPublicHealthCase investigation = QPublicHealthCase.publicHealthCase;
-        QConditionCode condition = QConditionCode.conditionCode;
+  private List<PatientTreatment> resolveResults(final long patient) {
+    return applyCriteria(
+        factory.selectDistinct(
+            TREATMENT.id,
+            RELATIONSHIP.addTime,
+            TREATMENT.cdDescTxt,
+            TREATMENT.localId,
+            ADMINISTERED.effectiveFromTime,
+            PROVIDER.nmPrefix,
+            PROVIDER.firstNm,
+            PROVIDER.lastNm,
+            PROVIDER.nmSuffix,
+            INVESTIGATION.id,
+            INVESTIGATION.localId,
+            CONDITION.conditionShortNm
+        ),
+        patient
+    )
+        .fetch()
+        .stream()
+        .map(this::mapTreatment)
+        .toList();
+  }
 
-        JPAQuery<Tuple> query = factory.selectDistinct(
-                        treatment.id,
-                        relationship.addTime,
-                        treatment.cdDescTxt,
-                        treatment.localId,
-                        administered.effectiveFromTime,
-                        provider.nmPrefix,
-                        provider.firstNm,
-                        provider.lastNm,
-                        provider.nmSuffix,
-                        investigation.id,
-                        investigation.localId,
-                        condition.conditionShortNm
-                ).from(patients)
-                .join(subjectOfTreatment).on(
-                        subjectOfTreatment.id.subjectEntityUid.eq(patients.id),
-                        subjectOfTreatment.id.typeCd.eq(SUBJECT_OF_TREATMENT),
-                        subjectOfTreatment.actClassCd.eq(TREATMENT),
-                        subjectOfTreatment.subjectClassCd.eq(PERSON),
-                        subjectOfTreatment.recordStatusCd.eq(RecordStatus.ACTIVE)
-                )
-                .join(treatment).on(
-                        treatment.id.eq(subjectOfTreatment.actUid.id),
-                        treatment.recordStatusCd.eq(ACTIVE)
-                )
-                .join(administered).on(
-                        administered.treatmentUid.id.eq(treatment.id)
-                )
-                .join(relationship).on(
-                        relationship.id.typeCd.eq(TREATMENT_TO_PUBLIC_HEALTH_CASE),
-                        relationship.sourceActUid.id.eq(treatment.id),
-                        relationship.sourceClassCd.eq(TREATMENT),
-                        relationship.targetClassCd.eq(CASE)
-                )
-                .leftJoin(treatmentProvider).on(
-                        treatmentProvider.actUid.id.eq(treatment.id),
-                        treatmentProvider.id.typeCd.eq(PROVIDER_OF_TREATMENT),
-                        treatmentProvider.subjectClassCd.eq(PERSON)
-                )
-                .leftJoin(provider).on(
-                        provider.id.personUid.eq(treatmentProvider.id.subjectEntityUid)
-                )
-                .join(investigation).on(
-                        investigation.id.eq(relationship.targetActUid.id),
-                        investigation.investigationStatusCd.in(OPEN, CLOSED),
-                        investigation.recordStatusCd.ne(DELETED)
-                )
-                .join(condition).on(
-                        condition.id.eq(investigation.cd)
-                )
-                .where(patients.personParentUid.id.eq(patient));
+  private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
+    return query.from(PATIENTS)
+        .join(SUBJECT_OF_TREATMENT).on(
+            SUBJECT_OF_TREATMENT.id.subjectEntityUid.eq(PATIENTS.id),
+            SUBJECT_OF_TREATMENT.id.typeCd.eq(SUBJECT_OF_TREATMENT_CODE),
+            SUBJECT_OF_TREATMENT.actClassCd.eq(TREATMENT_CODE),
+            SUBJECT_OF_TREATMENT.subjectClassCd.eq(PERSON_CODE),
+            SUBJECT_OF_TREATMENT.recordStatusCd.eq(RecordStatus.ACTIVE)
+        )
+        .join(TREATMENT).on(
+            TREATMENT.id.eq(SUBJECT_OF_TREATMENT.actUid.id),
+            TREATMENT.recordStatusCd.eq(ACTIVE)
+        )
+        .join(ADMINISTERED).on(
+            ADMINISTERED.treatmentUid.id.eq(TREATMENT.id)
+        )
+        .join(RELATIONSHIP).on(
+            RELATIONSHIP.id.typeCd.eq(TREATMENT_TO_PUBLIC_HEALTH_CASE_CODE),
+            RELATIONSHIP.sourceActUid.id.eq(TREATMENT.id),
+            RELATIONSHIP.sourceClassCd.eq(TREATMENT_CODE),
+            RELATIONSHIP.targetClassCd.eq(CASE_CODE)
+        )
+        .leftJoin(TREATMENT_PROVIDER).on(
+            TREATMENT_PROVIDER.actUid.id.eq(TREATMENT.id),
+            TREATMENT_PROVIDER.id.typeCd.eq(PROVIDER_OF_TREATMENT_CODE),
+            TREATMENT_PROVIDER.subjectClassCd.eq(PERSON_CODE)
+        )
+        .leftJoin(PROVIDER).on(
+            PROVIDER.id.personUid.eq(TREATMENT_PROVIDER.id.subjectEntityUid)
+        )
+        .join(INVESTIGATION).on(
+            INVESTIGATION.id.eq(RELATIONSHIP.targetActUid.id),
+            INVESTIGATION.investigationStatusCd.in(OPEN, CLOSED),
+            INVESTIGATION.recordStatusCd.ne(DELETED)
+        )
+        .join(CONDITION).on(
+            CONDITION.id.eq(INVESTIGATION.cd)
+        )
+        .where(PATIENTS.personParentUid.id.eq(patient));
+  }
 
+  private PatientTreatment mapTreatment(final Tuple tuple) {
+    Long treatment = Objects.requireNonNull(tuple.get(TREATMENT.id), "A treatment is required.");
+    Instant createdOn = tuple.get(RELATIONSHIP.addTime);
+    String description = tuple.get(TREATMENT.cdDescTxt);
+    String event = tuple.get(TREATMENT.localId);
+    Instant treatedOn = tuple.get(ADMINISTERED.effectiveFromTime);
+    String providerPrefix = tuple.get(PROVIDER.nmPrefix);
+    String providerFirstName = tuple.get(PROVIDER.firstNm);
+    String providerLastName = tuple.get(PROVIDER.lastNm);
+    Suffix providerSuffix = tuple.get(PROVIDER.nmSuffix);
 
-        return query.fetch()
-                .stream()
-                .map(this::mapTreatment)
-                .toList();
-    }
+    PatientTreatment.Investigation investigation = mapInvestigation(tuple);
 
-    private PatientTreatment mapTreatment(final Tuple tuple) {
-        Long treatment = Objects.requireNonNull(tuple.get(QTreatment.treatment.id), "A treatment is required.");
-        Instant createdOn = tuple.get(QActRelationship.actRelationship.addTime);
-        String description = tuple.get(QTreatment.treatment.cdDescTxt);
-        String event = tuple.get(QTreatment.treatment.localId);
-        Instant treatedOn = tuple.get(QTreatmentAdministered.treatmentAdministered.effectiveFromTime);
-        String providerPrefix = tuple.get(QPersonName.personName.nmPrefix);
-        String providerFirstName = tuple.get(QPersonName.personName.firstNm);
-        String providerLastName = tuple.get(QPersonName.personName.lastNm);
-        Suffix providerSuffix = tuple.get(QPersonName.personName.nmSuffix);
+    String provider = NameRenderer.render(
+        providerPrefix,
+        providerFirstName,
+        providerLastName,
+        providerSuffix
+    );
 
-        PatientTreatment.Investigation investigation = mapInvestigation(tuple);
+    return new PatientTreatment(
+        treatment,
+        createdOn,
+        provider,
+        treatedOn,
+        description,
+        event,
+        investigation
+    );
+  }
 
-        String provider = combineName(
-                providerPrefix,
-                providerFirstName,
-                providerLastName,
-                providerSuffix
-        );
+  private PatientTreatment.Investigation mapInvestigation(final Tuple tuple) {
+    Long identifier = Objects.requireNonNull(tuple.get(INVESTIGATION.id),
+        "An investigation is required.");
+    String local = tuple.get(INVESTIGATION.localId);
+    String condition = tuple.get(CONDITION.conditionShortNm);
 
-        return new PatientTreatment(
-                treatment,
-                createdOn,
-                provider,
-                treatedOn,
-                description,
-                event,
-                investigation
-        );
-    }
+    return new PatientTreatment.Investigation(
+        identifier,
+        local,
+        condition
+    );
+  }
 
-    private PatientTreatment.Investigation mapInvestigation(final Tuple tuple) {
-        Long identifier = Objects.requireNonNull(tuple.get(QPublicHealthCase.publicHealthCase.id),
-                "An investigation is required.");
-        String local = tuple.get(QPublicHealthCase.publicHealthCase.localId);
-        String condition = tuple.get(QConditionCode.conditionCode.conditionShortNm);
+  Page<PatientTreatment> find(final long patient, final Pageable pageable) {
+    long total = resolveTotal(patient);
 
-        return new PatientTreatment.Investigation(
-                identifier,
-                local,
-                condition
-        );
-    }
+    return total > 0
+        ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
+        : Page.empty(pageable);
+  }
 
-    private String combineName(
-            String prefix,
-            String first,
-            String last,
-            Suffix suffix
-    ) {
-        String suffixDisplay = suffix == null ? null : suffix.name();
-        return Stream.of(
-                        prefix,
-                        first,
-                        last,
-                        suffixDisplay
-                ).filter(Objects::nonNull)
-                .collect(Collectors.joining(NAME_SEPARATOR));
-    }
+  private long resolveTotal(final long patient) {
+    Long total = applyCriteria(factory.selectDistinct(TREATMENT.countDistinct()), patient)
+        .fetchOne();
+    return total == null ? 0L : total;
+  }
+
+  private List<PatientTreatment> resolvePage(final long patient, final Pageable pageable) {
+    return applyCriteria(
+        factory.selectDistinct(
+            TREATMENT.id,
+            RELATIONSHIP.addTime,
+            TREATMENT.cdDescTxt,
+            TREATMENT.localId,
+            ADMINISTERED.effectiveFromTime,
+            PROVIDER.nmPrefix,
+            PROVIDER.firstNm,
+            PROVIDER.lastNm,
+            PROVIDER.nmSuffix,
+            INVESTIGATION.id,
+            INVESTIGATION.localId,
+            CONDITION.conditionShortNm
+        ),
+        patient
+    )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch()
+        .stream()
+        .map(this::mapTreatment)
+        .toList();
+  }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/treatment/PatientTreatmentFinder.java
@@ -45,11 +45,11 @@ class PatientTreatmentFinder {
     List<PatientTreatment> find(long patient) {
 
         QPerson patients = QPerson.person;
-        QParticipation subjectOfTreatment = QParticipation.participation;
+        QParticipation subjectOfTreatment = new QParticipation("subject_of_treatment");
         QTreatment treatment = QTreatment.treatment;
         QTreatmentAdministered administered = QTreatmentAdministered.treatmentAdministered;
         QActRelationship relationship = QActRelationship.actRelationship;
-        QParticipation treatmentProvider = QParticipation.participation;
+        QParticipation treatmentProvider = new QParticipation("treatment_provider");
         QPersonName provider = QPersonName.personName;
         QPublicHealthCase investigation = QPublicHealthCase.publicHealthCase;
         QConditionCode condition = QConditionCode.conditionCode;

--- a/apps/modernization-api/src/main/resources/graphql/patient-treatment.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-treatment.graphqls
@@ -14,6 +14,12 @@ type PatientTreatmentInvestigation {
   condition: String!
 }
 
+type PatientTreatmentResults {
+  content: [PatientTreatment]!
+  total: Int!
+  number: Int!
+}
+
 extend type Query {
-  findTreatmentsForPatient(patient: ID!): [PatientTreatment]
+  findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/PatientTreatmentByPatientResolverTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/PatientTreatmentByPatientResolverTest.java
@@ -1,48 +1,76 @@
 package gov.cdc.nbs.patient.treatment;
 
+import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.graphql.GraphQLPage;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
-import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PatientTreatmentByPatientResolverTest {
 
-    @Test
-    void should_find_treatments_for_the_provided_patient_using_the_finder() {
+  @Test
+  void should_find_treatments_for_provided_patient_using_the_finder() {
+    PatientTreatmentFinder finder = mock(PatientTreatmentFinder.class);
 
-        PatientTreatmentFinder finder = mock(PatientTreatmentFinder.class);
+    when(finder.find(anyLong()))
+        .thenReturn(List.of(mock(PatientTreatment.class)));
 
-        when(finder.find(anyLong()))
-                .thenReturn(
-                        List.of(
-                                new PatientTreatment(
-                                        2119L,
-                                        Instant.parse("2022-05-13T10:34:00Z"),
-                                        "provider-value",
-                                        Instant.parse("2022-05-10T15:04:39Z"),
-                                        "description-value",
-                                        "event-value",
-                                        new PatientTreatment.Investigation(
-                                                2251L,
-                                                "local-value",
-                                                "condition-value"
-                                        )
+    PatientTreatmentByPatientResolver resolver = new PatientTreatmentByPatientResolver(25, finder);
 
-                                )
-                        )
-                );
+    Person patient = new Person(2963L, "local");
 
-        PatientTreatmentByPatientResolver resolver = new PatientTreatmentByPatientResolver(finder);
+    List<PatientTreatment> actual = resolver.resolve(patient);
 
-        List<PatientTreatment> actual = resolver.find(1861L);
+    assertThat(actual)
+        .as("The resolved list of patients comes from the finder")
+        .hasSize(1);
 
-        assertThat(actual)
-                .as("The resolved list of patients comes from the finder")
-                .hasSize(1);
+    verify(finder).find(2963L);
 
-        verify(finder).find(1861L);
-    }
+  }
+
+  @Test
+  void should_find_paginated_treatments_for_the_provided_patient_using_the_finder() {
+
+    PatientTreatmentFinder finder = mock(PatientTreatmentFinder.class);
+
+    when(finder.find(anyLong(), any()))
+        .thenAnswer(args -> new PageImpl<>(
+                List.of(mock(PatientTreatment.class)),
+                args.getArgument(1, Pageable.class),
+                1L
+            )
+        );
+
+    PatientTreatmentByPatientResolver resolver = new PatientTreatmentByPatientResolver(25, finder);
+
+    GraphQLPage page = new GraphQLPage(25, 2);
+
+    Page<PatientTreatment> actual = resolver.find(1861L, page);
+
+    assertThat(actual)
+        .as("The resolved paginated list of patients comes from the finder")
+        .hasSize(1);
+
+    ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+
+    verify(finder).find(eq(1861L), captor.capture());
+
+    Pageable actual_pageable = captor.getValue();
+
+    assertThat(actual_pageable.getPageNumber()).isEqualTo(2);
+    assertThat(actual_pageable.getPageSize()).isEqualTo(25);
+  }
 }

--- a/apps/modernization-ui/src/components/Table/Table.spec.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.spec.tsx
@@ -44,7 +44,7 @@ describe('Table component', () => {
         const tableData = container.getElementsByClassName('table-data');
         expect(tableHeader[0].innerHTML).toBe('Test Table HeaderTest Sub Header');
         expect(tableHead[0].innerHTML).toBe('Start Date');
-        expect(tableData[0].innerHTML).toBe('10/05/2022');
+        expect(tableData[0]).toHaveTextContent('10/05/2022');
     });
 
     it('table with no data', async () => {

--- a/apps/modernization-ui/src/components/Table/Table.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.tsx
@@ -142,7 +142,9 @@ export const TableComponent = ({
                             </tr>
                         ))
                     ) : (
-                        <tr className="text-center no-data not-available">Not Available</tr>
+                        <tr className="text-center no-data not-available">
+                            <td colSpan={tableHead.length}>Not Available</td>
+                        </tr>
                     )}
                 </tbody>
             </Table>

--- a/apps/modernization-ui/src/generated/gql/queries/findTreatmentsForPatient.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findTreatmentsForPatient.gql
@@ -1,15 +1,19 @@
-query findTreatmentsForPatient($patient: ID!){
-    findTreatmentsForPatient(patient: $patient){
-        treatment
-        createdOn
-        provider
-        treatedOn
-        description
-        event
-        associatedWith{
-            id
-            local
-            condition
+query findTreatmentsForPatient($patient: ID!, $page: Page){
+    findTreatmentsForPatient(patient: $patient, page: $page){
+        content{
+            treatment
+            createdOn
+            provider
+            treatedOn
+            description
+            event
+            associatedWith{
+                id
+                local
+                condition
+            }
         }
+        total
+        number
     }
 }

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -823,6 +823,12 @@ export type PatientTreatmentInvestigation = {
   local: Scalars['String'];
 };
 
+export type PatientTreatmentResults = {
+  __typename?: 'PatientTreatmentResults';
+  content: Array<Maybe<PatientTreatment>>;
+  total: Scalars['Int'];
+};
+
 export type Person = {
   __typename?: 'Person';
   addReasonCd?: Maybe<Scalars['String']>;
@@ -1187,7 +1193,7 @@ export type Query = {
   findPlaceById?: Maybe<Place>;
   findPlacesByFilter: Array<Maybe<Place>>;
   findSnomedCodedResults: SnomedCodedResults;
-  findTreatmentsForPatient?: Maybe<Array<Maybe<PatientTreatment>>>;
+  findTreatmentsForPatient?: Maybe<PatientTreatmentResults>;
 };
 
 
@@ -1366,6 +1372,7 @@ export type QueryFindSnomedCodedResultsArgs = {
 
 
 export type QueryFindTreatmentsForPatientArgs = {
+  page?: InputMaybe<Page>;
   patient: Scalars['ID'];
 };
 
@@ -1779,10 +1786,11 @@ export type FindSnomedCodedResultsQuery = { __typename?: 'Query', findSnomedCode
 
 export type FindTreatmentsForPatientQueryVariables = Exact<{
   patient: Scalars['ID'];
+  page?: InputMaybe<Page>;
 }>;
 
 
-export type FindTreatmentsForPatientQuery = { __typename?: 'Query', findTreatmentsForPatient?: Array<{ __typename?: 'PatientTreatment', treatment: string, createdOn: any, provider?: string | null, treatedOn: any, description: string, event: string, associatedWith: { __typename?: 'PatientTreatmentInvestigation', id: string, local: string, condition: string } } | null> | null };
+export type FindTreatmentsForPatientQuery = { __typename?: 'Query', findTreatmentsForPatient?: { __typename?: 'PatientTreatmentResults', total: number, content: Array<{ __typename?: 'PatientTreatment', treatment: string, createdOn: any, provider?: string | null, treatedOn: any, description: string, event: string, associatedWith: { __typename?: 'PatientTreatmentInvestigation', id: string, local: string, condition: string } } | null> } | null };
 
 
 export const CreatePatientDocument = gql`
@@ -4593,19 +4601,22 @@ export type FindSnomedCodedResultsQueryHookResult = ReturnType<typeof useFindSno
 export type FindSnomedCodedResultsLazyQueryHookResult = ReturnType<typeof useFindSnomedCodedResultsLazyQuery>;
 export type FindSnomedCodedResultsQueryResult = Apollo.QueryResult<FindSnomedCodedResultsQuery, FindSnomedCodedResultsQueryVariables>;
 export const FindTreatmentsForPatientDocument = gql`
-    query findTreatmentsForPatient($patient: ID!) {
-  findTreatmentsForPatient(patient: $patient) {
-    treatment
-    createdOn
-    provider
-    treatedOn
-    description
-    event
-    associatedWith {
-      id
-      local
-      condition
+    query findTreatmentsForPatient($patient: ID!, $page: Page) {
+  findTreatmentsForPatient(patient: $patient, page: $page) {
+    content {
+      treatment
+      createdOn
+      provider
+      treatedOn
+      description
+      event
+      associatedWith {
+        id
+        local
+        condition
+      }
     }
+    total
   }
 }
     `;
@@ -4623,6 +4634,7 @@ export const FindTreatmentsForPatientDocument = gql`
  * const { data, loading, error } = useFindTreatmentsForPatientQuery({
  *   variables: {
  *      patient: // value for 'patient'
+ *      page: // value for 'page'
  *   },
  * });
  */

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -826,6 +826,7 @@ export type PatientTreatmentInvestigation = {
 export type PatientTreatmentResults = {
   __typename?: 'PatientTreatmentResults';
   content: Array<Maybe<PatientTreatment>>;
+  number: Scalars['Int'];
   total: Scalars['Int'];
 };
 
@@ -1790,7 +1791,7 @@ export type FindTreatmentsForPatientQueryVariables = Exact<{
 }>;
 
 
-export type FindTreatmentsForPatientQuery = { __typename?: 'Query', findTreatmentsForPatient?: { __typename?: 'PatientTreatmentResults', total: number, content: Array<{ __typename?: 'PatientTreatment', treatment: string, createdOn: any, provider?: string | null, treatedOn: any, description: string, event: string, associatedWith: { __typename?: 'PatientTreatmentInvestigation', id: string, local: string, condition: string } } | null> } | null };
+export type FindTreatmentsForPatientQuery = { __typename?: 'Query', findTreatmentsForPatient?: { __typename?: 'PatientTreatmentResults', total: number, number: number, content: Array<{ __typename?: 'PatientTreatment', treatment: string, createdOn: any, provider?: string | null, treatedOn: any, description: string, event: string, associatedWith: { __typename?: 'PatientTreatmentInvestigation', id: string, local: string, condition: string } } | null> } | null };
 
 
 export const CreatePatientDocument = gql`
@@ -4617,6 +4618,7 @@ export const FindTreatmentsForPatientDocument = gql`
       }
     }
     total
+    number
   }
 }
     `;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -701,8 +701,14 @@ type PatientTreatmentInvestigation {
   condition: String!
 }
 
+type PatientTreatmentResults {
+  content: [PatientTreatment]!
+  total: Int!
+  number: Int!
+}
+
 extend type Query {
-  findTreatmentsForPatient(patient: ID!): [PatientTreatment]
+  findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
 }
 type Query {
   findPatientById(id: ID!): Person

--- a/apps/modernization-ui/src/pages/patientProfile/Events.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/Events.tsx
@@ -8,7 +8,6 @@ import {
     FindInvestigationsByFilterQuery,
     FindLabReportsByFilterQuery,
     FindMorbidtyReportForPatientQuery,
-    FindTreatmentsForPatientQuery,
     LabReport,
     OrganizationParticipation
 } from '../../generated/graphql/schema';
@@ -16,22 +15,23 @@ import format from 'date-fns/format';
 import { RedirectControllerService } from 'generated';
 import { UserContext } from 'providers/UserContext';
 import { Config } from 'config';
+import { PatientTreatmentTable } from 'patient/profile/treatment';
 
 type EventTabProp = {
+    patient: string | undefined;
     investigationData?: FindInvestigationsByFilterQuery['findInvestigationsByFilter'];
     labReports?: FindLabReportsByFilterQuery['findLabReportsByFilter'] | undefined;
     morbidityData?: FindMorbidtyReportForPatientQuery['findMorbidtyReportForPatient'] | undefined;
-    treatmentsData?: FindTreatmentsForPatientQuery['findTreatmentsForPatient'] | undefined;
     documentsData?: FindDocumentsForPatientQuery['findDocumentsForPatient'] | undefined;
     contactsData?: FindContactsForPatientQuery['findContactsForPatient'] | undefined;
     profileData?: any;
 };
 
 export const Events = ({
+    patient,
     investigationData,
     labReports,
     morbidityData,
-    treatmentsData,
     documentsData,
     contactsData,
     profileData
@@ -50,7 +50,6 @@ export const Events = ({
     const [labCurrentPage, setLabCurrentPage] = useState<number>(1);
 
     const [morbidityResults, setMorbidityResults] = useState<any>();
-    const [treatmentResults, setTreatmentResults] = useState<any>();
     const [contactNamedByPatient, setContactNamedByPatient] = useState<any>();
     const [patientByContact, setPatientByContact] = useState<any>();
 
@@ -254,55 +253,6 @@ export const Events = ({
         });
     };
 
-    const getTreatmentData = (treatments: FindTreatmentsForPatientQuery['findTreatmentsForPatient'] | undefined) => {
-        const tempArr: TableBody[] = [];
-        treatments?.map((treatment) => {
-            tempArr.push({
-                id: treatment?.event,
-                checkbox: false,
-                tableDetails: [
-                    {
-                        id: 1,
-                        title: (
-                            <>
-                                {format(new Date(treatment?.createdOn), 'MM/dd/yyyy')} <br />{' '}
-                                {format(new Date(treatment?.createdOn), 'hh:mm a')}
-                            </>
-                        ),
-                        class: 'link',
-                        link: ''
-                    },
-                    {
-                        id: 2,
-                        title: treatment?.provider
-                    },
-                    { id: 4, title: format(new Date(treatment?.treatedOn), 'MM/dd/yyyy') },
-                    { id: 7, title: treatment?.description || null },
-                    {
-                        id: 5,
-                        title:
-                            !treatment || treatment?.associatedWith.condition?.length == 0 ? null : (
-                                <>
-                                    {treatment.associatedWith && treatment.associatedWith.condition.length > 0 && (
-                                        <div>
-                                            <p
-                                                className="margin-0 text-primary text-bold link"
-                                                style={{ wordBreak: 'break-word' }}>
-                                                {treatment.associatedWith?.local}
-                                            </p>
-                                            <p className="margin-0">{treatment.associatedWith.condition}</p>
-                                        </div>
-                                    )}
-                                </>
-                            )
-                    },
-                    { id: 8, title: treatment?.event || null }
-                ]
-            });
-            setTreatmentResults(tempArr);
-        });
-    };
-
     const getContactNameByPatient = (contacts: FindContactsForPatientQuery['findContactsForPatient'] | undefined) => {
         const tempArr: TableBody[] = [];
         const tempArrByContact: TableBody[] = [];
@@ -417,15 +367,12 @@ export const Events = ({
         if (documentsData) {
             console.log('documentsData:', documentsData);
         }
-        if (treatmentsData) {
-            console.log('treatmentsData:', treatmentsData);
-            getTreatmentData(treatmentsData);
-        }
+
         if (contactsData) {
             console.log('contactsData:', contactsData);
             getContactNameByPatient(contactsData);
         }
-    }, [investigationData, labReports, morbidityData, documentsData, treatmentsData, contactsData]);
+    }, [investigationData, labReports, morbidityData, documentsData, contactsData]);
 
     const sortInvestigationData = (name: string, type: string) => {
         getData(
@@ -631,29 +578,7 @@ export const Events = ({
                 />
             </div>
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-                <TableComponent
-                    isPagination={true}
-                    buttons={
-                        <div className="grid-row">
-                            <Button type="button" className="grid-row">
-                                <Icon.Add className="margin-right-05" />
-                                Add treatment
-                            </Button>
-                        </div>
-                    }
-                    tableHeader={'Treatments'}
-                    tableHead={[
-                        { name: 'Date created', sortable: true },
-                        { name: 'Provider', sortable: true },
-                        { name: 'Treatment date', sortable: true },
-                        { name: 'Treatment', sortable: true },
-                        { name: 'Associated with', sortable: false },
-                        { name: 'Event #', sortable: false }
-                    ]}
-                    tableBody={treatmentResults}
-                    currentPage={currentPage}
-                    handleNext={(e) => setCurrentPage(e)}
-                />
+                <PatientTreatmentTable patient={patient} />
             </div>
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
                 <TableComponent

--- a/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
@@ -20,8 +20,7 @@ import {
     useFindInvestigationsByFilterLazyQuery,
     useFindLabReportsByFilterLazyQuery,
     useFindMorbidtyReportForPatientLazyQuery,
-    useFindPatientByIdLazyQuery,
-    useFindTreatmentsForPatientLazyQuery
+    useFindPatientByIdLazyQuery
 } from '../../generated/graphql/schema';
 import { calculateAge } from '../../utils/util';
 import { Summary } from './Summary';
@@ -45,7 +44,6 @@ export const PatientProfile = () => {
     const [getPatientLabReportData, { data: labReportData }] = useFindLabReportsByFilterLazyQuery();
     // const [getPatientProfileData, { data: patientProfileData }] = useFindPatientsByFilterLazyQuery();
     const [getMorbidityData, { data: morbidityData }] = useFindMorbidtyReportForPatientLazyQuery();
-    const [getTreatmentsData, { data: treatmentsData }] = useFindTreatmentsForPatientLazyQuery();
     const [getDocumentsData, { data: documentsData }] = useFindDocumentsForPatientLazyQuery();
     const [getContactsData, { data: contactsData }] = useFindContactsForPatientLazyQuery();
 
@@ -98,11 +96,6 @@ export const PatientProfile = () => {
                 getMorbidityData({
                     variables: {
                         patientId: +patientProfileData.findPatientById.id
-                    }
-                });
-                getTreatmentsData({
-                    variables: {
-                        patient: patientProfileData.findPatientById.id
                     }
                 });
                 getDocumentsData({
@@ -333,10 +326,10 @@ export const PatientProfile = () => {
                 {activeTab === ACTIVE_TAB.SUMMARY && <Summary profileData={profileData} />}
                 {activeTab === ACTIVE_TAB.EVENT && (
                     <Events
+                        patient={id}
                         investigationData={investigationData?.findInvestigationsByFilter}
                         labReports={labReportData?.findLabReportsByFilter}
                         morbidityData={morbidityData?.findMorbidtyReportForPatient}
-                        treatmentsData={treatmentsData?.findTreatmentsForPatient}
                         documentsData={documentsData?.findDocumentsForPatient}
                         contactsData={contactsData?.findContactsForPatient}
                         profileData={profileData}

--- a/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.spec.tsx
@@ -1,0 +1,120 @@
+import { PatientTreatmentTable } from './PatientTreatmentTable';
+import { render } from '@testing-library/react';
+import { FindTreatmentsForPatientDocument } from 'generated/graphql/schema';
+
+import { MockedProvider } from '@apollo/client/testing';
+
+describe('when rendered', () => {
+    it('should display sentence cased treatment headers', async () => {
+        const { container } = render(
+            <MockedProvider addTypename={false}>
+                <PatientTreatmentTable pageSize={3}></PatientTreatmentTable>
+            </MockedProvider>
+        );
+
+        const tableHeader = container.getElementsByClassName('table-header');
+        expect(tableHeader[0].innerHTML).toBe('Treatments');
+
+        const tableHeads = container.getElementsByClassName('head-name');
+
+        expect(tableHeads[0].innerHTML).toBe('Date created');
+        expect(tableHeads[1].innerHTML).toBe('Provider');
+        expect(tableHeads[2].innerHTML).toBe('Treatment date');
+        expect(tableHeads[3].innerHTML).toBe('Treatment');
+        expect(tableHeads[4].innerHTML).toBe('Associated with');
+        expect(tableHeads[5].innerHTML).toBe('Event #');
+    });
+});
+
+describe('when treatments are not available for a patient', () => {
+    const response = {
+        request: {
+            query: FindTreatmentsForPatientDocument,
+            variables: {
+                patient: '73',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 5
+                }
+            }
+        },
+        result: {
+            data: {
+                findTreatmentsForPatient: {
+                    content: [],
+                    total: 0,
+                    number: 0
+                }
+            }
+        }
+    };
+
+    it('should display Not Available', async () => {
+        const { findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientTreatmentTable patient={'73'} pageSize={5}></PatientTreatmentTable>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Not Available')).toBeInTheDocument();
+    });
+});
+
+describe('when treatments are available for a patient', () => {
+    const response = {
+        request: {
+            query: FindTreatmentsForPatientDocument,
+            variables: {
+                patient: '1823',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 5
+                }
+            }
+        },
+        result: {
+            data: {
+                findTreatmentsForPatient: {
+                    content: [
+                        {
+                            treatment: '2203',
+                            createdOn: '2023-03-20T15:36:16.317Z',
+                            provider: 'DR Indiana Jones',
+                            treatedOn: '2023-03-01T05:00:00Z',
+                            description: 'treatment-description',
+                            event: 'TRT10000000GA01',
+                            associatedWith: {
+                                id: '10000013',
+                                local: 'CAS10000000GA01',
+                                condition: 'Pertussis'
+                            }
+                        }
+                    ],
+                    total: 1,
+                    number: 0
+                }
+            }
+        }
+    };
+
+    it('should display the treatments', async () => {
+        const { container, findByText, getAllByRole } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientTreatmentTable patient={'1823'} pageSize={5}></PatientTreatmentTable>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Showing 1 of 1')).toBeInTheDocument();
+
+        const tableData = container.getElementsByClassName('table-data');
+
+        expect(tableData[0]).toContainHTML('<span class="link">03/20/2023 <br /> 10:36 AM</span>');
+        expect(tableData[1].innerHTML).toContain('DR Indiana Jones');
+        expect(tableData[2].innerHTML).toContain('03/01/2023');
+        expect(tableData[3].innerHTML).toContain('treatment-description');
+        expect(tableData[4]).toContainHTML(
+            '<div><p class="margin-0 text-primary text-bold link" style="word-break: break-word;">CAS10000000GA01</p><p class="margin-0">Pertussis</p></div></span>'
+        );
+        expect(tableData[5]).toHaveTextContent('TRT10000000GA01');
+    });
+});

--- a/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.tsx
+++ b/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.tsx
@@ -1,0 +1,114 @@
+import { TableBody, TableComponent } from 'components/Table/Table';
+import { useEffect, useState } from 'react';
+import { Button, Icon } from '@trussworks/react-uswds';
+import format from 'date-fns/format';
+import { FindTreatmentsForPatientQuery, useFindTreatmentsForPatientLazyQuery } from 'generated/graphql/schema';
+
+import { TOTAL_TABLE_DATA } from 'utils/util';
+
+export type PatientTreatments = FindTreatmentsForPatientQuery['findTreatmentsForPatient'];
+
+const asTableBody = (treatment: any): TableBody => ({
+    id: treatment?.event,
+    checkbox: false,
+    tableDetails: [
+        {
+            id: 1,
+            title: (
+                <>
+                    {format(new Date(treatment?.createdOn), 'MM/dd/yyyy')} <br />{' '}
+                    {format(new Date(treatment?.createdOn), 'hh:mm a')}
+                </>
+            ),
+            class: 'link',
+            link: ''
+        },
+        {
+            id: 2,
+            title: treatment?.provider
+        },
+        { id: 4, title: format(new Date(treatment?.treatedOn), 'MM/dd/yyyy') },
+        { id: 7, title: treatment?.description || null },
+        {
+            id: 5,
+            title:
+                !treatment || treatment?.associatedWith.condition?.length == 0 ? null : (
+                    <>
+                        {treatment.associatedWith && treatment.associatedWith.condition.length > 0 && (
+                            <div>
+                                <p className="margin-0 text-primary text-bold link" style={{ wordBreak: 'break-word' }}>
+                                    {treatment.associatedWith?.local}
+                                </p>
+                                <p className="margin-0">{treatment.associatedWith.condition}</p>
+                            </div>
+                        )}
+                    </>
+                )
+        },
+        { id: 8, title: treatment?.event || null }
+    ]
+});
+
+const asTableBodies = (treatments: PatientTreatments): TableBody[] => treatments?.content?.map(asTableBody) || [];
+
+type PatientTreatmentTableProps = {
+    patient?: string;
+    pageSize?: number;
+};
+
+export const PatientTreatmentTable = ({ patient, pageSize = TOTAL_TABLE_DATA }: PatientTreatmentTableProps) => {
+    const [currentPage, setCurrentPage] = useState<number>(1);
+    const [total, setTotal] = useState<number>(0);
+    const [tableBodies, setTableBodies] = useState<TableBody[]>([]);
+
+    const handleComplete = (data: FindTreatmentsForPatientQuery) => {
+        const total = data?.findTreatmentsForPatient?.total || 0;
+        setTotal(total);
+
+        const bodies = asTableBodies(data.findTreatmentsForPatient);
+        setTableBodies(bodies);
+    };
+
+    const [getTreatments] = useFindTreatmentsForPatientLazyQuery({ onCompleted: handleComplete });
+
+    useEffect(() => {
+        if (patient) {
+            getTreatments({
+                variables: {
+                    patient: patient,
+                    page: {
+                        pageNumber: currentPage - 1,
+                        pageSize
+                    }
+                }
+            });
+        }
+    }, [patient, currentPage]);
+
+    return (
+        <TableComponent
+            isPagination={true}
+            buttons={
+                <div className="grid-row">
+                    <Button type="button" className="grid-row">
+                        <Icon.Add className="margin-right-05" />
+                        Add treatment
+                    </Button>
+                </div>
+            }
+            tableHeader={'Treatments'}
+            tableHead={[
+                { name: 'Date created', sortable: true },
+                { name: 'Provider', sortable: true },
+                { name: 'Treatment date', sortable: true },
+                { name: 'Treatment', sortable: true },
+                { name: 'Associated with', sortable: false },
+                { name: 'Event #', sortable: false }
+            ]}
+            tableBody={tableBodies}
+            totalResults={total}
+            currentPage={currentPage}
+            handleNext={setCurrentPage}
+        />
+    );
+};

--- a/apps/modernization-ui/src/patient/profile/treatment/index.ts
+++ b/apps/modernization-ui/src/patient/profile/treatment/index.ts
@@ -1,0 +1,3 @@
+export type { PatientTreatments } from './PatientTreatmentTable';
+
+export { PatientTreatmentTable } from './PatientTreatmentTable';

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,12 @@ assertj = "3.24.2"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref ="assertj"}
+mockito-inline = {module = "org.mockito:mockito-inline", version = "4.11.0"}
 springBoot = {module = "org.springframework.boot:spring-boot-starter", version.ref="springBoot"}
 springBoot-jpa = {module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref="springBoot"}
 
 [bundles]
-testing = ["assertj-core"]
+testing = ["assertj-core", "mockito-inline"]
 jpa = ["springBoot", "springBoot-jpa"]
 
 [plugins]


### PR DESCRIPTION
Adds pagination to the result of the `findTreatmentsForPatient` query and ensures that the provider is included on the response.

```graphql
query treatments($patient: ID!, $page: Page) {
  findTreatmentsForPatient(patient: $patient, page: $page) {
    content {
      treatment
      createdOn
      provider
      treatedOn
      description
      event
      associatedWith {
        id
        local
        condition
      }
    }
    total
  }
}

```