### PR TITLE
Demographics api missed fields

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapper.java
@@ -24,7 +24,7 @@ public class SimpleCountyTupleMapper {
             tuple.get(this.tables.address().cntyCd),
             "A county identifier is required"
         );
-        String description = tuple.get(this.tables.county().codeShortDescTxt);
+        String description = tuple.get(this.tables.county().codeDescTxt);
 
         return resolve(id, description);
     }
@@ -38,7 +38,7 @@ public class SimpleCountyTupleMapper {
 
     public Optional<SimpleCounty> maybeMap(final Tuple tuple) {
         String id = tuple.get(this.tables.address().cntyCd);
-        String description = tuple.get(this.tables.county().codeShortDescTxt);
+        String description = tuple.get(this.tables.county().codeDescTxt);
 
         return id == null
             ? Optional.empty()

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
@@ -43,7 +43,7 @@ class PatientAddressFinder {
             tables.address().streetAddr2,
             tables.address().cityDescTxt,
             tables.address().cntyCd,
-            tables.county().codeShortDescTxt,
+            tables.county().codeDescTxt,
             tables.address().stateCd,
             tables.state().stateNm,
             tables.address().zipCd,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirth.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirth.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.patient.profile.birth;
 
 import gov.cdc.nbs.geo.country.SimpleCountry;
+import gov.cdc.nbs.geo.county.SimpleCounty;
 import gov.cdc.nbs.geo.state.SimpleState;
 
 import java.time.Instant;
@@ -14,8 +15,10 @@ record PatientBirth(
     LocalDate bornOn,
     Integer age,
     MultipleBirth multipleBirth,
+    Short birthOrder,
     String city,
     SimpleState state,
+    SimpleCounty county,
     SimpleCountry country
 ) {
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthFinder.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 class PatientBirthFinder {
     
     private static final QPostalEntityLocatorParticipation LOCATORS = QPostalEntityLocatorParticipation.postalEntityLocatorParticipation;
+    private static final String COUNTY_CODE_SET = "PHVS_COUNTY_FIPS_6-4";
     private static final String PATIENT_CODE = "PAT";
     private static final String BIRTH_ADDRESS_CODE = "BIR";
     private static final String ACTIVE_CODE = "ACTIVE";
@@ -33,10 +34,13 @@ class PatientBirthFinder {
                 tables.patient().asOfDateSex,
                 tables.patient().birthTime,
                 tables.patient().multipleBirthInd,
+                tables.patient().birthOrderNbr,
                 tables.multipleBirth().codeShortDescTxt,
                 tables.address().cityDescTxt,
                 tables.address().stateCd,
                 tables.state().stateNm,
+                tables.address().cntyCd,
+                tables.county().codeDescTxt,
                 tables.address().cntryCd,
                 tables.country().codeDescTxt
             ).from(this.tables.patient())
@@ -54,6 +58,10 @@ class PatientBirthFinder {
             )
             .leftJoin(this.tables.state()).on(
                 this.tables.state().id.eq(this.tables.address().stateCd)
+            )
+            .leftJoin(this.tables.county()).on(
+                this.tables.county().id.codeSetNm.eq(COUNTY_CODE_SET),
+                this.tables.county().id.code.eq(this.tables.address().cntyCd)
             )
             .leftJoin(this.tables.country()).on(
                 this.tables.country().id.eq(this.tables.address().cntryCd)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortality.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortality.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.patient.profile.mortality;
 
 import gov.cdc.nbs.geo.country.SimpleCountry;
+import gov.cdc.nbs.geo.county.SimpleCounty;
 import gov.cdc.nbs.geo.state.SimpleState;
 
 import java.time.Instant;
@@ -15,6 +16,7 @@ record PatientMortality(
     LocalDate deceasedOn,
     String city,
     SimpleState state,
+    SimpleCounty county,
     SimpleCountry country
 ) {
     record Deceased(String id, String description) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Component
 class PatientMortalityFinder {
 
+    private static final String COUNTY_CODE_SET = "PHVS_COUNTY_FIPS_6-4";
     private static final String PATIENT_CODE = "PAT";
     private static final String DEATH_ADDRESS_CODE = "DTH";
     private static final String ACTIVE_CODE = "ACTIVE";
@@ -33,6 +34,8 @@ class PatientMortalityFinder {
                 tables.address().cityDescTxt,
                 tables.address().stateCd,
                 tables.state().stateNm,
+                tables.address().cntyCd,
+                tables.county().codeDescTxt,
                 tables.address().cntryCd,
                 tables.country().codeDescTxt
             ).from(this.tables.patient())
@@ -46,6 +49,10 @@ class PatientMortalityFinder {
             )
             .leftJoin(this.tables.state()).on(
                 this.tables.state().id.eq(this.tables.address().stateCd)
+            )
+            .leftJoin(this.tables.county()).on(
+                this.tables.county().id.codeSetNm.eq(COUNTY_CODE_SET),
+                this.tables.county().id.code.eq(this.tables.address().cntyCd)
             )
             .leftJoin(this.tables.country()).on(
                 this.tables.country().id.eq(this.tables.address().cntryCd)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapper.java
@@ -9,6 +9,8 @@ import gov.cdc.nbs.entity.srte.QCountryCode;
 import gov.cdc.nbs.entity.srte.QStateCode;
 import gov.cdc.nbs.geo.country.SimpleCountry;
 import gov.cdc.nbs.geo.country.SimpleCountryTupleMapper;
+import gov.cdc.nbs.geo.county.SimpleCounty;
+import gov.cdc.nbs.geo.county.SimpleCountyTupleMapper;
 import gov.cdc.nbs.geo.state.SimpleState;
 import gov.cdc.nbs.geo.state.SimpleStateTupleMapper;
 import gov.cdc.nbs.message.enums.Deceased;
@@ -26,6 +28,7 @@ class PatientMortalityTupleMapper {
         QPostalEntityLocatorParticipation locators,
         QPostalLocator address,
         QStateCode state,
+        QCodeValueGeneral county,
         QCountryCode country
     ) {
 
@@ -36,6 +39,7 @@ class PatientMortalityTupleMapper {
                 QPostalEntityLocatorParticipation.postalEntityLocatorParticipation,
                 QPostalLocator.postalLocator,
                 QStateCode.stateCode,
+                new QCodeValueGeneral("county"),
                 QCountryCode.countryCode
             );
         }
@@ -45,6 +49,7 @@ class PatientMortalityTupleMapper {
     private final Tables tables;
     private final SimpleCountryTupleMapper countryMapper;
     private final SimpleStateTupleMapper stateMapper;
+    private final SimpleCountyTupleMapper countyMapper;
 
     PatientMortalityTupleMapper(final Tables tables) {
         this.tables = tables;
@@ -62,6 +67,12 @@ class PatientMortalityTupleMapper {
             )
         );
 
+        this.countyMapper = new SimpleCountyTupleMapper(
+            new SimpleCountyTupleMapper.Tables(
+                this.tables.address(),
+                this.tables.county()
+            )
+        );
     }
 
     PatientMortality map(final Tuple tuple) {
@@ -91,6 +102,8 @@ class PatientMortalityTupleMapper {
 
         SimpleState state = this.stateMapper.maybeMap(tuple).orElse(null);
 
+        SimpleCounty county = this.countyMapper.maybeMap(tuple).orElse(null);
+
         SimpleCountry country = this.countryMapper.maybeMap(tuple).orElse(null);
 
         return new PatientMortality(
@@ -102,6 +115,7 @@ class PatientMortalityTupleMapper {
             deceasedOn,
             city,
             state,
+            county,
             country
         );
     }

--- a/apps/modernization-api/src/main/resources/graphql/patient-profile.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-profile.graphqls
@@ -134,8 +134,10 @@ type PatientBirth {
     bornOn: Date
     age: Int
     multipleBirth: PatientCodedValue
+    birthOrder: Int
     city: String
     state: PatientCodedValue
+    county: PatientCodedValue
     country: PatientCodedValue
 }
 
@@ -178,6 +180,7 @@ type PatientMortality {
     deceasedOn: Date
     city: String
     state: PatientCodedValue
+    county: PatientCodedValue
     country: PatientCodedValue
 }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapperTest.java
@@ -24,7 +24,7 @@ class SimpleCountyTupleMapperTest {
         Tuple tuple = mock(Tuple.class);
 
         when(tuple.get(tables.address().cntyCd)).thenReturn("county-id");
-        when(tuple.get(tables.county().codeShortDescTxt)).thenReturn("county-description");
+        when(tuple.get(tables.county().codeDescTxt)).thenReturn("county-description");
 
         SimpleCountyTupleMapper mapper = new SimpleCountyTupleMapper(tables);
 
@@ -78,7 +78,7 @@ class SimpleCountyTupleMapperTest {
         Tuple tuple = mock(Tuple.class);
 
         when(tuple.get(tables.address().cntyCd)).thenReturn("county-id");
-        when(tuple.get(tables.county().codeShortDescTxt)).thenReturn("county-description");
+        when(tuple.get(tables.county().codeDescTxt)).thenReturn("county-description");
 
         SimpleCountyTupleMapper mapper = new SimpleCountyTupleMapper(tables);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientAddressTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientAddressTupleMapperTest.java
@@ -123,7 +123,7 @@ class PatientAddressTupleMapperTest {
         when(tuple.get(tables.locators().versionCtrlNbr)).thenReturn((short) 269);
 
         when(tuple.get(tables.address().cntyCd)).thenReturn("county-id");
-        when(tuple.get(tables.county().codeShortDescTxt)).thenReturn("county-description");
+        when(tuple.get(tables.county().codeDescTxt)).thenReturn("county-description");
 
         PatientAddressTupleMapper mapper = new PatientAddressTupleMapper(tables);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
@@ -1,0 +1,60 @@
+package gov.cdc.nbs.patient.profile.address;
+
+import gov.cdc.nbs.graphql.GraphQLPage;
+import gov.cdc.nbs.patient.TestPatients;
+import gov.cdc.nbs.patient.profile.PatientProfile;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PatientProfileAddressSteps {
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    PatientAddressResolver resolver;
+
+    @Then("the profile has associated addresses")
+    public void the_profile_has_associated_addresses() {
+        long patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        Page<PatientAddress> actual = this.resolver.resolve(profile, page);
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Then("the profile has associated no addresses")
+    public void the_profile_has_no_associated_addresses() {
+        long patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        Page<PatientAddress> actual = this.resolver.resolve(profile, page);
+        assertThat(actual).isEmpty();
+    }
+
+    @Then("the profile addresses are not accessible")
+    public void the_profile_address_is_not_accessible() {
+        long patient = this.patients.one();
+
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        assertThatThrownBy(
+            () -> this.resolver.resolve(profile, page)
+        )
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/birth/PatientBirthTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/birth/PatientBirthTupleMapperTest.java
@@ -41,10 +41,12 @@ class PatientBirthTupleMapperTest {
         assertThat(actual.bornOn()).isEqualTo("1999-09-09");
 
         assertThat(actual.multipleBirth()).isNull();
+        assertThat(actual.birthOrder()).isNull();
 
         assertThat(actual.city()).isEqualTo("birth-city");
 
         assertThat(actual.state()).isNull();
+        assertThat(actual.county()).isNull();
         assertThat(actual.country()).isNull();
     }
 
@@ -97,6 +99,27 @@ class PatientBirthTupleMapperTest {
     }
 
     @Test
+    void should_map_birth_from_tuple_with_birth_order() {
+        PatientBirthTupleMapper.Tables tables = new PatientBirthTupleMapper.Tables();
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.patient().personParentUid.id)).thenReturn(2357L);
+        when(tuple.get(tables.patient().id)).thenReturn(433L);
+        when(tuple.get(tables.patient().versionCtrlNbr)).thenReturn((short) 227);
+
+        when(tuple.get(tables.patient().birthOrderNbr)).thenReturn((short) 5);
+
+        PatientBirthTupleMapper mapper = new PatientBirthTupleMapper(tables);
+
+        PatientBirth actual = mapper.map(tuple);
+
+        assertThat(actual.birthOrder()).isEqualTo((short) 5);
+
+
+    }
+
+    @Test
     void should_map_birth_from_tuple_with_birth_state() {
         PatientBirthTupleMapper.Tables tables = new PatientBirthTupleMapper.Tables();
 
@@ -115,6 +138,28 @@ class PatientBirthTupleMapperTest {
 
         assertThat(actual.state().id()).isEqualTo("state-id");
         assertThat(actual.state().description()).isEqualTo("state-description");
+
+    }
+
+    @Test
+    void should_map_birth_from_tuple_with_birth_county() {
+        PatientBirthTupleMapper.Tables tables = new PatientBirthTupleMapper.Tables();
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.patient().personParentUid.id)).thenReturn(2357L);
+        when(tuple.get(tables.patient().id)).thenReturn(433L);
+        when(tuple.get(tables.patient().versionCtrlNbr)).thenReturn((short) 227);
+
+        when(tuple.get(tables.address().cntyCd)).thenReturn("county-id");
+        when(tuple.get(tables.county().codeDescTxt)).thenReturn("county-description");
+
+        PatientBirthTupleMapper mapper = new PatientBirthTupleMapper(tables);
+
+        PatientBirth actual = mapper.map(tuple);
+
+        assertThat(actual.county().id()).isEqualTo("county-id");
+        assertThat(actual.county().description()).isEqualTo("county-description");
 
     }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/birth/PatientProfileBirthSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/birth/PatientProfileBirthSteps.java
@@ -1,0 +1,46 @@
+package gov.cdc.nbs.patient.profile.birth;
+
+import gov.cdc.nbs.patient.TestPatients;
+import gov.cdc.nbs.patient.profile.PatientProfile;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+public class PatientProfileBirthSteps {
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    PatientBirthResolver resolver;
+
+    @Then("the profile has no associated birth")
+    public void the_profile_has_no_associated_birth() {
+        long patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        Optional<PatientBirth> actual = this.resolver.resolve(profile);
+        assertThat(actual).isEmpty();
+    }
+
+    @Then("the profile birth is not accessible")
+    public void the_profile_birth_is_not_accessible() {
+        long patient = this.patients.one();
+
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        assertThatThrownBy(
+            () -> this.resolver.resolve(profile)
+        )
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/identification/PatientProfileIdentificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/identification/PatientProfileIdentificationSteps.java
@@ -1,0 +1,60 @@
+package gov.cdc.nbs.patient.profile.identification;
+
+import gov.cdc.nbs.graphql.GraphQLPage;
+import gov.cdc.nbs.patient.TestPatients;
+import gov.cdc.nbs.patient.profile.PatientProfile;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PatientProfileIdentificationSteps {
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    PatientIdentificationResolver resolver;
+
+    @Then("the profile has associated identifications")
+    public void the_profile_has_associated_identificationes() {
+        long patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        Page<PatientIdentification> actual = this.resolver.resolve(profile, page);
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Then("the profile has associated no identifications")
+    public void the_profile_has_no_associated_identificationes() {
+        long patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        Page<PatientIdentification> actual = this.resolver.resolve(profile, page);
+        assertThat(actual).isEmpty();
+    }
+
+    @Then("the profile identifications are not accessible")
+    public void the_profile_identification_is_not_accessible() {
+        long patient = this.patients.one();
+
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        GraphQLPage page = new GraphQLPage(1);
+
+        assertThatThrownBy(
+            () -> this.resolver.resolve(profile, page)
+        )
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapperTest.java
@@ -44,6 +44,7 @@ class PatientMortalityTupleMapperTest {
         assertThat(actual.city()).isEqualTo("city");
 
         assertThat(actual.state()).isNull();
+        assertThat(actual.county()).isNull();
         assertThat(actual.country()).isNull();
     }
 
@@ -87,6 +88,28 @@ class PatientMortalityTupleMapperTest {
 
         assertThat(actual.state().id()).isEqualTo("state-id");
         assertThat(actual.state().description()).isEqualTo("state-description");
+
+    }
+
+    @Test
+    void should_map_mortality_from_tuple_with_mortality_county() {
+        PatientMortalityTupleMapper.Tables tables = new PatientMortalityTupleMapper.Tables();
+
+        Tuple tuple = mock(Tuple.class);
+
+        when(tuple.get(tables.patient().personParentUid.id)).thenReturn(2357L);
+        when(tuple.get(tables.patient().id)).thenReturn(433L);
+        when(tuple.get(tables.patient().versionCtrlNbr)).thenReturn((short) 227);
+
+        when(tuple.get(tables.address().cntyCd)).thenReturn("county-id");
+        when(tuple.get(tables.county().codeDescTxt)).thenReturn("county-description");
+
+        PatientMortalityTupleMapper mapper = new PatientMortalityTupleMapper(tables);
+
+        PatientMortality actual = mapper.map(tuple);
+
+        assertThat(actual.county().id()).isEqualTo("county-id");
+        assertThat(actual.county().description()).isEqualTo("county-description");
 
     }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileMortalitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileMortalitySteps.java
@@ -1,0 +1,46 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import gov.cdc.nbs.patient.TestPatients;
+import gov.cdc.nbs.patient.profile.PatientProfile;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+public class PatientProfileMortalitySteps {
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    PatientMortalityResolver resolver;
+
+    @Then("the profile has no associated mortality")
+    public void the_profile_has_no_associated_mortality() {
+        long patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        Optional<PatientMortality> actual = this.resolver.resolve(profile);
+        assertThat(actual).isEmpty();
+    }
+
+    @Then("the profile mortality is not accessible")
+    public void the_profile_mortality_is_not_accessible() {
+        long patient = this.patients.one();
+
+
+        PatientProfile profile = new PatientProfile(patient, "local", (short) 1);
+
+        assertThatThrownBy(
+            () -> this.resolver.resolve(profile)
+        )
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileAddress.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileAddress.feature
@@ -1,0 +1,13 @@
+@patient-profile-addresses
+  Feature: Patient Profile Addresses
+
+    Background:
+      Given I have a patient
+
+    Scenario: I can retrieve patient addresses for a patient
+      Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile has associated addresses
+
+    Scenario: I cannot retrieve patient addresses without proper authorities
+      Given I have the authorities: "OTHER" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile addresses are not accessible

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileBirth.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileBirth.feature
@@ -1,0 +1,13 @@
+@patient-profile-birth
+  Feature: Patient Profile Birth
+
+    Background:
+      Given I have a patient
+
+    Scenario: I cannot retrieve patient birth for a patient without birth demographics
+      Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile has no associated birth
+
+    Scenario: I cannot retrieve patient birth without proper authorities
+      Given I have the authorities: "OTHER" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile birth is not accessible

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileIdentification.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileIdentification.feature
@@ -1,0 +1,13 @@
+@patient-profile-identifications
+  Feature: Patient Profile Identifications
+
+    Background:
+      Given I have a patient
+
+    Scenario: I can retrieve patient identifications for a patient
+      Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile has associated identifications
+
+    Scenario: I cannot retrieve patient identifications without proper authorities
+      Given I have the authorities: "OTHER" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile identifications are not accessible

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileMortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileMortality.feature
@@ -1,0 +1,13 @@
+@patient-profile-mortality
+  Feature: Patient Profile Mortality
+
+    Background:
+      Given I have a patient
+
+    Scenario: I cannot retrieve patient mortality for a patient without mortality demographics
+      Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile has no associated mortality
+
+    Scenario: I cannot retrieve patient mortality without proper authorities
+      Given I have the authorities: "OTHER" for the jurisdiction: "ALL" and program area: "STD"
+      Then the profile mortality is not accessible

--- a/apps/modernization-ui/src/components/Table/Table.spec.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.spec.tsx
@@ -103,6 +103,10 @@ describe('when a table has a sortable header', () => {
                     {
                         id: 1,
                         tableDetails: [{ id: 1, title: 'one' }]
+                    },
+                    {
+                        id: 2,
+                        tableDetails: [{ id: 2, title: 'two' }]
                     }
                 ]}
             />
@@ -133,6 +137,10 @@ describe('when a table has a sortable header', () => {
                     {
                         id: 1,
                         tableDetails: [{ id: 1, title: 'one' }]
+                    },
+                    {
+                        id: 2,
+                        tableDetails: [{ id: 2, title: 'two' }]
                     }
                 ]}
             />
@@ -166,6 +174,10 @@ describe('when a table has a sortable header', () => {
                     {
                         id: 1,
                         tableDetails: [{ id: 1, title: 'one' }]
+                    },
+                    {
+                        id: 2,
+                        tableDetails: [{ id: 2, title: 'two' }]
                     }
                 ]}
             />

--- a/apps/modernization-ui/src/generated/gql/queries/findPatientProfile.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findPatientProfile.gql
@@ -174,8 +174,13 @@ query findPatientProfile($asOf: DateTime, $page: Page, $page1: Page, $page2: Pag
                 id
                 description
             }
+            birthOrder
             city
             state{
+                id
+                description
+            }
+            county{
                 id
                 description
             }
@@ -219,6 +224,10 @@ query findPatientProfile($asOf: DateTime, $page: Page, $page1: Page, $page2: Pag
             deceasedOn
             city
             state{
+                id
+                description
+            }
+            county{
                 id
                 description
             }

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -762,9 +762,11 @@ export type PatientBirth = {
   __typename?: 'PatientBirth';
   age?: Maybe<Scalars['Int']>;
   asOf: Scalars['DateTime'];
+  birthOrder?: Maybe<Scalars['Int']>;
   bornOn?: Maybe<Scalars['Date']>;
   city?: Maybe<Scalars['String']>;
   country?: Maybe<PatientCodedValue>;
+  county?: Maybe<PatientCodedValue>;
   id: Scalars['ID'];
   multipleBirth?: Maybe<PatientCodedValue>;
   patient: Scalars['Int'];
@@ -955,6 +957,7 @@ export type PatientMortality = {
   asOf: Scalars['DateTime'];
   city?: Maybe<Scalars['String']>;
   country?: Maybe<PatientCodedValue>;
+  county?: Maybe<PatientCodedValue>;
   deceased?: Maybe<PatientCodedValue>;
   deceasedOn?: Maybe<Scalars['Date']>;
   id: Scalars['ID'];
@@ -1154,7 +1157,7 @@ export type PatientTreatmentResults = {
 export type PatientVaccination = {
   __typename?: 'PatientVaccination';
   administered: Scalars['String'];
-  administeredOn: Scalars['DateTime'];
+  administeredOn?: Maybe<Scalars['DateTime']>;
   associatedWith?: Maybe<PatientVaccinationInvestigation>;
   createdOn: Scalars['DateTime'];
   event: Scalars['String'];
@@ -1804,7 +1807,7 @@ export enum SortDirection {
 export enum SortField {
   BirthTime = 'birthTime',
   LastNm = 'lastNm',
-  Relevance = 'relevance',
+  Relevance = 'relevance'
 }
 
 export type SortablePage = {
@@ -2157,7 +2160,7 @@ export type FindPatientProfileQueryVariables = Exact<{
 }>;
 
 
-export type FindPatientProfileQuery = { __typename?: 'Query', findPatientProfile?: { __typename?: 'PatientProfile', id: string, local: string, shortId?: number | null, version: number, summary?: { __typename?: 'PatientSummary', birthday?: any | null, age?: number | null, gender?: string | null, ethnicity?: string | null, race?: string | null, legalName?: { __typename?: 'PatientLegalName', prefix?: string | null, first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null } | null, phone?: Array<{ __typename?: 'PatientSummaryPhone', use?: string | null, number?: string | null } | null> | null, email?: Array<{ __typename?: 'PatientSummaryEmail', use?: string | null, address?: string | null } | null> | null, address?: { __typename?: 'PatientSummaryAddress', street?: string | null, city?: string | null, state?: string | null, zipcode?: string | null, country?: string | null } | null } | null, names?: { __typename?: 'PatientNameResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientName', patient: string, version: number, asOf: any, sequence: number, first?: string | null, middle?: string | null, secondMiddle?: string | null, last?: string | null, secondLast?: string | null, use: { __typename?: 'PatientCodedValue', id: string, description: string }, prefix?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, suffix?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, degree?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null> } | null, administrative?: { __typename?: 'PatientAdministrativeResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientAdministrative', patient: string, id: string, version: number, asOf: any, comment?: string | null } | null> } | null, addresses?: { __typename?: 'PatientAddressResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientAddress', patient: number, id: string, version: number, asOf: any, address1?: string | null, address2?: string | null, city?: string | null, zipcode?: string | null, censusTract?: string | null, comment?: string | null, type?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, county?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, state?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, country?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null> } | null, phones?: { __typename?: 'PatientPhoneResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientPhone', patient: number, id: string, version: number, asOf: any, countryCode?: string | null, number?: string | null, extension?: string | null, email?: string | null, url?: string | null, comment?: string | null } | null> } | null, identification?: { __typename?: 'PatientIdentificationResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientIdentification', patient: number, id: string, sequence: number, version: number, asOf: any, value?: string | null, authority?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null> } | null, races?: { __typename?: 'PatientRaceResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientRace', patient: number, id: string, version: number, asOf: any, category: { __typename?: 'PatientCodedValue', id: string, description: string }, detailed?: Array<{ __typename?: 'PatientCodedValue', id: string, description: string } | null> | null } | null> } | null, birth?: { __typename?: 'PatientBirth', patient: number, id: string, version: number, asOf: any, bornOn?: any | null, age?: number | null, city?: string | null, multipleBirth?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, state?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, country?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, gender?: { __typename?: 'PatientGender', patient: number, id: string, version: number, asOf: any, additional?: string | null, birth?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, current?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, unknownReason?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, preferred?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, mortality?: { __typename?: 'PatientMortality', patient: number, id: string, version: number, asOf: any, deceasedOn?: any | null, city?: string | null, deceased?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, state?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, country?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, general?: { __typename?: 'PatientGeneral', patient: number, id: string, version: number, asOf: any, maternalMaidenName?: string | null, adultsInHouse?: number | null, childrenInHouse?: number | null, stateHIVCase?: string | null, maritalStatus?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, occupation?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, educationLevel?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, primaryLanguage?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, speaksEnglish?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, ethnicity?: { __typename?: 'PatientEthnicity', patient: number, id: string, version: number, asOf: any, ethnicGroup: { __typename?: 'PatientCodedValue', id: string, description: string }, unknownReason?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, detailed: Array<{ __typename?: 'PatientCodedValue', id: string, description: string } | null> } | null } | null };
+export type FindPatientProfileQuery = { __typename?: 'Query', findPatientProfile?: { __typename?: 'PatientProfile', id: string, local: string, shortId?: number | null, version: number, summary?: { __typename?: 'PatientSummary', birthday?: any | null, age?: number | null, gender?: string | null, ethnicity?: string | null, race?: string | null, legalName?: { __typename?: 'PatientLegalName', prefix?: string | null, first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null } | null, phone?: Array<{ __typename?: 'PatientSummaryPhone', use?: string | null, number?: string | null } | null> | null, email?: Array<{ __typename?: 'PatientSummaryEmail', use?: string | null, address?: string | null } | null> | null, address?: { __typename?: 'PatientSummaryAddress', street?: string | null, city?: string | null, state?: string | null, zipcode?: string | null, country?: string | null } | null } | null, names?: { __typename?: 'PatientNameResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientName', patient: string, version: number, asOf: any, sequence: number, first?: string | null, middle?: string | null, secondMiddle?: string | null, last?: string | null, secondLast?: string | null, use: { __typename?: 'PatientCodedValue', id: string, description: string }, prefix?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, suffix?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, degree?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null> } | null, administrative?: { __typename?: 'PatientAdministrativeResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientAdministrative', patient: string, id: string, version: number, asOf: any, comment?: string | null } | null> } | null, addresses?: { __typename?: 'PatientAddressResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientAddress', patient: number, id: string, version: number, asOf: any, address1?: string | null, address2?: string | null, city?: string | null, zipcode?: string | null, censusTract?: string | null, comment?: string | null, type?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, county?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, state?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, country?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null> } | null, phones?: { __typename?: 'PatientPhoneResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientPhone', patient: number, id: string, version: number, asOf: any, countryCode?: string | null, number?: string | null, extension?: string | null, email?: string | null, url?: string | null, comment?: string | null } | null> } | null, identification?: { __typename?: 'PatientIdentificationResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientIdentification', patient: number, id: string, sequence: number, version: number, asOf: any, value?: string | null, authority?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null> } | null, races?: { __typename?: 'PatientRaceResults', total: number, number: number, size: number, content: Array<{ __typename?: 'PatientRace', patient: number, id: string, version: number, asOf: any, category: { __typename?: 'PatientCodedValue', id: string, description: string }, detailed?: Array<{ __typename?: 'PatientCodedValue', id: string, description: string } | null> | null } | null> } | null, birth?: { __typename?: 'PatientBirth', patient: number, id: string, version: number, asOf: any, bornOn?: any | null, age?: number | null, birthOrder?: number | null, city?: string | null, multipleBirth?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, state?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, county?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, country?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, gender?: { __typename?: 'PatientGender', patient: number, id: string, version: number, asOf: any, additional?: string | null, birth?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, current?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, unknownReason?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, preferred?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, mortality?: { __typename?: 'PatientMortality', patient: number, id: string, version: number, asOf: any, deceasedOn?: any | null, city?: string | null, deceased?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, state?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, county?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, country?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, general?: { __typename?: 'PatientGeneral', patient: number, id: string, version: number, asOf: any, maternalMaidenName?: string | null, adultsInHouse?: number | null, childrenInHouse?: number | null, stateHIVCase?: string | null, maritalStatus?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, occupation?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, educationLevel?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, primaryLanguage?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, speaksEnglish?: { __typename?: 'PatientCodedValue', id: string, description: string } | null } | null, ethnicity?: { __typename?: 'PatientEthnicity', patient: number, id: string, version: number, asOf: any, ethnicGroup: { __typename?: 'PatientCodedValue', id: string, description: string }, unknownReason?: { __typename?: 'PatientCodedValue', id: string, description: string } | null, detailed: Array<{ __typename?: 'PatientCodedValue', id: string, description: string } | null> } | null } | null };
 
 export type FindPatientsByFilterQueryVariables = Exact<{
   filter: PersonFilter;
@@ -2212,7 +2215,7 @@ export type FindVaccinationsForPatientQueryVariables = Exact<{
 }>;
 
 
-export type FindVaccinationsForPatientQuery = { __typename?: 'Query', findVaccinationsForPatient?: { __typename?: 'PatientVaccinationResults', total: number, number: number, content: Array<{ __typename?: 'PatientVaccination', vaccination: string, createdOn: any, provider?: string | null, administeredOn: any, administered: string, event: string, associatedWith?: { __typename?: 'PatientVaccinationInvestigation', id: string, local: string, condition: string } | null } | null> } | null };
+export type FindVaccinationsForPatientQuery = { __typename?: 'Query', findVaccinationsForPatient?: { __typename?: 'PatientVaccinationResults', total: number, number: number, content: Array<{ __typename?: 'PatientVaccination', vaccination: string, createdOn: any, provider?: string | null, administeredOn?: any | null, administered: string, event: string, associatedWith?: { __typename?: 'PatientVaccinationInvestigation', id: string, local: string, condition: string } | null } | null> } | null };
 
 
 export const CreatePatientDocument = gql`
@@ -4578,8 +4581,13 @@ export const FindPatientProfileDocument = gql`
         id
         description
       }
+      birthOrder
       city
       state {
+        id
+        description
+      }
+      county {
         id
         description
       }
@@ -4623,6 +4631,10 @@ export const FindPatientProfileDocument = gql`
       deceasedOn
       city
       state {
+        id
+        description
+      }
+      county {
         id
         description
       }

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -7,30 +7,30 @@ type ConditionCode {
     conditionDescTxt: String
 }
 extend type Query {
-  findAllCountryCodes(page: Page): [CountryCode]!
+    findAllCountryCodes(page: Page): [CountryCode]!
 }
 
 type CountryCode {
-  id: ID
-  assigningAuthorityCd: String
-  assigningAuthorityDescTxt: String
-  codeDescTxt: String
-  codeShortDescTxt: String
-  effectiveFromTime: DateTime
-  effectiveToTime: DateTime
-  excludedTxt: String
-  keyInfoTxt: String
-  indentLevelNbr: Int
-  isModifiableInd: String
-  parentIsCd: String
-  statusCd: String
-  statusTime: DateTime
-  codeSetNm: String
-  seqNum: Int
-  nbsUid: Int
-  sourceConceptId: String
-  codeSystemCd: String
-  codeSystemDescTxt: String
+    id: ID
+    assigningAuthorityCd: String
+    assigningAuthorityDescTxt: String
+    codeDescTxt: String
+    codeShortDescTxt: String
+    effectiveFromTime: DateTime
+    effectiveToTime: DateTime
+    excludedTxt: String
+    keyInfoTxt: String
+    indentLevelNbr: Int
+    isModifiableInd: String
+    parentIsCd: String
+    statusCd: String
+    statusTime: DateTime
+    codeSetNm: String
+    seqNum: Int
+    nbsUid: Int
+    sourceConceptId: String
+    codeSystemCd: String
+    codeSystemDescTxt: String
 }
 extend type Query {
     findAllCountyCodesForState(stateCode: String!, page: Page): [CountyCode]!
@@ -76,338 +76,333 @@ type IdentificationTypeId {
     code: String!
 }
 extend type Query {
-  findInvestigationsByFilter(
-    filter: InvestigationFilter!
-    page: SortablePage
-  ): InvestigationResults!
+    findInvestigationsByFilter(filter: InvestigationFilter!, page: SortablePage): InvestigationResults!
 }
 
 type InvestigationResults {
-  content: [Investigation]!
-  total: Int!
+    content: [Investigation]!
+    total: Int!
 }
 
 type Investigation {
-  id: ID
-  recordStatus: String
-  lastChangeTime: DateTime
-  publicHealthCaseUid: Int
-  caseClassCd: String
-  outbreakName: String
-  caseTypeCd: String
-  cdDescTxt: String
-  progAreaCd: String
-  jurisdictionCd: Int
-  jurisdictionCodeDescTxt: String
-  pregnantIndCd: String
-  localId: String
-  rptFormCmpltTime: DateTime
-  activityToTime: DateTime
-  activityFromTime: DateTime
-  addTime: DateTime
-  publicHealthCaseLastChgTime: DateTime
-  addUserId: Int
-  lastChangeUserId: Int
-  currProcessStateCd: String
-  investigationStatusCd: String
-  moodCd: String
-  notificationLocalId: String
-  notificationAddTime: DateTime
-  notificationRecordStatusCd: String
-  notificationLastChgTime: DateTime
-  personParticipations: [PersonParticipation]
-  organizationParticipations: [OrganizationParticipation]
-  actIds: [ActId]
+    id: ID
+    recordStatus: String
+    lastChangeTime: DateTime
+    publicHealthCaseUid: Int
+    caseClassCd: String
+    outbreakName: String
+    caseTypeCd: String
+    cdDescTxt: String
+    progAreaCd: String
+    jurisdictionCd: Int
+    jurisdictionCodeDescTxt: String
+    pregnantIndCd: String
+    localId: String
+    rptFormCmpltTime: DateTime
+    activityToTime: DateTime
+    activityFromTime: DateTime
+    addTime: DateTime
+    publicHealthCaseLastChgTime: DateTime
+    addUserId: Int
+    lastChangeUserId: Int
+    currProcessStateCd: String
+    investigationStatusCd: String
+    moodCd: String
+    notificationLocalId: String
+    notificationAddTime: DateTime
+    notificationRecordStatusCd: String
+    notificationLastChgTime: DateTime
+    personParticipations: [PersonParticipation]
+    organizationParticipations: [OrganizationParticipation]
+    actIds: [ActId]
 }
 
 type ActId {
-  id: Int
-  recordStatus: String
-  actIdSeq: Int
-  rootExtensionTxt: String
-  typeCd: String
-  lastChangeTime: DateTime
+    id: Int
+    recordStatus: String
+    actIdSeq: Int
+    rootExtensionTxt: String
+    typeCd: String
+    lastChangeTime: DateTime
 }
 
 input InvestigationFilter {
-  patientId: Int
-  conditions: [String]
-  programAreas: [String]
-  jurisdictions: [ID]
-  pregnancyStatus: PregnancyStatus
-  eventId: EventId
-  eventDate: InvestigationEventDateSearch
-  createdBy: String
-  lastUpdatedBy: String
-  providerFacilitySearch: ProviderFacilitySearch
-  investigatorId: ID
-  investigationStatus: InvestigationStatus
-  outbreakNames: [String]
-  caseStatuses: CaseStatuses
-  notificationStatuses: NotificationStatuses
-  processingStatuses: ProcessingStatuses
+    patientId: Int
+    conditions: [String]
+    programAreas: [String]
+    jurisdictions: [ID]
+    pregnancyStatus: PregnancyStatus
+    eventIdType: InvestigationEventIdType
+    eventId: String
+    eventDateSearch: InvestigationEventDateSearch
+    createdBy: String
+    lastUpdatedBy: String
+    providerFacilitySearch: ProviderFacilitySearch
+    investigatorId: ID
+    investigationStatus: InvestigationStatus
+    outbreakNames: [String]
+    caseStatuses: CaseStatuses
+    notificationStatuses: NotificationStatuses
+    processingStatuses: ProcessingStatuses
 }
 
 input EventId {
-  investigationEventType: InvestigationEventIdType!
-  id: String!
+    investigationEventType: InvestigationEventIdType!
+    id: String!
 }
 
 input CaseStatuses {
-  includeUnassigned: Boolean!
-  statusList: [CaseStatus!]!
+    includeUnassigned: Boolean!
+    statusList: [CaseStatus!]!
 }
 
 input NotificationStatuses {
-  includeUnassigned: Boolean!
-  statusList: [NotificationStatus!]!
+    includeUnassigned: Boolean!
+    statusList: [NotificationStatus!]!
 }
 
 input ProcessingStatuses {
-  includeUnassigned: Boolean!
-  statusList: [ProcessingStatus!]!
+    includeUnassigned: Boolean!
+    statusList: [ProcessingStatus!]!
 }
 
 input InvestigationEventDateSearch {
-  type: InvestigationEventDateType!
-  from: Date!
-  to: Date!
+    eventDateType: InvestigationEventDateType!
+    from: DateTime!
+    to: DateTime!
 }
 
 input ProviderFacilitySearch {
-  entityType: ReportingEntityType!
-  id: ID!
+    entityType: ReportingEntityType!
+    id: ID!
 }
 
 enum InvestigationEventIdType {
-  ABCS_CASE_ID
-  CITY_COUNTY_CASE_ID
-  INVESTIGATION_ID
-  NOTIFICATION_ID
-  STATE_CASE_ID
+    ABCS_CASE_ID
+    CITY_COUNTY_CASE_ID
+    INVESTIGATION_ID
+    NOTIFICATION_ID
+    STATE_CASE_ID
 }
 
 enum ReportingEntityType {
-  FACILITY
-  PROVIDER
+    FACILITY
+    PROVIDER
 }
 
 enum ProcessingStatus {
-  UNASSIGNED
-  AWAITING_INTERVIEW
-  CLOSED_CASE
-  FIELD_FOLLOW_UP
-  NO_FOLLOW_UP
-  OPEN_CASE
-  SURVEILLANCE_FOLLOW_UP
+    UNASSIGNED
+    AWAITING_INTERVIEW
+    CLOSED_CASE
+    FIELD_FOLLOW_UP
+    NO_FOLLOW_UP
+    OPEN_CASE
+    SURVEILLANCE_FOLLOW_UP
 }
 
 enum NotificationStatus {
-  UNASSIGNED
-  APPROVED
-  COMPLETED
-  MESSAGE_FAILED
-  PENDING_APPROVAL
-  REJECTED
+    UNASSIGNED
+    APPROVED
+    COMPLETED
+    MESSAGE_FAILED
+    PENDING_APPROVAL
+    REJECTED
 }
 
 enum CaseStatus {
-  UNASSIGNED
-  CONFIRMED
-  NOT_A_CASE
-  PROBABLE
-  SUSPECT
-  UNKNOWN
+    UNASSIGNED
+    CONFIRMED
+    NOT_A_CASE
+    PROBABLE
+    SUSPECT
+    UNKNOWN
 }
 
 enum InvestigationEventDateType {
-  DATE_OF_REPORT
-  INVESTIGATION_CLOSED_DATE
-  INVESTIGATION_CREATE_DATE
-  INVESTIGATION_START_DATE
-  LAST_UPDATE_DATE
-  NOTIFICATION_CREATE_DATE
+    DATE_OF_REPORT
+    INVESTIGATION_CLOSED_DATE
+    INVESTIGATION_CREATE_DATE
+    INVESTIGATION_START_DATE
+    LAST_UPDATE_DATE
+    NOTIFICATION_CREATE_DATE
 }
 
 enum InvestigationStatus {
-  OPEN
-  CLOSED
+    OPEN
+    CLOSED
 }
 extend type Query {
-  findAllJurisdictions(page: Page): [Jurisdiction]!
+    findAllJurisdictions(page: Page): [Jurisdiction]!
 }
 
 type Jurisdiction {
-  id: String!
-  typeCd: String!
-  assigningAuthorityCd: String
-  assigningAuthorityDescTxt: String
-  codeDescTxt: String
-  codeShortDescTxt: String
-  effectiveFromTime: DateTime
-  effectiveToTime: DateTime
-  indentLevelNbr: Int
-  isModifiableInd: String
-  parentIsCd: String
-  stateDomainCd: String
-  statusCd: String
-  statusTime: DateTime
-  codeSetNm: String
-  codeSeqNum: Int
-  nbsUid: ID
-  sourceConceptId: String
-  codeSystemCd: String
-  codeSystemDescTxt: String
-  exportInd: String
+    id: String!
+    typeCd: String!
+    assigningAuthorityCd: String
+    assigningAuthorityDescTxt: String
+    codeDescTxt: String
+    codeShortDescTxt: String
+    effectiveFromTime: DateTime
+    effectiveToTime: DateTime
+    indentLevelNbr: Int
+    isModifiableInd: String
+    parentIsCd: String
+    stateDomainCd: String
+    statusCd: String
+    statusTime: DateTime
+    codeSetNm: String
+    codeSeqNum: Int
+    nbsUid: ID
+    sourceConceptId: String
+    codeSystemCd: String
+    codeSystemDescTxt: String
+    exportInd: String
 }
 extend type Query {
-  findLabReportsByFilter(
-    filter: LabReportFilter!
-    page: SortablePage
-  ): LabReportResults!
+    findLabReportsByFilter(filter: LabReportFilter!, page: SortablePage): LabReportResults!
 }
 
 type LabReportResults {
-  content: [LabReport]!
-  total: Int!
+    content: [LabReport]!
+    total: Int!
 }
 
 input LabReportFilter {
-  patientId: Int
-  programAreas: [String]
-  jurisdictions: [ID]
-  pregnancyStatus: PregnancyStatus
-  eventId: LabReportEventId
-  eventDate: LaboratoryEventDateSearch
-  entryMethods: [EntryMethod]
-  enteredBy: [UserType]
-  eventStatus: [EventStatus]
-  processingStatus: [LaboratoryReportStatus]
-  createdBy: ID
-  lastUpdatedBy: ID
-  providerSearch: LabReportProviderSearch
-  resultedTest: String
-  codedResult: String
+    patientId: Int
+    programAreas: [String]
+    jurisdictions: [ID]
+    pregnancyStatus: PregnancyStatus
+    eventId: LabReportEventId
+    eventDate: LaboratoryEventDateSearch
+    entryMethods: [EntryMethod]
+    enteredBy: [UserType]
+    eventStatus: [EventStatus]
+    processingStatus: [LaboratoryReportStatus]
+    createdBy: ID
+    lastUpdatedBy: ID
+    providerSearch: LabReportProviderSearch
+    resultedTest: String
+    codedResult: String
 }
 
 input LabReportEventId {
-  labEventType: LaboratoryEventIdType!
-  labEventId: String!
+    labEventType: LaboratoryEventIdType!
+    labEventId: String!
 }
 
 type LabReport {
-  id: String
-  observationUid: Int
-  lastChange: DateTime
-  classCd: String
-  moodCd: String
-  observationLastChgTime: DateTime
-  cdDescTxt: String
-  recordStatusCd: String
-  programAreaCd: String
-  jurisdictionCd: Int
-  jurisdictionCodeDescTxt: String
-  pregnantIndCd: String
-  localId: String
-  activityToTime: DateTime
-  effectiveFromTime: DateTime
-  rptToStateTime: DateTime
-  addTime: DateTime
-  electronicInd: String
-  versionCtrlNbr: Int
-  addUserId: Int
-  lastChgUserId: Int
-  personParticipations: [PersonParticipation]
-  organizationParticipations: [OrganizationParticipation]
-  materialParticipations: [MaterialParticipation]
-  observations: [Observation]
-  actIds: [ActId]
-  associatedInvestigations: [AssociatedInvestigation]
+    id: String
+    observationUid: Int
+    lastChange: DateTime
+    classCd: String
+    moodCd: String
+    observationLastChgTime: DateTime
+    cdDescTxt: String
+    recordStatusCd: String
+    programAreaCd: String
+    jurisdictionCd: Int
+    jurisdictionCodeDescTxt: String
+    pregnantIndCd: String
+    localId: String
+    activityToTime: DateTime
+    effectiveFromTime: DateTime
+    rptToStateTime: DateTime
+    addTime: DateTime
+    electronicInd: String
+    versionCtrlNbr: Int
+    addUserId: Int
+    lastChgUserId: Int
+    personParticipations: [PersonParticipation]
+    organizationParticipations: [OrganizationParticipation]
+    materialParticipations: [MaterialParticipation]
+    observations: [Observation]
+    actIds: [ActId]
+    associatedInvestigations: [AssociatedInvestigation]
 }
 
 type MaterialParticipation {
-  actUid: Int
-  typeCd: String
-  entityId: String
-  subjectClassCd: String
-  typeDescTxt: String
-  participationRecordStatus: String
-  participationLastChangeTime: DateTime
-  cd: String
-  cdDescTxt: String
+    actUid: Int
+    typeCd: String
+    entityId: String
+    subjectClassCd: String
+    typeDescTxt: String
+    participationRecordStatus: String
+    participationLastChangeTime: DateTime
+    cd: String
+    cdDescTxt: String
 }
 
 type Observation {
-  cd: String
-  cdDescTxt: String
-  domainCd: String
-  statusCd: String
-  altCd: String
-  altDescTxt: String
-  altCdSystemCd: String
-  displayName: String
-  ovcCode: String
-  ovcAltCode: String
-  ovcAltDescTxt: String
-  ovcAltCdSystemCd: String
+    cd: String
+    cdDescTxt: String
+    domainCd: String
+    statusCd: String
+    altCd: String
+    altDescTxt: String
+    altCdSystemCd: String
+    displayName: String
+    ovcCode: String
+    ovcAltCode: String
+    ovcAltDescTxt: String
+    ovcAltCdSystemCd: String
 }
 
 type AssociatedInvestigation {
-  publicHealthCaseUid: Int
-  cdDescTxt: String
-  localId: String
-  lastChgTime: DateTime
-  actRelationshipLastChgTime: DateTime
+    publicHealthCaseUid: Int
+    cdDescTxt: String
+    localId: String
+    lastChgTime: DateTime
+    actRelationshipLastChgTime: DateTime
 }
 
 input LaboratoryEventDateSearch {
-  type: LaboratoryReportEventDateType!
-  from: Date!
-  to: Date!
+    eventDateType: LaboratoryReportEventDateType!
+    from: DateTime!
+    to: DateTime!
 }
 
 input LabReportProviderSearch {
-  providerType: ProviderType!
-  providerId: ID!
+    providerType: ProviderType!
+    providerId: ID!
 }
 
 enum ProviderType {
-  ORDERING_FACILITY
-  ORDERING_PROVIDER
-  REPORTING_FACILITY
+    ORDERING_FACILITY
+    ORDERING_PROVIDER
+    REPORTING_FACILITY
 }
 
 enum LaboratoryEventIdType {
-  ACCESSION_NUMBER
-  LAB_ID
+    ACCESSION_NUMBER
+    LAB_ID
 }
 
 enum LaboratoryReportEventDateType {
-  DATE_OF_REPORT
-  DATE_RECEIVED_BY_PUBLIC_HEALTH
-  DATE_OF_SPECIMEN_COLLECTION
-  LAB_REPORT_CREATE_DATE
-  LAST_UPDATE_DATE
+    DATE_OF_REPORT
+    DATE_RECEIVED_BY_PUBLIC_HEALTH
+    DATE_OF_SPECIMEN_COLLECTION
+    LAB_REPORT_CREATE_DATE
+    LAST_UPDATE_DATE
 }
 
 enum EntryMethod {
-  ELECTRONIC
-  MANUAL
+    ELECTRONIC
+    MANUAL
 }
 
 enum UserType {
-  INTERNAL
-  EXTERNAL
+    INTERNAL
+    EXTERNAL
 }
 
 enum EventStatus {
-  NEW
-  UPDATE
+    NEW
+    UPDATE
 }
 
 enum LaboratoryReportStatus {
-  PROCESSED
-  UNPROCESSED
+    PROCESSED
+    UNPROCESSED
 }
 extend type Query {
     findLocalCodedResults(searchText: String!, page: Page): LocalCodedResults!
@@ -464,67 +459,64 @@ type LoincCode {
     relatedClassCd: String
 }
 extend type Query {
-  findOrganizationById(id: ID!): Organization
-  findAllOrganizations(page: Page): OrganizationResults!
-  findOrganizationsByFilter(
-    filter: OrganizationFilter!
-    page: Page
-  ): OrganizationResults!
+    findOrganizationById(id: ID!): Organization
+    findAllOrganizations(page: Page): OrganizationResults!
+    findOrganizationsByFilter(filter: OrganizationFilter!, page: Page): OrganizationResults!
 }
 
 type OrganizationResults {
-  content: [Organization]!
-  total: Int!
+    content: [Organization]!
+    total: Int!
 }
 
 input OrganizationFilter {
-  id: ID
-  displayNm: String
-  streetAddr1: String
-  streetAddr2: String
-  cityCd: String
-  cityDescTxt: String
-  stateCd: String
-  zipCd: String
+    id: ID
+    displayNm: String
+    streetAddr1: String
+    streetAddr2: String
+    cityCd: String
+    cityDescTxt: String
+    stateCd: String
+    zipCd: String
 }
 
 type Organization {
-  id: ID
-  addReasonCd: String
-  addTime: DateTime
-  addUserId: ID
-  cd: String
-  cdDescTxt: String
-  description: String
-  durationAmt: String
-  durationUnitCd: String
-  fromTime: DateTime
-  lastChgReasonCd: String
-  lastChgTime: DateTime
-  lastChgUserId: Int
-  localId: String
-  recordStatusCd: RecordStatus
-  recordStatusTime: DateTime
-  standardIndustryClassCd: String
-  standardIndustryDescTxt: String
-  statusCd: String
-  statusTime: DateTime
-  toTime: DateTime
-  userAffiliationTxt: String
-  displayNm: String
-  streetAddr1: String
-  streetAddr2: String
-  cityCd: String
-  cityDescTxt: String
-  stateCd: String
-  cntyCd: String
-  cntryCd: String
-  zipCd: String
-  phoneNbr: String
-  phoneCntryCd: String
-  versionCtrlNbr: Int
-  electronicInd: String
-  edxInd: String
+    id: ID
+    addReasonCd: String
+    addTime: DateTime
+    addUserId: ID
+    cd: String
+    cdDescTxt: String
+    description: String
+    durationAmt: String
+    durationUnitCd: String
+    fromTime: DateTime
+    lastChgReasonCd: String
+    lastChgTime: DateTime
+    lastChgUserId: Int
+    localId: String
+    recordStatusCd: RecordStatus
+    recordStatusTime: DateTime
+    standardIndustryClassCd: String
+    standardIndustryDescTxt: String
+    statusCd: String
+    statusTime: DateTime
+    toTime: DateTime
+    userAffiliationTxt: String
+    displayNm: String
+    streetAddr1: String
+    streetAddr2: String
+    cityCd: String
+    cityDescTxt: String
+    stateCd: String
+    cntyCd: String
+    cntryCd: String
+    zipCd: String
+    phoneNbr: String
+    phoneCntryCd: String
+    versionCtrlNbr: Int
+    electronicInd: String
+    edxInd: String
 }
 extend type Query {
     findAllOutbreaks(page: Page): OutbreakResults!
@@ -545,56 +537,54 @@ type OutbreakId {
     code: String!
 }
 type NamedContact {
-  id: ID!
-  name: String!
+    id: ID!
+    name: String!
 }
 
 type PatientContactInvestigation {
-  id: ID!
-  local: String!
-  condition: String!
+    id: ID!
+    local: String!
+    condition: String!
 }
 
 type NamedByPatient {
-  contactRecord: ID!
-  createdOn: DateTime!
-  condition: String
-  contact: NamedContact!
-  namedOn: DateTime!
-  priority: String
-  disposition: String
-  event: String!
-  associatedWith: PatientContactInvestigation
+    contactRecord: ID!
+    createdOn: DateTime!
+    condition: String
+    contact: NamedContact!
+    namedOn: DateTime!
+    priority: String
+    disposition: String
+    event: String!
+    associatedWith: PatientContactInvestigation
 }
 
 type ContactsNamedByPatientResults {
-  content: [NamedByPatient]!
-  total: Int!
-  number: Int!
+    content: [NamedByPatient]!
+    total: Int!
+    number: Int!
 }
 
 type NamedByContact {
-  contactRecord: ID!
-  createdOn: DateTime!
-  contact: NamedContact!
-  namedOn: DateTime!
-  condition: String
-  event: String!
-  associatedWith: PatientContactInvestigation
+    contactRecord: ID!
+    createdOn: DateTime!
+    contact: NamedContact!
+    namedOn: DateTime!
+    condition: String
+    event: String!
+    associatedWith: PatientContactInvestigation
 }
 
 type PatientNamedByContactResults {
-  content: [NamedByPatient]!
-  total: Int!
-  number: Int!
+    content: [NamedByPatient]!
+    total: Int!
+    number: Int!
 }
 
-
 extend type Query {
+    findContactsNamedByPatient(patient: ID!, page: Page): ContactsNamedByPatientResults
 
-  findContactsNamedByPatient(patient:ID!, page: Page) : ContactsNamedByPatientResults
-
-  findPatientNamedByContact(patient:ID!, page: Page) : PatientNamedByContactResults
+    findPatientNamedByContact(patient: ID!, page: Page): PatientNamedByContactResults
 }
 type PatientDocument {
     document: ID!
@@ -677,7 +667,7 @@ type PatientMorbidityResults {
 }
 
 extend type Query {
-    findMorbidityReportsForPatient(patient: ID! page: Page ): PatientMorbidityResults
+    findMorbidityReportsForPatient(patient: ID!, page: Page): PatientMorbidityResults
 }
 
 type PatientCodedValue {
@@ -816,8 +806,10 @@ type PatientBirth {
     bornOn: Date
     age: Int
     multipleBirth: PatientCodedValue
+    birthOrder: Int
     city: String
     state: PatientCodedValue
+    county: PatientCodedValue
     country: PatientCodedValue
 }
 
@@ -928,29 +920,29 @@ extend type Query {
     findPatientProfile(patient: ID, shortId: Int): PatientProfile
 }
 type PatientTreatment {
-  treatment: ID!
-  createdOn: DateTime!
-  provider: String
-  treatedOn: DateTime!
-  description: String!
-  event: String!
-  associatedWith: PatientTreatmentInvestigation!
+    treatment: ID!
+    createdOn: DateTime!
+    provider: String
+    treatedOn: DateTime!
+    description: String!
+    event: String!
+    associatedWith: PatientTreatmentInvestigation!
 }
 
 type PatientTreatmentInvestigation {
-  id: ID!
-  local: String!
-  condition: String!
+    id: ID!
+    local: String!
+    condition: String!
 }
 
 type PatientTreatmentResults {
-  content: [PatientTreatment]!
-  total: Int!
-  number: Int!
+    content: [PatientTreatment]!
+    total: Int!
+    number: Int!
 }
 
 extend type Query {
-  findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
+    findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
 }
 type PatientVaccination {
     vaccination: ID!
@@ -1358,69 +1350,69 @@ type NBSEntity {
     entityLocatorParticipations: [LocatorParticipations]
 }
 extend type Query {
-  findPlaceById(id: ID!): Place
-  findAllPlaces(page: Page): [Place]!
-  findPlacesByFilter(filter: PlaceFilter!, page: Page): [Place]!
+    findPlaceById(id: ID!): Place
+    findAllPlaces(page: Page): [Place]!
+    findPlacesByFilter(filter: PlaceFilter!, page: Page): [Place]!
 }
 
 input PlaceFilter {
-  id: ID
-  description: String
-  nm: String
-  streetAddr1: String
-  streetAddr2: String
-  cityCd: String
-  cityDescTxt: String
-  stateCd: String
-  zipCd: String
+    id: ID
+    description: String
+    nm: String
+    streetAddr1: String
+    streetAddr2: String
+    cityCd: String
+    cityDescTxt: String
+    stateCd: String
+    zipCd: String
 }
 
 type Place {
-  id: ID
-  addReasonCd: String
-  addTime: DateTime
-  addUserId: Int
-  cd: String
-  cdDescTxt: String
-  description: String
-  durationAmt: String
-  durationUnitCd: String
-  fromTime: DateTime
-  lastChgReasonCd: String
-  lastChgTime: DateTime
-  lastChgUserId: Int
-  localId: String
-  nm: String
-  recordStatusCd: String
-  recordStatusTime: DateTime
-  statusCd: String
-  statusTime: DateTime
-  toTime: DateTime
-  userAffiliationTxt: String
-  streetAddr1: String
-  streetAddr2: String
-  cityCd: String
-  cityDescTxt: String
-  stateCd: String
-  zipCd: String
-  cntyCd: String
-  cntryCd: String
-  phoneNbr: String
-  phoneCntryCd: String
-  versionCtrlNbr: Int
+    id: ID
+    addReasonCd: String
+    addTime: DateTime
+    addUserId: Int
+    cd: String
+    cdDescTxt: String
+    description: String
+    durationAmt: String
+    durationUnitCd: String
+    fromTime: DateTime
+    lastChgReasonCd: String
+    lastChgTime: DateTime
+    lastChgUserId: Int
+    localId: String
+    nm: String
+    recordStatusCd: String
+    recordStatusTime: DateTime
+    statusCd: String
+    statusTime: DateTime
+    toTime: DateTime
+    userAffiliationTxt: String
+    streetAddr1: String
+    streetAddr2: String
+    cityCd: String
+    cityDescTxt: String
+    stateCd: String
+    zipCd: String
+    cntyCd: String
+    cntryCd: String
+    phoneNbr: String
+    phoneCntryCd: String
+    versionCtrlNbr: Int
 }
 extend type Query {
-  findAllProgramAreas(page: Page): [ProgramAreaCode]!
+    findAllProgramAreas(page: Page): [ProgramAreaCode]!
 }
 
 type ProgramAreaCode {
-  id: String!
-  progAreaDescTxt: String
-  nbsUid: ID
-  statusCd: String
-  statusTime: DateTime
-  codeSetNm: String
-  codeSeq: Int
+    id: String!
+    progAreaDescTxt: String
+    nbsUid: ID
+    statusCd: String
+    statusTime: DateTime
+    codeSetNm: String
+    codeSeq: Int
 }
 extend type Query {
     findAllRaceValues(page: Page): RaceResults!
@@ -1443,65 +1435,65 @@ scalar Date
 scalar DateTime
 
 input Page {
-  pageSize: Int!
-  pageNumber: Int!
+    pageSize: Int!
+    pageNumber: Int!
 }
 
 input SortablePage {
-  pageSize: Int
-  pageNumber: Int
-  sortField: SortField
-  sortDirection: SortDirection
+    pageSize: Int
+    pageNumber: Int
+    sortField: SortField
+    sortDirection: SortDirection
 }
 
 type PersonParticipation {
-  actUid: Int!
-  localId: String
-  typeCd: String
-  entityId: Int!
-  subjectClassCd: String
-  participationRecordStatus: String
-  typeDescTxt: String
-  participationLastChangeTime: DateTime
-  firstName: String
-  lastName: String
-  birthTime: DateTime
-  currSexCd: String
-  personCd: String!
-  personParentUid: Int
-  personRecordStatus: String!
-  personLastChangeTime: DateTime
+    actUid: Int!
+    localId: String
+    typeCd: String
+    entityId: Int!
+    subjectClassCd: String
+    participationRecordStatus: String
+    typeDescTxt: String
+    participationLastChangeTime: DateTime
+    firstName: String
+    lastName: String
+    birthTime: DateTime
+    currSexCd: String
+    personCd: String!
+    personParentUid: Int
+    personRecordStatus: String!
+    personLastChangeTime: DateTime
 }
 
 type OrganizationParticipation {
-  actUid: Int
-  typeCd: String
-  entityId: Int
-  subjectClassCd: String
-  typeDescTxt: String
-  participationRecordStatus: String
-  participationLastChangeTime: DateTime
-  name: String
-  organizationLastChangeTime: DateTime
+    actUid: Int
+    typeCd: String
+    entityId: Int
+    subjectClassCd: String
+    typeDescTxt: String
+    participationRecordStatus: String
+    participationLastChangeTime: DateTime
+    name: String
+    organizationLastChangeTime: DateTime
 }
 
 enum SortField {
-  lastNm
-  birthTime
-  relevance
+    lastNm
+    birthTime
+    relevance
 }
 
 enum RecordStatus {
-  ACTIVE
-  INACTIVE
-  LOG_DEL
-  SUPERCEDED
+    ACTIVE
+    INACTIVE
+    LOG_DEL
+    SUPERCEDED
 }
 
 enum PregnancyStatus {
-  YES
-  NO
-  UNKNOWN
+    YES
+    NO
+    UNKNOWN
 }
 extend type Query {
     findSnomedCodedResults(searchText: String!, page: Page): SnomedCodedResults!
@@ -1517,30 +1509,30 @@ type SnomedCode {
     snomedDescTxt: String
 }
 extend type Query {
-  findAllStateCodes(page: Page): [StateCode]!
+    findAllStateCodes(page: Page): [StateCode]!
 }
 
 type StateCode {
-  id: String
-  assigningAuthorityCd: String
-  assigningAuthorityDescTxt: String
-  stateNm: String
-  codeDescTxt: String
-  effectiveFromTime: DateTime
-  effectiveToTime: DateTime
-  excludedTxt: String
-  indentLevelNbr: Int
-  isModifiableInd: String
-  keyInfoTxt: String
-  parentIsCd: String
-  statusCd: String
-  statusTime: DateTime
-  codeSetNm: String
-  seqNum: Int
-  nbsUid: Int
-  sourceConceptId: String
-  codeSystemCd: String
-  codeSystemDescTxt: String
+    id: String
+    assigningAuthorityCd: String
+    assigningAuthorityDescTxt: String
+    stateNm: String
+    codeDescTxt: String
+    effectiveFromTime: DateTime
+    effectiveToTime: DateTime
+    excludedTxt: String
+    indentLevelNbr: Int
+    isModifiableInd: String
+    keyInfoTxt: String
+    parentIsCd: String
+    statusCd: String
+    statusTime: DateTime
+    codeSetNm: String
+    seqNum: Int
+    nbsUid: Int
+    sourceConceptId: String
+    codeSystemCd: String
+    codeSystemDescTxt: String
 }
 extend type Query {
     findAllUsers(page: Page): UserResults!

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -7,30 +7,30 @@ type ConditionCode {
     conditionDescTxt: String
 }
 extend type Query {
-    findAllCountryCodes(page: Page): [CountryCode]!
+  findAllCountryCodes(page: Page): [CountryCode]!
 }
 
 type CountryCode {
-    id: ID
-    assigningAuthorityCd: String
-    assigningAuthorityDescTxt: String
-    codeDescTxt: String
-    codeShortDescTxt: String
-    effectiveFromTime: DateTime
-    effectiveToTime: DateTime
-    excludedTxt: String
-    keyInfoTxt: String
-    indentLevelNbr: Int
-    isModifiableInd: String
-    parentIsCd: String
-    statusCd: String
-    statusTime: DateTime
-    codeSetNm: String
-    seqNum: Int
-    nbsUid: Int
-    sourceConceptId: String
-    codeSystemCd: String
-    codeSystemDescTxt: String
+  id: ID
+  assigningAuthorityCd: String
+  assigningAuthorityDescTxt: String
+  codeDescTxt: String
+  codeShortDescTxt: String
+  effectiveFromTime: DateTime
+  effectiveToTime: DateTime
+  excludedTxt: String
+  keyInfoTxt: String
+  indentLevelNbr: Int
+  isModifiableInd: String
+  parentIsCd: String
+  statusCd: String
+  statusTime: DateTime
+  codeSetNm: String
+  seqNum: Int
+  nbsUid: Int
+  sourceConceptId: String
+  codeSystemCd: String
+  codeSystemDescTxt: String
 }
 extend type Query {
     findAllCountyCodesForState(stateCode: String!, page: Page): [CountyCode]!
@@ -76,333 +76,338 @@ type IdentificationTypeId {
     code: String!
 }
 extend type Query {
-    findInvestigationsByFilter(filter: InvestigationFilter!, page: SortablePage): InvestigationResults!
+  findInvestigationsByFilter(
+    filter: InvestigationFilter!
+    page: SortablePage
+  ): InvestigationResults!
 }
 
 type InvestigationResults {
-    content: [Investigation]!
-    total: Int!
+  content: [Investigation]!
+  total: Int!
 }
 
 type Investigation {
-    id: ID
-    recordStatus: String
-    lastChangeTime: DateTime
-    publicHealthCaseUid: Int
-    caseClassCd: String
-    outbreakName: String
-    caseTypeCd: String
-    cdDescTxt: String
-    progAreaCd: String
-    jurisdictionCd: Int
-    jurisdictionCodeDescTxt: String
-    pregnantIndCd: String
-    localId: String
-    rptFormCmpltTime: DateTime
-    activityToTime: DateTime
-    activityFromTime: DateTime
-    addTime: DateTime
-    publicHealthCaseLastChgTime: DateTime
-    addUserId: Int
-    lastChangeUserId: Int
-    currProcessStateCd: String
-    investigationStatusCd: String
-    moodCd: String
-    notificationLocalId: String
-    notificationAddTime: DateTime
-    notificationRecordStatusCd: String
-    notificationLastChgTime: DateTime
-    personParticipations: [PersonParticipation]
-    organizationParticipations: [OrganizationParticipation]
-    actIds: [ActId]
+  id: ID
+  recordStatus: String
+  lastChangeTime: DateTime
+  publicHealthCaseUid: Int
+  caseClassCd: String
+  outbreakName: String
+  caseTypeCd: String
+  cdDescTxt: String
+  progAreaCd: String
+  jurisdictionCd: Int
+  jurisdictionCodeDescTxt: String
+  pregnantIndCd: String
+  localId: String
+  rptFormCmpltTime: DateTime
+  activityToTime: DateTime
+  activityFromTime: DateTime
+  addTime: DateTime
+  publicHealthCaseLastChgTime: DateTime
+  addUserId: Int
+  lastChangeUserId: Int
+  currProcessStateCd: String
+  investigationStatusCd: String
+  moodCd: String
+  notificationLocalId: String
+  notificationAddTime: DateTime
+  notificationRecordStatusCd: String
+  notificationLastChgTime: DateTime
+  personParticipations: [PersonParticipation]
+  organizationParticipations: [OrganizationParticipation]
+  actIds: [ActId]
 }
 
 type ActId {
-    id: Int
-    recordStatus: String
-    actIdSeq: Int
-    rootExtensionTxt: String
-    typeCd: String
-    lastChangeTime: DateTime
+  id: Int
+  recordStatus: String
+  actIdSeq: Int
+  rootExtensionTxt: String
+  typeCd: String
+  lastChangeTime: DateTime
 }
 
 input InvestigationFilter {
-    patientId: Int
-    conditions: [String]
-    programAreas: [String]
-    jurisdictions: [ID]
-    pregnancyStatus: PregnancyStatus
-    eventIdType: InvestigationEventIdType
-    eventId: String
-    eventDateSearch: InvestigationEventDateSearch
-    createdBy: String
-    lastUpdatedBy: String
-    providerFacilitySearch: ProviderFacilitySearch
-    investigatorId: ID
-    investigationStatus: InvestigationStatus
-    outbreakNames: [String]
-    caseStatuses: CaseStatuses
-    notificationStatuses: NotificationStatuses
-    processingStatuses: ProcessingStatuses
+  patientId: Int
+  conditions: [String]
+  programAreas: [String]
+  jurisdictions: [ID]
+  pregnancyStatus: PregnancyStatus
+  eventId: EventId
+  eventDate: InvestigationEventDateSearch
+  createdBy: String
+  lastUpdatedBy: String
+  providerFacilitySearch: ProviderFacilitySearch
+  investigatorId: ID
+  investigationStatus: InvestigationStatus
+  outbreakNames: [String]
+  caseStatuses: CaseStatuses
+  notificationStatuses: NotificationStatuses
+  processingStatuses: ProcessingStatuses
 }
 
 input EventId {
-    investigationEventType: InvestigationEventIdType!
-    id: String!
+  investigationEventType: InvestigationEventIdType!
+  id: String!
 }
 
 input CaseStatuses {
-    includeUnassigned: Boolean!
-    statusList: [CaseStatus!]!
+  includeUnassigned: Boolean!
+  statusList: [CaseStatus!]!
 }
 
 input NotificationStatuses {
-    includeUnassigned: Boolean!
-    statusList: [NotificationStatus!]!
+  includeUnassigned: Boolean!
+  statusList: [NotificationStatus!]!
 }
 
 input ProcessingStatuses {
-    includeUnassigned: Boolean!
-    statusList: [ProcessingStatus!]!
+  includeUnassigned: Boolean!
+  statusList: [ProcessingStatus!]!
 }
 
 input InvestigationEventDateSearch {
-    eventDateType: InvestigationEventDateType!
-    from: DateTime!
-    to: DateTime!
+  type: InvestigationEventDateType!
+  from: Date!
+  to: Date!
 }
 
 input ProviderFacilitySearch {
-    entityType: ReportingEntityType!
-    id: ID!
+  entityType: ReportingEntityType!
+  id: ID!
 }
 
 enum InvestigationEventIdType {
-    ABCS_CASE_ID
-    CITY_COUNTY_CASE_ID
-    INVESTIGATION_ID
-    NOTIFICATION_ID
-    STATE_CASE_ID
+  ABCS_CASE_ID
+  CITY_COUNTY_CASE_ID
+  INVESTIGATION_ID
+  NOTIFICATION_ID
+  STATE_CASE_ID
 }
 
 enum ReportingEntityType {
-    FACILITY
-    PROVIDER
+  FACILITY
+  PROVIDER
 }
 
 enum ProcessingStatus {
-    UNASSIGNED
-    AWAITING_INTERVIEW
-    CLOSED_CASE
-    FIELD_FOLLOW_UP
-    NO_FOLLOW_UP
-    OPEN_CASE
-    SURVEILLANCE_FOLLOW_UP
+  UNASSIGNED
+  AWAITING_INTERVIEW
+  CLOSED_CASE
+  FIELD_FOLLOW_UP
+  NO_FOLLOW_UP
+  OPEN_CASE
+  SURVEILLANCE_FOLLOW_UP
 }
 
 enum NotificationStatus {
-    UNASSIGNED
-    APPROVED
-    COMPLETED
-    MESSAGE_FAILED
-    PENDING_APPROVAL
-    REJECTED
+  UNASSIGNED
+  APPROVED
+  COMPLETED
+  MESSAGE_FAILED
+  PENDING_APPROVAL
+  REJECTED
 }
 
 enum CaseStatus {
-    UNASSIGNED
-    CONFIRMED
-    NOT_A_CASE
-    PROBABLE
-    SUSPECT
-    UNKNOWN
+  UNASSIGNED
+  CONFIRMED
+  NOT_A_CASE
+  PROBABLE
+  SUSPECT
+  UNKNOWN
 }
 
 enum InvestigationEventDateType {
-    DATE_OF_REPORT
-    INVESTIGATION_CLOSED_DATE
-    INVESTIGATION_CREATE_DATE
-    INVESTIGATION_START_DATE
-    LAST_UPDATE_DATE
-    NOTIFICATION_CREATE_DATE
+  DATE_OF_REPORT
+  INVESTIGATION_CLOSED_DATE
+  INVESTIGATION_CREATE_DATE
+  INVESTIGATION_START_DATE
+  LAST_UPDATE_DATE
+  NOTIFICATION_CREATE_DATE
 }
 
 enum InvestigationStatus {
-    OPEN
-    CLOSED
+  OPEN
+  CLOSED
 }
 extend type Query {
-    findAllJurisdictions(page: Page): [Jurisdiction]!
+  findAllJurisdictions(page: Page): [Jurisdiction]!
 }
 
 type Jurisdiction {
-    id: String!
-    typeCd: String!
-    assigningAuthorityCd: String
-    assigningAuthorityDescTxt: String
-    codeDescTxt: String
-    codeShortDescTxt: String
-    effectiveFromTime: DateTime
-    effectiveToTime: DateTime
-    indentLevelNbr: Int
-    isModifiableInd: String
-    parentIsCd: String
-    stateDomainCd: String
-    statusCd: String
-    statusTime: DateTime
-    codeSetNm: String
-    codeSeqNum: Int
-    nbsUid: ID
-    sourceConceptId: String
-    codeSystemCd: String
-    codeSystemDescTxt: String
-    exportInd: String
+  id: String!
+  typeCd: String!
+  assigningAuthorityCd: String
+  assigningAuthorityDescTxt: String
+  codeDescTxt: String
+  codeShortDescTxt: String
+  effectiveFromTime: DateTime
+  effectiveToTime: DateTime
+  indentLevelNbr: Int
+  isModifiableInd: String
+  parentIsCd: String
+  stateDomainCd: String
+  statusCd: String
+  statusTime: DateTime
+  codeSetNm: String
+  codeSeqNum: Int
+  nbsUid: ID
+  sourceConceptId: String
+  codeSystemCd: String
+  codeSystemDescTxt: String
+  exportInd: String
 }
 extend type Query {
-    findLabReportsByFilter(filter: LabReportFilter!, page: SortablePage): LabReportResults!
+  findLabReportsByFilter(
+    filter: LabReportFilter!
+    page: SortablePage
+  ): LabReportResults!
 }
 
 type LabReportResults {
-    content: [LabReport]!
-    total: Int!
+  content: [LabReport]!
+  total: Int!
 }
 
 input LabReportFilter {
-    patientId: Int
-    programAreas: [String]
-    jurisdictions: [ID]
-    pregnancyStatus: PregnancyStatus
-    eventId: LabReportEventId
-    eventDate: LaboratoryEventDateSearch
-    entryMethods: [EntryMethod]
-    enteredBy: [UserType]
-    eventStatus: [EventStatus]
-    processingStatus: [LaboratoryReportStatus]
-    createdBy: ID
-    lastUpdatedBy: ID
-    providerSearch: LabReportProviderSearch
-    resultedTest: String
-    codedResult: String
+  patientId: Int
+  programAreas: [String]
+  jurisdictions: [ID]
+  pregnancyStatus: PregnancyStatus
+  eventId: LabReportEventId
+  eventDate: LaboratoryEventDateSearch
+  entryMethods: [EntryMethod]
+  enteredBy: [UserType]
+  eventStatus: [EventStatus]
+  processingStatus: [LaboratoryReportStatus]
+  createdBy: ID
+  lastUpdatedBy: ID
+  providerSearch: LabReportProviderSearch
+  resultedTest: String
+  codedResult: String
 }
 
 input LabReportEventId {
-    labEventType: LaboratoryEventIdType!
-    labEventId: String!
+  labEventType: LaboratoryEventIdType!
+  labEventId: String!
 }
 
 type LabReport {
-    id: String
-    observationUid: Int
-    lastChange: DateTime
-    classCd: String
-    moodCd: String
-    observationLastChgTime: DateTime
-    cdDescTxt: String
-    recordStatusCd: String
-    programAreaCd: String
-    jurisdictionCd: Int
-    jurisdictionCodeDescTxt: String
-    pregnantIndCd: String
-    localId: String
-    activityToTime: DateTime
-    effectiveFromTime: DateTime
-    rptToStateTime: DateTime
-    addTime: DateTime
-    electronicInd: String
-    versionCtrlNbr: Int
-    addUserId: Int
-    lastChgUserId: Int
-    personParticipations: [PersonParticipation]
-    organizationParticipations: [OrganizationParticipation]
-    materialParticipations: [MaterialParticipation]
-    observations: [Observation]
-    actIds: [ActId]
-    associatedInvestigations: [AssociatedInvestigation]
+  id: String
+  observationUid: Int
+  lastChange: DateTime
+  classCd: String
+  moodCd: String
+  observationLastChgTime: DateTime
+  cdDescTxt: String
+  recordStatusCd: String
+  programAreaCd: String
+  jurisdictionCd: Int
+  jurisdictionCodeDescTxt: String
+  pregnantIndCd: String
+  localId: String
+  activityToTime: DateTime
+  effectiveFromTime: DateTime
+  rptToStateTime: DateTime
+  addTime: DateTime
+  electronicInd: String
+  versionCtrlNbr: Int
+  addUserId: Int
+  lastChgUserId: Int
+  personParticipations: [PersonParticipation]
+  organizationParticipations: [OrganizationParticipation]
+  materialParticipations: [MaterialParticipation]
+  observations: [Observation]
+  actIds: [ActId]
+  associatedInvestigations: [AssociatedInvestigation]
 }
 
 type MaterialParticipation {
-    actUid: Int
-    typeCd: String
-    entityId: String
-    subjectClassCd: String
-    typeDescTxt: String
-    participationRecordStatus: String
-    participationLastChangeTime: DateTime
-    cd: String
-    cdDescTxt: String
+  actUid: Int
+  typeCd: String
+  entityId: String
+  subjectClassCd: String
+  typeDescTxt: String
+  participationRecordStatus: String
+  participationLastChangeTime: DateTime
+  cd: String
+  cdDescTxt: String
 }
 
 type Observation {
-    cd: String
-    cdDescTxt: String
-    domainCd: String
-    statusCd: String
-    altCd: String
-    altDescTxt: String
-    altCdSystemCd: String
-    displayName: String
-    ovcCode: String
-    ovcAltCode: String
-    ovcAltDescTxt: String
-    ovcAltCdSystemCd: String
+  cd: String
+  cdDescTxt: String
+  domainCd: String
+  statusCd: String
+  altCd: String
+  altDescTxt: String
+  altCdSystemCd: String
+  displayName: String
+  ovcCode: String
+  ovcAltCode: String
+  ovcAltDescTxt: String
+  ovcAltCdSystemCd: String
 }
 
 type AssociatedInvestigation {
-    publicHealthCaseUid: Int
-    cdDescTxt: String
-    localId: String
-    lastChgTime: DateTime
-    actRelationshipLastChgTime: DateTime
+  publicHealthCaseUid: Int
+  cdDescTxt: String
+  localId: String
+  lastChgTime: DateTime
+  actRelationshipLastChgTime: DateTime
 }
 
 input LaboratoryEventDateSearch {
-    eventDateType: LaboratoryReportEventDateType!
-    from: DateTime!
-    to: DateTime!
+  type: LaboratoryReportEventDateType!
+  from: Date!
+  to: Date!
 }
 
 input LabReportProviderSearch {
-    providerType: ProviderType!
-    providerId: ID!
+  providerType: ProviderType!
+  providerId: ID!
 }
 
 enum ProviderType {
-    ORDERING_FACILITY
-    ORDERING_PROVIDER
-    REPORTING_FACILITY
+  ORDERING_FACILITY
+  ORDERING_PROVIDER
+  REPORTING_FACILITY
 }
 
 enum LaboratoryEventIdType {
-    ACCESSION_NUMBER
-    LAB_ID
+  ACCESSION_NUMBER
+  LAB_ID
 }
 
 enum LaboratoryReportEventDateType {
-    DATE_OF_REPORT
-    DATE_RECEIVED_BY_PUBLIC_HEALTH
-    DATE_OF_SPECIMEN_COLLECTION
-    LAB_REPORT_CREATE_DATE
-    LAST_UPDATE_DATE
+  DATE_OF_REPORT
+  DATE_RECEIVED_BY_PUBLIC_HEALTH
+  DATE_OF_SPECIMEN_COLLECTION
+  LAB_REPORT_CREATE_DATE
+  LAST_UPDATE_DATE
 }
 
 enum EntryMethod {
-    ELECTRONIC
-    MANUAL
+  ELECTRONIC
+  MANUAL
 }
 
 enum UserType {
-    INTERNAL
-    EXTERNAL
+  INTERNAL
+  EXTERNAL
 }
 
 enum EventStatus {
-    NEW
-    UPDATE
+  NEW
+  UPDATE
 }
 
 enum LaboratoryReportStatus {
-    PROCESSED
-    UNPROCESSED
+  PROCESSED
+  UNPROCESSED
 }
 extend type Query {
     findLocalCodedResults(searchText: String!, page: Page): LocalCodedResults!
@@ -459,64 +464,67 @@ type LoincCode {
     relatedClassCd: String
 }
 extend type Query {
-    findOrganizationById(id: ID!): Organization
-    findAllOrganizations(page: Page): OrganizationResults!
-    findOrganizationsByFilter(filter: OrganizationFilter!, page: Page): OrganizationResults!
+  findOrganizationById(id: ID!): Organization
+  findAllOrganizations(page: Page): OrganizationResults!
+  findOrganizationsByFilter(
+    filter: OrganizationFilter!
+    page: Page
+  ): OrganizationResults!
 }
 
 type OrganizationResults {
-    content: [Organization]!
-    total: Int!
+  content: [Organization]!
+  total: Int!
 }
 
 input OrganizationFilter {
-    id: ID
-    displayNm: String
-    streetAddr1: String
-    streetAddr2: String
-    cityCd: String
-    cityDescTxt: String
-    stateCd: String
-    zipCd: String
+  id: ID
+  displayNm: String
+  streetAddr1: String
+  streetAddr2: String
+  cityCd: String
+  cityDescTxt: String
+  stateCd: String
+  zipCd: String
 }
 
 type Organization {
-    id: ID
-    addReasonCd: String
-    addTime: DateTime
-    addUserId: ID
-    cd: String
-    cdDescTxt: String
-    description: String
-    durationAmt: String
-    durationUnitCd: String
-    fromTime: DateTime
-    lastChgReasonCd: String
-    lastChgTime: DateTime
-    lastChgUserId: Int
-    localId: String
-    recordStatusCd: RecordStatus
-    recordStatusTime: DateTime
-    standardIndustryClassCd: String
-    standardIndustryDescTxt: String
-    statusCd: String
-    statusTime: DateTime
-    toTime: DateTime
-    userAffiliationTxt: String
-    displayNm: String
-    streetAddr1: String
-    streetAddr2: String
-    cityCd: String
-    cityDescTxt: String
-    stateCd: String
-    cntyCd: String
-    cntryCd: String
-    zipCd: String
-    phoneNbr: String
-    phoneCntryCd: String
-    versionCtrlNbr: Int
-    electronicInd: String
-    edxInd: String
+  id: ID
+  addReasonCd: String
+  addTime: DateTime
+  addUserId: ID
+  cd: String
+  cdDescTxt: String
+  description: String
+  durationAmt: String
+  durationUnitCd: String
+  fromTime: DateTime
+  lastChgReasonCd: String
+  lastChgTime: DateTime
+  lastChgUserId: Int
+  localId: String
+  recordStatusCd: RecordStatus
+  recordStatusTime: DateTime
+  standardIndustryClassCd: String
+  standardIndustryDescTxt: String
+  statusCd: String
+  statusTime: DateTime
+  toTime: DateTime
+  userAffiliationTxt: String
+  displayNm: String
+  streetAddr1: String
+  streetAddr2: String
+  cityCd: String
+  cityDescTxt: String
+  stateCd: String
+  cntyCd: String
+  cntryCd: String
+  zipCd: String
+  phoneNbr: String
+  phoneCntryCd: String
+  versionCtrlNbr: Int
+  electronicInd: String
+  edxInd: String
 }
 extend type Query {
     findAllOutbreaks(page: Page): OutbreakResults!
@@ -537,54 +545,56 @@ type OutbreakId {
     code: String!
 }
 type NamedContact {
-    id: ID!
-    name: String!
+  id: ID!
+  name: String!
 }
 
 type PatientContactInvestigation {
-    id: ID!
-    local: String!
-    condition: String!
+  id: ID!
+  local: String!
+  condition: String!
 }
 
 type NamedByPatient {
-    contactRecord: ID!
-    createdOn: DateTime!
-    condition: String
-    contact: NamedContact!
-    namedOn: DateTime!
-    priority: String
-    disposition: String
-    event: String!
-    associatedWith: PatientContactInvestigation
+  contactRecord: ID!
+  createdOn: DateTime!
+  condition: String
+  contact: NamedContact!
+  namedOn: DateTime!
+  priority: String
+  disposition: String
+  event: String!
+  associatedWith: PatientContactInvestigation
 }
 
 type ContactsNamedByPatientResults {
-    content: [NamedByPatient]!
-    total: Int!
-    number: Int!
+  content: [NamedByPatient]!
+  total: Int!
+  number: Int!
 }
 
 type NamedByContact {
-    contactRecord: ID!
-    createdOn: DateTime!
-    contact: NamedContact!
-    namedOn: DateTime!
-    condition: String
-    event: String!
-    associatedWith: PatientContactInvestigation
+  contactRecord: ID!
+  createdOn: DateTime!
+  contact: NamedContact!
+  namedOn: DateTime!
+  condition: String
+  event: String!
+  associatedWith: PatientContactInvestigation
 }
 
 type PatientNamedByContactResults {
-    content: [NamedByPatient]!
-    total: Int!
-    number: Int!
+  content: [NamedByPatient]!
+  total: Int!
+  number: Int!
 }
 
-extend type Query {
-    findContactsNamedByPatient(patient: ID!, page: Page): ContactsNamedByPatientResults
 
-    findPatientNamedByContact(patient: ID!, page: Page): PatientNamedByContactResults
+extend type Query {
+
+  findContactsNamedByPatient(patient:ID!, page: Page) : ContactsNamedByPatientResults
+
+  findPatientNamedByContact(patient:ID!, page: Page) : PatientNamedByContactResults
 }
 type PatientDocument {
     document: ID!
@@ -667,7 +677,7 @@ type PatientMorbidityResults {
 }
 
 extend type Query {
-    findMorbidityReportsForPatient(patient: ID!, page: Page): PatientMorbidityResults
+    findMorbidityReportsForPatient(patient: ID! page: Page ): PatientMorbidityResults
 }
 
 type PatientCodedValue {
@@ -852,6 +862,7 @@ type PatientMortality {
     deceasedOn: Date
     city: String
     state: PatientCodedValue
+    county: PatientCodedValue
     country: PatientCodedValue
 }
 
@@ -920,35 +931,35 @@ extend type Query {
     findPatientProfile(patient: ID, shortId: Int): PatientProfile
 }
 type PatientTreatment {
-    treatment: ID!
-    createdOn: DateTime!
-    provider: String
-    treatedOn: DateTime!
-    description: String!
-    event: String!
-    associatedWith: PatientTreatmentInvestigation!
+  treatment: ID!
+  createdOn: DateTime!
+  provider: String
+  treatedOn: DateTime!
+  description: String!
+  event: String!
+  associatedWith: PatientTreatmentInvestigation!
 }
 
 type PatientTreatmentInvestigation {
-    id: ID!
-    local: String!
-    condition: String!
+  id: ID!
+  local: String!
+  condition: String!
 }
 
 type PatientTreatmentResults {
-    content: [PatientTreatment]!
-    total: Int!
-    number: Int!
+  content: [PatientTreatment]!
+  total: Int!
+  number: Int!
 }
 
 extend type Query {
-    findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
+  findTreatmentsForPatient(patient: ID!, page: Page): PatientTreatmentResults
 }
 type PatientVaccination {
     vaccination: ID!
     createdOn: DateTime!
     provider: String
-    administeredOn: DateTime!
+    administeredOn: DateTime
     administered: String!
     event: String!
     associatedWith: PatientVaccinationInvestigation
@@ -1350,69 +1361,69 @@ type NBSEntity {
     entityLocatorParticipations: [LocatorParticipations]
 }
 extend type Query {
-    findPlaceById(id: ID!): Place
-    findAllPlaces(page: Page): [Place]!
-    findPlacesByFilter(filter: PlaceFilter!, page: Page): [Place]!
+  findPlaceById(id: ID!): Place
+  findAllPlaces(page: Page): [Place]!
+  findPlacesByFilter(filter: PlaceFilter!, page: Page): [Place]!
 }
 
 input PlaceFilter {
-    id: ID
-    description: String
-    nm: String
-    streetAddr1: String
-    streetAddr2: String
-    cityCd: String
-    cityDescTxt: String
-    stateCd: String
-    zipCd: String
+  id: ID
+  description: String
+  nm: String
+  streetAddr1: String
+  streetAddr2: String
+  cityCd: String
+  cityDescTxt: String
+  stateCd: String
+  zipCd: String
 }
 
 type Place {
-    id: ID
-    addReasonCd: String
-    addTime: DateTime
-    addUserId: Int
-    cd: String
-    cdDescTxt: String
-    description: String
-    durationAmt: String
-    durationUnitCd: String
-    fromTime: DateTime
-    lastChgReasonCd: String
-    lastChgTime: DateTime
-    lastChgUserId: Int
-    localId: String
-    nm: String
-    recordStatusCd: String
-    recordStatusTime: DateTime
-    statusCd: String
-    statusTime: DateTime
-    toTime: DateTime
-    userAffiliationTxt: String
-    streetAddr1: String
-    streetAddr2: String
-    cityCd: String
-    cityDescTxt: String
-    stateCd: String
-    zipCd: String
-    cntyCd: String
-    cntryCd: String
-    phoneNbr: String
-    phoneCntryCd: String
-    versionCtrlNbr: Int
+  id: ID
+  addReasonCd: String
+  addTime: DateTime
+  addUserId: Int
+  cd: String
+  cdDescTxt: String
+  description: String
+  durationAmt: String
+  durationUnitCd: String
+  fromTime: DateTime
+  lastChgReasonCd: String
+  lastChgTime: DateTime
+  lastChgUserId: Int
+  localId: String
+  nm: String
+  recordStatusCd: String
+  recordStatusTime: DateTime
+  statusCd: String
+  statusTime: DateTime
+  toTime: DateTime
+  userAffiliationTxt: String
+  streetAddr1: String
+  streetAddr2: String
+  cityCd: String
+  cityDescTxt: String
+  stateCd: String
+  zipCd: String
+  cntyCd: String
+  cntryCd: String
+  phoneNbr: String
+  phoneCntryCd: String
+  versionCtrlNbr: Int
 }
 extend type Query {
-    findAllProgramAreas(page: Page): [ProgramAreaCode]!
+  findAllProgramAreas(page: Page): [ProgramAreaCode]!
 }
 
 type ProgramAreaCode {
-    id: String!
-    progAreaDescTxt: String
-    nbsUid: ID
-    statusCd: String
-    statusTime: DateTime
-    codeSetNm: String
-    codeSeq: Int
+  id: String!
+  progAreaDescTxt: String
+  nbsUid: ID
+  statusCd: String
+  statusTime: DateTime
+  codeSetNm: String
+  codeSeq: Int
 }
 extend type Query {
     findAllRaceValues(page: Page): RaceResults!
@@ -1435,65 +1446,65 @@ scalar Date
 scalar DateTime
 
 input Page {
-    pageSize: Int!
-    pageNumber: Int!
+  pageSize: Int!
+  pageNumber: Int!
 }
 
 input SortablePage {
-    pageSize: Int
-    pageNumber: Int
-    sortField: SortField
-    sortDirection: SortDirection
+  pageSize: Int
+  pageNumber: Int
+  sortField: SortField
+  sortDirection: SortDirection
 }
 
 type PersonParticipation {
-    actUid: Int!
-    localId: String
-    typeCd: String
-    entityId: Int!
-    subjectClassCd: String
-    participationRecordStatus: String
-    typeDescTxt: String
-    participationLastChangeTime: DateTime
-    firstName: String
-    lastName: String
-    birthTime: DateTime
-    currSexCd: String
-    personCd: String!
-    personParentUid: Int
-    personRecordStatus: String!
-    personLastChangeTime: DateTime
+  actUid: Int!
+  localId: String
+  typeCd: String
+  entityId: Int!
+  subjectClassCd: String
+  participationRecordStatus: String
+  typeDescTxt: String
+  participationLastChangeTime: DateTime
+  firstName: String
+  lastName: String
+  birthTime: DateTime
+  currSexCd: String
+  personCd: String!
+  personParentUid: Int
+  personRecordStatus: String!
+  personLastChangeTime: DateTime
 }
 
 type OrganizationParticipation {
-    actUid: Int
-    typeCd: String
-    entityId: Int
-    subjectClassCd: String
-    typeDescTxt: String
-    participationRecordStatus: String
-    participationLastChangeTime: DateTime
-    name: String
-    organizationLastChangeTime: DateTime
+  actUid: Int
+  typeCd: String
+  entityId: Int
+  subjectClassCd: String
+  typeDescTxt: String
+  participationRecordStatus: String
+  participationLastChangeTime: DateTime
+  name: String
+  organizationLastChangeTime: DateTime
 }
 
 enum SortField {
-    lastNm
-    birthTime
-    relevance
+  lastNm
+  birthTime
+  relevance
 }
 
 enum RecordStatus {
-    ACTIVE
-    INACTIVE
-    LOG_DEL
-    SUPERCEDED
+  ACTIVE
+  INACTIVE
+  LOG_DEL
+  SUPERCEDED
 }
 
 enum PregnancyStatus {
-    YES
-    NO
-    UNKNOWN
+  YES
+  NO
+  UNKNOWN
 }
 extend type Query {
     findSnomedCodedResults(searchText: String!, page: Page): SnomedCodedResults!
@@ -1509,30 +1520,30 @@ type SnomedCode {
     snomedDescTxt: String
 }
 extend type Query {
-    findAllStateCodes(page: Page): [StateCode]!
+  findAllStateCodes(page: Page): [StateCode]!
 }
 
 type StateCode {
-    id: String
-    assigningAuthorityCd: String
-    assigningAuthorityDescTxt: String
-    stateNm: String
-    codeDescTxt: String
-    effectiveFromTime: DateTime
-    effectiveToTime: DateTime
-    excludedTxt: String
-    indentLevelNbr: Int
-    isModifiableInd: String
-    keyInfoTxt: String
-    parentIsCd: String
-    statusCd: String
-    statusTime: DateTime
-    codeSetNm: String
-    seqNum: Int
-    nbsUid: Int
-    sourceConceptId: String
-    codeSystemCd: String
-    codeSystemDescTxt: String
+  id: String
+  assigningAuthorityCd: String
+  assigningAuthorityDescTxt: String
+  stateNm: String
+  codeDescTxt: String
+  effectiveFromTime: DateTime
+  effectiveToTime: DateTime
+  excludedTxt: String
+  indentLevelNbr: Int
+  isModifiableInd: String
+  keyInfoTxt: String
+  parentIsCd: String
+  statusCd: String
+  statusTime: DateTime
+  codeSetNm: String
+  seqNum: Int
+  nbsUid: Int
+  sourceConceptId: String
+  codeSystemCd: String
+  codeSystemDescTxt: String
 }
 extend type Query {
     findAllUsers(page: Page): UserResults!


### PR DESCRIPTION
Adds missing fields to Birth and Mortality Demographics

Birth:
- Birth Order
- Birth County

Mortality:
- Death County

Changes the source of the county description from `code_short_desc_txt` to `code_desc_txt` so that a county name is displayed without the State abbreviation.  For example; `Iron` over `Iron, UT`

Fixes the TableComponent test to account for the sorting buttons being disabled when only one row exists.