### PR TITLE
Allows sandbox proxy to use local ui and/or backend servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 ### Mac ARM system (M1/M2)
 
 1. Install [Java 17](docs/InstallJava.md)
-1. Install Node / NPM
-1. Clone [NBS](https://github.com/cdcent/NEDSSDev)
-1. Set `NEDSS_HOME` environment variable, this should point to the directory `NBS` was cloned into. Example:
+2. Install Node / NPM
+3. Clone [NBS](https://github.com/cdcent/NEDSSDev)
+4. Set `NEDSS_HOME` environment variable, this should point to the directory `NBS` was cloned into. Example:
 
    ```sh
    export NEDSS_HOME="/Users/michaelpeels/Projects/NBS/NEDSSDev"
@@ -33,52 +33,52 @@
 
    ```
 
-1. CD into the `cdc-sandbox` directory
+5. CD into the `cdc-sandbox` directory
    ```sh
    cd cdc-sandbox
    ```
-1. Run the NBS [build script](cdc-sandbox/build.sh) to build the image
+6. Run the NBS [build script](cdc-sandbox/build.sh) to build the image
    ```sh
    ./build.sh
    ```
-1. Download the [database restore file](https://enquizit.sharepoint.com/:u:/s/CDCNBSProject/EQtb-5WSO9xGrocNofv_eMgBH1WX30TNV0wTlZ84E5coYg?e=uNtem1) and place it in `cdc-sandbox/db/restore/restore.d/`
-1. Run the NBS [run script](cdc-sandbox/run.sh) to start the `nbs-mssql` database and `nbs`. NBS runs inside [WildFly 10.0.0](https://www.wildfly.org/news/2016/01/30/WildFly10-Released/), so the container is named `wildfly`
+7. Download the [database restore file](https://enquizit.sharepoint.com/:u:/s/CDCNBSProject/EQtb-5WSO9xGrocNofv_eMgBH1WX30TNV0wTlZ84E5coYg?e=uNtem1) and place it in `cdc-sandbox/db/restore/restore.d/`
+8. Run the NBS [run script](cdc-sandbox/run.sh) to start the `nbs-mssql` database and `nbs`. NBS runs inside [WildFly 10.0.0](https://www.wildfly.org/news/2016/01/30/WildFly10-Released/), so the container is named `wildfly`
    ```sh
    ./run.sh
    ```
-1. Start `Elasticsearch`, `Kibana`, and the [Traefik](https://traefik.io/) reverse proxy
+9. Start `Elasticsearch`, `Kibana`, and the [Traefik](https://traefik.io/) reverse proxy
    ```sh
    docker-compose up elasticsearch kibana reverse-proxy -d
    ```
-1. CD into the `apps/modernization-ui` directory
-   ```sh
-   cd ../apps/modernization-ui
-   ```
-1. Run `npm install`
-   ```sh
-   npm i
-   ```
-1. CD to the `apps/modernization-api` directory
-   ```sh
-   cd ../modernization-api
-   ```
-1. Start the `modernization-api` container
-   ```sh
-   docker-compose up modernization-api -d
-   ```
-1. CD into the `cdc-sandbox` directory and Start NiFi
-   ```sh
-   cd ../cdc-sandbox
-   docker-compose up nifi -d
-   ```
-1. Visit http://localhost:8080/nbs/login
+10. CD into the `apps/modernization-ui` directory
+    ```sh
+    cd ../apps/modernization-ui
+    ```
+11. Run `npm install`
+    ```sh
+    npm i
+    ```
+12. CD to the `apps/modernization-api` directory
+    ```sh
+    cd ../modernization-api
+    ```
+13. Start the `modernization-api` container
+    ```sh
+    docker-compose up modernization-api -d
+    ```
+14. CD into the `cdc-sandbox` directory and Start NiFi
+    ```sh
+    cd ../cdc-sandbox
+    docker-compose up nifi -d
+    ```
+15. Visit http://localhost:8080/nbs/login
 
-   ```
-   username: msa
-   password:
-   ```
+    ```
+    username: msa
+    password:
+    ```
 
-1. To create your own user account visit site (line 15):
+16. To create your own user account visit site (line 15):
 
 - Navigate to System Management
 - Expand Security Management
@@ -87,3 +87,50 @@
 - Add a Role & click submit
 
 ## Code Formatting
+
+## Running with local servers
+
+By default, the reverse proxy will route to the containerized `modernization-api` or `modernization-ui`.  Routing to a local `modernization-api` or `modernization-ui` servers can be achieved by altering the configuration to point to the local instances.
+
+| Name                     | Default             | Description                                                |
+|--------------------------|---------------------|------------------------------------------------------------|
+| MODERNIZATION_UI_SERVER  | `modernization-ui`  | The host name of the server that provides the frontend UI. |
+| MODERNIZATION_UI_PORT    | `80`                | The port the frontend UI is served from.                   |
+| MODERNIZATION_API_SERVER | `modernization-api` | The host name of the server that provides the backend API  |
+| MODERNIZATION_API_PORT   | `8080`              | The port the frontend UI is served from.                   |
+
+### Configuring the Reverse Proxy to use local modernization-ui
+
+Start the frontend UI locally by running the following command from the `apps/modernization-ui` folder.
+
+```shell
+npm run start
+```
+
+Start the reverse proxy configured to route to the local frontend instance by running the following command from the `cdc-sandbox` folder
+
+```shell
+MODERNIZATION_UI_SERVER=host.docker.internal MODERNIZATION_UI_PORT=3000 docker compose up -d reverse-proxy
+```
+
+### Configuring the Reverse Proxy to use local modernization-api
+
+Start the backend API locally listening on port 9080 from the root project folder.  The `cdc-sandbox` exposes the reverse-proxy on port `8080`, which is the default port for Spring Boot.  It must be changed in order for the backend to stat properly.
+
+```shell
+./gradlew :modernization-api:bootRun --args='--server.port=9080'
+```
+
+Start the reverse proxy configured to route to the local backend by running the following command from the `cdc-sandbox` folder
+
+```shell
+MODERNIZATION_API_SERVER=host.docker.internal MODERNIZATION_API_PORT=9080 docker compose up -d reverse-proxy
+```
+
+### Resetting to Docker only
+
+Start the reverse proxy by running the following command from the `cdc-sandbox` folder
+
+```shell
+docker compose up -d reverse-proxy
+```

--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -21,15 +21,15 @@ services:
       - FORCE_RESTORE
     networks:
       - nbs
-  wildfly: 
+  wildfly:
     build: ./
     container_name: wildfly
     depends_on:
       - nbs-mssql
-    ports: 
+    ports:
       - "9990:9990"
       - "7001:7001"
-      - "8787:8787" 
+      - "8787:8787"
     networks:
       - nbs
   reverse-proxy:
@@ -41,15 +41,20 @@ services:
       - "8081:8081" # traefik dashboard
     networks:
       - nbs
+    environment:
+      - MODERNIZATION_UI_SERVER=${MODERNIZATION_UI_SERVER:-modernization-ui}
+      - MODERNIZATION_UI_PORT=${MODERNIZATION_UI_PORT:-80}
+      - MODERNIZATION_API_SERVER=${MODERNIZATION_API_SERVER:-modernization-api}
+      - MODERNIZATION_API_PORT=${MODERNIZATION_API_PORT:-8080}
     # volumes:
-    #   - ./proxy/:/etc/traefik/    
+    #   - ./proxy/:/etc/traefik/
   elasticsearch:
     container_name: elasticsearch
-    build:  ./elasticsearch
+    build: ./elasticsearch
     networks:
       - nbs
     ports:
-      - 9200:9200 
+      - 9200:9200
       - 9300:9300
     # environment:
     #   - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m" # Uncomment to limit memory usage
@@ -65,10 +70,10 @@ services:
     ports:
       - 5601:5601
     # volumes:
-    #   - ./kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml]   
+    #   - ./kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml]
   nifi:
     container_name: nifi
-    build: ./nifi 
+    build: ./nifi
     restart: unless-stopped
     ports:
       - 8443:8443
@@ -76,7 +81,7 @@ services:
     #   - ./nifi/nifi_drivers:/var/opt/nifi_drivers:ro
     #   - ./nifi/nifi_conf/conf:/opt/nifi/nifi-current/conf:rw
     networks:
-      - nbs    
+      - nbs
 volumes:
   nbs-mssql-data:
 networks:

--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -46,8 +46,6 @@ services:
       - MODERNIZATION_UI_PORT=${MODERNIZATION_UI_PORT:-80}
       - MODERNIZATION_API_SERVER=${MODERNIZATION_API_SERVER:-modernization-api}
       - MODERNIZATION_API_PORT=${MODERNIZATION_API_PORT:-8080}
-    # volumes:
-    #   - ./proxy/:/etc/traefik/
   elasticsearch:
     container_name: elasticsearch
     build: ./elasticsearch

--- a/cdc-sandbox/proxy/providers.yml
+++ b/cdc-sandbox/proxy/providers.yml
@@ -1,7 +1,13 @@
 http:
   routers:
     # Modernization app
+    login:
+      service: modernization-api
+      rule: "PathPrefix(`/login`)"
     modernizationForward:
+      service: modernization-api
+      rule: "Path(`/graphql`) || PathPrefix(`/encryption`)"
+    ui-forward:
       service: modernization
       rule: "PathPrefix(`/`)"
     # Base /nbs forward
@@ -10,12 +16,12 @@ http:
       rule: "PathPrefix(`/nbs`)"
     # NBS to modernization overrides
     simpleSearch:
-      service: modernization
+      service: modernization-api
       rule: "Path(`/nbs/HomePage.do`) && Query(`method=patientSearchSubmit`)"
       middlewares:
         - "simpleSearchRewritepath"
     advancedSearch:
-      service: modernization
+      service: modernization-api
       middlewares:
         - "advancedSearchRewritepath"
       rule: "Path(`/nbs/MyTaskList1.do`)&& Query(`ContextAction=GlobalPatient`)"
@@ -31,10 +37,14 @@ http:
       replacePath:
         path: /nbs/redirect/advancedSearch
   services:
+    modernization-api:
+      loadBalancer:
+        servers:
+          - url: 'http://{{ env "MODERNIZATION_API_SERVER" | default "modernization-api" }}:{{ env "MODERNIZATION_API_PORT" | default "8080" }}/'
     modernization:
       loadBalancer:
         servers:
-          - url: "http://modernization-api:8080/"
+          - url: 'http://{{ env "MODERNIZATION_UI_SERVER" | default "modernization-api" }}:{{ env "MODERNIZATION_UI_PORT" | default "8080" }}/'
     nbs:
       loadBalancer:
         servers:


### PR DESCRIPTION
Changes the sandbox reverse proxy to resolve the host name of the `modernization-api` and `modernization-ui` from environment variables.  This would allow routing from sandboxed reverse proxy to a locally running `modernization-api` and `modernization-ui` instance.

For example, if the `modernization-api` was started locally as follows;

```shell
./gradlew :modernization-api:bootRun --args='--server.port=9080'
```

then starting the reverse proxy by running this command from the `cdc-sandbox` folder

```shell
MODERNIZATION_API_SERVER=host.docker.internal MODERNIZATION_API_PORT=9080 docker compose up -d reverse-proxy
```

---

Details on the configuration (and how to reset to defaults) have been added to the [README](https://github.com/CDCgov/NEDSS-Modernization/tree/configurable_traefik#configuring-the-reverse-proxy-to-use-local-modernization-api).