### PR TITLE
Elasticsearch memory default

### DIFF
--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -54,8 +54,8 @@ services:
     ports:
       - 9200:9200
       - 9300:9300
-    # environment:
-    #   - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m" # Uncomment to limit memory usage
+    environment:
+      - "ES_JAVA_OPTS=-Xms2048m -Xmx2048m" # limit memory usage
   kibana:
     container_name: kibana
     build: ./kibana


### PR DESCRIPTION
When setting up the local environment, elasticsearch is using 6+ Gb of memory with no data. This change will set the default limit to 2Gb.

@szamfir, will this change affect the deployed environments?