### PR TITLE
CNFT1-747 vaccinations table api

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/investigation/association/AssociatedWith.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/investigation/association/AssociatedWith.java
@@ -1,0 +1,8 @@
+package gov.cdc.nbs.investigation.association;
+
+public record AssociatedWith(
+    long id,
+    String local,
+    String condition
+) {
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/investigation/association/AssociatedWithTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/investigation/association/AssociatedWithTupleMapper.java
@@ -1,0 +1,39 @@
+package gov.cdc.nbs.investigation.association;
+
+import com.querydsl.core.Tuple;
+import gov.cdc.nbs.entity.odse.QPublicHealthCase;
+import gov.cdc.nbs.entity.srte.QConditionCode;
+
+import java.util.Optional;
+
+public class AssociatedWithTupleMapper {
+
+    public record Tables(
+        QPublicHealthCase investigation,
+        QConditionCode condition
+    ) {
+    }
+
+
+    private final Tables tables;
+
+    public AssociatedWithTupleMapper(final Tables tables) {
+        this.tables = tables;
+    }
+
+    public Optional<AssociatedWith> maybeMap(final Tuple tuple) {
+        Long identifier = tuple.get(tables.investigation().id);
+        String local = tuple.get(tables.investigation().localId);
+        String condition = tuple.get(tables.condition().conditionShortNm);
+
+        return identifier == null
+            ? Optional.empty()
+            : Optional.of(
+            new AssociatedWith(
+                identifier,
+                local,
+                condition
+            )
+        );
+    }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccination.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccination.java
@@ -1,0 +1,18 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import gov.cdc.nbs.investigation.association.AssociatedWith;
+
+import java.time.Instant;
+
+record PatientVaccination(
+    long vaccination,
+    Instant createdOn,
+    String provider,
+    Instant administeredOn,
+    String administered,
+    String event,
+    AssociatedWith associatedWith
+) {
+
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationFinder.java
@@ -1,0 +1,137 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.enums.RecordStatus;
+import gov.cdc.nbs.entity.odse.QActRelationship;
+import gov.cdc.nbs.entity.odse.QParticipation;
+import gov.cdc.nbs.entity.odse.QPerson;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+class PatientVaccinationFinder {
+
+    private static final String PATIENT_CODE = "PAT";
+
+    private static final QPerson PATIENT = QPerson.person;
+
+    private static final QParticipation VACCINATED = new QParticipation("vaccinated");
+
+    private static final QParticipation PROVIDED_BY = new QParticipation("provided_by");
+
+    private static final QActRelationship RELATIONSHIP = QActRelationship.actRelationship;
+
+
+    private static final String SUBJECT_OF_VACCINATION = "SubOfVacc";
+    private static final String VACCINATION_GIVEN = "VaccGiven";
+    private static final String VACCINE_CODE_SET = "VAC_NM";
+    private static final String PERFORMER_OF_VACCINATION_TYPE = "PerformerOfVacc";
+    private static final String PERSON_CLASS = "PSN";
+    private static final String INVESTIGATION_CLASS = "CASE";
+    private static final String VACCINATION_CLASS = "INTV";
+    private static final String DELETED = "LOG_DEL";
+
+    private final JPAQueryFactory factory;
+    private final PatientVaccinationTupleMapper.Tables tables;
+    private final PatientVaccinationTupleMapper mapper;
+
+    PatientVaccinationFinder(final JPAQueryFactory factory) {
+        this.factory = factory;
+        this.tables = new PatientVaccinationTupleMapper.Tables();
+        mapper = new PatientVaccinationTupleMapper(tables);
+    }
+
+    private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
+        return query.from(PATIENT)
+            .join(VACCINATED).on(
+                VACCINATED.recordStatusCd.eq(RecordStatus.ACTIVE),
+                VACCINATED.id.typeCd.in(SUBJECT_OF_VACCINATION, VACCINATION_GIVEN),
+                VACCINATED.id.subjectEntityUid.eq(PATIENT.id),
+                VACCINATED.subjectClassCd.eq(PATIENT_CODE)
+            )
+            .join(this.tables.vaccination()).on(
+                this.tables.vaccination().id.eq(VACCINATED.id.actUid),
+                this.tables.vaccination().recordStatusCd.eq("ACTIVE")
+            )
+            .where(
+                PATIENT.id.eq(patient),
+                PATIENT.cd.eq(PATIENT_CODE),
+                PATIENT.recordStatusCd.eq(RecordStatus.ACTIVE)
+            );
+
+    }
+
+    private long resolveTotal(final long patient) {
+        Long total = applyCriteria(
+            factory.select(PATIENT.countDistinct()),
+            patient
+        )
+            .fetchOne();
+        return total == null ? 0L : total;
+    }
+
+    private List<PatientVaccination> resolvePage(final long patient, final Pageable pageable) {
+        return applyCriteria(
+            this.factory.selectDistinct(
+                this.tables.vaccination().id,
+                this.tables.vaccination().addTime,
+                this.tables.provider().name().nmPrefix,
+                this.tables.provider().name().firstNm,
+                this.tables.provider().name().lastNm,
+                this.tables.provider().name().nmSuffix,
+                this.tables.vaccination().activityFromTime,
+                this.tables.vaccine().codeShortDescTxt,
+                this.tables.associatedWith().investigation().id,
+                this.tables.associatedWith().investigation().localId,
+                this.tables.associatedWith().condition().conditionShortNm,
+                this.tables.vaccination().localId
+            ),
+            patient
+        )
+            .join(this.tables.vaccine()).on(
+                this.tables.vaccine().id.codeSetNm.eq(VACCINE_CODE_SET),
+                this.tables.vaccine().id.code.eq(this.tables.vaccination().materialCd)
+            )
+            .leftJoin(PROVIDED_BY).on(
+                PROVIDED_BY.actUid.id.eq(this.tables.vaccination().id),
+                PROVIDED_BY.id.typeCd.eq(PERFORMER_OF_VACCINATION_TYPE),
+                PROVIDED_BY.subjectClassCd.eq(PERSON_CLASS)
+            )
+            .leftJoin(this.tables.provider().name()).on(
+                this.tables.provider().name().id.personUid.eq(PROVIDED_BY.id.subjectEntityUid)
+            )
+            .leftJoin(RELATIONSHIP).on(
+                RELATIONSHIP.targetClassCd.eq(INVESTIGATION_CLASS),
+                RELATIONSHIP.sourceClassCd.eq(VACCINATION_CLASS),
+                RELATIONSHIP.id.sourceActUid.eq(this.tables.vaccination().id)
+            )
+            .leftJoin(this.tables.associatedWith().investigation()).on(
+                this.tables.associatedWith().investigation().id.eq(RELATIONSHIP.id.targetActUid),
+                this.tables.associatedWith().investigation().recordStatusCd.ne(DELETED)
+            )
+            .leftJoin(this.tables.associatedWith().condition()).on(
+                this.tables.associatedWith().condition().id.eq(this.tables.associatedWith().investigation().cd)
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch()
+            .stream()
+            .map(mapper::map)
+            .toList()
+            ;
+
+    }
+
+    Page<PatientVaccination> find(final long patient, final Pageable pageable) {
+        long total = resolveTotal(patient);
+
+        return total > 0
+            ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
+            : Page.empty(pageable);
+    }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationResolver.java
@@ -1,0 +1,39 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import gov.cdc.nbs.graphql.GraphQLPage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+
+@Controller
+class PatientVaccinationResolver {
+
+    private final int maxPageSize;
+    private final PatientVaccinationFinder finder;
+
+    PatientVaccinationResolver(
+        @Value("${nbs.max-page-size}") final int maxPageSize,
+        final PatientVaccinationFinder finder
+    ) {
+        this.maxPageSize = maxPageSize;
+        this.finder = finder;
+    }
+
+    @QueryMapping("findVaccinationsForPatient")
+    @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-INTERVENTIONVACCINERECORD')")
+    Page<PatientVaccination> find(
+        @Argument("patient") final long patient,
+        @Argument final GraphQLPage page
+    ) {
+        Pageable pageable = GraphQLPage.toPageable(page, maxPageSize);
+        return this.finder.find(
+            patient,
+            pageable
+        );
+    }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationTupleMapper.java
@@ -1,0 +1,80 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import com.querydsl.core.Tuple;
+import gov.cdc.nbs.entity.odse.QIntervention;
+import gov.cdc.nbs.entity.odse.QPersonName;
+import gov.cdc.nbs.entity.odse.QPublicHealthCase;
+import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
+import gov.cdc.nbs.entity.srte.QConditionCode;
+import gov.cdc.nbs.investigation.association.AssociatedWith;
+import gov.cdc.nbs.investigation.association.AssociatedWithTupleMapper;
+import gov.cdc.nbs.provider.ProviderNameTupleMapper;
+
+import java.time.Instant;
+import java.util.Objects;
+
+class PatientVaccinationTupleMapper {
+
+    record Tables(
+        QIntervention vaccination,
+        QCodeValueGeneral vaccine,
+        ProviderNameTupleMapper.Tables provider,
+        AssociatedWithTupleMapper.Tables associatedWith
+    ) {
+
+        Tables() {
+            this(
+                QIntervention.intervention,
+                new QCodeValueGeneral("vaccine"),
+                new ProviderNameTupleMapper.Tables(QPersonName.personName),
+                new AssociatedWithTupleMapper.Tables(
+                    QPublicHealthCase.publicHealthCase,
+                    new QConditionCode("condition")
+                )
+            );
+        }
+    }
+
+
+    private final Tables tables;
+    private final ProviderNameTupleMapper providerMapper;
+    private final AssociatedWithTupleMapper associatedWithMapper;
+
+    PatientVaccinationTupleMapper(final Tables tables) {
+        this.tables = tables;
+        this.providerMapper = new ProviderNameTupleMapper(tables.provider());
+        this.associatedWithMapper = new AssociatedWithTupleMapper(tables.associatedWith());
+    }
+
+    PatientVaccination map(final Tuple tuple) {
+
+        long identifier = Objects.requireNonNull(
+            tuple.get(this.tables.vaccination().id),
+            "A vaccination identifier is required."
+        );
+
+        Instant createdOn = tuple.get(this.tables.vaccination().addTime);
+
+        String provider = this.providerMapper.map(tuple);
+
+        Instant administeredOn = tuple.get(this.tables.vaccination().activityFromTime);
+
+        String administered = tuple.get(this.tables.vaccine().codeShortDescTxt);
+        String event = tuple.get(this.tables.vaccination().localId);
+
+        AssociatedWith associatedWith = this.associatedWithMapper.maybeMap(tuple)
+            .orElse(null);
+
+        return new PatientVaccination(
+            identifier,
+            createdOn,
+            provider,
+            administeredOn,
+            administered,
+            event,
+            associatedWith
+        );
+    }
+
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/provider/ProviderNameTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/provider/ProviderNameTupleMapper.java
@@ -1,0 +1,31 @@
+package gov.cdc.nbs.provider;
+
+import com.querydsl.core.Tuple;
+import gov.cdc.nbs.entity.odse.QPersonName;
+import gov.cdc.nbs.message.enums.Suffix;
+import gov.cdc.nbs.patient.NameRenderer;
+
+public class ProviderNameTupleMapper {
+
+    public record Tables(QPersonName name) {
+    }
+    private final Tables tables;
+
+    public ProviderNameTupleMapper(final Tables tables) {
+        this.tables = tables;
+    }
+
+    public String map(final Tuple tuple) {
+        String providerPrefix = tuple.get(tables.name().nmPrefix);
+        String providerFirstName = tuple.get(tables.name().firstNm);
+        String providerLastName = tuple.get(tables.name().lastNm);
+        Suffix providerSuffix = tuple.get(tables.name().nmSuffix);
+
+        return NameRenderer.render(
+            providerPrefix,
+            providerFirstName,
+            providerLastName,
+            providerSuffix
+        );
+    }
+}

--- a/apps/modernization-api/src/main/resources/graphql/patient-vaccination.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-vaccination.graphqls
@@ -1,0 +1,25 @@
+type PatientVaccination {
+    vaccination: ID!
+    createdOn: DateTime!
+    provider: String
+    administeredOn: DateTime!
+    administered: String!
+    event: String!
+    associatedWith: PatientVaccinationInvestigation
+}
+
+type PatientVaccinationInvestigation {
+    id: ID!
+    local: String!
+    condition: String!
+}
+
+type PatientVaccinationResults {
+    content: [PatientVaccination]!
+    total: Int!
+    number: Int!
+}
+
+extend type Query {
+    findVaccinationsForPatient(patient: ID!, page: Page): PatientVaccinationResults
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/investigation/association/AssociatedWithTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/investigation/association/AssociatedWithTupleMapperTest.java
@@ -1,0 +1,59 @@
+package gov.cdc.nbs.investigation.association;
+
+import com.querydsl.core.Tuple;
+import gov.cdc.nbs.entity.odse.QPublicHealthCase;
+import gov.cdc.nbs.entity.srte.QConditionCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AssociatedWithTupleMapperTest {
+
+    @Test
+    void should_map_associated_with_when_identifier_is_present() {
+
+        AssociatedWithTupleMapper.Tables tables = new AssociatedWithTupleMapper.Tables(
+            QPublicHealthCase.publicHealthCase,
+            QConditionCode.conditionCode
+        );
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.investigation().id)).thenReturn(4127L);
+        when(tuple.get(tables.investigation().localId)).thenReturn("investigation-local");
+        when(tuple.get(tables.condition().conditionShortNm)).thenReturn("investigation-condition");
+
+        AssociatedWithTupleMapper mapper = new AssociatedWithTupleMapper(tables);
+
+        Optional<AssociatedWith> actual = mapper.maybeMap(tuple);
+
+        assertThat(actual).hasValueSatisfying(
+            actual_associated -> assertThat(actual_associated)
+                .returns(4127L, AssociatedWith::id)
+                .returns("investigation-local", AssociatedWith::local)
+                .returns("investigation-condition", AssociatedWith::condition)
+        );
+    }
+
+
+    @Test
+    void should_map_empty_when_identifier_is_not_present() {
+
+        AssociatedWithTupleMapper.Tables tables = new AssociatedWithTupleMapper.Tables(
+            QPublicHealthCase.publicHealthCase,
+            QConditionCode.conditionCode
+        );
+
+        Tuple tuple = mock(Tuple.class);
+
+        AssociatedWithTupleMapper mapper = new AssociatedWithTupleMapper(tables);
+
+        Optional<AssociatedWith> actual = mapper.maybeMap(tuple);
+
+        assertThat(actual).isNotPresent();
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/ParticipationCleaner.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/ParticipationCleaner.java
@@ -1,0 +1,36 @@
+package gov.cdc.nbs.patient;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.odse.QAct;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+
+
+@Component
+public class ParticipationCleaner {
+
+    private final JPAQueryFactory factory;
+    private final EntityManager entityManager;
+
+    public ParticipationCleaner(
+        final JPAQueryFactory factory,
+        final EntityManager entityManager
+    ) {
+        this.factory = factory;
+        this.entityManager = entityManager;
+    }
+
+    public void clean(final long identifier, final String classCode) {
+        this.factory.from(QAct.act)
+            .where(
+                QAct.act.classCd.eq(classCode),
+                QAct.act.id.eq(identifier)
+            ).fetch()
+            //  The all participation instances are associated with the Act entity that
+            //  shares the same identifier.  Removing the Act will remove any associations.
+            .forEach(entityManager::remove);
+
+    }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationResolverTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationResolverTest.java
@@ -1,0 +1,55 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import gov.cdc.nbs.graphql.GraphQLPage;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PatientVaccinationResolverTest {
+
+    @Test
+    void should_find_paginated_vaccination_reports_for_the_provided_patient_using_the_finder() {
+
+        PatientVaccinationFinder finder = mock(PatientVaccinationFinder.class);
+
+        when(finder.find(anyLong(), any()))
+            .thenAnswer(args -> new PageImpl<>(
+                    List.of(mock(PatientVaccination.class)),
+                    args.getArgument(1, Pageable.class),
+                    1L
+                )
+            );
+
+        PatientVaccinationResolver resolver = new PatientVaccinationResolver(25, finder);
+
+        GraphQLPage page = new GraphQLPage(25, 2);
+
+        Page<PatientVaccination> actual = resolver.find(1861L, page);
+
+        assertThat(actual)
+            .as("The resolved paginated list of patient vaccinations comes from the finder")
+            .hasSize(1);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+
+        verify(finder).find(eq(1861L), captor.capture());
+
+        Pageable actual_pageable = captor.getValue();
+
+        assertThat(actual_pageable.getPageNumber()).isEqualTo(2);
+        assertThat(actual_pageable.getPageSize()).isEqualTo(25);
+    }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationSteps.java
@@ -1,0 +1,69 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import gov.cdc.nbs.graphql.GraphQLPage;
+import gov.cdc.nbs.patient.TestPatients;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+public class PatientVaccinationSteps {
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    PatientVaccinationResolver resolver;
+
+    @Autowired
+    VaccinationMother mother;
+
+    @Before
+    public void clean() {
+        mother.reset();
+    }
+
+    @When("the patient is vaccinated")
+    public void the_patient_has_a_Case_Report() {
+        long patient = this.patients.one();
+        this.mother.vaccinate(patient);
+    }
+
+    @Then("the profile has an associated vaccination")
+    public void the_profile_has_an_associated_vaccination() {
+        long patient = this.patients.one();
+
+        Page<PatientVaccination> actual = this.resolver.find(patient, new GraphQLPage(1));
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Then("the profile has no associated vaccination")
+    public void the_profile_has_no_associated_vaccination() {
+        long patient = this.patients.one();
+
+        Page<PatientVaccination> actual = this.resolver.find(patient, new GraphQLPage(1));
+        assertThat(actual).isEmpty();
+    }
+
+    @Then("the profile vaccinations are not accessible")
+    public void the_profile_vaccinations_are_not_accessible() {
+        long patient = this.patients.one();
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        assertThatThrownBy(
+            () -> this.resolver.find(
+                patient,
+                page
+            )
+        )
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationTupleMapperTest.java
@@ -1,0 +1,109 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import com.querydsl.core.Tuple;
+import gov.cdc.nbs.investigation.association.AssociatedWith;
+import gov.cdc.nbs.message.enums.Suffix;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+class PatientVaccinationTupleMapperTest {
+
+    @Test
+    void should_map_vaccination_from_tuple() {
+
+        PatientVaccinationTupleMapper.Tables tables = new PatientVaccinationTupleMapper.Tables();
+
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.vaccination().id)).thenReturn(5669L);
+        when(tuple.get(tables.vaccination().addTime)).thenReturn(Instant.parse("2022-03-17T00:45:07Z"));
+
+        when(tuple.get(tables.vaccination().activityFromTime)).thenReturn(Instant.parse("2021-04-07T05:49:00Z"));
+
+        when(tuple.get(tables.vaccine().codeShortDescTxt)).thenReturn("administered");
+
+        when(tuple.get(tables.vaccination().localId)).thenReturn("event");
+
+        PatientVaccinationTupleMapper mapper = new PatientVaccinationTupleMapper(tables);
+
+        PatientVaccination actual = mapper.map(tuple);
+
+        assertThat(actual.vaccination()).isEqualTo(5669L);
+        assertThat(actual.createdOn()).isEqualTo("2022-03-17T00:45:07Z");
+
+        assertThat(actual.administeredOn()).isEqualTo("2021-04-07T05:49:00Z");
+        assertThat(actual.administered()).isEqualTo("administered");
+        assertThat(actual.event()).isEqualTo("event");
+
+        assertThat(actual.associatedWith()).isNull();
+    }
+
+    @Test
+    void should_map_vaccination_from_tuple_with_associated_investigation() {
+
+        PatientVaccinationTupleMapper.Tables tables = new PatientVaccinationTupleMapper.Tables();
+
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.vaccination().id)).thenReturn(5669L);
+
+        when(tuple.get(tables.associatedWith().investigation().id)).thenReturn(4127L);
+        when(tuple.get(tables.associatedWith().investigation().localId)).thenReturn("investigation-local");
+        when(tuple.get(tables.associatedWith().condition().conditionShortNm)).thenReturn("investigation-condition");
+
+        PatientVaccinationTupleMapper mapper = new PatientVaccinationTupleMapper(tables);
+
+        PatientVaccination actual = mapper.map(tuple);
+
+        assertThat(actual).extracting(PatientVaccination::associatedWith)
+            .returns(4127L, AssociatedWith::id)
+            .returns("investigation-local", AssociatedWith::local)
+            .returns("investigation-condition", AssociatedWith::condition);
+    }
+
+    @Test
+    void should_map_vaccination_from_tuple_with_associated_provider() {
+
+        PatientVaccinationTupleMapper.Tables tables = new PatientVaccinationTupleMapper.Tables();
+
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.vaccination().id)).thenReturn(5669L);
+
+        when(tuple.get(tables.provider().name().nmPrefix)).thenReturn("prefix");
+        when(tuple.get(tables.provider().name().firstNm)).thenReturn("first");
+        when(tuple.get(tables.provider().name().lastNm)).thenReturn("last");
+        when(tuple.get(tables.provider().name().nmSuffix)).thenReturn(Suffix.IV);
+
+        PatientVaccinationTupleMapper mapper = new PatientVaccinationTupleMapper(tables);
+
+        PatientVaccination actual = mapper.map(tuple);
+
+        assertThat(actual.provider()).isEqualTo("prefix first last IV");
+    }
+
+    @Test
+    void should_not_map_address_from_tuple_without_identifier() {
+        PatientVaccinationTupleMapper.Tables tables = new PatientVaccinationTupleMapper.Tables();
+
+
+        Tuple tuple = mock(Tuple.class);
+
+        PatientVaccinationTupleMapper mapper = new PatientVaccinationTupleMapper(tables);
+
+
+        assertThatThrownBy(() -> mapper.map(tuple))
+            .hasMessageContaining("identifier is required");
+
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/TestVaccinationCleaner.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/TestVaccinationCleaner.java
@@ -1,0 +1,54 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.odse.Intervention;
+import gov.cdc.nbs.entity.odse.QIntervention;
+import gov.cdc.nbs.patient.ParticipationCleaner;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+
+@Component
+class TestVaccinationCleaner {
+
+    private static final QIntervention TABLE = QIntervention.intervention;
+    private final EntityManager entityManager;
+    private final JPAQueryFactory factory;
+
+    private final ParticipationCleaner participationCleaner;
+
+    TestVaccinationCleaner(
+        final EntityManager entityManager,
+        final JPAQueryFactory factory,
+        final ParticipationCleaner participationCleaner
+    ) {
+        this.entityManager = entityManager;
+        this.factory = factory;
+        this.participationCleaner = participationCleaner;
+    }
+
+    void clean(final long starting) {
+        this.factory.select(TABLE)
+            .from(TABLE)
+            .where(criteria(starting))
+            .fetch()
+            .forEach(this::remove);
+    }
+
+    private BooleanExpression criteria(final long starting) {
+        BooleanExpression threshold = TABLE.id.goe(starting);
+        return starting < 0
+            ? threshold.and(TABLE.id.lt(0))
+            : threshold;
+    }
+
+    private void remove(final Intervention intervention) {
+        participationCleaner.clean(intervention.getId(), "INTV");
+
+        this.entityManager.remove(intervention);
+    }
+
+
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/TestVaccinations.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/TestVaccinations.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
+@Component
+class TestVaccinations {
+  private final Collection<Long> identifiers;
+
+  TestVaccinations() {
+    identifiers = new ArrayList<>();
+  }
+
+  void available(final long patient) {
+    this.identifiers.add(patient);
+  }
+
+  void reset() {
+    this.identifiers.clear();
+  }
+
+  public Optional<Long> maybeOne() {
+    return this.identifiers.stream().findFirst();
+  }
+
+  public long one() {
+    return maybeOne()
+        .orElseThrow(() -> new IllegalStateException("there is no document"));
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/VaccinationMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/VaccinationMother.java
@@ -1,0 +1,99 @@
+package gov.cdc.nbs.patient.profile.vaccination;
+
+import gov.cdc.nbs.entity.enums.RecordStatus;
+import gov.cdc.nbs.entity.odse.Act;
+import gov.cdc.nbs.entity.odse.Intervention;
+import gov.cdc.nbs.entity.odse.Participation;
+import gov.cdc.nbs.entity.odse.ParticipationId;
+import gov.cdc.nbs.identity.MotherSettings;
+import gov.cdc.nbs.identity.TestUniqueIdGenerator;
+import gov.cdc.nbs.patient.ParticipationCleaner;
+import gov.cdc.nbs.support.util.RandomUtil;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+
+@Component
+class VaccinationMother {
+
+    private static final String VACCINATION_CLASS = "INTV";
+    private static final String PERSON_CLASS = "PAT";
+
+    private final MotherSettings settings;
+    private final TestUniqueIdGenerator idGenerator;
+    private final EntityManager entityManager;
+    private final TestVaccinationCleaner cleaner;
+    private final TestVaccinations vaccinations;
+
+    VaccinationMother(
+        final MotherSettings settings,
+        final TestUniqueIdGenerator idGenerator,
+        final EntityManager entityManager,
+        final TestVaccinationCleaner cleaner,
+        final TestVaccinations vaccinations
+    ) {
+        this.settings = settings;
+        this.idGenerator = idGenerator;
+        this.entityManager = entityManager;
+        this.cleaner = cleaner;
+        this.vaccinations = vaccinations;
+    }
+
+    void reset() {
+        this.cleaner.clean(this.settings.starting());
+        this.vaccinations.reset();
+    }
+
+    /**
+     * Creates a Vaccination for the given {@code patient}
+     *
+     * @param patient The identifier of the patient.
+     * @return An {@link Intervention} representing a vaccination of a patient.
+     */
+    Intervention vaccinate(final long patient) {
+        //  create a vaccination
+        long identifier = idGenerator.next();
+        String local = idGenerator.nextLocal(VACCINATION_CLASS);
+
+        Intervention vaccination = new Intervention(identifier, local);
+
+        vaccination.setRecordStatusTime(settings.createdOn());
+        vaccination.setAddTime(settings.createdOn());
+        vaccination.setAddUserId(settings.createdBy());
+
+        vaccination.setActivityFromTime(RandomUtil.getRandomDateInPast());
+        vaccination.setMaterialCd("115"); // Tdap
+
+        subjectOfVaccination(patient, vaccination.getAct());
+
+        entityManager.persist(vaccination);
+
+        this.vaccinations.available(vaccination.getId());
+
+        return vaccination;
+    }
+
+    private Participation subjectOfVaccination(final long patient, final Act act) {
+
+        // create the participation
+        ParticipationId identifier = new ParticipationId(patient, act.getId(), "SubOfVacc");
+
+        Participation participation = new Participation();
+        participation.setId(identifier);
+        participation.setActClassCd(VACCINATION_CLASS);
+        participation.setSubjectClassCd(PERSON_CLASS);
+
+        participation.setRecordStatusCd(RecordStatus.ACTIVE);
+        participation.setRecordStatusTime(settings.createdOn());
+        participation.setAddTime(settings.createdOn());
+        participation.setAddUserId(settings.createdBy());
+        participation.setActUid(act);
+
+        act.addParticipation(participation);
+
+        entityManager.persist(act);
+
+        return participation;
+    }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/provider/ProviderNameTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/provider/ProviderNameTupleMapperTest.java
@@ -1,0 +1,109 @@
+package gov.cdc.nbs.provider;
+
+import com.querydsl.core.Tuple;
+import gov.cdc.nbs.entity.odse.QPersonName;
+import gov.cdc.nbs.message.enums.Suffix;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProviderNameTupleMapperTest {
+
+    @Test
+    void should_map_full_provider_name_from_tuple() {
+
+        ProviderNameTupleMapper.Tables tables = new ProviderNameTupleMapper.Tables(QPersonName.personName);
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.name().nmPrefix)).thenReturn("prefix");
+        when(tuple.get(tables.name().firstNm)).thenReturn("first-name");
+        when(tuple.get(tables.name().lastNm)).thenReturn("last-name");
+        when(tuple.get(tables.name().nmSuffix)).thenReturn(Suffix.ESQ);
+
+        ProviderNameTupleMapper mapper = new ProviderNameTupleMapper(tables);
+
+        String actual = mapper.map(tuple);
+
+        assertThat(actual).isEqualTo("prefix first-name last-name ESQ");
+
+    }
+
+    @Test
+    void should_map_full_provider_name_from_tuple_without_prefix() {
+
+        ProviderNameTupleMapper.Tables tables = new ProviderNameTupleMapper.Tables(QPersonName.personName);
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.name().firstNm)).thenReturn("first-name");
+        when(tuple.get(tables.name().lastNm)).thenReturn("last-name");
+        when(tuple.get(tables.name().nmSuffix)).thenReturn(Suffix.ESQ);
+
+        ProviderNameTupleMapper mapper = new ProviderNameTupleMapper(tables);
+
+        String actual = mapper.map(tuple);
+
+        assertThat(actual).isEqualTo("first-name last-name ESQ");
+
+    }
+
+    @Test
+    void should_map_full_provider_name_from_tuple_without_first_name() {
+
+        ProviderNameTupleMapper.Tables tables = new ProviderNameTupleMapper.Tables(QPersonName.personName);
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.name().nmPrefix)).thenReturn("prefix");
+        when(tuple.get(tables.name().lastNm)).thenReturn("last-name");
+        when(tuple.get(tables.name().nmSuffix)).thenReturn(Suffix.ESQ);
+
+        ProviderNameTupleMapper mapper = new ProviderNameTupleMapper(tables);
+
+        String actual = mapper.map(tuple);
+
+        assertThat(actual).isEqualTo("prefix last-name ESQ");
+
+    }
+
+    @Test
+    void should_map_full_provider_name_from_tuple_without_last_name() {
+
+        ProviderNameTupleMapper.Tables tables = new ProviderNameTupleMapper.Tables(QPersonName.personName);
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.name().nmPrefix)).thenReturn("prefix");
+        when(tuple.get(tables.name().firstNm)).thenReturn("first-name");
+        when(tuple.get(tables.name().nmSuffix)).thenReturn(Suffix.ESQ);
+
+        ProviderNameTupleMapper mapper = new ProviderNameTupleMapper(tables);
+
+        String actual = mapper.map(tuple);
+
+        assertThat(actual).isEqualTo("prefix first-name ESQ");
+
+    }
+
+    @Test
+    void should_map_full_provider_name_from_tuple_without_suffix() {
+
+        ProviderNameTupleMapper.Tables tables = new ProviderNameTupleMapper.Tables(QPersonName.personName);
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.name().nmPrefix)).thenReturn("prefix");
+        when(tuple.get(tables.name().firstNm)).thenReturn("first-name");
+        when(tuple.get(tables.name().lastNm)).thenReturn("last-name");
+
+        ProviderNameTupleMapper mapper = new ProviderNameTupleMapper(tables);
+
+        String actual = mapper.map(tuple);
+
+        assertThat(actual).isEqualTo("prefix first-name last-name");
+
+    }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileVaccination.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileVaccination.feature
@@ -1,0 +1,18 @@
+@patient-profile-vaccination
+Feature: Patient Profile Vaccinations
+
+  Background:
+    Given I have a patient
+
+  Scenario: I can retrieve vaccinations for a patient
+    Given I have the authorities: "FIND-PATIENT,VIEW-INTERVENTIONVACCINERECORD" for the jurisdiction: "ALL" and program area: "STD"
+    When the patient is vaccinated
+    Then the profile has an associated vaccination
+
+  Scenario: I cannot retrieve vaccinations for a patient without vaccinations
+    Given I have the authorities: "FIND-PATIENT,VIEW-INTERVENTIONVACCINERECORD" for the jurisdiction: "ALL" and program area: "STD"
+    Then the profile has no associated vaccination
+
+    Scenario: I cannot retrieve vaccinations without proper authorities
+      Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile vaccinations are not accessible

--- a/apps/modernization-ui/src/generated/gql/queries/findVaccinationsForPatient.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findVaccinationsForPatient.gql
@@ -1,0 +1,19 @@
+query findVaccinationsForPatient($patient: ID!, $page: Page){
+    findVaccinationsForPatient(patient: $patient, page: $page){
+        content{
+            vaccination
+            createdOn
+            provider
+            administeredOn
+            administered
+            event
+            associatedWith{
+                id
+                local
+                condition
+            }
+        }
+        total
+        number
+    }
+}

--- a/apps/modernization-ui/src/generated/gql/queries/index.js
+++ b/apps/modernization-ui/src/generated/gql/queries/index.js
@@ -28,6 +28,7 @@ module.exports.findDocumentsForPatient = fs.readFileSync(path.join(__dirname, 'f
 module.exports.findMorbidityReportsForPatient = fs.readFileSync(path.join(__dirname, 'findMorbidityReportsForPatient.gql'), 'utf8');
 module.exports.findPatientProfile = fs.readFileSync(path.join(__dirname, 'findPatientProfile.gql'), 'utf8');
 module.exports.findTreatmentsForPatient = fs.readFileSync(path.join(__dirname, 'findTreatmentsForPatient.gql'), 'utf8');
+module.exports.findVaccinationsForPatient = fs.readFileSync(path.join(__dirname, 'findVaccinationsForPatient.gql'), 'utf8');
 module.exports.findPlaceById = fs.readFileSync(path.join(__dirname, 'findPlaceById.gql'), 'utf8');
 module.exports.findAllPlaces = fs.readFileSync(path.join(__dirname, 'findAllPlaces.gql'), 'utf8');
 module.exports.findPlacesByFilter = fs.readFileSync(path.join(__dirname, 'findPlacesByFilter.gql'), 'utf8');

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -1122,6 +1122,31 @@ export type PatientTreatmentResults = {
   total: Scalars['Int'];
 };
 
+export type PatientVaccination = {
+  __typename?: 'PatientVaccination';
+  administered: Scalars['String'];
+  administeredOn: Scalars['DateTime'];
+  associatedWith?: Maybe<PatientVaccinationInvestigation>;
+  createdOn: Scalars['DateTime'];
+  event: Scalars['String'];
+  provider?: Maybe<Scalars['String']>;
+  vaccination: Scalars['ID'];
+};
+
+export type PatientVaccinationInvestigation = {
+  __typename?: 'PatientVaccinationInvestigation';
+  condition: Scalars['String'];
+  id: Scalars['ID'];
+  local: Scalars['String'];
+};
+
+export type PatientVaccinationResults = {
+  __typename?: 'PatientVaccinationResults';
+  content: Array<Maybe<PatientVaccination>>;
+  number: Scalars['Int'];
+  total: Scalars['Int'];
+};
+
 export type Person = {
   __typename?: 'Person';
   addReasonCd?: Maybe<Scalars['String']>;
@@ -1490,6 +1515,7 @@ export type Query = {
   findPlacesByFilter: Array<Maybe<Place>>;
   findSnomedCodedResults: SnomedCodedResults;
   findTreatmentsForPatient?: Maybe<PatientTreatmentResults>;
+  findVaccinationsForPatient?: Maybe<PatientVaccinationResults>;
 };
 
 
@@ -1682,6 +1708,12 @@ export type QueryFindSnomedCodedResultsArgs = {
 
 
 export type QueryFindTreatmentsForPatientArgs = {
+  page?: InputMaybe<Page>;
+  patient: Scalars['ID'];
+};
+
+
+export type QueryFindVaccinationsForPatientArgs = {
   page?: InputMaybe<Page>;
   patient: Scalars['ID'];
 };
@@ -2126,6 +2158,14 @@ export type FindTreatmentsForPatientQueryVariables = Exact<{
 
 
 export type FindTreatmentsForPatientQuery = { __typename?: 'Query', findTreatmentsForPatient?: { __typename?: 'PatientTreatmentResults', total: number, number: number, content: Array<{ __typename?: 'PatientTreatment', treatment: string, createdOn: any, provider?: string | null, treatedOn: any, description: string, event: string, associatedWith: { __typename?: 'PatientTreatmentInvestigation', id: string, local: string, condition: string } } | null> } | null };
+
+export type FindVaccinationsForPatientQueryVariables = Exact<{
+  patient: Scalars['ID'];
+  page?: InputMaybe<Page>;
+}>;
+
+
+export type FindVaccinationsForPatientQuery = { __typename?: 'Query', findVaccinationsForPatient?: { __typename?: 'PatientVaccinationResults', total: number, number: number, content: Array<{ __typename?: 'PatientVaccination', vaccination: string, createdOn: any, provider?: string | null, administeredOn: any, administered: string, event: string, associatedWith?: { __typename?: 'PatientVaccinationInvestigation', id: string, local: string, condition: string } | null } | null> } | null };
 
 
 export const CreatePatientDocument = gql`
@@ -5188,3 +5228,53 @@ export function useFindTreatmentsForPatientLazyQuery(baseOptions?: Apollo.LazyQu
 export type FindTreatmentsForPatientQueryHookResult = ReturnType<typeof useFindTreatmentsForPatientQuery>;
 export type FindTreatmentsForPatientLazyQueryHookResult = ReturnType<typeof useFindTreatmentsForPatientLazyQuery>;
 export type FindTreatmentsForPatientQueryResult = Apollo.QueryResult<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>;
+export const FindVaccinationsForPatientDocument = gql`
+    query findVaccinationsForPatient($patient: ID!, $page: Page) {
+  findVaccinationsForPatient(patient: $patient, page: $page) {
+    content {
+      vaccination
+      createdOn
+      provider
+      administeredOn
+      administered
+      event
+      associatedWith {
+        id
+        local
+        condition
+      }
+    }
+    total
+    number
+  }
+}
+    `;
+
+/**
+ * __useFindVaccinationsForPatientQuery__
+ *
+ * To run a query within a React component, call `useFindVaccinationsForPatientQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindVaccinationsForPatientQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindVaccinationsForPatientQuery({
+ *   variables: {
+ *      patient: // value for 'patient'
+ *      page: // value for 'page'
+ *   },
+ * });
+ */
+export function useFindVaccinationsForPatientQuery(baseOptions: Apollo.QueryHookOptions<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>(FindVaccinationsForPatientDocument, options);
+      }
+export function useFindVaccinationsForPatientLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>(FindVaccinationsForPatientDocument, options);
+        }
+export type FindVaccinationsForPatientQueryHookResult = ReturnType<typeof useFindVaccinationsForPatientQuery>;
+export type FindVaccinationsForPatientLazyQueryHookResult = ReturnType<typeof useFindVaccinationsForPatientLazyQuery>;
+export type FindVaccinationsForPatientQueryResult = Apollo.QueryResult<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -922,6 +922,31 @@ type PatientTreatmentResults {
 extend type Query {
   findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
 }
+type PatientVaccination {
+    vaccination: ID!
+    createdOn: DateTime!
+    provider: String
+    administeredOn: DateTime!
+    administered: String!
+    event: String!
+    associatedWith: PatientVaccinationInvestigation
+}
+
+type PatientVaccinationInvestigation {
+    id: ID!
+    local: String!
+    condition: String!
+}
+
+type PatientVaccinationResults {
+    content: [PatientVaccination]!
+    total: Int!
+    number: Int!
+}
+
+extend type Query {
+    findVaccinationsForPatient(patient: ID!, page: Page): PatientVaccinationResults
+}
 type Query {
     findPatientById(id: ID!): Person
     findAllPatients(page: SortablePage): PersonResults!

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Act.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Act.java
@@ -43,8 +43,11 @@ public class Act {
     @OneToMany(mappedBy = "id", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Notification> notifications;
 
-    @OneToMany(mappedBy = "id", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "id", fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE})
     private List<Observation> observations;
+
+    @OneToMany(mappedBy = "id", fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE})
+    private List<Intervention> interventions;
 
     @OneToMany(mappedBy = "targetActUid", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ActRelationship> targetActRelationships;

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Intervention.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Intervention.java
@@ -1,16 +1,18 @@
 package gov.cdc.nbs.entity.odse;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
 import java.time.Instant;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
 @Entity
@@ -20,7 +22,14 @@ public class Intervention {
     private Long id;
 
     @MapsId
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(
+        fetch = FetchType.LAZY,
+        cascade = {
+            CascadeType.PERSIST,
+            CascadeType.REMOVE
+        },
+        optional = false
+    )
     @JoinColumn(name = "intervention_uid", nullable = false)
     private Act act;
 
@@ -183,4 +192,18 @@ public class Intervention {
     @Column(name = "electronic_ind")
     private Character electronicInd;
 
+    public Intervention() {
+    }
+
+    public Intervention(final long identifier, final String local) {
+        this.id = identifier;
+        this.localId = local;
+
+        this.recordStatusCd = "ACTIVE";
+
+        this.sharedInd = 'F';
+        this.versionCtrlNbr = 1;
+
+        this.act = new Act(identifier, "INTV");
+    }
 }


### PR DESCRIPTION
Implements [CNFT1-747](https://cdc-nbs.atlassian.net/browse/CNFT1-747) by adding the graphql query `findVaccinationsForPatient` to retrieve vaccinations for a patient.

```graphql
query vaccinations($patient: ID!, $page: Page) {
  findVaccinationsForPatient(patient: $patient, page: $page) {
    content {
      vaccination
      createdOn
      provider
      administeredOn
      administered
      event
      associatedWith {
        id
        local
        condition
      }
    }
    total
  }
}
```