### PR TITLE
CNFT1 693 documents table api

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.patient.document;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.enums.RecordStatus;
@@ -96,7 +98,8 @@ class PatientDocumentFinder {
             .leftJoin(INVESTIGATION).on(
                 INVESTIGATION.id.eq(RELATIONSHIP.id.targetActUid),
                 INVESTIGATION.recordStatusCd.ne(DELETED)
-            );
+            )
+            .orderBy(new OrderSpecifier<>(Order.DESC, DOCUMENT.addTime));
     }
 
     private PatientDocument map(final Tuple tuple) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentFinder.java
@@ -1,10 +1,18 @@
 package gov.cdc.nbs.patient.document;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.enums.RecordStatus;
-import gov.cdc.nbs.entity.odse.*;
+import gov.cdc.nbs.entity.odse.QActRelationship;
+import gov.cdc.nbs.entity.odse.QNbsDocument;
+import gov.cdc.nbs.entity.odse.QParticipation;
+import gov.cdc.nbs.entity.odse.QPerson;
+import gov.cdc.nbs.entity.odse.QPublicHealthCase;
 import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -14,29 +22,39 @@ import java.util.Objects;
 @Component
 class PatientDocumentFinder {
 
-  private static final QPublicHealthCase INVESTIGATION = new QPublicHealthCase("investigation");
-  private static final QPerson PATIENT = QPerson.person;
-  private static final QParticipation PARTICIPATION = QParticipation.participation;
-  private static final QNbsDocument DOCUMENT = QNbsDocument.nbsDocument;
-  private static final QCodeValueGeneral DOCUMENT_TYPE = QCodeValueGeneral.codeValueGeneral;
-  private static final QActRelationship RELATIONSHIP = QActRelationship.actRelationship;
-  private static final String DELETED = "LOG_DEL";
-  private static final String SUBJECT_OF_DOCUMENT = "SubjOfDoc";
-  private static final String DOCUMENT_TYPE_CODE_NAME_SET = "PUBLIC_HEALTH_EVENT";
-  private static final String PERSON_CLASS = "PSN";
-  private static final String DOCUMENT_CLASS = "DOC";
-  private static final String INVESTIGATION_CLASS = "CASE";
-  public static final String UPDATED_MODIFIER = "(Updated)";
+    private static final QPublicHealthCase INVESTIGATION = new QPublicHealthCase("investigation");
+    private static final QPerson PATIENT = QPerson.person;
+    private static final QParticipation PARTICIPATION = QParticipation.participation;
+    private static final QNbsDocument DOCUMENT = QNbsDocument.nbsDocument;
+    private static final QCodeValueGeneral DOCUMENT_TYPE = QCodeValueGeneral.codeValueGeneral;
+    private static final QActRelationship RELATIONSHIP = QActRelationship.actRelationship;
+    private static final String DELETED = "LOG_DEL";
+    private static final String SUBJECT_OF_DOCUMENT = "SubjOfDoc";
+    private static final String DOCUMENT_TYPE_CODE_NAME_SET = "PUBLIC_HEALTH_EVENT";
+    private static final String PERSON_CLASS = "PSN";
+    private static final String DOCUMENT_CLASS = "DOC";
+    private static final String INVESTIGATION_CLASS = "CASE";
+    public static final String UPDATED_MODIFIER = "(Updated)";
 
-  private final JPAQueryFactory factory;
+    private final JPAQueryFactory factory;
 
 
-  PatientDocumentFinder(final JPAQueryFactory factory) {
-    this.factory = factory;
-  }
+    PatientDocumentFinder(final JPAQueryFactory factory) {
+        this.factory = factory;
+    }
 
-  List<PatientDocument> find(final long patient) {
-    return this.factory.selectDistinct(
+    List<PatientDocument> find(final long patient) {
+        return applyCriteria(
+            selection(),
+            patient
+        ).fetch()
+            .stream()
+            .map(this::map)
+            .toList();
+    }
+
+    private JPAQuery<Tuple> selection() {
+        return this.factory.selectDistinct(
             DOCUMENT.id,
             DOCUMENT.addTime,
             DOCUMENT_TYPE.codeShortDescTxt,
@@ -46,78 +64,109 @@ class PatientDocumentFinder {
             DOCUMENT.externalVersionCtrlNbr,
             INVESTIGATION.id,
             INVESTIGATION.localId
-        ).from(PATIENT)
-        .join(PARTICIPATION).on(
-            PARTICIPATION.id.subjectEntityUid.eq(PATIENT.id),
-            PARTICIPATION.id.typeCd.eq(SUBJECT_OF_DOCUMENT),
-            PARTICIPATION.actClassCd.eq(DOCUMENT_CLASS),
-            PARTICIPATION.subjectClassCd.eq(PERSON_CLASS),
-            PARTICIPATION.recordStatusCd.eq(RecordStatus.ACTIVE)
+        );
+    }
+
+    private <R> JPAQuery<R> applyBaseCriteria(final JPAQuery<R> query, final long patient) {
+        return query.from(PATIENT)
+            .join(PARTICIPATION).on(
+                PARTICIPATION.id.subjectEntityUid.eq(PATIENT.id),
+                PARTICIPATION.id.typeCd.eq(SUBJECT_OF_DOCUMENT),
+                PARTICIPATION.actClassCd.eq(DOCUMENT_CLASS),
+                PARTICIPATION.subjectClassCd.eq(PERSON_CLASS),
+                PARTICIPATION.recordStatusCd.eq(RecordStatus.ACTIVE)
+            )
+            .join(DOCUMENT).on(
+                DOCUMENT.id.eq(PARTICIPATION.id.actUid),
+                DOCUMENT.recordStatusCd.ne(DELETED)
+            )
+            .join(DOCUMENT_TYPE).on(
+                DOCUMENT_TYPE.id.codeSetNm.eq(DOCUMENT_TYPE_CODE_NAME_SET),
+                DOCUMENT_TYPE.id.code.eq(DOCUMENT.docTypeCd)
+            )
+            .where(PATIENT.personParentUid.id.eq(patient));
+    }
+
+    private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
+        return applyBaseCriteria(query, patient)
+            .leftJoin(RELATIONSHIP).on(
+                RELATIONSHIP.targetClassCd.eq(INVESTIGATION_CLASS),
+                RELATIONSHIP.sourceClassCd.eq(DOCUMENT_CLASS)
+            )
+            .leftJoin(INVESTIGATION).on(
+                INVESTIGATION.id.eq(RELATIONSHIP.id.targetActUid),
+                INVESTIGATION.recordStatusCd.ne(DELETED)
+            );
+    }
+
+    private PatientDocument map(final Tuple tuple) {
+        Long identifier = Objects.requireNonNull(tuple.get(DOCUMENT.id), "A document id is required.");
+        Instant added = tuple.get(DOCUMENT.addTime);
+        String type = tuple.get(DOCUMENT_TYPE.codeShortDescTxt);
+        String sendingFacility = tuple.get(DOCUMENT.sendingFacilityNm);
+        String condition = tuple.get(DOCUMENT.cdDescTxt);
+        String localId = tuple.get(DOCUMENT.localId);
+        Short version = tuple.get(DOCUMENT.externalVersionCtrlNbr);
+
+        String event = resolveEvent(localId, version);
+
+        PatientDocument.Investigation investigation = maybeMapInvestigation(tuple);
+
+        return new PatientDocument(
+            identifier,
+            added,
+            type,
+            sendingFacility,
+            added,
+            condition,
+            event,
+            investigation
+        );
+    }
+
+    private String resolveEvent(final String localId, final Short version) {
+        return version != null && version > 1
+            ? localId + UPDATED_MODIFIER
+            : localId;
+    }
+
+    private PatientDocument.Investigation maybeMapInvestigation(final Tuple tuple) {
+        Long identifier = tuple.get(INVESTIGATION.id);
+        String local = tuple.get(INVESTIGATION.localId);
+
+        return identifier == null
+            ? null
+            : new PatientDocument.Investigation(
+            identifier,
+            local
+        );
+    }
+
+    Page<PatientDocument> find(final long patient, final Pageable pageable) {
+        long total = resolveTotal(patient);
+
+        return total > 0
+            ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
+            : Page.empty(pageable);
+    }
+
+    private long resolveTotal(final long patient) {
+        Long total = applyBaseCriteria(factory.selectDistinct(DOCUMENT.countDistinct()), patient)
+            .fetchOne();
+        return total == null ? 0L : total;
+    }
+
+    private List<PatientDocument> resolvePage(final long patient, final Pageable pageable) {
+        return applyCriteria(
+            selection(),
+            patient
         )
-        .join(DOCUMENT).on(
-            DOCUMENT.id.eq(PARTICIPATION.id.actUid),
-            DOCUMENT.recordStatusCd.ne(DELETED)
-        )
-        .join(DOCUMENT_TYPE).on(
-            DOCUMENT_TYPE.id.codeSetNm.eq(DOCUMENT_TYPE_CODE_NAME_SET),
-            DOCUMENT_TYPE.id.code.eq(DOCUMENT.docTypeCd)
-        )
-        .leftJoin(RELATIONSHIP).on(
-            RELATIONSHIP.targetClassCd.eq(INVESTIGATION_CLASS),
-            RELATIONSHIP.sourceClassCd.eq(DOCUMENT_CLASS)
-        )
-        .leftJoin(INVESTIGATION).on(
-            INVESTIGATION.id.eq(RELATIONSHIP.id.targetActUid),
-            INVESTIGATION.recordStatusCd.ne(DELETED)
-        )
-        .where(PATIENT.personParentUid.id.eq(patient))
-        .fetch()
-        .stream()
-        .map(this::map)
-        .toList()
-        ;
-  }
-
-  private PatientDocument map(final Tuple tuple) {
-    Long identifier = Objects.requireNonNull(tuple.get(DOCUMENT.id), "A document id is required.");
-    Instant added = tuple.get(DOCUMENT.addTime);
-    String type = tuple.get(DOCUMENT_TYPE.codeShortDescTxt);
-    String sendingFacility = tuple.get(DOCUMENT.sendingFacilityNm);
-    String condition = tuple.get(DOCUMENT.cdDescTxt);
-    String localId = tuple.get(DOCUMENT.localId);
-    Short version = tuple.get(DOCUMENT.externalVersionCtrlNbr);
-
-    String event = resolveEvent(localId, version);
-
-    PatientDocument.Investigation investigation = maybeMapInvestigation(tuple);
-
-    return new PatientDocument(
-        identifier,
-        added,
-        type,
-        sendingFacility,
-        added,
-        condition,
-        event,
-        investigation
-    );
-  }
-
-  private String resolveEvent(final String localId, final Short version) {
-    return version != null && version > 1
-        ? localId + UPDATED_MODIFIER
-        : localId;
-  }
-
-  private PatientDocument.Investigation maybeMapInvestigation(final Tuple tuple) {
-    Long identifier = tuple.get(INVESTIGATION.id);
-    String local = tuple.get(INVESTIGATION.localId);
-
-    return identifier == null
-        ? null
-        : new PatientDocument.Investigation(
-        identifier,
-        local
-    );
-  }
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch()
+            .stream()
+            .map(this::map)
+            .toList()
+            ;
+    }
 }

--- a/apps/modernization-api/src/main/resources/graphql/patient-document.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-document.graphqls
@@ -1,19 +1,25 @@
 type PatientDocument {
-  document: ID!
-  receivedOn: DateTime!
-  type: String!
-  sendingFacility: String!
-  reportedOn: DateTime!
-  condition: String
-  event: String!
-  associatedWith: PatientDocumentInvestigation
+    document: ID!
+    receivedOn: DateTime!
+    type: String!
+    sendingFacility: String!
+    reportedOn: DateTime!
+    condition: String
+    event: String!
+    associatedWith: PatientDocumentInvestigation
 }
 
 type PatientDocumentInvestigation {
-  id: ID!
-  local: String!
+    id: ID!
+    local: String!
+}
+
+type PatientDocumentResults {
+    content: [PatientDocument]!
+    total: Int!
+    number: Int!
 }
 
 extend type Query {
-  findDocumentsForPatient(patient: ID!): [PatientDocument]
+    findDocumentsForPatient(patient: ID!, page: Page): PatientDocumentResults
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
@@ -1,10 +1,12 @@
 package gov.cdc.nbs.patient.document;
 
+import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.patient.TestPatients;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,48 +18,56 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional
 public class PatientDocumentSteps {
 
-  @Autowired
-  TestPatients patients;
+    @Autowired
+    TestPatients patients;
 
-  @Autowired
-  PatientDocumentByPatientResolver resolver;
+    @Autowired
+    PatientDocumentByPatientResolver resolver;
 
-  @Autowired
-  DocumentMother mother;
+    @Autowired
+    DocumentMother mother;
 
-  @Before
-  public void clean() {
-    mother.reset();
-  }
+    @Before
+    public void clean() {
+        mother.reset();
+    }
 
-  @When("the patient has a Case Report")
-  public void the_patient_has_a_Case_Report() {
-    long patient = this.patients.one();
-    this.mother.caseReport(patient);
-  }
+    @When("the patient has a Case Report")
+    public void the_patient_has_a_Case_Report() {
+        long patient = this.patients.one();
+        this.mother.caseReport(patient);
+    }
 
 
-  @Then("the profile has an associated document")
-  public void the_profile_has_an_associated_document() {
-    long patient = this.patients.one();
+    @Then("the profile has an associated document")
+    public void the_profile_has_an_associated_document() {
+        long patient = this.patients.one();
 
-    List<PatientDocument> actual = this.resolver.find(patient);
-    assertThat(actual).isNotEmpty();
-  }
+        Page<PatientDocument> actual = this.resolver.find(patient, new GraphQLPage(1));
+        assertThat(actual).isNotEmpty();
+    }
 
-  @Then("the profile documents are not returned")
-  public void the_profile_documents_are_not_returned() {
-    long patient = this.patients.one();
+    @Then("the profile documents are not returned")
+    public void the_profile_documents_are_not_returned() {
+        long patient = this.patients.one();
 
-    assertThatThrownBy(() -> this.resolver.find(patient))
-        .isInstanceOf(AccessDeniedException.class);
-  }
 
-  @Then("the profile has no associated document")
-  public void the_profile_has_no_associated_document() {
-    long patient = this.patients.one();
+        GraphQLPage page = new GraphQLPage(1);
 
-    List<PatientDocument> actual = this.resolver.find(patient);
-    assertThat(actual).isEmpty();
-  }
+        assertThatThrownBy(
+            () -> this.resolver.find(
+                patient,
+                page
+            )
+        )
+            .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Then("the profile has no associated document")
+    public void the_profile_has_no_associated_document() {
+        long patient = this.patients.one();
+
+        Page<PatientDocument> actual = this.resolver.find(patient, new GraphQLPage(1));
+        assertThat(actual).isEmpty();
+    }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
@@ -10,8 +10,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/apps/modernization-ui/src/components/Table/Table.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.tsx
@@ -25,6 +25,7 @@ export type TableContentProps = {
     tableHead: { name: string; sortable: boolean }[];
     tableBody: TableBody[];
     isPagination?: boolean;
+    pageSize?: number;
     totalResults?: number;
     currentPage?: number;
     handleNext?: (page: number) => void;
@@ -38,6 +39,7 @@ export const TableComponent = ({
     tableHead,
     tableBody,
     isPagination = false,
+    pageSize = TOTAL_TABLE_DATA,
     totalResults = 20,
     currentPage = 1,
     handleNext,
@@ -158,12 +160,12 @@ export const TableComponent = ({
             </Table>
             <div className="padding-2 padding-top-0 grid-row flex-align-center flex-justify">
                 <p className="margin-0 show-length-text">
-                    Showing {tableBody?.length} of {tableBody?.length}
+                    Showing {tableBody?.length} of {totalResults}
                 </p>
-                {isPagination && tableBody?.length >= TOTAL_TABLE_DATA && (
+                {isPagination && totalResults >= pageSize && (
                     <Pagination
                         className="margin-0 pagination"
-                        totalPages={Math.ceil(totalResults / TOTAL_TABLE_DATA)}
+                        totalPages={Math.ceil(totalResults / pageSize)}
                         currentPage={currentPage}
                         pathname={'/patient-profile'}
                         onClickNext={() => handleNext?.(currentPage + 1)}

--- a/apps/modernization-ui/src/components/Table/Table.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.tsx
@@ -34,6 +34,9 @@ export type TableContentProps = {
     handleAction?: (type: string, data: any) => void;
 };
 
+const renderTitle = (detail: TableDetail) =>
+    detail.link ? <a href={detail.link}>{detail.title}</a> : <>{detail.title}</>;
+
 export const TableComponent = ({
     tableHeader,
     tableHead,
@@ -88,7 +91,7 @@ export const TableComponent = ({
                     {tableBody?.length > 0 ? (
                         tableBody.map((item: any, index) => (
                             <tr key={index}>
-                                {item.tableDetails.map((td: any, ind: number) =>
+                                {item.tableDetails.map((td: TableDetail, ind: number) =>
                                     td.title ? (
                                         td.title === 'Not available yet' ? (
                                             <td key={ind} className="font-sans-md no-data table-data">
@@ -117,7 +120,7 @@ export const TableComponent = ({
                                                                 ? td.class
                                                                 : 'table-span'
                                                         }>
-                                                        {td.title}
+                                                        {renderTitle(td)}
                                                     </span>
                                                 )}
                                                 {td?.type === 'actions' && (

--- a/apps/modernization-ui/src/generated/gql/queries/findDocumentsForPatient.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findDocumentsForPatient.gql
@@ -1,15 +1,19 @@
-query findDocumentsForPatient($patient: ID!){
-    findDocumentsForPatient(patient: $patient){
-        document
-        receivedOn
-        type
-        sendingFacility
-        reportedOn
-        condition
-        event
-        associatedWith{
-            id
-            local
+query findDocumentsForPatient($patient: ID!, $page: Page){
+    findDocumentsForPatient(patient: $patient, page: $page){
+        content{
+            document
+            receivedOn
+            type
+            sendingFacility
+            reportedOn
+            condition
+            event
+            associatedWith{
+                id
+                local
+            }
         }
+        total
+        number
     }
 }

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -731,6 +731,13 @@ export type PatientDocumentInvestigation = {
   local: Scalars['String'];
 };
 
+export type PatientDocumentResults = {
+  __typename?: 'PatientDocumentResults';
+  content: Array<Maybe<PatientDocument>>;
+  number: Scalars['Int'];
+  total: Scalars['Int'];
+};
+
 export type PatientEventResponse = {
   __typename?: 'PatientEventResponse';
   patientId: Scalars['ID'];
@@ -1159,7 +1166,7 @@ export type Query = {
   findAllStateCodes: Array<Maybe<StateCode>>;
   findAllUsers: UserResults;
   findContactsNamedByPatient?: Maybe<ContactsNamedByPatientResults>;
-  findDocumentsForPatient?: Maybe<Array<Maybe<PatientDocument>>>;
+  findDocumentsForPatient?: Maybe<PatientDocumentResults>;
   findDocumentsRequiringReviewForPatient: LabReportResults;
   findInvestigationsByFilter: InvestigationResults;
   findLabReportsByFilter: LabReportResults;
@@ -1259,6 +1266,7 @@ export type QueryFindContactsNamedByPatientArgs = {
 
 
 export type QueryFindDocumentsForPatientArgs = {
+  page?: InputMaybe<Page>;
   patient: Scalars['ID'];
 };
 
@@ -1646,10 +1654,11 @@ export type FindContactsNamedByPatientQuery = { __typename?: 'Query', findContac
 
 export type FindDocumentsForPatientQueryVariables = Exact<{
   patient: Scalars['ID'];
+  page?: InputMaybe<Page>;
 }>;
 
 
-export type FindDocumentsForPatientQuery = { __typename?: 'Query', findDocumentsForPatient?: Array<{ __typename?: 'PatientDocument', document: string, receivedOn: any, type: string, sendingFacility: string, reportedOn: any, condition?: string | null, event: string, associatedWith?: { __typename?: 'PatientDocumentInvestigation', id: string, local: string } | null } | null> | null };
+export type FindDocumentsForPatientQuery = { __typename?: 'Query', findDocumentsForPatient?: { __typename?: 'PatientDocumentResults', total: number, number: number, content: Array<{ __typename?: 'PatientDocument', document: string, receivedOn: any, type: string, sendingFacility: string, reportedOn: any, condition?: string | null, event: string, associatedWith?: { __typename?: 'PatientDocumentInvestigation', id: string, local: string } | null } | null> } | null };
 
 export type FindDocumentsRequiringReviewForPatientQueryVariables = Exact<{
   patientId: Scalars['Int'];
@@ -2835,19 +2844,23 @@ export type FindContactsNamedByPatientQueryHookResult = ReturnType<typeof useFin
 export type FindContactsNamedByPatientLazyQueryHookResult = ReturnType<typeof useFindContactsNamedByPatientLazyQuery>;
 export type FindContactsNamedByPatientQueryResult = Apollo.QueryResult<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>;
 export const FindDocumentsForPatientDocument = gql`
-    query findDocumentsForPatient($patient: ID!) {
-  findDocumentsForPatient(patient: $patient) {
-    document
-    receivedOn
-    type
-    sendingFacility
-    reportedOn
-    condition
-    event
-    associatedWith {
-      id
-      local
+    query findDocumentsForPatient($patient: ID!, $page: Page) {
+  findDocumentsForPatient(patient: $patient, page: $page) {
+    content {
+      document
+      receivedOn
+      type
+      sendingFacility
+      reportedOn
+      condition
+      event
+      associatedWith {
+        id
+        local
+      }
     }
+    total
+    number
   }
 }
     `;
@@ -2865,6 +2878,7 @@ export const FindDocumentsForPatientDocument = gql`
  * const { data, loading, error } = useFindDocumentsForPatientQuery({
  *   variables: {
  *      patient: // value for 'patient'
+ *      page: // value for 'page'
  *   },
  * });
  */

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -589,23 +589,29 @@ extend type Query {
   findPatientNamedByContact(patient:ID!, page: Page) : PatientNamedByContactResults
 }
 type PatientDocument {
-  document: ID!
-  receivedOn: DateTime!
-  type: String!
-  sendingFacility: String!
-  reportedOn: DateTime!
-  condition: String
-  event: String!
-  associatedWith: PatientDocumentInvestigation
+    document: ID!
+    receivedOn: DateTime!
+    type: String!
+    sendingFacility: String!
+    reportedOn: DateTime!
+    condition: String
+    event: String!
+    associatedWith: PatientDocumentInvestigation
 }
 
 type PatientDocumentInvestigation {
-  id: ID!
-  local: String!
+    id: ID!
+    local: String!
+}
+
+type PatientDocumentResults {
+    content: [PatientDocument]!
+    total: Int!
+    number: Int!
 }
 
 extend type Query {
-  findDocumentsForPatient(patient: ID!): [PatientDocument]
+    findDocumentsForPatient(patient: ID!, page: Page): PatientDocumentResults
 }
 type PatientMorbidity {
     morbidity: ID!

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/SearchCriteria.spec.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/SearchCriteria.spec.tsx
@@ -4,9 +4,36 @@ import { useForm } from 'react-hook-form';
 import { SearchCriteria } from './SearchCriteria';
 
 describe('SearchCriteria component tests', () => {
+    it('should render the expected Investigation status', () => {
+        const { result } = renderHook(() => useForm());
+        const { container, getAllByTestId } = render(<SearchCriteria control={result.current.control} />);
+
+        const investigationStatus = container.querySelectorAll('select[name="investigationStatus"] option');
+
+        expect(investigationStatus).toHaveLength(3);
+        expect(investigationStatus[0]).toHaveValue('- Select -');
+
+        expect(investigationStatus[1]).toHaveTextContent('Closed');
+        expect(investigationStatus[1]).toHaveValue('CLOSED');
+
+        expect(investigationStatus[2]).toHaveTextContent('Open');
+        expect(investigationStatus[2]).toHaveValue('OPEN');
+    });
+
+    it('should render the expected Outbreak Names', () => {
+        const { result } = renderHook(() => useForm());
+        const { container, getAllByTestId } = render(<SearchCriteria control={result.current.control} />);
+
+        const outBreakNames = container.querySelectorAll('select[name="outbreakNames"] option');
+
+        expect(outBreakNames).toHaveLength(1);
+        expect(outBreakNames[0]).toHaveValue('- Select -');
+    });
+
     it('should render the expected labels', () => {
         const { result } = renderHook(() => useForm());
         const { getAllByTestId } = render(<SearchCriteria control={result.current.control} />);
+
         const labelTexts = [
             'Investigation status',
             'Outbreak name',
@@ -14,6 +41,21 @@ describe('SearchCriteria component tests', () => {
             'Current processing status',
             'Notification status'
         ];
+
+        const labels = getAllByTestId('label');
+
+        // Should have expected labels
+        labelTexts.forEach((text, idx) => {
+            expect(labels[idx]).toHaveTextContent(text);
+        });
+    });
+
+    xit('should render the expected dropdown values', () => {
+        const { result } = renderHook(() => useForm());
+        const { getAllByTestId } = render(<SearchCriteria control={result.current.control} />);
+
+        //  These tests were added before Case Status, Processing Status, and Notification Status
+        // were switched to multi-selects however, the PR was merged after causing this test to be out of sync with the implementation.
         const dropdownOptions = [
             ['Closed', 'Open'],
             [''],
@@ -28,13 +70,8 @@ describe('SearchCriteria component tests', () => {
             ],
             ['Approved', 'Completed', 'Message Failed', 'Pending Approval', 'Rejected']
         ];
-        const labels = getAllByTestId('label');
-        const dropdowns = getAllByTestId('dropdown');
 
-        // Should have expected labels
-        labelTexts.forEach((text, idx) => {
-            expect(labels[idx]).toHaveTextContent(text);
-        });
+        const dropdowns = getAllByTestId('dropdown');
 
         // should have expected dropdowns each with correct options
         dropdownOptions.forEach((optionsExpected, dropdownIdx) => {

--- a/apps/modernization-ui/src/pages/patientProfile/Events.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/Events.tsx
@@ -3,7 +3,6 @@ import { TableBody, TableComponent } from '../../components/Table/Table';
 import { Button, Icon } from '@trussworks/react-uswds';
 import {
     AssociatedInvestigation,
-    FindDocumentsForPatientQuery,
     FindInvestigationsByFilterQuery,
     FindLabReportsByFilterQuery,
     FindMorbidityReportsForPatientQuery,
@@ -16,17 +15,18 @@ import { UserContext } from 'providers/UserContext';
 import { Config } from 'config';
 import { PatientTreatmentTable } from 'patient/profile/treatment';
 import { PatientNamedByContactTable, ContactNamedByPatientTable } from 'patient/profile/contact';
+import { PatientDocumentTable } from 'patient/profile/document';
+import { TOTAL_TABLE_DATA } from 'utils/util';
 
 type EventTabProp = {
     patient: string | undefined;
     investigationData?: FindInvestigationsByFilterQuery['findInvestigationsByFilter'];
     labReports?: FindLabReportsByFilterQuery['findLabReportsByFilter'] | undefined;
     morbidityData?: FindMorbidityReportsForPatientQuery['findMorbidityReportsForPatient'] | undefined;
-    documentsData?: FindDocumentsForPatientQuery['findDocumentsForPatient'] | undefined;
     profileData?: any;
 };
 
-export const Events = ({ patient, investigationData, labReports, morbidityData, documentsData }: EventTabProp) => {
+export const Events = ({ patient, investigationData, labReports, morbidityData }: EventTabProp) => {
     const { state } = useContext(UserContext);
     const NBS_URL = Config.nbsUrl;
 
@@ -249,10 +249,7 @@ export const Events = ({ patient, investigationData, labReports, morbidityData, 
             getMorbidityData(morbidityData);
             setMorbidities(morbidityData);
         }
-        if (documentsData) {
-            console.log('documentsData:', documentsData);
-        }
-    }, [investigationData, labReports, morbidityData, documentsData]);
+    }, [investigationData, labReports, morbidityData]);
 
     const sortInvestigationData = (name: string, type: string) => {
         getData(
@@ -505,20 +502,7 @@ export const Events = ({ patient, investigationData, labReports, morbidityData, 
                 <PatientTreatmentTable patient={patient} />
             </div>
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-                <TableComponent
-                    isPagination={true}
-                    tableHeader={'Documents'}
-                    tableHead={[
-                        { name: 'Date created', sortable: true },
-                        { name: 'Type', sortable: true },
-                        { name: 'Purpose', sortable: true },
-                        { name: 'Description', sortable: true },
-                        { name: 'Document ID', sortable: false }
-                    ]}
-                    tableBody={[]}
-                    currentPage={currentPage}
-                    handleNext={(e) => setCurrentPage(e)}
-                />
+                <PatientDocumentTable patient={patient} pageSize={TOTAL_TABLE_DATA} />
             </div>
 
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">

--- a/apps/modernization-ui/src/pages/patientProfile/Events.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/Events.tsx
@@ -502,7 +502,7 @@ export const Events = ({ patient, investigationData, labReports, morbidityData }
                 <PatientTreatmentTable patient={patient} />
             </div>
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-                <PatientDocumentTable patient={patient} pageSize={TOTAL_TABLE_DATA} />
+                <PatientDocumentTable patient={patient} pageSize={TOTAL_TABLE_DATA} nbsBase={NBS_URL} />
             </div>
 
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">

--- a/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
@@ -17,7 +17,6 @@ import { RedirectControllerService } from 'generated';
 import { UserContext } from 'providers/UserContext';
 import {
     FindPatientsByFilterQuery,
-    useFindDocumentsForPatientLazyQuery,
     useFindInvestigationsByFilterLazyQuery,
     useFindLabReportsByFilterLazyQuery,
     useFindMorbidityReportsForPatientLazyQuery,
@@ -45,9 +44,7 @@ export const PatientProfile = () => {
 
     const [getPatientInvestigationData, { data: investigationData }] = useFindInvestigationsByFilterLazyQuery();
     const [getPatientLabReportData, { data: labReportData }] = useFindLabReportsByFilterLazyQuery();
-    // const [getPatientProfileData, { data: patientProfileData }] = useFindPatientsByFilterLazyQuery();
     const [getMorbidityData, { data: morbidityData }] = useFindMorbidityReportsForPatientLazyQuery();
-    const [getDocumentsData, { data: documentsData }] = useFindDocumentsForPatientLazyQuery();
 
     const [getPatientProfileDataById, { data: patientProfileData }] = useFindPatientByIdLazyQuery();
 
@@ -100,11 +97,6 @@ export const PatientProfile = () => {
                     }
                 });
                 getMorbidityData({
-                    variables: {
-                        patient: patientProfileData.findPatientById.id
-                    }
-                });
-                getDocumentsData({
                     variables: {
                         patient: patientProfileData.findPatientById.id
                     }
@@ -338,7 +330,6 @@ export const PatientProfile = () => {
                         investigationData={investigationData?.findInvestigationsByFilter}
                         labReports={labReportData?.findLabReportsByFilter}
                         morbidityData={morbidityData?.findMorbidityReportsForPatient}
-                        documentsData={documentsData?.findDocumentsForPatient}
                     />
                 )}
                 {activeTab === ACTIVE_TAB.DEMOGRAPHICS && (

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.spec.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.spec.ts
@@ -1,0 +1,391 @@
+import { Direction } from 'sorting';
+import { sort } from './PatientDocumentSorter';
+import { Headers } from './PatientDocuments';
+
+describe('when sorting documents', () => {
+    it('should default sorting to by id', () => {
+        const documents = [
+            {
+                document: '1583',
+                receivedOn: new Date('2021-10-07T15:01:10Z'),
+                type: 'type',
+                sendingFacility: 'sending-facility',
+                reportedOn: new Date('2021-09-21T17:04:11Z'),
+                event: 'event'
+            },
+            {
+                document: '617',
+                receivedOn: new Date('2021-10-07T15:01:10Z'),
+                type: 'type',
+                sendingFacility: 'sending-facility',
+                reportedOn: new Date('2021-09-21T17:04:11Z'),
+                event: 'event'
+            },
+            {
+                document: '727',
+                receivedOn: new Date('2021-10-07T15:01:10Z'),
+                type: 'type',
+                sendingFacility: 'sending-facility',
+                reportedOn: new Date('2021-09-21T17:04:11Z'),
+                event: 'event'
+            }
+        ];
+
+        const actual = sort(documents, {});
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '1583' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Date received', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'document-type-value',
+            sendingFacility: 'sending-facility-value',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event-value'
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2023-08-15T00:00:00Z'),
+            type: 'document-type-other',
+            sendingFacility: 'sending-facility-other',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2022-03-05T01:41:47Z'),
+            type: 'document-type-other',
+            sendingFacility: 'sending-facility-other',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.DateReceived, type: Direction.Ascending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.DateReceived, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Type', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'B',
+            sendingFacility: 'sending-facility-value',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event-value'
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2023-08-15T00:00:00Z'),
+            type: 'C',
+            sendingFacility: 'sending-facility-other',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2022-03-05T01:41:47Z'),
+            type: 'A',
+            sendingFacility: 'sending-facility-other',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.Type, type: Direction.Ascending });
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.Type, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Sending facility', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'document-type-value',
+            sendingFacility: 'B',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event-value'
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2023-08-15T00:00:00Z'),
+            type: 'document-type-other',
+            sendingFacility: 'C',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2022-03-05T01:41:47Z'),
+            type: 'document-type-other',
+            sendingFacility: 'A',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.SendingFacility, type: Direction.Ascending });
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.SendingFacility, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Date reported', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'document-type-value',
+            sendingFacility: 'sending-facility-value',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event-value'
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2023-08-15T00:00:00Z'),
+            type: 'document-type-other',
+            sendingFacility: 'sending-facility-other',
+            reportedOn: new Date('2023-12-15T23:04:00Z'),
+            event: 'event-other'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2022-03-05T01:41:47Z'),
+            type: 'document-type-other',
+            sendingFacility: 'sending-facility-other',
+            reportedOn: new Date('2021-07-15T00:00:00Z'),
+            event: 'event-other'
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.DateReported, type: Direction.Ascending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.DateReported, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Condition', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event',
+            condition: 'B'
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event',
+            condition: 'A'
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.Condition, type: Direction.Ascending });
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.Condition, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Associated with', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event',
+            associatedWith: {
+                id: 'associatedWith-a',
+                local: 'B'
+            }
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'event',
+            associatedWith: {
+                id: 'associatedWith-a',
+                local: 'A'
+            }
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.AssociatedWith, type: Direction.Ascending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.AssociatedWith, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+});
+
+describe('when sorting documents by Event ID', () => {
+    const documents = [
+        {
+            document: '1583',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: '56B'
+        },
+        {
+            document: '727',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'C'
+        },
+        {
+            document: '617',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'type',
+            sendingFacility: 'sending-facility',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            event: 'A'
+        }
+    ];
+
+    it('should sort ascending', () => {
+        const actual = sort(documents, { name: Headers.EventID, type: Direction.Ascending });
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '1583' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '727' })
+        ]);
+    });
+
+    it('should sort descending', () => {
+        const actual = sort(documents, { name: Headers.EventID, type: Direction.Decending });
+
+        expect(actual).toEqual([
+            expect.objectContaining({ document: '727' }),
+            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' })
+        ]);
+    });
+});

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.spec.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.spec.ts
@@ -3,11 +3,11 @@ import { sort } from './PatientDocumentSorter';
 import { Headers } from './PatientDocuments';
 
 describe('when sorting documents', () => {
-    it('should default sorting to by id', () => {
+    it('should default sorting to by Date received descending', () => {
         const documents = [
             {
                 document: '1583',
-                receivedOn: new Date('2021-10-07T15:01:10Z'),
+                receivedOn: new Date('2023-10-07T00:00:00Z'),
                 type: 'type',
                 sendingFacility: 'sending-facility',
                 reportedOn: new Date('2021-09-21T17:04:11Z'),
@@ -15,7 +15,7 @@ describe('when sorting documents', () => {
             },
             {
                 document: '617',
-                receivedOn: new Date('2021-10-07T15:01:10Z'),
+                receivedOn: new Date('2021-10-07T00:00:00Z'),
                 type: 'type',
                 sendingFacility: 'sending-facility',
                 reportedOn: new Date('2021-09-21T17:04:11Z'),
@@ -23,7 +23,7 @@ describe('when sorting documents', () => {
             },
             {
                 document: '727',
-                receivedOn: new Date('2021-10-07T15:01:10Z'),
+                receivedOn: new Date('2022-02-06T00:00:00Z'),
                 type: 'type',
                 sendingFacility: 'sending-facility',
                 reportedOn: new Date('2021-09-21T17:04:11Z'),
@@ -34,9 +34,9 @@ describe('when sorting documents', () => {
         const actual = sort(documents, {});
 
         expect(actual).toEqual([
-            expect.objectContaining({ document: '617' }),
+            expect.objectContaining({ document: '1583' }),
             expect.objectContaining({ document: '727' }),
-            expect.objectContaining({ document: '1583' })
+            expect.objectContaining({ document: '617' })
         ]);
     });
 });

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.ts
@@ -1,5 +1,5 @@
 import { Document, Headers, isAssociatedWith } from './PatientDocuments';
-import { Direction, sortBy, sortByAlphanumeric, sortByDate, withDirection, simpleSort } from 'sorting';
+import { Direction, sortBy, sortByAlphanumeric, sortByDate, withDirection, simpleSort, descending } from 'sorting';
 
 type Comparator<T> = (left: T, right: T) => number;
 
@@ -41,4 +41,4 @@ const sortByAssociatedWith = (left: Document, right: Document): number => {
         : simpleSort(value, comp);
 };
 
-const defaultSort = sortByAlphanumeric('document');
+const defaultSort = descending(sortByDate('receivedOn'));

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentSorter.ts
@@ -1,0 +1,44 @@
+import { Document, Headers, isAssociatedWith } from './PatientDocuments';
+import { Direction, sortBy, sortByAlphanumeric, sortByDate, withDirection, simpleSort } from 'sorting';
+
+type Comparator<T> = (left: T, right: T) => number;
+
+export type SortCriteria = {
+    name?: Headers;
+    type?: Direction;
+};
+
+export const sort = (documents: Document[], { name, type }: SortCriteria): Document[] =>
+    documents.slice().sort(withDirection(resolveComparator(name), type));
+
+const resolveComparator = (name?: Headers): Comparator<Document> => {
+    switch (name) {
+        case Headers.DateReceived:
+            return sortByDate('receivedOn');
+        case Headers.Type:
+            return sortBy('type');
+        case Headers.SendingFacility:
+            return sortBy('sendingFacility');
+        case Headers.DateReported:
+            return sortByDate('reportedOn');
+        case Headers.Condition:
+            return sortByAlphanumeric('condition');
+        case Headers.AssociatedWith:
+            return sortByAssociatedWith;
+        case Headers.EventID:
+            return sortByAlphanumeric('event');
+        default:
+            return defaultSort;
+    }
+};
+
+const sortByAssociatedWith = (left: Document, right: Document): number => {
+    const value = left.associatedWith;
+    const comp = right.associatedWith;
+
+    return value && isAssociatedWith(value) && comp && isAssociatedWith(comp)
+        ? sortByAlphanumeric('local')(value, comp)
+        : simpleSort(value, comp);
+};
+
+const defaultSort = sortByAlphanumeric('document');

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
@@ -1,0 +1,172 @@
+import { PatientDocumentTable } from './PatientDocumentTable';
+import { render } from '@testing-library/react';
+import { FindDocumentsForPatientDocument } from 'generated/graphql/schema';
+
+import { MockedProvider } from '@apollo/client/testing';
+
+describe('when rendered', () => {
+    it('should display sentence cased document headers', async () => {
+        const { container } = render(
+            <MockedProvider addTypename={false}>
+                <PatientDocumentTable pageSize={1}></PatientDocumentTable>
+            </MockedProvider>
+        );
+
+        const tableHeader = container.getElementsByClassName('table-header');
+        expect(tableHeader[0].innerHTML).toBe('Documents');
+
+        const tableHeads = container.getElementsByClassName('head-name');
+
+        expect(tableHeads[0].innerHTML).toBe('Date received');
+        expect(tableHeads[1].innerHTML).toBe('Type');
+        expect(tableHeads[2].innerHTML).toBe('Sending facility');
+        expect(tableHeads[3].innerHTML).toBe('Date reported');
+        expect(tableHeads[4].innerHTML).toBe('Condition');
+        expect(tableHeads[5].innerHTML).toBe('Associated with');
+        expect(tableHeads[6].innerHTML).toBe('Event ID');
+    });
+});
+
+describe('when documents are not available for a patient', () => {
+    const response = {
+        request: {
+            query: FindDocumentsForPatientDocument,
+            variables: {
+                patient: '73',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 5
+                }
+            }
+        },
+        result: {
+            data: {
+                findDocumentsForPatient: {
+                    content: [],
+                    total: 0,
+                    number: 0
+                }
+            }
+        }
+    };
+
+    it('should display Not Available', async () => {
+        const { findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientDocumentTable patient={'73'} pageSize={5}></PatientDocumentTable>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Not Available')).toBeInTheDocument();
+    });
+});
+
+describe('when at least one document is available for a patient', () => {
+    const response = {
+        request: {
+            query: FindDocumentsForPatientDocument,
+            variables: {
+                patient: '1823',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 5
+                }
+            }
+        },
+        result: {
+            data: {
+                findDocumentsForPatient: {
+                    content: [
+                        {
+                            document: 'document-id',
+                            receivedOn: '2021-10-07T15:01:10Z',
+                            type: 'document-type-value',
+                            sendingFacility: 'sending-facility-value',
+                            reportedOn: '2021-09-21T17:04:11Z',
+                            condition: 'condition-value',
+                            event: 'event-value',
+                            associatedWith: {
+                                id: 'associated-id',
+                                local: 'associated-local-value',
+                                condition: 'associated-condition-value'
+                            }
+                        }
+                    ],
+                    total: 1,
+                    number: 0
+                }
+            }
+        }
+    };
+
+    it('should display the documents', async () => {
+        const { container, findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientDocumentTable patient={'1823'} pageSize={5}></PatientDocumentTable>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Showing 1 of 1')).toBeInTheDocument();
+
+        const tableData = container.getElementsByClassName('table-data');
+
+        expect(tableData[0]).toContainHTML('<span class="link">10/07/2021 <br /> 10:01 AM</span>');
+        expect(tableData[1].innerHTML).toContain('document-type-value');
+        expect(tableData[2].innerHTML).toContain('sending-facility-value');
+        expect(tableData[3].innerHTML).toContain('09/21/2021');
+        expect(tableData[4].innerHTML).toContain('condition-value');
+        expect(tableData[5]).toContainHTML(
+            '<div><p class="margin-0 text-primary text-bold link" style="word-break: break-word;">associated-local-value</p></div></span>'
+        );
+        expect(tableData[6]).toHaveTextContent('event-value');
+    });
+});
+
+describe('when documents are available for a patient', () => {
+    const response = {
+        request: {
+            query: FindDocumentsForPatientDocument,
+            variables: {
+                patient: '1823',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 5
+                }
+            }
+        },
+        result: {
+            data: {
+                findDocumentsForPatient: {
+                    content: [
+                        {
+                            document: 'document-id',
+                            receivedOn: '2021-10-07T15:01:10Z',
+                            type: 'document-type-value',
+                            sendingFacility: 'sending-facility-value',
+                            reportedOn: '2021-09-21T17:04:11Z',
+                            condition: 'condition-value',
+                            event: 'event-value',
+                            associatedWith: {
+                                id: 'associated-id',
+                                local: 'associated-local-value',
+                                condition: 'associated-condition-value'
+                            }
+                        }
+                    ],
+                    total: 6,
+                    number: 1
+                }
+            }
+        }
+    };
+
+    it('should display the documents', async () => {
+        const { container, findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientDocumentTable patient={'1823'} pageSize={5}></PatientDocumentTable>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Showing 1 of 6')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
@@ -8,7 +8,7 @@ describe('when rendered', () => {
     it('should display sentence cased document headers', async () => {
         const { container } = render(
             <MockedProvider addTypename={false}>
-                <PatientDocumentTable pageSize={1}></PatientDocumentTable>
+                <PatientDocumentTable pageSize={1} nbsBase={'base'}></PatientDocumentTable>
             </MockedProvider>
         );
 
@@ -53,7 +53,7 @@ describe('when documents are not available for a patient', () => {
     it('should display Not Available', async () => {
         const { findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientDocumentTable patient={'73'} pageSize={5}></PatientDocumentTable>
+                <PatientDocumentTable patient={'73'} pageSize={5} nbsBase={'base'}></PatientDocumentTable>
             </MockedProvider>
         );
 
@@ -102,7 +102,7 @@ describe('when at least one document is available for a patient', () => {
     it('should display the documents', async () => {
         const { container, findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientDocumentTable patient={'1823'} pageSize={5}></PatientDocumentTable>
+                <PatientDocumentTable patient={'1823'} pageSize={5} nbsBase={'base'}></PatientDocumentTable>
             </MockedProvider>
         );
 
@@ -163,7 +163,7 @@ describe('when documents are available for a patient', () => {
     it('should display the documents', async () => {
         const { container, findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientDocumentTable patient={'1823'} pageSize={5}></PatientDocumentTable>
+                <PatientDocumentTable patient={'1823'} pageSize={5} nbsBase={'base'}></PatientDocumentTable>
             </MockedProvider>
         );
 

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
@@ -110,7 +110,9 @@ describe('when at least one document is available for a patient', () => {
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toContainHTML('<span class="link">10/07/2021 <br /> 10:01 AM</span>');
+        expect(tableData[0]).toContainHTML(
+            '<span class="link"><a href="base/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=document-id">10/07/2021 <br /> 10:01 AM</a></span>'
+        );
         expect(tableData[1].innerHTML).toContain('document-type-value');
         expect(tableData[2].innerHTML).toContain('sending-facility-value');
         expect(tableData[3].innerHTML).toContain('09/21/2021');

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.tsx
@@ -82,7 +82,8 @@ export const PatientDocumentTable = ({ patient, pageSize, nbsBase }: Props) => {
 
         setItems(content);
 
-        setBodies(asTableBodies(nbsBase, content));
+        const sorted = sort(content, {});
+        setBodies(asTableBodies(nbsBase, sorted));
     };
 
     const [getDocuments] = useFindDocumentsForPatientLazyQuery({ onCompleted: handleComplete });

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.tsx
@@ -1,0 +1,111 @@
+import { TableBody, TableComponent } from 'components/Table/Table';
+import { useEffect, useState } from 'react';
+import format from 'date-fns/format';
+import { Document, AssociatedWith } from './PatientDocuments';
+import { FindDocumentsForPatientQuery, useFindDocumentsForPatientLazyQuery } from 'generated/graphql/schema';
+import { Config } from 'config';
+
+const NBS_URL = Config.nbsUrl;
+
+export type Result = FindDocumentsForPatientQuery['findDocumentsForPatient'];
+
+const headers = [
+    { name: 'Date received', sortable: true },
+    { name: 'Type', sortable: true },
+    { name: 'Sending facility', sortable: true },
+    { name: 'Date reported', sortable: true },
+    { name: 'Condition', sortable: true },
+    { name: 'Associated with', sortable: true },
+    { name: 'Event ID', sortable: true }
+];
+
+const association = (association?: AssociatedWith | null) =>
+    association && (
+        <>
+            <div>
+                <p className="margin-0 text-primary text-bold link" style={{ wordBreak: 'break-word' }}>
+                    {association.local}
+                </p>
+            </div>
+        </>
+    );
+
+const asTableBody = (document: Document | null): TableBody => ({
+    id: document?.event,
+    checkbox: false,
+    tableDetails: [
+        {
+            id: 1,
+            title: (
+                <>
+                    {format(new Date(document?.receivedOn), 'MM/dd/yyyy')} <br />{' '}
+                    {format(new Date(document?.receivedOn), 'hh:mm a')}
+                </>
+            ),
+            class: 'link',
+            link: `${NBS_URL}/nbs/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=${document?.document}`
+        },
+        {
+            id: 2,
+            title: document?.type
+        },
+        { id: 3, title: document?.sendingFacility || null },
+        { id: 4, title: format(new Date(document?.reportedOn), 'MM/dd/yyyy') },
+        { id: 5, title: document?.condition || null },
+        {
+            id: 6,
+            title: association(document?.associatedWith)
+        },
+        { id: 7, title: document?.event || null }
+    ]
+});
+
+const asTableBodies = (documents: Result): TableBody[] => documents?.content?.map(asTableBody) || [];
+
+type Props = {
+    patient?: string;
+    pageSize: number;
+};
+
+export const PatientDocumentTable = ({ patient, pageSize }: Props) => {
+    const [currentPage, setCurrentPage] = useState<number>(1);
+    const [total, setTotal] = useState<number>(0);
+    const [tableBodies, setTableBodies] = useState<TableBody[]>([]);
+
+    const handleComplete = (data: FindDocumentsForPatientQuery) => {
+        const total = data?.findDocumentsForPatient?.total || 0;
+        setTotal(total);
+
+        const bodies = asTableBodies(data.findDocumentsForPatient);
+        setTableBodies(bodies);
+    };
+
+    const [getDocuments] = useFindDocumentsForPatientLazyQuery({ onCompleted: handleComplete });
+
+    useEffect(() => {
+        if (patient) {
+            getDocuments({
+                variables: {
+                    patient: patient,
+                    page: {
+                        pageNumber: currentPage - 1,
+                        pageSize
+                    }
+                }
+            });
+        }
+    }, [patient, currentPage]);
+
+    return (
+        <TableComponent
+            tableHeader={'Documents'}
+            tableHead={headers}
+            tableBody={tableBodies}
+            isPagination={true}
+            pageSize={pageSize}
+            totalResults={total}
+            currentPage={currentPage}
+            handleNext={setCurrentPage}
+        />
+    );
+};

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTransformer.spec.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTransformer.spec.ts
@@ -1,0 +1,77 @@
+import { transform } from './PatientDocumentTransformer';
+
+describe('when the result is empty', () => {
+    it('should return an empty array of documents', () => {
+        const result = {
+            content: [],
+            total: 0,
+            number: 0
+        };
+
+        const actual = transform(result);
+
+        expect(actual).toHaveLength(0);
+    });
+});
+
+describe('when the result has content', () => {
+    it('should return an array of documents', () => {
+        const result = {
+            content: [
+                {
+                    document: '1583',
+                    receivedOn: '2021-10-07T15:01:10Z',
+                    type: 'document-type-value',
+                    sendingFacility: 'sending-facility-value',
+                    reportedOn: '2021-09-21T17:04:11Z',
+                    condition: 'condition-value',
+                    event: 'event-value',
+                    associatedWith: {
+                        id: 'associated-id',
+                        local: 'associated-local-value',
+                        condition: 'associated-condition-value'
+                    }
+                },
+                {
+                    document: '727',
+                    receivedOn: '2022-03-05T01:41:47Z',
+                    type: 'document-type-other',
+                    sendingFacility: 'sending-facility-other',
+                    reportedOn: '2023-12-15T23:04:00Z',
+                    event: 'event-other'
+                }
+            ],
+            total: 1,
+            number: 0
+        };
+
+        const actual = transform(result);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    document: '1583',
+                    receivedOn: new Date('2021-10-07T15:01:10Z'),
+                    type: 'document-type-value',
+                    sendingFacility: 'sending-facility-value',
+                    reportedOn: new Date('2021-09-21T17:04:11Z'),
+                    condition: 'condition-value',
+                    event: 'event-value',
+                    associatedWith: {
+                        id: 'associated-id',
+                        local: 'associated-local-value',
+                        condition: 'associated-condition-value'
+                    }
+                }),
+                expect.objectContaining({
+                    document: '727',
+                    receivedOn: new Date('2022-03-05T01:41:47Z'),
+                    type: 'document-type-other',
+                    sendingFacility: 'sending-facility-other',
+                    reportedOn: new Date('2023-12-15T23:04:00Z'),
+                    event: 'event-other'
+                })
+            ])
+        );
+    });
+});

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTransformer.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTransformer.ts
@@ -1,0 +1,43 @@
+import { FindDocumentsForPatientQuery } from 'generated/graphql/schema';
+import { Document } from './PatientDocuments';
+
+type Result = FindDocumentsForPatientQuery['findDocumentsForPatient'];
+
+type Content = {
+    __typename?: 'PatientDocument';
+    document: string;
+    receivedOn: any;
+    type: string;
+    sendingFacility: string;
+    reportedOn: any;
+    condition?: string | null;
+    event: string;
+    associatedWith?: {
+        __typename?: 'PatientDocumentInvestigation';
+        id: string;
+        local: string;
+    } | null;
+} | null;
+
+const internalized = (content: Content): Document | null =>
+    content && {
+        ...content,
+        receivedOn: new Date(content.receivedOn),
+        reportedOn: new Date(content.reportedOn)
+    };
+
+export const transform = (result: Result): Document[] => {
+    if (result) {
+        return result.content.reduce((existing: Document[], next: Content | null) => {
+            if (next) {
+                const doc = internalized(next);
+                if (doc) {
+                    return [...existing, doc];
+                }
+            }
+
+            return existing;
+        }, []);
+    }
+    return [];
+};

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocuments.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocuments.ts
@@ -1,0 +1,15 @@
+export type AssociatedWith = {
+    id: string;
+    local: string;
+};
+
+export type Document = {
+    document: string;
+    receivedOn: any;
+    type: string;
+    sendingFacility: string;
+    reportedOn: any;
+    condition?: string | null | undefined;
+    event: string;
+    associatedWith?: AssociatedWith | null;
+};

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocuments.ts
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocuments.ts
@@ -1,15 +1,27 @@
-export type AssociatedWith = {
+export interface AssociatedWith {
     id: string;
     local: string;
-};
+}
+
+export const isAssociatedWith = (obj: any): obj is AssociatedWith => 'id' in obj && 'local' in obj;
 
 export type Document = {
     document: string;
-    receivedOn: any;
+    receivedOn: Date;
     type: string;
     sendingFacility: string;
-    reportedOn: any;
-    condition?: string | null | undefined;
+    reportedOn: Date;
+    condition?: string | null;
     event: string;
     associatedWith?: AssociatedWith | null;
 };
+
+export enum Headers {
+    DateReceived = 'Date received',
+    Type = 'Type',
+    SendingFacility = 'Sending facility',
+    DateReported = 'Date reported',
+    Condition = 'Condition',
+    AssociatedWith = 'Associated with',
+    EventID = 'Event ID'
+}

--- a/apps/modernization-ui/src/patient/profile/document/index.ts
+++ b/apps/modernization-ui/src/patient/profile/document/index.ts
@@ -1,0 +1,1 @@
+export { PatientDocumentTable } from './PatientDocumentTable';

--- a/apps/modernization-ui/src/sorting/Sort.ts
+++ b/apps/modernization-ui/src/sorting/Sort.ts
@@ -1,0 +1,85 @@
+type Comparator<T> = (left: T, right: T) => number;
+
+export enum Direction {
+    Ascending = 'asc',
+    Decending = 'desc'
+}
+
+export const ascending = <T>(comparator: Comparator<T>): Comparator<T> => comparator;
+
+export const descending =
+    <T>(comparator: Comparator<T>): Comparator<T> =>
+    (left: T, right: T) =>
+        -1 * comparator(left, right);
+
+export const withDirection = <T>(c: Comparator<T>, type?: Direction): Comparator<T> => {
+    switch (type) {
+        case Direction.Decending:
+            return descending(c);
+        default:
+            return ascending(c);
+    }
+};
+
+export const sortBy =
+    <T>(property: keyof T): Comparator<T> =>
+    (left: T, right: T): number => {
+        const value = left[property];
+        const comparing = right[property];
+
+        if (value > comparing) {
+            return -1;
+        } else if (value < comparing) {
+            return 1;
+        } else {
+            return 0;
+        }
+    };
+
+export const sortByAlpha =
+    <T>(property: keyof T): Comparator<T> =>
+    (left: T, right: T): number => {
+        const value = left[property];
+        const comparing = right[property];
+
+        if (typeof value === 'string' && typeof comparing === 'string') {
+            return value.localeCompare(comparing);
+        }
+        return fallbackComparator(value, comparing);
+    };
+
+export const sortByAlphanumeric =
+    <T>(property: keyof T): Comparator<T> =>
+    (left: T, right: T): number => {
+        const value = left[property];
+        const comparing = right[property];
+
+        if (typeof value === 'string' && typeof comparing === 'string') {
+            return value.localeCompare(comparing, undefined, { numeric: true });
+        }
+        return fallbackComparator(value, comparing);
+    };
+
+export const sortByDate =
+    <T>(property: keyof T) =>
+    (left: T, right: T): number => {
+        const value = left[property];
+        const comparing = right[property];
+
+        if (value instanceof Date && comparing instanceof Date) {
+            return value.getTime() - comparing.getTime();
+        }
+        return fallbackComparator(value, comparing);
+    };
+
+const fallbackComparator = (left: any, right: any): number => {
+    if (left && !right) {
+        return 1;
+    } else if (!left && right) {
+        return -1;
+    } else {
+        return 0;
+    }
+};
+
+export const simpleSort = fallbackComparator;

--- a/apps/modernization-ui/src/sorting/index.ts
+++ b/apps/modernization-ui/src/sorting/index.ts
@@ -1,0 +1,11 @@
+export {
+    Direction,
+    descending,
+    ascending,
+    withDirection,
+    sortBy,
+    sortByDate,
+    sortByAlpha,
+    sortByAlphanumeric,
+    simpleSort
+} from './Sort';


### PR DESCRIPTION
Implements the features of [CNFT1-693](https://cdc-nbs.atlassian.net/browse/CNFT1-693) by displaying a patient's documents on the Patient Profile.  In a local development environment user `10023357` has many documents.

Paging was also added to the Patient Documents API

```graphql
query documents($patient: ID!, $page: Page) {
  findDocumentsForPatient(patient: $patient, page: $page) {
    content {
      document
      receivedOn
      type
      sendingFacility
      reportedOn
      condition
      event
      associatedWith {
        id
        local
      }
    }
    total
  }
}

```

Documents are paged when more then 10 results are returned.

![image](https://user-images.githubusercontent.com/124325935/230192288-bc9b1fd9-3fe0-4c2b-a281-27799c347224.png)


Documents can be sorted.

[CNFT1-693]: https://cdc-nbs.atlassian.net/browse/CNFT1-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ