### PR TITLE
Use local test db image

### DIFF
--- a/apps/modernization-api/README.md
+++ b/apps/modernization-api/README.md
@@ -12,11 +12,17 @@
 
 1. In the ui directory run `npm install`
 2. In the modernization-api directory run `./gradlew build`
-    - Alternatively, from the root directory run `./gradlew :modernization-api:buildDependents`
+   - Alternatively, from the root directory run `./gradlew :modernization-api:buildDependents`
 3. Press `Cmd+Shift+P` and run `Java: Clean Language Server Workspace`
 4. VSCode should now recognize the QueryDSL generated Q classes and be able to launch the debugger
 
 ## Tests
+
+Prior to running tests the `cdc-sandbox/test-db/` image must be built. To build this image run the following command in the `cdc-sandbox` directory.
+
+```sh
+docker-compose up test-db -d
+```
 
 To run all tests:
 
@@ -89,14 +95,14 @@ Environment Variable,
 and [other useful means](https://docs.spring.io/spring-boot/docs/2.7.5/reference/html/features.html#features.external-config)
 . The default profile contains the following properties configuration most likely to change.
 
-| Name                           | Default   | Description                                         |
-|--------------------------------|-----------|-----------------------------------------------------|
-| nbs.elasticsearch.server       | localhost | The host name of the server running ElasticSearch   |
-| nbs.elasticsearch.port         | 9200      | The port in which ElasticSearch is listening        |
-| nbs.wildfly.server             | localhost | The host name of the server running NBS Classic     |
-| nbs.wildfly.port               | 7001      | The port in which NBS Classic is listening          |
-| nbs.datasource.server          | localhost | The host name of the server running MS SQL Server   |
-| nbs.identifier.person.initial  | 10000000  | The initial seed value for Person local identifiers |
+| Name                          | Default   | Description                                         |
+| ----------------------------- | --------- | --------------------------------------------------- |
+| nbs.elasticsearch.server      | localhost | The host name of the server running ElasticSearch   |
+| nbs.elasticsearch.port        | 9200      | The port in which ElasticSearch is listening        |
+| nbs.wildfly.server            | localhost | The host name of the server running NBS Classic     |
+| nbs.wildfly.port              | 7001      | The port in which NBS Classic is listening          |
+| nbs.datasource.server         | localhost | The host name of the server running MS SQL Server   |
+| nbs.identifier.person.initial | 10000000  | The initial seed value for Person local identifiers |
 
 Configuration properties can be overwritten at runtime using the `--args` Gradle option to pass arguments to Spring
 Boot.
@@ -107,5 +113,3 @@ by executing.
 ```bash
 ./gradlew :modernization-api:bootRun --args'--nbs-datasource.server=other '
 ```
-
-

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/containers/NbsElasticsearchContainer.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/containers/NbsElasticsearchContainer.java
@@ -16,6 +16,7 @@ public class NbsElasticsearchContainer extends ElasticsearchContainer {
         super(DockerImageName.parse(ELASTIC_SEARCH_DOCKER)
                 .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"));
         this.addEnv(CLUSTER_NAME, ELASTIC_SEARCH);
+        this.addEnv("ES_JAVA_OPTS", "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=536870912");
     }
 
     public void startWithPlugins() throws UnsupportedOperationException, IOException, InterruptedException {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/containers/database/NbsDatabaseContainer.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/containers/database/NbsDatabaseContainer.java
@@ -8,7 +8,7 @@ class NbsDatabaseContainer extends GenericContainer<NbsDatabaseContainer> {
     private static final int DEFAULT_PORT = 1433;
 
     public NbsDatabaseContainer() {
-        super(DockerImageName.parse("cdc-nbs-modernization/modernization-test-db:1.0.7-SNAPSHOT.41470e8"));
+        super(DockerImageName.parse("cdc-sandbox-test-db"));
 
         addExposedPorts(DEFAULT_PORT);
     }

--- a/apps/modernization-api/src/test/resources/application-test.yml
+++ b/apps/modernization-api/src/test/resources/application-test.yml
@@ -5,8 +5,6 @@ nbs:
     tokenExpirationMillis: 60000
     parameterSecret: Yq4vh+mbi4B4QYThc/M+33VtPJ5O2Adc
   max-page-size: 1000
-  datasource:
-    server: localhost
 
 logging:
   file.path: ./log/
@@ -32,7 +30,6 @@ spring:
         hbm2ddl:
           jdbc_metadata_extraction_strategy: individually
   datasource:
-    url: jdbc:sqlserver://${nbs.datasource.server}:1434;database=nbs_odse;encrypt=true;trustServerCertificate=true;
     username: sa
     password: fake.fake.fake.1234
   mvc:


### PR DESCRIPTION
Reduce elasticsearch test container memory usage. Use local test db until ECR config is resolved.

Pre-req to running tests is to build test-db image.