### PR TITLE
CNFT1-809 changes state description from full name to two character name

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/geo/state/SimpleStateTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/geo/state/SimpleStateTupleMapper.java
@@ -24,7 +24,7 @@ public class SimpleStateTupleMapper {
             tuple.get(this.tables.address().stateCd),
             "A state identifier is required"
         );
-        String description = tuple.get(this.tables.state().codeDescTxt);
+        String description = tuple.get(this.tables.state().stateNm);
 
         return resolve(id, description);
     }
@@ -38,7 +38,7 @@ public class SimpleStateTupleMapper {
 
     public Optional<SimpleState> maybeMap(final Tuple tuple) {
         String id = tuple.get(this.tables.address().stateCd);
-        String description = tuple.get(this.tables.state().codeDescTxt);
+        String description = tuple.get(this.tables.state().stateNm);
 
         return id == null
             ? Optional.empty()

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
@@ -45,7 +45,7 @@ class PatientAddressFinder {
             tables.address().cntyCd,
             tables.county().codeShortDescTxt,
             tables.address().stateCd,
-            tables.state().codeDescTxt,
+            tables.state().stateNm,
             tables.address().zipCd,
             tables.address().cntryCd,
             tables.country().codeDescTxt,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthFinder.java
@@ -36,7 +36,7 @@ class PatientBirthFinder {
                 tables.multipleBirth().codeShortDescTxt,
                 tables.address().cityDescTxt,
                 tables.address().stateCd,
-                tables.state().codeDescTxt,
+                tables.state().stateNm,
                 tables.address().cntryCd,
                 tables.country().codeDescTxt
             ).from(this.tables.patient())

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
@@ -32,7 +32,7 @@ class PatientMortalityFinder {
                 tables.patient().deceasedTime,
                 tables.address().cityDescTxt,
                 tables.address().stateCd,
-                tables.state().codeDescTxt,
+                tables.state().stateNm,
                 tables.address().cntryCd,
                 tables.country().codeDescTxt
             ).from(this.tables.patient())

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryFinder.java
@@ -67,7 +67,7 @@ class PatientSummaryFinder {
                 this.tables.emailUse().codeShortDescTxt,
                 this.tables.address().streetAddr1,
                 this.tables.address().cityDescTxt,
-                this.tables.state().codeDescTxt,
+                this.tables.state().stateNm,
                 this.tables.address().zipCd,
                 this.tables.country().codeDescTxt
             ).from(this.tables.patient())

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryTupleMapper.java
@@ -190,7 +190,7 @@ class PatientSummaryTupleMapper {
     private PatientSummary.Address maybeMapAddress(final Tuple tuple) {
         String street = tuple.get(this.tables.address().streetAddr1);
         String city = tuple.get(this.tables.address().cityDescTxt);
-        String state = tuple.get(this.tables.state().codeDescTxt);
+        String state = tuple.get(this.tables.state().stateNm);
         String zip = tuple.get(this.tables.address().zipCd);
         String country = tuple.get(this.tables.country().codeDescTxt);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/geo/state/SimpleStateTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/geo/state/SimpleStateTupleMapperTest.java
@@ -24,7 +24,7 @@ class SimpleStateTupleMapperTest {
         Tuple tuple = mock(Tuple.class);
 
         when(tuple.get(tables.address().stateCd)).thenReturn("state-id");
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state-description");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state-description");
 
         SimpleStateTupleMapper mapper = new SimpleStateTupleMapper(tables);
 
@@ -78,7 +78,7 @@ class SimpleStateTupleMapperTest {
         Tuple tuple = mock(Tuple.class);
 
         when(tuple.get(tables.address().stateCd)).thenReturn("state-id");
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state-description");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state-description");
 
         SimpleStateTupleMapper mapper = new SimpleStateTupleMapper(tables);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientAddressTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientAddressTupleMapperTest.java
@@ -164,7 +164,7 @@ class PatientAddressTupleMapperTest {
         when(tuple.get(tables.locators().versionCtrlNbr)).thenReturn((short) 269);
 
         when(tuple.get(tables.address().stateCd)).thenReturn("state-id");
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state-description");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state-description");
 
         PatientAddressTupleMapper mapper = new PatientAddressTupleMapper(tables);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/birth/PatientBirthTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/birth/PatientBirthTupleMapperTest.java
@@ -107,7 +107,7 @@ class PatientBirthTupleMapperTest {
         when(tuple.get(tables.patient().versionCtrlNbr)).thenReturn((short) 227);
 
         when(tuple.get(tables.address().stateCd)).thenReturn("state-id");
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state-description");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state-description");
 
         PatientBirthTupleMapper mapper = new PatientBirthTupleMapper(tables);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapperTest.java
@@ -79,7 +79,7 @@ class PatientMortalityTupleMapperTest {
         when(tuple.get(tables.patient().versionCtrlNbr)).thenReturn((short) 227);
 
         when(tuple.get(tables.address().stateCd)).thenReturn("state-id");
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state-description");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state-description");
 
         PatientMortalityTupleMapper mapper = new PatientMortalityTupleMapper(tables);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryTupleMapperTest.java
@@ -306,7 +306,7 @@ class PatientSummaryTupleMapperTest {
 
         when(tuple.get(tables.address().streetAddr1)).thenReturn("street");
         when(tuple.get(tables.address().cityDescTxt)).thenReturn("city");
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state");
         when(tuple.get(tables.address().zipCd)).thenReturn("zip");
         when(tuple.get(tables.country().codeDescTxt)).thenReturn("country");
 
@@ -366,7 +366,7 @@ class PatientSummaryTupleMapperTest {
 
         when(tuple.get(tables.patient().personParentUid.id)).thenReturn(113L);
 
-        when(tuple.get(tables.state().codeDescTxt)).thenReturn("state");
+        when(tuple.get(tables.state().stateNm)).thenReturn("state");
 
         PatientSummaryTupleMapper mapper = new PatientSummaryTupleMapper(tables);
 


### PR DESCRIPTION
Implements features of [CNFT1-809](https://cdc-nbs.atlassian.net/browse/CNFT1-809) by changing the state description returned by the Patient Profile API's from the full state name to the two character state name.

The source of the state name is changed however the data structure has not changed.  There is no changed required in the `modernization-ui` for users of the API.

[CNFT1-809]: https://cdc-nbs.atlassian.net/browse/CNFT1-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ