### PR TITLE
Add  to @ApiImplicitParam annotations

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/EncryptionController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/EncryptionController.java
@@ -17,13 +17,23 @@ public class EncryptionController {
     private final EncryptionService encryptionService;
 
     @PostMapping("/encrypt")
-    @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+    @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     public EncryptionResponse encrypt(@RequestBody Object object) {
         return new EncryptionResponse(encryptionService.handleEncryption(object));
     }
 
     @PostMapping("/decrypt")
-    @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+    @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     public Object decrypt(@RequestBody String encryptedString) {
         return encryptionService.handleDecryption(encryptedString);
     }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/ExportController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/ExportController.java
@@ -33,7 +33,12 @@ public class ExportController {
 
     @PostMapping(value = "/investigation/export/pdf", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_PDF_VALUE)
-    @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+    @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     public ResponseEntity<byte[]> generateInvestigationPdf(@RequestBody InvestigationFilter filter)
             throws DocumentException, IOException {
         var investigations = investigationFinder.find(filter, Pageable.ofSize(MAX_EXPORT_SIZE));
@@ -49,7 +54,12 @@ public class ExportController {
     }
 
     @PostMapping("/investigation/export/csv")
-    @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+    @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     public ResponseEntity<String> generateInvestigationCsv(@RequestBody InvestigationFilter filter) {
         var investigations = investigationFinder.find(filter, Pageable.ofSize(MAX_EXPORT_SIZE));
         var csv = exportService.generateInvestigationCsv(investigations);
@@ -65,7 +75,12 @@ public class ExportController {
 
     @PostMapping(value = "/labreport/export/pdf", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_PDF_VALUE)
-    @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+    @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     public ResponseEntity<byte[]> generateLabReportPdf(@RequestBody LabReportFilter filter)
             throws DocumentException, IOException {
         var labReports = labReportFinder.find(filter, Pageable.ofSize(MAX_EXPORT_SIZE));
@@ -79,7 +94,12 @@ public class ExportController {
     }
 
     @PostMapping("/labreport/export/csv")
-    @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+    @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     public ResponseEntity<String> generateLabReportCsv(@RequestBody LabReportFilter filter) {
         var labReports = labReportFinder.find(filter, Pageable.ofSize(MAX_EXPORT_SIZE));
         var csv = exportService.generateLabReportCsv(labReports);

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/RedirectController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/RedirectController.java
@@ -77,7 +77,12 @@ public class RedirectController {
    * to set up the session variables so that we can navigate directly to Add Patient or Patient Details pages
    */
   @GetMapping("/preparePatientDetails")
-  @ApiImplicitParam(name = "Authorization", required = true, allowEmptyValue = false, paramType = "header")
+  @ApiImplicitParam(
+            name = "Authorization",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
   public void preparePatientDetails(HttpServletRequest request) {
     String url = wildFlyUrl + "/nbs/HomePage.do?method=patientSearchSubmit";
     // copy cookie header that contains the JSESSIONID from the original request


### PR DESCRIPTION
This PR fixes some startup warnings by adding the `dataTypeClass` to `@ApiImplicitParam` annotations.


The warnings:
![image](https://user-images.githubusercontent.com/109251240/229911749-62205d61-c611-41d2-a6bf-1284a3dbd358.png)


