### PR TITLE
CNFT1-857/ Patient Profile Documents Navigation

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/document/ViewDocumentRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/document/ViewDocumentRedirector.java
@@ -1,0 +1,42 @@
+package gov.cdc.nbs.patient.profile.document;
+
+import gov.cdc.nbs.patient.profile.redirect.outgoing.ClassicPatientProfileRedirector;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+import springfox.documentation.annotations.ApiIgnore;
+
+import java.net.URI;
+
+@ApiIgnore
+@RestController
+class ViewDocumentRedirector {
+
+    private static final String LOCATION = "/nbs/ViewFile1.do";
+
+    private final ClassicPatientProfileRedirector redirector;
+
+    ViewDocumentRedirector(final ClassicPatientProfileRedirector redirector) {
+        this.redirector = redirector;
+    }
+
+    @PreAuthorize("hasAuthority('VIEW-DOCUMENT')")
+    @GetMapping("/nbs/api/profile/{patient}/document/{identifier}")
+    ResponseEntity<Void> view(
+        @PathVariable("patient") final long patient,
+        @PathVariable("identifier") final long identifier
+    ) {
+
+
+        URI location = UriComponentsBuilder.fromPath(LOCATION)
+            .queryParam("ContextAction", "DocumentIDOnEvents")
+            .queryParam("nbsDocumentUid", identifier)
+            .build()
+            .toUri();
+
+        return redirector.preparedRedirect(patient, location);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/TestDocuments.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/TestDocuments.java
@@ -1,34 +1,10 @@
 package gov.cdc.nbs.patient.document;
 
+import gov.cdc.nbs.support.TestAvailable;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Optional;
-
 @Component
-class TestDocuments {
-  private final Collection<Long> identifiers;
+public class TestDocuments extends TestAvailable<Long> {
 
-  TestDocuments() {
-    identifiers = new ArrayList<>();
-  }
-
-  void available(final long patient) {
-    this.identifiers.add(patient);
-  }
-
-  void reset() {
-    this.identifiers.clear();
-  }
-
-  public Optional<Long> maybeOne() {
-    return this.identifiers.stream().findFirst();
-  }
-
-  public long one() {
-    return maybeOne()
-        .orElseThrow(() -> new IllegalStateException("there is no document"));
-  }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/document/PatientProfileViewDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/document/PatientProfileViewDocumentSteps.java
@@ -1,0 +1,127 @@
+package gov.cdc.nbs.patient.profile.document;
+
+import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.patient.TestPatients;
+import gov.cdc.nbs.patient.document.TestDocuments;
+import gov.cdc.nbs.support.TestActive;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class PatientProfileViewDocumentSteps {
+
+    @Value("${nbs.wildfly.url:http://wildfly:7001}")
+    String classicUrl;
+
+    @Autowired
+    TestPatients patients;
+
+    @Autowired
+    TestDocuments documents;
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    TestActive<SessionCookie> activeSession;
+
+    @Autowired
+    TestActive<MockHttpServletResponse> activeResponse;
+
+    @Autowired
+    TestActive<UserDetails> activeUserDetails;
+
+    @Autowired
+    @Qualifier("classic")
+    MockRestServiceServer server;
+
+    @Before
+    public void reset() {
+        activeResponse.reset();
+        server.reset();
+    }
+
+    @When("the Document is viewed from the Patient Profile")
+    public void the_document_is_viewed_from_the_patient_profile() throws Exception {
+        long patient = patients.one();
+
+        server.expect(
+                requestTo(classicUrl + "/nbs/HomePage.do?method=patientSearchSubmit")
+            )
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess())
+        ;
+
+        server.expect(requestTo(classicUrl + "/nbs/PatientSearchResults1.do?ContextAction=ViewFile&uid=" + patient))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess())
+        ;
+
+        long document = documents.one();
+
+        String request = String.format(
+            "/nbs/api/profile/%d/document/%d",
+            patient,
+            document
+        );
+
+        activeResponse.active(
+            mvc.perform(
+                    MockMvcRequestBuilders.get(request)
+                        .with(user(activeUserDetails.active()))
+                        .cookie(activeSession.active().asCookie())
+                )
+                .andReturn()
+                .getResponse()
+        );
+    }
+
+    @Then("the classic profile is prepared to view a Document")
+    public void the_classic_profile_is_prepared_to_view_a_document() {
+        server.verify();
+    }
+
+    @Then("I am redirected to Classic NBS to view a Document")
+    public void i_am_redirected_to_classic_nbs_to_view_a_document() {
+        long patient = patients.one();
+        long document = documents.one();
+
+        String expected =
+            "/nbs/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=" + document;
+
+        MockHttpServletResponse response = activeResponse.active();
+
+        assertThat(response.getRedirectedUrl()).contains(expected);
+
+        assertThat(response.getCookies())
+            .satisfiesOnlyOnce(cookie -> {
+                    assertThat(cookie.getName()).isEqualTo("Returning-Patient");
+                    assertThat(cookie.getValue()).isEqualTo(String.valueOf(patient));
+                }
+            );
+    }
+
+    @Then("I am not allowed to view a Classic NBS Document")
+    public void i_am_not_allowed_to_view_a_classic_nbs_document() {
+        MockHttpServletResponse response = activeResponse.active();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
+}

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
@@ -17,3 +17,19 @@ Feature: Patient Profile Documents
   Scenario: I cannot retrieve documents without proper authorities
     Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
     Then the profile documents are not returned
+
+
+  Scenario: A Document is viewed from the Patient Profile
+    Given I am logged into NBS and a security log entry exists
+    And I have the authorities: "VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"
+    And the patient has a Case Report
+    When the Document is viewed from the Patient Profile
+    Then the classic profile is prepared to view a Document
+    And I am redirected to Classic NBS to view a Document
+
+  Scenario: A Document is viewed from the Patient Profile without required permissions
+    Given I am logged into NBS and a security log entry exists
+    And I have the authorities: "OTHER" for the jurisdiction: "ALL" and program area: "STD"
+    And the patient has a Case Report
+    When the Document is viewed from the Patient Profile
+    Then I am not allowed to view a Classic NBS Document

--- a/apps/modernization-ui/src/pages/patient/profile/document/PatientDocumentContainer.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/document/PatientDocumentContainer.tsx
@@ -3,10 +3,9 @@ import { PatientDocumentTable } from './PatientDocumentTable';
 
 type Props = {
     source: (patient?: string) => Document[];
-    nbsBase: string;
     patient?: string;
 };
 
-export const PatientDocumentContainer = ({ source, nbsBase, patient }: Props) => (
-    <PatientDocumentTable nbsBase={nbsBase} documents={source(patient)} />
+export const PatientDocumentContainer = ({ source, patient }: Props) => (
+    <PatientDocumentTable patient={patient} documents={source(patient)} />
 );

--- a/apps/modernization-ui/src/pages/patient/profile/document/PatientDocumentTable.spec.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/document/PatientDocumentTable.spec.tsx
@@ -6,7 +6,7 @@ describe('when rendered', () => {
     it('should display sentence cased document headers', async () => {
         const { container } = render(
             <PageProvider>
-                <PatientDocumentTable nbsBase={'base'} documents={[]}></PatientDocumentTable>
+                <PatientDocumentTable patient={'patient'} documents={[]}></PatientDocumentTable>
             </PageProvider>
         );
 
@@ -29,7 +29,7 @@ describe('when documents are not available for a patient', () => {
     it('should display Not Available', async () => {
         const { findByText } = render(
             <PageProvider>
-                <PatientDocumentTable nbsBase={'base'} documents={[]}></PatientDocumentTable>
+                <PatientDocumentTable patient={'patient'} documents={[]}></PatientDocumentTable>
             </PageProvider>
         );
 
@@ -58,7 +58,7 @@ describe('when at least one document is available for a patient', () => {
     it('should display the documents', async () => {
         const { container, findByText } = render(
             <PageProvider>
-                <PatientDocumentTable nbsBase={'base'} documents={documents}></PatientDocumentTable>
+                <PatientDocumentTable patient={'patient'} documents={documents}></PatientDocumentTable>
             </PageProvider>
         );
 
@@ -67,10 +67,6 @@ describe('when at least one document is available for a patient', () => {
         const dateCreated = await findByText(/10\/07\/2021/);
 
         expect(dateCreated).toHaveTextContent('10:01 AM');
-        expect(dateCreated).toHaveAttribute(
-            'href',
-            'base/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=document-id'
-        );
 
         expect(tableData[0]).toContainElement(dateCreated);
 

--- a/apps/modernization-ui/src/pages/patient/profile/document/PatientProfileDocuments.spec.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/document/PatientProfileDocuments.spec.tsx
@@ -3,13 +3,12 @@ import { render } from '@testing-library/react';
 import { FindDocumentsForPatientDocument } from 'generated/graphql/schema';
 
 import { MockedProvider } from '@apollo/client/testing';
-import { PageProvider } from 'page';
 
 describe('when rendered', () => {
     it('should display sentence cased document headers', async () => {
         const { container } = render(
             <MockedProvider addTypename={false}>
-                <PatientProfileDocuments nbsBase={'base'} pageSize={1}></PatientProfileDocuments>
+                <PatientProfileDocuments pageSize={1}></PatientProfileDocuments>
             </MockedProvider>
         );
 
@@ -54,7 +53,7 @@ describe('when documents are not available for a patient', () => {
     it('should display Not Available', async () => {
         const { findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientProfileDocuments patient={'73'} nbsBase={'base'} pageSize={10}></PatientProfileDocuments>
+                <PatientProfileDocuments patient={'73'} pageSize={10}></PatientProfileDocuments>
             </MockedProvider>
         );
 
@@ -103,7 +102,7 @@ describe('when at least one document is available for a patient', () => {
     it('should display the documents', async () => {
         const { container, findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientProfileDocuments patient={'1823'} nbsBase={'base'} pageSize={10}></PatientProfileDocuments>
+                <PatientProfileDocuments patient={'1823'} pageSize={10}></PatientProfileDocuments>
             </MockedProvider>
         );
 
@@ -114,10 +113,6 @@ describe('when at least one document is available for a patient', () => {
         const dateCreated = await findByText(/10\/07\/2021/);
 
         expect(dateCreated).toHaveTextContent('10:01 AM');
-        expect(dateCreated).toHaveAttribute(
-            'href',
-            'base/ViewFile1.do?ContextAction=DocumentIDOnEvents&nbsDocumentUid=document-id'
-        );
 
         expect(tableData[0]).toContainElement(dateCreated);
 
@@ -176,7 +171,7 @@ describe('when documents are available for a patient', () => {
     it('should display the documents', async () => {
         const { container, findByText } = render(
             <MockedProvider mocks={[response]} addTypename={false}>
-                <PatientProfileDocuments patient={'1823'} nbsBase={'base'} pageSize={5}></PatientProfileDocuments>
+                <PatientProfileDocuments patient={'1823'} pageSize={5}></PatientProfileDocuments>
             </MockedProvider>
         );
 

--- a/apps/modernization-ui/src/pages/patient/profile/document/PatientProfileDocuments.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/document/PatientProfileDocuments.tsx
@@ -5,15 +5,14 @@ import { PatientDocumentContainer } from './PatientDocumentContainer';
 
 type Props = {
     patient?: string;
-    nbsBase: string;
     pageSize: number;
 };
 
-export const PatientProfileDocuments = ({ patient, nbsBase, pageSize }: Props) => {
+export const PatientProfileDocuments = ({ patient, pageSize }: Props) => {
     return (
         <div className="margin-top-6 margin-bottom-2 flex-row common-card">
             <PageProvider pageSize={pageSize}>
-                <PatientDocumentContainer source={usePatientProfileDocumentsAPI} nbsBase={nbsBase} patient={patient} />
+                <PatientDocumentContainer source={usePatientProfileDocumentsAPI} patient={patient} />
             </PageProvider>
         </div>
     );

--- a/apps/modernization-ui/src/pages/patientProfile/Events.tsx
+++ b/apps/modernization-ui/src/pages/patientProfile/Events.tsx
@@ -3,7 +3,6 @@ import {
     FindLabReportsByFilterQuery,
     FindMorbidityReportsForPatientQuery
 } from '../../generated/graphql/schema';
-import { Config } from 'config';
 import { PatientTreatmentTable } from 'pages/patient/profile/treatment';
 import { PatientNamedByContactTable, ContactNamedByPatientTable } from 'pages/patient/profile/contact';
 import { PatientProfileDocuments } from 'pages/patient/profile/document';
@@ -22,8 +21,6 @@ type EventTabProp = {
 };
 
 export const Events = ({ patient }: EventTabProp) => {
-    const NBS_URL = Config.nbsUrl;
-
     return (
         <>
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
@@ -44,7 +41,7 @@ export const Events = ({ patient }: EventTabProp) => {
                 <PatientTreatmentTable patient={patient} />
             </div>
 
-            <PatientProfileDocuments patient={patient} nbsBase={NBS_URL} pageSize={TOTAL_TABLE_DATA} />
+            <PatientProfileDocuments patient={patient} pageSize={TOTAL_TABLE_DATA} />
 
             <div className="margin-top-6 margin-bottom-2 flex-row common-card">
                 <ContactNamedByPatientTable patient={patient} />


### PR DESCRIPTION
Implements features of [CNFT1-857](https://cdc-nbs.atlassian.net/browse/CNFT1-857) by adding an endpoint to support viewing a Document from the Modernized Patient Profile.  Documents can only be viewed from the Patient Profile.  Returning from the Classic NBS Document uses the redirection that is already in place for `ContextAction=ReturnToFileEvents`

*Routing will only work in a local development environment*

- Adds the endpont GET /nbs/api/profile/{patient}/document/{identifier} which prepares the Classic NBS Session to view a Document and then returns a redirect response with the url the client will navigate to  view a Document in Classic NBS. The identifier of the patient is added as the value of the Returning-Patient cookie.



[CNFT1-857]: https://cdc-nbs.atlassian.net/browse/CNFT1-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ