### PR TITLE
CNFT1-856/ Patient Profile Treatments Navigation

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/treatment/ViewTreatmentRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/treatment/ViewTreatmentRedirector.java
@@ -1,0 +1,44 @@
+package gov.cdc.nbs.patient.profile.treatment;
+
+import gov.cdc.nbs.patient.profile.redirect.outgoing.ClassicPatientProfileRedirector;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+import springfox.documentation.annotations.ApiIgnore;
+
+import java.net.URI;
+
+@ApiIgnore
+@RestController
+class ViewTreatmentRedirector {
+
+    private static final String LOCATION = "/nbs/ViewFile1.do";
+
+    private final ClassicPatientProfileRedirector redirector;
+
+    ViewTreatmentRedirector(final ClassicPatientProfileRedirector redirector) {
+        this.redirector = redirector;
+    }
+
+    @PreAuthorize("hasAuthority('VIEW-TREATMENT')")
+    @GetMapping("/nbs/api/profile/{patient}/treatment/{identifier}")
+    ResponseEntity<Void> view(
+        @PathVariable("patient") final long patient,
+        @PathVariable("identifier") final long identifier
+    ) {
+
+
+        URI location = UriComponentsBuilder.fromPath(LOCATION)
+            .queryParam("ContextAction", "TreatmentIDOnEvents")
+            .queryParam("treatmentUID", identifier)
+            .build()
+            .toUri();
+
+        return redirector.preparedRedirect(patient, location);
+    }
+
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/treatment/PatientProfileViewTreatmentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/treatment/PatientProfileViewTreatmentSteps.java
@@ -1,0 +1,126 @@
+package gov.cdc.nbs.patient.profile.treatment;
+
+import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.patient.TestPatients;
+import gov.cdc.nbs.patient.treatment.TestTreatments;
+import gov.cdc.nbs.support.TestActive;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class PatientProfileViewTreatmentSteps {
+
+    @Value("${nbs.wildfly.url:http://wildfly:7001}")
+    String classicUrl;
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    TestTreatments treatments;
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    TestActive<SessionCookie> activeSession;
+
+    @Autowired
+    TestActive<MockHttpServletResponse> activeResponse;
+
+    @Autowired
+    TestActive<UserDetails> activeUserDetails;
+
+    @Autowired
+    @Qualifier("classic")
+    MockRestServiceServer server;
+
+    @Before
+    public void reset() {
+        activeResponse.reset();
+        server.reset();
+    }
+
+    @When("the Treatment is viewed from the Patient Profile")
+    public void the_treatment_is_viewed_from_the_patient_profile() throws Exception {
+        long patient = patients.one();
+
+        server.expect(
+                requestTo(classicUrl + "/nbs/HomePage.do?method=patientSearchSubmit")
+            )
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess())
+        ;
+
+        server.expect(requestTo(classicUrl + "/nbs/PatientSearchResults1.do?ContextAction=ViewFile&uid=" + patient))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess())
+        ;
+
+        long treatment = treatments.one();
+
+        String request = String.format(
+            "/nbs/api/profile/%d/treatment/%d",
+            patient,
+            treatment
+        );
+
+        activeResponse.active(
+            mvc.perform(
+                    MockMvcRequestBuilders.get(request)
+                        .with(user(activeUserDetails.active()))
+                        .cookie(activeSession.active().asCookie())
+                )
+                .andReturn()
+                .getResponse()
+        );
+    }
+
+    @Then("the classic profile is prepared to view a Treatment")
+    public void the_classic_profile_is_prepared_to_view_a_treatment() {
+        server.verify();
+    }
+
+    @Then("I am redirected to Classic NBS to view a Treatment")
+    public void i_am_redirected_to_classic_nbs_to_view_a_treatment() {
+        long patient = patients.one();
+        long treatment = treatments.one();
+
+        String expected =
+            "/nbs/ViewFile1.do?ContextAction=TreatmentIDOnEvents&treatmentUID=" + treatment;
+
+        MockHttpServletResponse response = activeResponse.active();
+
+        assertThat(response.getRedirectedUrl()).contains(expected);
+
+        assertThat(response.getCookies())
+            .satisfiesOnlyOnce(cookie -> {
+                    assertThat(cookie.getName()).isEqualTo("Returning-Patient");
+                    assertThat(cookie.getValue()).isEqualTo(String.valueOf(patient));
+                }
+            );
+    }
+
+    @Then("I am not allowed to view a Classic NBS Treatment")
+    public void i_am_not_allowed_to_view_a_classic_nbs_treatment() {
+        MockHttpServletResponse response = activeResponse.active();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/PatientTreatmentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/PatientTreatmentSteps.java
@@ -1,0 +1,72 @@
+package gov.cdc.nbs.patient.treatment;
+
+import gov.cdc.nbs.graphql.GraphQLPage;
+import gov.cdc.nbs.investigation.TestInvestigations;
+import gov.cdc.nbs.patient.TestPatients;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+public class PatientTreatmentSteps {
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    TestInvestigations investigations;
+
+    @Autowired
+    TreatmentMother mother;
+
+    @Autowired
+    PatientTreatmentByPatientResolver resolver;
+
+    @Before
+    public void clean() {
+        mother.reset();
+    }
+
+    @When("the patient is a subject of a Treatment")
+    public void the_patient_is_a_subject_of_a_treatment() {
+        long patient = patients.one();
+        long investigation = investigations.one();
+
+        mother.treated(patient, investigation);
+    }
+
+    @Then("the profile has an associated Treatment")
+    public void the_profile_has_an_associated_treatment() {
+        long patient = this.patients.one();
+
+        Page<PatientTreatment> actual = this.resolver.find(patient, new GraphQLPage(5));
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Then("the profile has no associated Treatments")
+    public void the_profile_has_no_associated_treatments() {
+        long patient = this.patients.one();
+
+        Page<PatientTreatment> actual = this.resolver.find(patient, new GraphQLPage(5));
+        assertThat(actual).isEmpty();
+    }
+
+    @Then("the profile Treatments are not returned")
+    public void the_profile_treatments_are_not_returned() {
+        long patient = this.patients.one();
+
+        GraphQLPage page = new GraphQLPage(5);
+
+        assertThatThrownBy(() -> {
+            this.resolver.find(patient, page);
+        })
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/TestTreatmentCleaner.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/TestTreatmentCleaner.java
@@ -1,0 +1,56 @@
+package gov.cdc.nbs.patient.treatment;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.entity.odse.Act;
+import gov.cdc.nbs.entity.odse.QTreatment;
+import gov.cdc.nbs.entity.odse.Treatment;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+@Component
+class TestTreatmentCleaner {
+
+    private static final QTreatment TREATMENT = QTreatment.treatment;
+    private final EntityManager entityManager;
+    private final JPAQueryFactory factory;
+
+    TestTreatmentCleaner(final EntityManager entityManager, final JPAQueryFactory factory) {
+        this.entityManager = entityManager;
+        this.factory = factory;
+    }
+
+    @Transactional
+    void clean(final long starting) {
+        this.factory.select(TREATMENT)
+            .from(TREATMENT)
+            .where(criteria(starting))
+            .fetch()
+            .forEach(this::remove);
+    }
+
+    private BooleanExpression criteria(final long starting) {
+        BooleanExpression threshold = TREATMENT.id.goe(starting);
+        return starting < 0
+            ? threshold.and(TREATMENT.id.lt(0))
+            : threshold;
+    }
+
+    private void remove(final Treatment treatment) {
+        removeParticipation(treatment);
+
+        this.entityManager.remove(treatment);
+    }
+
+    private void removeParticipation(final Treatment treatment) {
+        //  The all treatment participation instances are associated with the Act entity.  Removing the Act will remove any
+        //  associations.
+        Act existing = this.entityManager.find(Act.class, treatment.getId());
+
+        if (existing != null) {
+            this.entityManager.remove(existing);
+        }
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/TestTreatments.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/TestTreatments.java
@@ -1,0 +1,8 @@
+package gov.cdc.nbs.patient.treatment;
+
+import gov.cdc.nbs.support.TestAvailable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestTreatments extends TestAvailable<Long> {
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/TreatmentMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/treatment/TreatmentMother.java
@@ -1,0 +1,127 @@
+package gov.cdc.nbs.patient.treatment;
+
+import gov.cdc.nbs.entity.enums.RecordStatus;
+import gov.cdc.nbs.entity.odse.Act;
+import gov.cdc.nbs.entity.odse.Participation;
+import gov.cdc.nbs.entity.odse.ParticipationId;
+import gov.cdc.nbs.entity.odse.Treatment;
+import gov.cdc.nbs.entity.odse.TreatmentAdministered;
+import gov.cdc.nbs.identity.MotherSettings;
+import gov.cdc.nbs.identity.TestUniqueIdGenerator;
+import gov.cdc.nbs.support.util.RandomUtil;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+
+@Component
+class TreatmentMother {
+
+    private static final String PERSON_CLASS = "PSN";
+    private static final String SUBJECT_OF_TREATMENT = "SubjOfTrmt";
+    private static final String TREATMENT_OF_INVESTIGATION = "TreatmentToPHC";
+
+    private final MotherSettings settings;
+    private final TestUniqueIdGenerator idGenerator;
+    private final EntityManager entityManager;
+    private final TestTreatmentCleaner cleaner;
+
+    private final TestTreatments treatments;
+
+    TreatmentMother(
+        final MotherSettings settings,
+        final TestUniqueIdGenerator idGenerator,
+        final EntityManager entityManager,
+        final TestTreatmentCleaner cleaner,
+        final TestTreatments treatments
+    ) {
+        this.settings = settings;
+        this.idGenerator = idGenerator;
+        this.entityManager = entityManager;
+        this.cleaner = cleaner;
+        this.treatments = treatments;
+    }
+
+    void reset() {
+        this.cleaner.clean(this.settings.starting());
+        this.treatments.reset();
+    }
+
+    Treatment treated(final long patient, final long investigation) {
+        long identifier = idGenerator.next();
+        String localId = idGenerator.nextLocal("TRT");
+
+        Treatment treatment = new Treatment(identifier, localId);
+        treatment.setActivityToTime(RandomUtil.getRandomDateInPast());
+
+        // Treatment: Other
+        treatment.setCd("OTH");
+        treatment.setCdDescTxt("Other");
+
+        // Jurisdiction: Out of system
+        treatment.setJurisdictionCd("999999");
+
+        treatment.setRecordStatusCd("ACTIVE");
+        treatment.setRecordStatusTime(settings.createdOn());
+        treatment.setAddTime(settings.createdOn());
+        treatment.setAddUserId(settings.createdBy());
+
+        subjectOfTreatment(treatment, patient);
+
+        administered(treatment);
+
+        treatedWithInvestigation(treatment, investigation);
+
+        this.entityManager.persist(treatment);
+
+        this.treatments.available(identifier);
+
+
+        return treatment;
+    }
+
+    private void subjectOfTreatment(final Treatment treatment, final long patient) {
+
+        Act act = treatment.getAct();
+
+        // create the participation
+        ParticipationId identifier = new ParticipationId(patient, act.getId(), SUBJECT_OF_TREATMENT);
+
+        Participation participation = new Participation();
+        participation.setId(identifier);
+        participation.setActClassCd(act.getClassCd());
+        participation.setSubjectClassCd(PERSON_CLASS);
+
+        participation.setRecordStatusCd(RecordStatus.ACTIVE);
+        participation.setRecordStatusTime(settings.createdOn());
+        participation.setAddTime(settings.createdOn());
+        participation.setAddUserId(settings.createdBy());
+        participation.setActUid(act);
+
+        act.addParticipation(participation);
+
+    }
+
+    private void administered(final Treatment treatment) {
+
+        TreatmentAdministered administered = treatment.administer();
+        administered.setEffectiveFromTime(treatment.getAddTime());
+
+    }
+
+    private void treatedWithInvestigation(
+        final Treatment treatment,
+        final long investigation
+    ) {
+
+        treatment.getAct().addRelationship(
+            resolve(investigation),
+            TREATMENT_OF_INVESTIGATION
+        );
+
+
+    }
+
+    private Act resolve(final long identifier) {
+        return this.entityManager.find(Act.class, identifier);
+    }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileTreatment.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileTreatment.feature
@@ -1,0 +1,34 @@
+@patient-profile-treatments
+Feature: Patient Profile Treatments
+
+  Background:
+    Given I have a patient
+    And the patient is a subject of an investigation
+
+  Scenario: I can retrieve treatments for a patient
+    Given I have the authorities: "FIND-PATIENT,VIEW-TREATMENT" for the jurisdiction: "ALL" and program area: "STD"
+    When the patient is a subject of a Treatment
+    Then the profile has an associated Treatment
+
+  Scenario: I cannot retrieve Treatments for a patient without Treatments
+    Given I have the authorities: "FIND-PATIENT,VIEW-TREATMENT" for the jurisdiction: "ALL" and program area: "STD"
+    Then the profile has no associated Treatments
+
+  Scenario: I cannot retrieve Treatments without proper authorities
+    Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+    Then the profile Treatments are not returned
+
+  Scenario: A Treatment is viewed from the Patient Profile
+    Given I am logged into NBS and a security log entry exists
+    And I have the authorities: "VIEW-TREATMENT" for the jurisdiction: "ALL" and program area: "STD"
+    And the patient is a subject of a Treatment
+    When the Treatment is viewed from the Patient Profile
+    Then the classic profile is prepared to view a Treatment
+    And I am redirected to Classic NBS to view a Treatment
+
+  Scenario: A Treatment is viewed from the Patient Profile without required permissions
+    Given I am logged into NBS and a security log entry exists
+    And I have the authorities: "OTHER" for the jurisdiction: "ALL" and program area: "STD"
+    And the patient is a subject of a Treatment
+    When the Treatment is viewed from the Patient Profile
+    Then I am not allowed to view a Classic NBS Treatment

--- a/apps/modernization-ui/src/pages/patient/profile/treatment/PatientTreatmentTable.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/treatment/PatientTreatmentTable.tsx
@@ -5,6 +5,7 @@ import { FindTreatmentsForPatientQuery, useFindTreatmentsForPatientLazyQuery } f
 
 import { TOTAL_TABLE_DATA } from 'utils/util';
 import { SortableTable } from 'components/Table/SortableTable';
+import { ClassicLink } from 'classic';
 
 export type PatientTreatments = FindTreatmentsForPatientQuery['findTreatmentsForPatient'];
 
@@ -12,6 +13,25 @@ type PatientTreatmentTableProps = {
     patient?: string;
     pageSize?: number;
 };
+
+const displayCreatedOn = (patient: string, treatment: any) => {
+    const createdOn = new Date(treatment.createdOn);
+
+    return (
+        <ClassicLink url={`/nbs/api/profile/${patient}/treatment/${treatment.treatment}`}>
+            {format(createdOn, 'MM/dd/yyyy')} <br /> {format(createdOn, 'hh:mm a')}
+        </ClassicLink>
+    );
+};
+
+const displayAssociation = (patient: string, associatedWith: any) => (
+    <div>
+        <ClassicLink url={`/nbs/api/profile/${patient}/investigation/${associatedWith.id}`}>
+            {associatedWith?.local}
+        </ClassicLink>
+        <p className="margin-0">{associatedWith?.condition}</p>
+    </div>
+);
 
 export const PatientTreatmentTable = ({ patient, pageSize = TOTAL_TABLE_DATA }: PatientTreatmentTableProps) => {
     const [currentPage, setCurrentPage] = useState<number>(1);
@@ -142,11 +162,8 @@ export const PatientTreatmentTable = ({ patient, pageSize = TOTAL_TABLE_DATA }: 
                     return (
                         <tr key={index}>
                             <td className={`font-sans-md table-data ${tableHead[0].sort !== 'all' && 'sort-td'}`}>
-                                {treatment?.createdOn ? (
-                                    <a href="#" className="table-span">
-                                        {format(new Date(treatment?.createdOn), 'MM/dd/yyyy')} <br />{' '}
-                                        {format(new Date(treatment?.createdOn), 'hh:mm a')}
-                                    </a>
+                                {patient && treatment?.createdOn ? (
+                                    displayCreatedOn(patient, treatment)
                                 ) : (
                                     <span className="no-data">No data</span>
                                 )}
@@ -176,17 +193,10 @@ export const PatientTreatmentTable = ({ patient, pageSize = TOTAL_TABLE_DATA }: 
                                 )}
                             </td>
                             <td className={`font-sans-md table-data ${tableHead[4].sort !== 'all' && 'sort-td'}`}>
-                                {!treatment || !treatment?.associatedWith ? (
-                                    <span className="no-data">No data</span>
+                                {patient && treatment?.associatedWith ? (
+                                    displayAssociation(patient, treatment.associatedWith)
                                 ) : (
-                                    <div>
-                                        <p
-                                            className="margin-0 text-primary text-bold link"
-                                            style={{ wordBreak: 'break-word' }}>
-                                            {treatment.associatedWith?.local}
-                                        </p>
-                                        <p className="margin-0">{treatment.associatedWith.condition}</p>
-                                    </div>
+                                    <span className="no-data">No data</span>
                                 )}
                             </td>
                             <td className={`font-sans-md table-data ${tableHead[5].sort !== 'all' && 'sort-td'}`}>

--- a/documentation/Routing.md
+++ b/documentation/Routing.md
@@ -19,7 +19,7 @@ THe following routes should be proxied to the `modernization-api` service.
 | Path is exactly `/graphql`    | `/graphql`    | Handles all GraphQL requests                           |
 | Path is exactly `/encryption` | `/encryption` | Encryption and Decryption of Patient Search parameters |
 | Path starts with `/`          | `/`           | Routes to the packaged frontend application            |
-| Path starts with `/nbs/api`   | `/nbs/api`    |                                                        |
+| Path starts with `/nbs/api`   | `/nbs/api`    | Routes to endpoints on the `modernization-api`         |
 
 ### Patient Search Routes
 
@@ -34,11 +34,11 @@ THe following routes should be proxied to the `modernization-api` service.
 Transforms requests to a Classic Patient Profile into an authenticated request that redirects to the Modernized Patient
 Profile of the Patient identified by the `MPRUid` or `uid` request parameter.
 
-| Criteria                                                                              | API Path                       | Description                                                                                              |
-|---------------------------------------------------------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|
-| Contains the Query Parameter `ContextAction` with a value of `ViewFile`               | `/nbs/redirect/patientProfile` | View a Patient Profile link within Classic NBS.                                                          |
-| Contains the Query Parameter `ContextAction` with a value of `FileSummary`            | `/nbs/redirect/patientProfile` | View a Patient Profile link within Classic NBS                                                           |
-| A GET request where the Query Parameter `ContextAction` with a value of `FileSummary` | `/nbs/redirect/patientProfile` | View a Patient Profile link within Classic NBS after Morbidity Report `Submit and Create Investigation`  |
+| Criteria                                                                                  | API Path                       | Description                                                                                              |
+|-------------------------------------------------------------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|
+| A POST request Contains the Query Parameter `ContextAction` with a value of `ViewFile`    | `/nbs/redirect/patientProfile` | View a Patient Profile link within Classic NBS.                                                          |
+| A POST request Contains the Query Parameter `ContextAction` with a value of `FileSummary` | `/nbs/redirect/patientProfile` | View a Patient Profile link within Classic NBS                                                           |
+| A GET request where the Query Parameter `ContextAction` with a value of `FileSummary`     | `/nbs/redirect/patientProfile` | View a Patient Profile link within Classic NBS after Morbidity Report `Submit and Create Investigation`  |
 
 Transforms requests to return to a Classic Profile into an authenticated request that redirects to the Modernized
 Patient Profile of the Patient identified by the value of the `Return-Patient` cookie. This cookie added to requests via

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Act.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Act.java
@@ -1,7 +1,9 @@
 package gov.cdc.nbs.entity.odse;
 
-import java.util.ArrayList;
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -9,11 +11,8 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.ArrayList;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -49,10 +48,21 @@ public class Act {
     @OneToMany(mappedBy = "id", fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE})
     private List<Intervention> interventions;
 
+    @OneToMany(mappedBy = "id", fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE})
+    private List<Treatment> treatments;
+
     @OneToMany(mappedBy = "targetActUid", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ActRelationship> targetActRelationships;
 
-    @OneToMany(mappedBy = "sourceActUid", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(
+        mappedBy = "sourceActUid",
+        fetch = FetchType.LAZY,
+        cascade = {
+            CascadeType.PERSIST,
+            CascadeType.MERGE,
+            CascadeType.REMOVE
+        }
+    )
     private List<ActRelationship> actRelationships;
 
     public Act(final long identifier, final String classCd) {
@@ -67,10 +77,26 @@ public class Act {
     }
 
     private List<Participation> ensureParticipation() {
-        if(this.participations == null) {
+        if (this.participations == null) {
             this.participations = new ArrayList<>();
         }
 
         return this.participations;
+    }
+
+    private List<ActRelationship> ensureRelationships() {
+        if(this.actRelationships == null) {
+            this.actRelationships = new ArrayList<>();
+        }
+        return this.actRelationships;
+    }
+
+    public void addRelationship(final Act target, final String type) {
+        ActRelationship relationship = new ActRelationship(
+            this,
+            target,
+            type
+        );
+        ensureRelationships().add(relationship);
     }
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/ActRelationship.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/ActRelationship.java
@@ -1,14 +1,19 @@
 package gov.cdc.nbs.entity.odse;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
 import java.time.Instant;
 
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -85,4 +90,24 @@ public class ActRelationship {
     @Column(name = "user_affiliation_txt", length = 20)
     private String userAffiliationTxt;
 
+    public ActRelationship(
+        Act source,
+        Act target,
+        String type
+    ) {
+        this.id = new ActRelationshipId(
+            source.getId(),
+            target.getId(),
+            type
+        );
+
+        this.sourceActUid = source;
+        this.sourceClassCd = source.getClassCd();
+
+        this.targetActUid = target;
+        this.targetClassCd = target.getClassCd();
+
+        this.recordStatusCd = "ACTIVE";
+        this.statusCd = 'A';
+    }
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/TreatmentAdministered.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/TreatmentAdministered.java
@@ -87,4 +87,11 @@ public class TreatmentAdministered {
     @Column(name = "status_time")
     private Instant statusTime;
 
+    public TreatmentAdministered(final Treatment treatment) {
+        short sequence = (short) (treatment.getAdministered().size() + (short)1);
+
+        this.id = new TreatmentAdministeredId(treatment.getId(), sequence);
+        this.treatmentUid = treatment;
+        this.cd = treatment.getCd();
+    }
 }


### PR DESCRIPTION
Implements features of [CNFT1-856](https://cdc-nbs.atlassian.net/browse/CNFT1-856) by adding an endpoint to support viewing a Treatment from the Modernized Patient Profile.  Treatments can only be viewed from the Patient Profile.  Returning from the Classic NBS Treatment uses the redirection that is already in place for `ContextAction=ReturnToFileEvents`

*Routing will only work in a local development environment*

- Adds the endpont GET /nbs/api/profile/{patient}/treatment/{identifier} which prepares the Classic NBS Session to view a Treatment and then returns a redirect response with the url the client will navigate to  view a Treatment in Classic NBS. The identifier of the patient is added as the value of the Returning-Patient cookie.

Code was added to the `database-entities` library which is not yet reporting test coverage.

[CNFT1-856]: https://cdc-nbs.atlassian.net/browse/CNFT1-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ