### PR TITLE
CNFT1-747 Vaccination for patient API find by parent

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/vaccination/PatientVaccinationFinder.java
@@ -59,7 +59,7 @@ class PatientVaccinationFinder {
                 this.tables.vaccination().recordStatusCd.eq("ACTIVE")
             )
             .where(
-                PATIENT.id.eq(patient),
+                PATIENT.personParentUid.id.eq(patient),
                 PATIENT.cd.eq(PATIENT_CODE),
                 PATIENT.recordStatusCd.eq(RecordStatus.ACTIVE)
             );


### PR DESCRIPTION
vaccination finder will now use parent id to include vaccinations for all child records.  The query to find all vaccinations was using the person id over the parent id.  it's still unclear as so when a new person record is created over using an existing person record.