### PR TITLE
Patient Profile Demographics API Changes

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
@@ -57,7 +57,7 @@ class PatientAddressFinder {
     private <R> JPAQuery<R> applyBaseCriteria(final JPAQuery<R> query, final long patient) {
         return query.from(this.tables.patient())
             .where(
-                this.tables.patient().personParentUid.id.eq(patient),
+                this.tables.patient().id.eq(patient),
                 this.tables.patient().cd.eq(PATIENT_CODE),
                 this.tables.patient().recordStatusCd.eq(RecordStatus.ACTIVE)
             )

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameTupleMapper.java
@@ -134,7 +134,7 @@ class PatientNameTupleMapper {
 
     private PatientName.Degree maybeMapDegree(final Tuple tuple) {
         String id = tuple.get(tables.name().nmDegree);
-        String description = tuple.get(tables.degree().codeShortDescTxt);
+        String description = tuple.get(tables.degree().codeDescTxt);
 
         return id == null
             ? null

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/phone/PatientPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/phone/PatientPhoneFinder.java
@@ -51,7 +51,7 @@ class PatientPhoneFinder {
     private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
         return query.from(this.tables.patient())
             .where(
-                this.tables.patient().personParentUid.id.eq(patient),
+                this.tables.patient().id.eq(patient),
                 this.tables.patient().cd.eq(PATIENT_CODE),
                 this.tables.patient().recordStatusCd.eq(RecordStatus.ACTIVE)
             )

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryFinder.java
@@ -202,7 +202,7 @@ class PatientSummaryFinder {
                 this.tables.emailUse().id.codeSetNm.eq("EL_USE_TELE_PAT"),
                 this.tables.emailUse().id.code.eq(this.tables.net().useCd)
             )
-            .where(this.tables.patient().personParentUid.id.eq(identifier), this.tables.patient().cd.eq(PATIENT_CODE))
+            .where(this.tables.patient().id.eq(identifier), this.tables.patient().cd.eq(PATIENT_CODE))
             .fetch()
             .stream()
             .map(mapper::map)

--- a/apps/modernization-api/src/main/resources/graphql/patient-vaccination.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-vaccination.graphqls
@@ -2,7 +2,7 @@ type PatientVaccination {
     vaccination: ID!
     createdOn: DateTime!
     provider: String
-    administeredOn: DateTime!
+    administeredOn: DateTime
     administered: String!
     event: String!
     associatedWith: PatientVaccinationInvestigation

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/PatientNameTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/PatientNameTupleMapperTest.java
@@ -122,7 +122,7 @@ class PatientNameTupleMapperTest {
         when(tuple.get(tables.use().codeShortDescTxt)).thenReturn("use-code-description");
 
         when(tuple.get(tables.name().nmDegree)).thenReturn("degree-patient");
-        when(tuple.get(tables.degree().codeShortDescTxt)).thenReturn("degree-description");
+        when(tuple.get(tables.degree().codeDescTxt)).thenReturn("degree-description");
 
         PatientNameTupleMapper mapper = new PatientNameTupleMapper(tables);
 

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/IndicatorStringConverter.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/IndicatorStringConverter.java
@@ -20,7 +20,7 @@ public class IndicatorStringConverter {
         if (value == null) {
             return null;
         }
-        return value.code();
+        return value.getId();
     }
 
     private IndicatorStringConverter() {

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/IndicatorStringConverterTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/IndicatorStringConverterTest.java
@@ -33,7 +33,7 @@ class IndicatorStringConverterTest {
 
     static Stream<Arguments> indicatorToString() {
         return Arrays.stream(Indicator.values())
-            .map(e -> arguments(e, e.code()));
+            .map(e -> arguments(e, e.getId()));
     }
 
 
@@ -48,7 +48,7 @@ class IndicatorStringConverterTest {
 
     static Stream<Arguments> stringToIndicator() {
         return Arrays.stream(Indicator.values())
-            .map(e -> arguments(e.code(), e));
+            .map(e -> arguments(e.getId(), e));
     }
 
     @Test

--- a/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Indicator.java
+++ b/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Indicator.java
@@ -12,11 +12,11 @@ public enum Indicator {
         this.display = display;
     }
 
-    public String code() {
+    public String getId() {
         return code;
     }
 
-    public String display() {
+    public String getDescription() {
         return display;
     }
 }


### PR DESCRIPTION
Patient Address, Phone, and Summary now pull from the specific Patient requested instead of including results from revisions of the same Patient.

Patient `names.degree.description` now uses the code_desc_txt as the value.
Patient vaccinations schema has now specifies `administeredOn` as nullable.

The Indicator object used by Patient `general.speaksEnglish` will now correctly return the id and description fields.
