### PR TITLE
corrects name of request topic property

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/kafka/KafkaProducer.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/kafka/KafkaProducer.java
@@ -16,7 +16,7 @@ public class KafkaProducer {
     @Autowired
     private KafkaTemplate<String, PatientRequest> kafkaPatientEventTemplate;
 
-    @Value("${kafkadef.topics.request.patient}")
+    @Value("${kafkadef.topics.patient.request}")
     private String patientTopic;
 
     public void requestPatientEventEnvelope(final PatientRequest request) {


### PR DESCRIPTION
The property `kafkadef.topics.request.patient` was renamed to `kafkadef.topics.patient.request` the change in `KafkaProducer` may have been lost in a merge.