### PR TITLE
Maven version 3.8.7 not found

### DIFF
--- a/cdc-sandbox/Dockerfile-antbuild
+++ b/cdc-sandbox/Dockerfile-antbuild
@@ -1,19 +1,19 @@
-FROM amazoncorretto:8-al2-jdk
+FROM maven:3.9-amazoncorretto-8
 
 ARG ant_version=1.10.12
-ARG maven_version=3.8.8
 
+# update
 RUN yum update -y
 RUN yum install -y tar gzip hostname
+
+# install ant
 WORKDIR /home
 ADD https://dlcdn.apache.org/ant/binaries/apache-ant-$ant_version-bin.tar.gz .
 RUN tar -zxvf apache-ant-$ant_version-bin.tar.gz
 RUN rm apache-ant-$ant_version*.gz
 ENV ANT_HOME=/home/apache-ant-$ant_version
-ADD https://dlcdn.apache.org/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz .
-RUN tar -zxvf apache-maven-$maven_version-bin.tar.gz
-RUN rm apache-maven-$maven_version-bin.tar.gz
-ENV MAVEN_HOME=/home/apache-maven-$maven_version
+
+# run build
 ENV JBOSS_HOME=build
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=ISO-8859-1
 ADD docker-entrypoint-ant.sh .

--- a/cdc-sandbox/Dockerfile-antbuild
+++ b/cdc-sandbox/Dockerfile-antbuild
@@ -1,7 +1,7 @@
 FROM amazoncorretto:8-al2-jdk
 
 ARG ant_version=1.10.12
-ARG maven_version=3.8.7
+ARG maven_version=3.8.8
 
 RUN yum update -y
 RUN yum install -y tar gzip hostname


### PR DESCRIPTION
When building fresh, the following error occurs when building the Wildfly container:

![image](https://user-images.githubusercontent.com/109251240/231264511-c5e42813-ea86-449b-aad5-4286e038758a.png)

Change to using the maven amazoncorretto 8 docker image resolves this issue