### PR TITLE
CNFT1-771 Text meet color contrast

### DIFF
--- a/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/PatientProfile.tsx
@@ -109,7 +109,7 @@ export const PatientProfile = () => {
                         </p>
                     ))
                 ) : (
-                    <p className="text-italic margin-0 text-gray-30">No Data</p>
+                    <p className="text-italic margin-0 text-gray-50">No Data</p>
                 )}
             </div>
         );


### PR DESCRIPTION
Bumped the contrast on "No Data" fields in `patient-profile`--up to USWDS class .text-grey-50.

We could include a function to calculate text color based on contrast-ratio on the fly a la: 
https://www.w3.org/TR/AERT/#color-contrast

Would be up for discussing that.