### PR TITLE
create test db

### DIFF
--- a/.github/workflows/Build-modernization-test-db.yaml
+++ b/.github/workflows/Build-modernization-test-db.yaml
@@ -1,0 +1,15 @@
+name: Build and Push modernization-test-db
+on:
+  push:
+    tags:
+      - "*SNAPSHOT*"
+
+jobs:
+  call-build-microservice-container-workflow:
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-microservice-container.yaml@main
+    with:
+      microservice_name: modernization-test-db
+      dockerfile_relative_path: ./cdc-sandbox/test-db
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/DocumentsRequiringReviewSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/DocumentsRequiringReviewSteps.java
@@ -4,69 +4,45 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
-import gov.cdc.nbs.entity.elasticsearch.ElasticsearchPerson;
 import gov.cdc.nbs.entity.elasticsearch.LabReport;
 import gov.cdc.nbs.labreport.LabReportFinder;
-import gov.cdc.nbs.repository.elasticsearch.ElasticsearchPersonRepository;
 import gov.cdc.nbs.repository.elasticsearch.LabReportRepository;
 import gov.cdc.nbs.support.EventMother;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class)
-@AutoConfigureMockMvc
-@ActiveProfiles("test")
-@Transactional
 public class DocumentsRequiringReviewSteps {
-    @Autowired
-    private ElasticsearchPersonRepository elasticsearchPersonRepository;
-
     @Autowired
     private LabReportRepository labReportRepository;
 
     @Autowired
     private LabReportFinder labReportFinder;
 
-    private Page<ElasticsearchPerson> personPage;
     private Page<LabReport> labReportResults;
+    private final long patientId = 12345L;
 
     @Given("a patient has documents requiring review")
     public void a_patient_has_documents_requiring_review() {
-        setAvailablePatients();
-        var firstPerson = personPage.getContent().get(0);
-        var report = EventMother.labReport_acidFastStain(firstPerson.getPersonUid());
+        var report = EventMother.labReport_acidFastStain(patientId);
         assertEquals("UNPROCESSED", report.getRecordStatusCd());
-        var processedReport = EventMother.labReport_acidFastStain_complete(firstPerson.getPersonUid());
-        assertEquals("PROCESSED", processedReport.getRecordStatusCd());
         labReportRepository.save(report);
+
+        var processedReport = EventMother.labReport_acidFastStain_complete(patientId);
+        assertEquals("PROCESSED", processedReport.getRecordStatusCd());
         labReportRepository.save(processedReport);
     }
 
     @Given("a patient does not have documents requiring review")
     public void a_patient_does_not_have_documents_requiring_review() {
-        setAvailablePatients();
-        var patientId = personPage.getContent().get(0).getPersonUid();
-        var reportsForPatient = labReportFinder.findUnprocessedDocumentsForPatient(patientId, Pageable.ofSize(100));
-        labReportRepository.deleteAll(reportsForPatient.getContent());
+        labReportRepository.deleteAll();
     }
 
     @When("I search for documents requiring review for a patient")
     public void i_search_for_documents_requiring_review_for_a_patient() {
-        setAvailablePatients();
-        var patientId = personPage.getContent().get(0).getPersonUid();
         labReportResults = labReportFinder.findUnprocessedDocumentsForPatient(patientId, Pageable.ofSize(100));
     }
 
@@ -81,11 +57,6 @@ public class DocumentsRequiringReviewSteps {
     public void none_are_returned() {
         assertNotNull(labReportResults);
         assertTrue(labReportResults.isEmpty());
-    }
-
-    private void setAvailablePatients() {
-        var pageable = PageRequest.of(0, 2, Sort.by(ElasticsearchPerson.PERSON_UID));
-        personPage = elasticsearchPersonRepository.findAll(pageable);
     }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/DocumentMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/DocumentMother.java
@@ -111,6 +111,15 @@ class DocumentMother {
   }
 
   private NbsDocumentMetadatum metadatum() {
-    return this.entityManager.getReference(NbsDocumentMetadatum.class, 1003L);
-  }
+    var ref = entityManager.find(NbsDocumentMetadatum.class,1003L);
+  if (ref == null){
+    var metadatum = new NbsDocumentMetadatum();
+    metadatum.setId(1003L);
+    metadatum.setXmlSchemaLocation("schemaLocation");
+    metadatum.setDocumentViewXsl("docViewXsl");
+    entityManager.persist(metadatum);
+    return metadatum;
+  } 
+  return ref;
+}
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/EventMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/EventMother.java
@@ -17,16 +17,16 @@ public class EventMother {
     public static Long CREATED_BY = 999999L;
     public static Long UPDATED_BY = 999998L;
 
-    // jurisdiction codes from NBS_SRTE.Jurisdiction_code
-    public static Long DEKALB_CODE = 930005L;
-    public static Long CLAYTON_CODE = 930006L;
+    // jurisdiction codes from NBS_SRTE.Jurisdiction_code - nbs_uid
+    public static Long DEKALB_CODE = 13005L;
+    public static Long CLAYTON_CODE = 13006L;
 
     // from NBS_SRTE.Program_area_code
     public static Integer STD_ID = 15;
     public static Integer ARBO_ID = 13;
 
-    public static Long DEKALB_ARBO_OID = (DEKALB_CODE * 100000L) + ARBO_ID;
-    public static Long CLAYTON_STD_OID = (CLAYTON_CODE * 100000L) + STD_ID;
+    public static Long DEKALB_ARBO_OID = (DEKALB_CODE * 100000L) + ARBO_ID; // 1300500015
+    public static Long CLAYTON_STD_OID = (CLAYTON_CODE * 100000L) + STD_ID; // 1300600015
 
     public static Investigation investigation_bacterialVaginosis(Long personId) {
         var participations = Arrays.asList(ElasticsearchPersonParticipation.builder()

--- a/apps/modernization-api/src/test/resources/application-test.yml
+++ b/apps/modernization-api/src/test/resources/application-test.yml
@@ -32,7 +32,7 @@ spring:
         hbm2ddl:
           jdbc_metadata_extraction_strategy: individually
   datasource:
-    url: jdbc:sqlserver://${nbs.datasource.server}:1433;database=nbs_odse;encrypt=true;trustServerCertificate=true;
+    url: jdbc:sqlserver://${nbs.datasource.server}:1434;database=nbs_odse;encrypt=true;trustServerCertificate=true;
     username: sa
     password: fake.fake.fake.1234
   mvc:

--- a/apps/modernization-api/src/test/resources/features/DocumentsRequiringReview.feature
+++ b/apps/modernization-api/src/test/resources/features/DocumentsRequiringReview.feature
@@ -1,9 +1,8 @@
 @documents_requiring_review
 Feature: Documents Requiring Review
 
-  Background:
+  Background: 
     Given I have the authorities: "VIEWWORKUP-PATIENT,VIEW-OBSERVATIONLABREPORT" for the jurisdiction: "ALL" and program area: "STD"
-    And there are 2 patients
 
   Scenario: I can retrieve documents requiring review for a particular patient
     Given a patient has documents requiring review

--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -80,6 +80,11 @@ services:
     #   - ./nifi/nifi_conf/conf:/opt/nifi/nifi-current/conf:rw
     networks:
       - nbs
+  test-db:
+    build: ./test-db
+    container_name: test-db
+    ports:
+      - 1434:1433
 volumes:
   nbs-mssql-data:
 networks:

--- a/cdc-sandbox/test-db/Dockerfile
+++ b/cdc-sandbox/test-db/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/azure-sql-edge:latest
+USER root
+
+# Install sqlcmd, see https://docs.microsoft.com/en-us/sql/tools/go-sqlcmd-utility?view=sql-server-ver16
+RUN apt-get update
+RUN apt-get install -y software-properties-common tar
+RUN add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/20.04/prod.list)"
+RUN apt-get install -y sqlcmd
+
+# Copy restore files and unzip
+ADD ./restore /var/opt/db-restore/
+RUN tar -xzf /var/opt/db-restore/restore.d/restore.tar.gz -C /var/opt/db-restore/restore.d/
+
+USER mssql
+
+# Set default passwords
+ENV ACCEPT_EULA=1
+ENV SQLCMDPASSWORD=fake.fake.fake.1234
+ENV SA_PASSWORD=fake.fake.fake.1234
+
+# Start the database and execute restore scripts
+RUN /opt/mssql/bin/sqlservr & /var/opt/db-restore/restore.sh
+
+ENTRYPOINT [ "/opt/mssql/bin/sqlservr" ]

--- a/cdc-sandbox/test-db/restore/restore.sh
+++ b/cdc-sandbox/test-db/restore/restore.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+restore_file_directory=/var/opt/db-restore/restore.d
+
+for restore_file in $(find "$restore_file_directory" -iname "*.sql" |sort) ; do
+  echo "Restoring: $restore_file"
+  for i in {1..50};
+  do
+      /usr/bin/sqlcmd -S localhost -U sa -i "$restore_file"
+      if [ $? -eq 0 ]
+      then
+          echo "restore $restore_file completed"
+          break
+      else
+          echo "database not ready yet..."
+          sleep 1
+      fi
+  done
+done


### PR DESCRIPTION
1. Creates a `cdc-sandbox/test-db` folder with restore files for a stripped down NBS database for use in testing. The test-db is added to the cdc-sandbox docker-compose for use in running tests locally.
1. Fixes a couple of tests that were failing with the new db due to missing expected data.
1. Adds the `Build-modernization-test-db.yml` workflow to build and push the test-db image to ECR.

The next step will be to verify the image is pushed to ECR and is available, then update the tests to pull this image in a test container. 