### PR TITLE
Refactor patient profile documents for reuse

### DIFF
--- a/apps/modernization-ui/src/page/index.ts
+++ b/apps/modernization-ui/src/page/index.ts
@@ -1,0 +1,1 @@
+export { PageProvider, usePage } from './page';

--- a/apps/modernization-ui/src/page/page.tsx
+++ b/apps/modernization-ui/src/page/page.tsx
@@ -1,0 +1,51 @@
+import { createContext, ReactNode, useContext, useReducer } from 'react';
+import { TOTAL_TABLE_DATA } from 'utils/util';
+
+type Page = {
+    pageSize: number;
+    total: number;
+    current: number;
+};
+
+type Action = { type: 'ready'; total: number; page: number } | { type: 'go-to'; page: number };
+type Dispatch = (action: Action) => void;
+
+const PageContext = createContext<{ page: Page; dispatch: Dispatch } | undefined>(undefined);
+
+const pageReducer = (state: Page, action: Action) => {
+    switch (action.type) {
+        case 'ready':
+            return { ...state, total: action.total, page: action.page };
+        case 'go-to':
+            return { ...state, current: action.page };
+    }
+};
+
+type PageProviderProps = {
+    pageSize?: number;
+    children: ReactNode;
+};
+
+const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, children }: PageProviderProps) => {
+    const startPage = { pageSize, total: 0, current: 1 };
+
+    const [page, dispatch] = useReducer(pageReducer, startPage);
+
+    const value = { page, dispatch };
+
+    return <PageContext.Provider value={value}>{children}</PageContext.Provider>;
+};
+
+const usePage = () => {
+    const context = useContext(PageContext);
+
+    if (context === undefined) {
+        throw new Error('usePage must be used within a PageProvider');
+    }
+
+    return context;
+};
+
+const goToPage = (dispatch: Dispatch) => (page: number) => dispatch({ type: 'go-to', page: page });
+
+export { PageProvider, usePage, goToPage };

--- a/apps/modernization-ui/src/pages/patientProfile/Events.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/Events.tsx
@@ -6,7 +6,7 @@ import {
 import { Config } from 'config';
 import { PatientTreatmentTable } from 'patient/profile/treatment';
 import { PatientNamedByContactTable, ContactNamedByPatientTable } from 'patient/profile/contact';
-import { PatientDocumentTable } from 'patient/profile/document';
+import { PatientProfileDocuments } from 'patient/profile/document';
 import { TOTAL_TABLE_DATA } from 'utils/util';
 import { PatientInvestigationsTable } from 'patient/profile/investigation';
 import { MorbidityTable } from 'patient/profile/morbidity';
@@ -43,9 +43,8 @@ export const Events = ({ patient }: EventTabProp) => {
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
                 <PatientTreatmentTable patient={patient} />
             </div>
-            <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-                <PatientDocumentTable patient={patient} pageSize={TOTAL_TABLE_DATA} nbsBase={NBS_URL} />
-            </div>
+
+            <PatientProfileDocuments patient={patient} nbsBase={NBS_URL} pageSize={TOTAL_TABLE_DATA} />
 
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
                 <ContactNamedByPatientTable patient={patient} />

--- a/apps/modernization-ui/src/patient/profile/contact/ContactNamedByPatientTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/contact/ContactNamedByPatientTable.spec.tsx
@@ -110,15 +110,29 @@ describe('when the patient has been named by a contact', () => {
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toContainHTML('<span class="link">03/17/2023 <br /> 03:08 PM</span>');
-        expect(tableData[1].innerHTML).toContain('Surma Singh');
-        expect(tableData[2].innerHTML).toContain('01/17/2023');
-        expect(tableData[3]).toContainHTML(
-            '<b>condition-value</b><br/><b>Priority:</b> priority-value<br/><b>Disposition:</b> disposition-value<br/>'
-        );
-        expect(tableData[4]).toContainHTML(
-            '<div><p class="margin-0 text-primary text-bold link" style="word-break: break-word;">CAS10000000GA01</p><p class="margin-0">associated-condition</p></div></span>'
-        );
+        const dateCreated = await findByText(/03\/17\/2023/);
+
+        expect(dateCreated).toHaveTextContent('03:08 PM');
+
+        expect(tableData[0]).toContainElement(dateCreated);
+        expect(tableData[1]).toHaveTextContent('Surma Singh');
+        expect(tableData[2]).toHaveTextContent('01/17/2023');
+
+        //  Description fields
+        const dispositionLabel = await findByText(/Disposition:/);
+        expect(tableData[3]).toContainElement(dispositionLabel);
+
+        const dispositionValue = await findByText(/disposition-value/);
+        expect(tableData[3]).toContainElement(dispositionValue);
+
+        //  Associated With
+        const association = await findByText('CAS10000000GA01');
+
+        expect(tableData[4]).toContainElement(association);
+        const associationCondition = await findByText('associated-condition');
+
+        expect(tableData[4]).toContainElement(associationCondition);
+
         expect(tableData[5]).toHaveTextContent('CON10000002GA01');
     });
 });

--- a/apps/modernization-ui/src/patient/profile/contact/PatientNamedByContactTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/contact/PatientNamedByContactTable.spec.tsx
@@ -110,15 +110,37 @@ describe('when the patient has been named by a contact', () => {
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toContainHTML('<span class="link">03/17/2023 <br /> 03:08 PM</span>');
+        const dateCreated = await findByText(/03\/17\/2023/);
+
+        expect(dateCreated).toHaveTextContent('03:08 PM');
+
+        expect(tableData[0]).toContainElement(dateCreated);
+
         expect(tableData[1].innerHTML).toContain('Surma Singh');
         expect(tableData[2].innerHTML).toContain('01/17/2023');
-        expect(tableData[3]).toContainHTML(
-            '<b>condition-value</b><br/><b>Priority:</b> priority-value<br/><b>Disposition:</b> disposition-value<br/>'
-        );
-        expect(tableData[4]).toContainHTML(
-            '<div><p class="margin-0 text-primary text-bold link" style="word-break: break-word;">CAS10000000GA01</p><p class="margin-0">associated-condition</p></div></span>'
-        );
+
+        //  Description fields
+        const dispositionLabel = await findByText(/Disposition:/);
+        expect(tableData[3]).toContainElement(dispositionLabel);
+
+        const dispositionValue = await findByText(/disposition-value/);
+        expect(tableData[3]).toContainElement(dispositionValue);
+
+        const priorityLabel = await findByText(/Priority:/);
+        expect(tableData[3]).toContainElement(priorityLabel);
+
+        const priorityValue = await findByText(/priority-value/);
+        expect(tableData[3]).toContainElement(priorityValue);
+
+        //  Associated With
+        const association = await findByText('CAS10000000GA01');
+
+        expect(tableData[4]).toContainElement(association);
+
+        const associationCondition = await findByText('associated-condition');
+
+        expect(tableData[4]).toContainElement(associationCondition);
+
         expect(tableData[5]).toHaveTextContent('CON10000002GA01');
     });
 });
@@ -223,7 +245,11 @@ describe('when the patient has been named by a contact without a priority', () =
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[3]).toContainHTML('<b>condition-value</b><br/><b>Disposition:</b> disposition-value<br/>');
+        const dispositionLabel = await findByText(/Disposition:/);
+        expect(tableData[3]).toContainElement(dispositionLabel);
+
+        const dispositionValue = await findByText(/disposition-value/);
+        expect(tableData[3]).toContainElement(dispositionValue);
     });
 });
 
@@ -277,6 +303,10 @@ describe('when the patient has been named by a contact without a disposition', (
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[3]).toContainHTML('<b>condition-value</b><br/><b>Priority:</b> priority-value<br/>');
+        const priorityLabel = await findByText(/Priority:/);
+        expect(tableData[3]).toContainElement(priorityLabel);
+
+        const priorityValue = await findByText(/priority-value/);
+        expect(tableData[3]).toContainElement(priorityValue);
     });
 });

--- a/apps/modernization-ui/src/patient/profile/contact/PatientNamedByContactTable.tsx
+++ b/apps/modernization-ui/src/patient/profile/contact/PatientNamedByContactTable.tsx
@@ -160,7 +160,7 @@ export const PatientNamedByContactTable = ({ patient, pageSize = TOTAL_TABLE_DAT
     return (
         <SortableTable
             isPagination={true}
-            tableHeader={'Contact records (contacts named by patient)'}
+            tableHeader={'Contact records (patient named by contacts)'}
             tableHead={tableHead}
             tableBody={
                 namedByPatientData?.length > 0 &&

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentContainer.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentContainer.tsx
@@ -1,0 +1,12 @@
+import { Document } from './PatientDocuments';
+import { PatientDocumentTable } from './PatientDocumentTable';
+
+type Props = {
+    source: (patient?: string) => Document[];
+    nbsBase: string;
+    patient?: string;
+};
+
+export const PatientDocumentContainer = ({ source, nbsBase, patient }: Props) => (
+    <PatientDocumentTable nbsBase={nbsBase} documents={source(patient)} />
+);

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.spec.tsx
@@ -1,15 +1,13 @@
+import { PageProvider } from 'page';
 import { PatientDocumentTable } from './PatientDocumentTable';
 import { render } from '@testing-library/react';
-import { FindDocumentsForPatientDocument } from 'generated/graphql/schema';
-
-import { MockedProvider } from '@apollo/client/testing';
 
 describe('when rendered', () => {
     it('should display sentence cased document headers', async () => {
         const { container } = render(
-            <MockedProvider addTypename={false}>
-                <PatientDocumentTable pageSize={1} nbsBase={'base'}></PatientDocumentTable>
-            </MockedProvider>
+            <PageProvider>
+                <PatientDocumentTable nbsBase={'base'} documents={[]}></PatientDocumentTable>
+            </PageProvider>
         );
 
         const tableHeader = container.getElementsByClassName('table-header');
@@ -28,33 +26,11 @@ describe('when rendered', () => {
 });
 
 describe('when documents are not available for a patient', () => {
-    const response = {
-        request: {
-            query: FindDocumentsForPatientDocument,
-            variables: {
-                patient: '73',
-                page: {
-                    pageNumber: 0,
-                    pageSize: 5
-                }
-            }
-        },
-        result: {
-            data: {
-                findDocumentsForPatient: {
-                    content: [],
-                    total: 0,
-                    number: 0
-                }
-            }
-        }
-    };
-
     it('should display Not Available', async () => {
         const { findByText } = render(
-            <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientDocumentTable patient={'73'} pageSize={5} nbsBase={'base'}></PatientDocumentTable>
-            </MockedProvider>
+            <PageProvider>
+                <PatientDocumentTable nbsBase={'base'} documents={[]}></PatientDocumentTable>
+            </PageProvider>
         );
 
         expect(await findByText('Not Available')).toBeInTheDocument();
@@ -62,113 +38,52 @@ describe('when documents are not available for a patient', () => {
 });
 
 describe('when at least one document is available for a patient', () => {
-    const response = {
-        request: {
-            query: FindDocumentsForPatientDocument,
-            variables: {
-                patient: '1823',
-                page: {
-                    pageNumber: 0,
-                    pageSize: 5
-                }
-            }
-        },
-        result: {
-            data: {
-                findDocumentsForPatient: {
-                    content: [
-                        {
-                            document: 'document-id',
-                            receivedOn: '2021-10-07T15:01:10Z',
-                            type: 'document-type-value',
-                            sendingFacility: 'sending-facility-value',
-                            reportedOn: '2021-09-21T17:04:11Z',
-                            condition: 'condition-value',
-                            event: 'event-value',
-                            associatedWith: {
-                                id: 'associated-id',
-                                local: 'associated-local-value',
-                                condition: 'associated-condition-value'
-                            }
-                        }
-                    ],
-                    total: 1,
-                    number: 0
-                }
+    const documents = [
+        {
+            document: 'document-id',
+            receivedOn: new Date('2021-10-07T15:01:10Z'),
+            type: 'document-type-value',
+            sendingFacility: 'sending-facility-value',
+            reportedOn: new Date('2021-09-21T17:04:11Z'),
+            condition: 'condition-value',
+            event: 'event-value',
+            associatedWith: {
+                id: 'associated-id',
+                local: 'associated-local-value',
+                condition: 'associated-condition-value'
             }
         }
-    };
+    ];
 
     it('should display the documents', async () => {
         const { container, findByText } = render(
-            <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientDocumentTable patient={'1823'} pageSize={5} nbsBase={'base'}></PatientDocumentTable>
-            </MockedProvider>
+            <PageProvider>
+                <PatientDocumentTable nbsBase={'base'} documents={documents}></PatientDocumentTable>
+            </PageProvider>
         );
-
-        expect(await findByText('Showing 1 of 1')).toBeInTheDocument();
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toContainHTML(
-            '<span class="link"><a href="base/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=document-id">10/07/2021 <br /> 10:01 AM</a></span>'
+        const dateCreated = await findByText(/10\/07\/2021/);
+
+        expect(dateCreated).toHaveTextContent('10:01 AM');
+        expect(dateCreated).toHaveAttribute(
+            'href',
+            'base/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=document-id'
         );
-        expect(tableData[1].innerHTML).toContain('document-type-value');
-        expect(tableData[2].innerHTML).toContain('sending-facility-value');
-        expect(tableData[3].innerHTML).toContain('09/21/2021');
-        expect(tableData[4].innerHTML).toContain('condition-value');
-        expect(tableData[5]).toContainHTML(
-            '<div><p class="margin-0 text-primary text-bold link" style="word-break: break-word;">associated-local-value</p></div></span>'
-        );
+
+        expect(tableData[0]).toContainElement(dateCreated);
+
+        expect(tableData[1]).toHaveTextContent('document-type-value');
+        expect(tableData[2]).toHaveTextContent('sending-facility-value');
+        expect(tableData[3]).toHaveTextContent('09/21/2021');
+        expect(tableData[4]).toHaveTextContent('condition-value');
+
+        //  Associated With
+        const association = await findByText('associated-local-value');
+
+        expect(tableData[5]).toContainElement(association);
+
         expect(tableData[6]).toHaveTextContent('event-value');
-    });
-});
-
-describe('when documents are available for a patient', () => {
-    const response = {
-        request: {
-            query: FindDocumentsForPatientDocument,
-            variables: {
-                patient: '1823',
-                page: {
-                    pageNumber: 0,
-                    pageSize: 5
-                }
-            }
-        },
-        result: {
-            data: {
-                findDocumentsForPatient: {
-                    content: [
-                        {
-                            document: 'document-id',
-                            receivedOn: '2021-10-07T15:01:10Z',
-                            type: 'document-type-value',
-                            sendingFacility: 'sending-facility-value',
-                            reportedOn: '2021-09-21T17:04:11Z',
-                            condition: 'condition-value',
-                            event: 'event-value',
-                            associatedWith: {
-                                id: 'associated-id',
-                                local: 'associated-local-value',
-                                condition: 'associated-condition-value'
-                            }
-                        }
-                    ],
-                    total: 6,
-                    number: 1
-                }
-            }
-        }
-    };
-
-    it('should display the documents', async () => {
-        const { container, findByText } = render(
-            <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientDocumentTable patient={'1823'} pageSize={5} nbsBase={'base'}></PatientDocumentTable>
-            </MockedProvider>
-        );
-
-        expect(await findByText('Showing 1 of 6')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientDocumentTable.tsx
@@ -1,11 +1,21 @@
+import { TableBody, TableComponent } from 'components/Table/Table';
 import { useEffect, useState } from 'react';
 import format from 'date-fns/format';
 import { Document, AssociatedWith, Headers } from './PatientDocuments';
-import { FindDocumentsForPatientQuery, useFindDocumentsForPatientLazyQuery } from 'generated/graphql/schema';
-import { transform } from './PatientDocumentTransformer';
 import { sort } from './PatientDocumentSorter';
 import { Direction } from 'sorting';
-import { SortableTable } from 'components/Table/SortableTable';
+import { usePage } from 'page';
+import { goToPage } from 'page/page';
+
+const headers = [
+    { name: Headers.DateReceived, sortable: true },
+    { name: Headers.Type, sortable: true },
+    { name: Headers.SendingFacility, sortable: true },
+    { name: Headers.DateReported, sortable: true },
+    { name: Headers.Condition, sortable: true },
+    { name: Headers.AssociatedWith, sortable: true },
+    { name: Headers.EventID, sortable: true }
+];
 
 const association = (association?: AssociatedWith | null) =>
     association && (
@@ -18,141 +28,71 @@ const association = (association?: AssociatedWith | null) =>
         </>
     );
 
+const asTableBody =
+    (nbsBase: string) =>
+    (document: Document): TableBody => ({
+        id: document?.event,
+        checkbox: false,
+        tableDetails: [
+            {
+                id: 1,
+                title: (
+                    <>
+                        {format(document?.receivedOn, 'MM/dd/yyyy')} <br /> {format(document?.receivedOn, 'hh:mm a')}
+                    </>
+                ),
+                class: 'link',
+                link: `${nbsBase}/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=${document?.document}`
+            },
+            {
+                id: 2,
+                title: document?.type
+            },
+            { id: 3, title: document?.sendingFacility || null },
+            { id: 4, title: format(new Date(document?.reportedOn), 'MM/dd/yyyy') },
+            { id: 5, title: document?.condition || null },
+            {
+                id: 6,
+                title: association(document?.associatedWith)
+            },
+            { id: 7, title: document?.event || null }
+        ]
+    });
+
+const asTableBodies = (nbsBase: string, documents: Document[]): TableBody[] =>
+    documents?.map(asTableBody(nbsBase)) || [];
+
 type Props = {
-    patient?: string;
-    pageSize: number;
     nbsBase: string;
+    documents: Document[];
 };
 
-export const PatientDocumentTable = ({ patient, pageSize, nbsBase }: Props) => {
-    const [currentPage, setCurrentPage] = useState<number>(1);
-    const [total, setTotal] = useState<number>(0);
-    const [items, setItems] = useState<Document[]>([]);
-    const [tableHead, setTableHead] = useState<{ name: string; sortable: boolean; sort?: string }[]>([
-        { name: Headers.DateReceived, sortable: true, sort: 'all' },
-        { name: Headers.Type, sortable: true, sort: 'all' },
-        { name: Headers.SendingFacility, sortable: true, sort: 'all' },
-        { name: Headers.DateReported, sortable: true, sort: 'all' },
-        { name: Headers.Condition, sortable: true, sort: 'all' },
-        { name: Headers.AssociatedWith, sortable: true, sort: 'all' },
-        { name: Headers.EventID, sortable: true, sort: 'all' }
-    ]);
+export const PatientDocumentTable = ({ nbsBase, documents }: Props) => {
+    const { page, dispatch } = usePage();
 
-    const handleComplete = (data: FindDocumentsForPatientQuery) => {
-        const total = data?.findDocumentsForPatient?.total || 0;
-        setTotal(total);
-
-        const content = transform(data?.findDocumentsForPatient);
-        setItems(content);
-    };
-
-    const [getDocuments] = useFindDocumentsForPatientLazyQuery({ onCompleted: handleComplete });
+    const [bodies, setBodies] = useState<TableBody[]>([]);
 
     useEffect(() => {
-        if (patient) {
-            getDocuments({
-                variables: {
-                    patient: patient,
-                    page: {
-                        pageNumber: currentPage - 1,
-                        pageSize
-                    }
-                }
-            });
-        }
-    }, [patient, currentPage]);
-
-    const tableHeadChanges = (name: string, type: string) => {
-        tableHead.map((item) => {
-            if (item.name.toLowerCase() === name.toLowerCase()) {
-                item.sort = type;
-            } else {
-                item.sort = 'all';
-            }
-        });
-        setTableHead(tableHead);
-    };
+        const sorted = sort(documents, {});
+        setBodies(asTableBodies(nbsBase, sorted));
+    }, [documents]);
 
     const handleSort = (name: string, direction: string): void => {
-        tableHeadChanges(name, direction);
         const criteria = { name: name as Headers, type: direction as Direction };
-        setItems(sort(items, criteria));
+        const sorted = sort(documents, criteria);
+        setBodies(asTableBodies(nbsBase, sorted));
     };
 
     return (
-        <SortableTable
+        <TableComponent
             tableHeader={'Documents'}
-            tableHead={tableHead}
-            tableBody={
-                items?.length > 0 &&
-                items?.map((document: any, index: number) => {
-                    return (
-                        <tr key={index}>
-                            <td className={`font-sans-md table-data ${tableHead[0].sort !== 'all' && 'sort-td'}`}>
-                                {document?.receivedOn ? (
-                                    <a
-                                        href={`${nbsBase}/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=${document?.document}`}
-                                        className="table-span">
-                                        {format(document?.receivedOn, 'MM/dd/yyyy')} <br />{' '}
-                                        {format(document?.receivedOn, 'hh:mm a')}
-                                    </a>
-                                ) : (
-                                    <span className="no-data">No data</span>
-                                )}
-                            </td>
-                            <td className={`font-sans-md table-data ${tableHead[1].sort !== 'all' && 'sort-td'}`}>
-                                {document?.type ? (
-                                    <span>{document?.type}</span>
-                                ) : (
-                                    <span className="no-data">No data</span>
-                                )}
-                            </td>
-                            <td className={`font-sans-md table-data ${tableHead[2].sort !== 'all' && 'sort-td'}`}>
-                                {document?.sendingFacility ? (
-                                    <span>{document?.sendingFacility}</span>
-                                ) : (
-                                    <span className="no-data">No data</span>
-                                )}
-                            </td>
-                            <td className={`font-sans-md table-data ${tableHead[3].sort !== 'all' && 'sort-td'}`}>
-                                {document?.reportedOn ? (
-                                    <span className="table-span">
-                                        {format(new Date(document?.reportedOn), 'MM/dd/yyyy')}
-                                    </span>
-                                ) : (
-                                    <span className="no-data">No data</span>
-                                )}
-                            </td>
-                            <td className={`font-sans-md table-data ${tableHead[4].sort !== 'all' && 'sort-td'}`}>
-                                {document?.condition ? (
-                                    <span>{document?.condition}</span>
-                                ) : (
-                                    <span className="no-data">No data</span>
-                                )}
-                            </td>
-                            <td className={`font-sans-md table-data ${tableHead[5].sort !== 'all' && 'sort-td'}`}>
-                                {!document?.associatedWith ? (
-                                    <span className="no-data">No data</span>
-                                ) : (
-                                    association(document?.associatedWith)
-                                )}
-                            </td>
-                            <td className={`font-sans-md table-data ${tableHead[6].sort !== 'all' && 'sort-td'}`}>
-                                {document?.event ? (
-                                    <span>{document?.event}</span>
-                                ) : (
-                                    <span className="no-data">No data</span>
-                                )}
-                            </td>
-                        </tr>
-                    );
-                })
-            }
+            tableHead={headers}
+            tableBody={bodies}
             isPagination={true}
-            pageSize={pageSize}
-            totalResults={total}
-            currentPage={currentPage}
-            handleNext={setCurrentPage}
+            pageSize={page.pageSize}
+            totalResults={page.total}
+            currentPage={page.current}
+            handleNext={goToPage(dispatch)}
             sortData={handleSort}
         />
     );

--- a/apps/modernization-ui/src/patient/profile/document/PatientProfileDocuments.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientProfileDocuments.spec.tsx
@@ -1,0 +1,185 @@
+import { PatientProfileDocuments } from './PatientProfileDocuments';
+import { render } from '@testing-library/react';
+import { FindDocumentsForPatientDocument } from 'generated/graphql/schema';
+
+import { MockedProvider } from '@apollo/client/testing';
+import { PageProvider } from 'page';
+
+describe('when rendered', () => {
+    it('should display sentence cased document headers', async () => {
+        const { container } = render(
+            <MockedProvider addTypename={false}>
+                <PatientProfileDocuments nbsBase={'base'} pageSize={1}></PatientProfileDocuments>
+            </MockedProvider>
+        );
+
+        const tableHeader = container.getElementsByClassName('table-header');
+        expect(tableHeader[0].innerHTML).toBe('Documents');
+
+        const tableHeads = container.getElementsByClassName('head-name');
+
+        expect(tableHeads[0].innerHTML).toBe('Date received');
+        expect(tableHeads[1].innerHTML).toBe('Type');
+        expect(tableHeads[2].innerHTML).toBe('Sending facility');
+        expect(tableHeads[3].innerHTML).toBe('Date reported');
+        expect(tableHeads[4].innerHTML).toBe('Condition');
+        expect(tableHeads[5].innerHTML).toBe('Associated with');
+        expect(tableHeads[6].innerHTML).toBe('Event ID');
+    });
+});
+
+describe('when documents are not available for a patient', () => {
+    const response = {
+        request: {
+            query: FindDocumentsForPatientDocument,
+            variables: {
+                patient: '73',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 10
+                }
+            }
+        },
+        result: {
+            data: {
+                findDocumentsForPatient: {
+                    content: [],
+                    total: 0,
+                    number: 0
+                }
+            }
+        }
+    };
+
+    it('should display Not Available', async () => {
+        const { findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientProfileDocuments patient={'73'} nbsBase={'base'} pageSize={10}></PatientProfileDocuments>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Not Available')).toBeInTheDocument();
+    });
+});
+
+describe('when at least one document is available for a patient', () => {
+    const response = {
+        request: {
+            query: FindDocumentsForPatientDocument,
+            variables: {
+                patient: '1823',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 10
+                }
+            }
+        },
+        result: {
+            data: {
+                findDocumentsForPatient: {
+                    content: [
+                        {
+                            document: 'document-id',
+                            receivedOn: '2021-10-07T15:01:10Z',
+                            type: 'document-type-value',
+                            sendingFacility: 'sending-facility-value',
+                            reportedOn: '2021-09-21T17:04:11Z',
+                            condition: 'condition-value',
+                            event: 'event-value',
+                            associatedWith: {
+                                id: 'associated-id',
+                                local: 'associated-local-value',
+                                condition: 'associated-condition-value'
+                            }
+                        }
+                    ],
+                    total: 1,
+                    number: 0
+                }
+            }
+        }
+    };
+
+    it('should display the documents', async () => {
+        const { container, findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientProfileDocuments patient={'1823'} nbsBase={'base'} pageSize={10}></PatientProfileDocuments>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Showing 1 of 1')).toBeInTheDocument();
+
+        const tableData = container.getElementsByClassName('table-data');
+
+        const dateCreated = await findByText(/10\/07\/2021/);
+
+        expect(dateCreated).toHaveTextContent('10:01 AM');
+        expect(dateCreated).toHaveAttribute(
+            'href',
+            'base/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=document-id'
+        );
+
+        expect(tableData[0]).toContainElement(dateCreated);
+
+        expect(tableData[1]).toHaveTextContent('document-type-value');
+        expect(tableData[2]).toHaveTextContent('sending-facility-value');
+        expect(tableData[3]).toHaveTextContent('09/21/2021');
+        expect(tableData[4]).toHaveTextContent('condition-value');
+
+        //  Associated With
+        const association = await findByText('associated-local-value');
+
+        expect(tableData[5]).toContainElement(association);
+
+        expect(tableData[6]).toHaveTextContent('event-value');
+    });
+});
+
+describe('when documents are available for a patient', () => {
+    const response = {
+        request: {
+            query: FindDocumentsForPatientDocument,
+            variables: {
+                patient: '1823',
+                page: {
+                    pageNumber: 0,
+                    pageSize: 5
+                }
+            }
+        },
+        result: {
+            data: {
+                findDocumentsForPatient: {
+                    content: [
+                        {
+                            document: 'document-id',
+                            receivedOn: '2021-10-07T15:01:10Z',
+                            type: 'document-type-value',
+                            sendingFacility: 'sending-facility-value',
+                            reportedOn: '2021-09-21T17:04:11Z',
+                            condition: 'condition-value',
+                            event: 'event-value',
+                            associatedWith: {
+                                id: 'associated-id',
+                                local: 'associated-local-value',
+                                condition: 'associated-condition-value'
+                            }
+                        }
+                    ],
+                    total: 6,
+                    number: 1
+                }
+            }
+        }
+    };
+
+    it('should display the documents', async () => {
+        const { container, findByText } = render(
+            <MockedProvider mocks={[response]} addTypename={false}>
+                <PatientProfileDocuments patient={'1823'} nbsBase={'base'} pageSize={5}></PatientProfileDocuments>
+            </MockedProvider>
+        );
+
+        expect(await findByText('Showing 1 of 6')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/patient/profile/document/PatientProfileDocuments.tsx
+++ b/apps/modernization-ui/src/patient/profile/document/PatientProfileDocuments.tsx
@@ -1,0 +1,20 @@
+import { PageProvider } from 'page';
+
+import { usePatientProfileDocumentsAPI } from './usePatientProfileDocumentsAPI';
+import { PatientDocumentContainer } from './PatientDocumentContainer';
+
+type Props = {
+    patient?: string;
+    nbsBase: string;
+    pageSize: number;
+};
+
+export const PatientProfileDocuments = ({ patient, nbsBase, pageSize }: Props) => {
+    return (
+        <div className="margin-top-6 margin-bottom-2 flex-row common-card">
+            <PageProvider pageSize={pageSize}>
+                <PatientDocumentContainer source={usePatientProfileDocumentsAPI} nbsBase={nbsBase} patient={patient} />
+            </PageProvider>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/patient/profile/document/index.ts
+++ b/apps/modernization-ui/src/patient/profile/document/index.ts
@@ -1,1 +1,1 @@
-export { PatientDocumentTable } from './PatientDocumentTable';
+export { PatientProfileDocuments } from './PatientProfileDocuments';

--- a/apps/modernization-ui/src/patient/profile/document/usePatientProfileDocumentsAPI.ts
+++ b/apps/modernization-ui/src/patient/profile/document/usePatientProfileDocumentsAPI.ts
@@ -1,0 +1,45 @@
+import { usePage } from 'page';
+import { Document } from './PatientDocuments';
+import { FindDocumentsForPatientQuery, useFindDocumentsForPatientLazyQuery } from 'generated/graphql/schema';
+import { useEffect, useState } from 'react';
+import { transform } from './PatientDocumentTransformer';
+
+/**
+ * Responds to "current" state changes of the PageContext by executing an API request for Patient Documents.  Upon completion the PageContext is updated with the total count.
+ *
+ * @param {string} patient The unique identifier of a patient
+ * @return {Document[]} The currently resolved documents for the page and patient
+ */
+export const usePatientProfileDocumentsAPI = (patient?: string) => {
+    const [documents, setDocuments] = useState<Document[]>([]);
+
+    const { page, dispatch: pageDispatch } = usePage();
+
+    const handleComplete = (data: FindDocumentsForPatientQuery) => {
+        const total = data?.findDocumentsForPatient?.total || 0;
+        const pageNumber = data?.findDocumentsForPatient?.number || 0;
+        pageDispatch({ type: 'ready', total: total, page: pageNumber + 1 });
+
+        const content = transform(data?.findDocumentsForPatient);
+
+        setDocuments(content);
+    };
+
+    const [getDocuments] = useFindDocumentsForPatientLazyQuery({ onCompleted: handleComplete });
+
+    useEffect(() => {
+        if (patient) {
+            getDocuments({
+                variables: {
+                    patient: patient,
+                    page: {
+                        pageNumber: page.current - 1,
+                        pageSize: page.pageSize
+                    }
+                }
+            });
+        }
+    }, [patient, page.current]);
+
+    return documents;
+};

--- a/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.spec.tsx
@@ -98,7 +98,7 @@ describe('when treatments are available for a patient', () => {
     };
 
     it('should display the treatments', async () => {
-        const { container, findByText, getAllByRole } = render(
+        const { container, findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
                 <PatientTreatmentTable patient={'1823'} pageSize={5}></PatientTreatmentTable>
             </MockedProvider>

--- a/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.spec.tsx
+++ b/apps/modernization-ui/src/patient/profile/treatment/PatientTreatmentTable.spec.tsx
@@ -108,13 +108,25 @@ describe('when treatments are available for a patient', () => {
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toContainHTML('<span class="link">03/20/2023 <br /> 10:36 AM</span>');
-        expect(tableData[1].innerHTML).toContain('DR Indiana Jones');
-        expect(tableData[2].innerHTML).toContain('03/01/2023');
-        expect(tableData[3].innerHTML).toContain('treatment-description');
-        expect(tableData[4]).toContainHTML(
-            '<div><p class="margin-0 text-primary text-bold link" style="word-break: break-word;">CAS10000000GA01</p><p class="margin-0">Pertussis</p></div></span>'
-        );
+        const dateCreated = await findByText(/03\/20\/2023/);
+
+        expect(dateCreated).toHaveTextContent('10:36 AM');
+
+        expect(tableData[0]).toContainElement(dateCreated);
+
+        expect(tableData[1]).toHaveTextContent('DR Indiana Jones');
+        expect(tableData[2]).toHaveTextContent('03/01/2023');
+        expect(tableData[3]).toHaveTextContent('treatment-description');
+
+        //  Associated With
+        const association = await findByText('CAS10000000GA01');
+
+        expect(tableData[4]).toContainElement(association);
+
+        const associationCondition = await findByText('Pertussis');
+
+        expect(tableData[4]).toContainElement(associationCondition);
+
         expect(tableData[5]).toHaveTextContent('TRT10000000GA01');
     });
 });


### PR DESCRIPTION
Refactors the Patient Profile Documents components to decouple API calls from the display component.  This pattern will allow re-usability of components for Patient Profile and Patient Merge Review.

This also fixes some of the failing tests from the Patient Profile tables by making the tests less reliable on the expected HTML structure. 