### PR TITLE
Question bank support tabs

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DateQuestionEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DateQuestionEntity.java
@@ -38,6 +38,7 @@ public class DateQuestionEntity extends DisplayElementEntity {
         this.label = command.label();
         this.tooltip = command.tooltip();
         this.allowFuture = command.allowFutureDates();
+        this.setCodeSet(command.codeSet());
         this.setAudit(new AuditInfo(command));
         this.setVersion(1);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DisplayElementEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DisplayElementEntity.java
@@ -9,6 +9,8 @@ import javax.persistence.DiscriminatorColumn;
 import javax.persistence.DiscriminatorType;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
@@ -17,6 +19,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.Table;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,7 +30,7 @@ import lombok.Setter;
 @EqualsAndHashCode
 @Table(name = "display_element", catalog = "question_bank")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@IdClass(DisplayElementId.class)
+@IdClass(VersionId.class)
 @DiscriminatorColumn(name = "display_type", discriminatorType = DiscriminatorType.STRING)
 public abstract class DisplayElementEntity implements Serializable {
 
@@ -41,6 +44,10 @@ public abstract class DisplayElementEntity implements Serializable {
     @Id
     @Column(name = "version", nullable = false)
     private Integer version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "code_set")
+    private CodeSet codeSet;
 
     @Embedded
     private AuditInfo audit;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DisplayElementRef.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DisplayElementRef.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @DiscriminatorValue(DisplayElementRef.TYPE)
-public class DisplayElementRef extends Reference {
+public class DisplayElementRef extends ReferenceEntity {
     static final String TYPE = "display_element";
 
     @OneToOne(fetch = FetchType.EAGER)

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DisplayGroupRef.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DisplayGroupRef.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @DiscriminatorValue(DisplayGroupRef.TYPE)
-public class DisplayGroupRef extends Reference {
+public class DisplayGroupRef extends ReferenceEntity {
     static final String TYPE = "display_group";
 
     @OneToOne(fetch = FetchType.EAGER)

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DropdownQuestionEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/DropdownQuestionEntity.java
@@ -50,6 +50,7 @@ public class DropdownQuestionEntity extends DisplayElementEntity {
         this.valueSet = command.valueSet();
         this.defaultAnswer = command.defaultValue();
         this.multiSelect = command.isMultiSelect();
+        this.setCodeSet(command.codeSet());
         this.setAudit(new AuditInfo(command));
         this.setVersion(1);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/NumericQuestionEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/NumericQuestionEntity.java
@@ -53,6 +53,7 @@ public class NumericQuestionEntity extends DisplayElementEntity {
         this.maxValue = command.maxValue();
         this.defaultNumericValue = command.defaultValue();
         this.unitsSet = command.unitsOptions();
+        this.setCodeSet(command.codeSet());
         this.setAudit(new AuditInfo(command));
         this.setVersion(1);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/QuestionnaireEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/QuestionnaireEntity.java
@@ -10,6 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
@@ -22,6 +23,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
+@IdClass(VersionId.class)
 @Table(name = "questionnaire", catalog = "question_bank")
 public class QuestionnaireEntity {
 
@@ -32,9 +34,16 @@ public class QuestionnaireEntity {
     @Column(name = "id", columnDefinition = "uniqueidentifier", nullable = false)
     private UUID id;
 
+    @Id
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
     @CollectionTable(
             name = "questionnaire_conditions",
-            joinColumns = @JoinColumn(name = "questionnaire_id"))
+            joinColumns = {
+                    @JoinColumn(name = "questionnaire_id"),
+                    @JoinColumn(name = "questionnaire_version")
+            })
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> conditionCodes;
 
@@ -46,7 +55,7 @@ public class QuestionnaireEntity {
 
     @OrderBy("display_order")
     @OneToMany(mappedBy = "questionnaire", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<Reference> references;
+    private List<TabEntity> tabs;
 
     @OneToMany(mappedBy = "questionnaire", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<QuestionnaireRule> rules;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/ReferenceEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/ReferenceEntity.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @Table(name = "group_or_element_ref", catalog = "question_bank")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "reference_type", discriminatorType = DiscriminatorType.STRING)
-public abstract class Reference {
+public abstract class ReferenceEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,8 +33,8 @@ public abstract class Reference {
     private Integer displayOrder;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "questionnaire_id", nullable = false)
-    private QuestionnaireEntity questionnaire;
+    @JoinColumn(name = "tab_id", nullable = false)
+    private TabEntity tab;
 
     public abstract String getReferenceType();
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/TabEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/TabEntity.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.questionbank.entities;
 
+import java.util.List;
 import java.util.UUID;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,13 +10,19 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 @Entity
-@Table(name = "questionnaire_rule", catalog = "question_bank")
-public class QuestionnaireRule {
+@Table(name = "tab", catalog = "question_bank")
+public class TabEntity {
 
     @Id
     @GenericGenerator(name = "UUID", strategy = "gov.cdc.nbs.questionbank.entities.UUIDGenerator")
@@ -23,10 +31,18 @@ public class QuestionnaireRule {
     @Column(name = "id", columnDefinition = "uniqueidentifier", nullable = false)
     private UUID id;
 
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @OrderBy("display_order")
+    @OneToMany(mappedBy = "tab", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<ReferenceEntity> references;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionnaire_id", nullable = false)
     @JoinColumn(name = "version", nullable = false)
     private QuestionnaireEntity questionnaire;
-
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/TextQuestionEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/TextQuestionEntity.java
@@ -46,6 +46,7 @@ public class TextQuestionEntity extends DisplayElementEntity {
         this.maxLength = command.maxLength();
         this.placeholder = command.placeholder();
         this.defaultTextValue = command.defaultValue();
+        this.setCodeSet(command.codeSet());
         this.setAudit(new AuditInfo(command));
         this.setVersion(1);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/ValueSet.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/ValueSet.java
@@ -17,6 +17,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -39,8 +40,8 @@ public class ValueSet implements Serializable {
     private String code;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
-    private ValueSetType type;
+    @Column(name = "code_set", nullable = false, length = 20)
+    private CodeSet codeSet;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -50,11 +51,5 @@ public class ValueSet implements Serializable {
 
     @OneToMany(mappedBy = "valueSet", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<ValueEntity> values;
-
-
-    public enum ValueSetType {
-        LOCAL,
-        PHIN
-    }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/VersionId.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/VersionId.java
@@ -9,17 +9,17 @@ import lombok.Setter;
 @EqualsAndHashCode
 @Getter
 @Setter
-public class DisplayElementId implements Serializable {
+public class VersionId implements Serializable {
 
     private UUID id;
 
     private Integer version;
 
-    public DisplayElementId() {
+    public VersionId() {
         this.version = 1;
     }
 
-    public DisplayElementId(UUID id, Integer version) {
+    public VersionId(UUID id, Integer version) {
         this.id = id;
         this.version = version;
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/enums/CodeSet.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entities/enums/CodeSet.java
@@ -1,0 +1,6 @@
+package gov.cdc.nbs.questionbank.entities.enums;
+
+public enum CodeSet {
+    LOCAL,
+    PHIN
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/kafka/message/QuestionBankRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/kafka/message/QuestionBankRequest.java
@@ -6,12 +6,7 @@ import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(QuestionRequest.class),
-        @JsonSubTypes.Type(QuestionRequest.CreateTextQuestionRequest.class),
-        @JsonSubTypes.Type(QuestionRequest.UpdateTextQuestionRequest.class),
-        @JsonSubTypes.Type(QuestionRequest.CreateDateQuestionRequest.class),
-        @JsonSubTypes.Type(QuestionRequest.CreateDropdownQuestionRequest.class),
-        @JsonSubTypes.Type(QuestionRequest.CreateNumericQuestionRequest.class)
+        @JsonSubTypes.Type(QuestionRequest.class)
 })
 public interface QuestionBankRequest {
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/kafka/message/question/QuestionRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/kafka/message/question/QuestionRequest.java
@@ -1,9 +1,19 @@
 package gov.cdc.nbs.questionbank.kafka.message.question;
 
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import gov.cdc.nbs.questionbank.kafka.message.QuestionBankRequest;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(QuestionRequest.CreateTextQuestionRequest.class),
+        @JsonSubTypes.Type(QuestionRequest.UpdateTextQuestionRequest.class),
+        @JsonSubTypes.Type(QuestionRequest.CreateDateQuestionRequest.class),
+        @JsonSubTypes.Type(QuestionRequest.CreateDropdownQuestionRequest.class),
+        @JsonSubTypes.Type(QuestionRequest.CreateNumericQuestionRequest.class)})
 public sealed interface QuestionRequest extends QuestionBankRequest {
+
 
     record CreateTextQuestionRequest(
             String requestId,

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/kafka/message/question/QuestionRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/kafka/message/question/QuestionRequest.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.questionbank.kafka.message.question;
 import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import gov.cdc.nbs.questionbank.kafka.message.QuestionBankRequest;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -13,7 +14,6 @@ import gov.cdc.nbs.questionbank.kafka.message.QuestionBankRequest;
         @JsonSubTypes.Type(QuestionRequest.CreateDropdownQuestionRequest.class),
         @JsonSubTypes.Type(QuestionRequest.CreateNumericQuestionRequest.class)})
 public sealed interface QuestionRequest extends QuestionBankRequest {
-
 
     record CreateTextQuestionRequest(
             String requestId,
@@ -26,7 +26,8 @@ public sealed interface QuestionRequest extends QuestionBankRequest {
             String tooltip,
             Integer maxLength,
             String placeholder,
-            String defaultValue) {
+            String defaultValue,
+            CodeSet codeSet) {
     }
 
     record CreateDateQuestionRequest(
@@ -38,7 +39,8 @@ public sealed interface QuestionRequest extends QuestionBankRequest {
     record DateQuestionData(
             String label,
             String tooltip,
-            boolean allowFutureDates) {
+            boolean allowFutureDates,
+            CodeSet codeSet) {
     }
 
     record CreateDropdownQuestionRequest(
@@ -52,7 +54,8 @@ public sealed interface QuestionRequest extends QuestionBankRequest {
             String tooltip,
             UUID valueSet,
             UUID defaultValue,
-            boolean isMultiSelect) {
+            boolean isMultiSelect,
+            CodeSet codeSet) {
     }
 
     record CreateNumericQuestionRequest(
@@ -67,7 +70,8 @@ public sealed interface QuestionRequest extends QuestionBankRequest {
             Integer minValue,
             Integer maxValue,
             Integer defaultValue,
-            UUID unitValueSet) {
+            UUID unitValueSet,
+            CodeSet codeSet) {
     }
 
     record UpdateTextQuestionRequest(

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionCreator.java
@@ -68,7 +68,8 @@ class QuestionCreator {
                 data.tooltip(),
                 data.maxLength(),
                 data.placeholder(),
-                data.defaultValue());
+                data.defaultValue(),
+                data.codeSet());
     }
 
     private AddDateQuestion asAdd(long userId, QuestionRequest.DateQuestionData data) {
@@ -78,7 +79,8 @@ class QuestionCreator {
                 Instant.now(clock),
                 data.label(),
                 data.tooltip(),
-                data.allowFutureDates());
+                data.allowFutureDates(),
+                data.codeSet());
     }
 
     private AddDropDownQuestion adAdd(long userId, QuestionRequest.DropdownQuestionData data) {
@@ -90,7 +92,8 @@ class QuestionCreator {
                 data.tooltip(),
                 getReference(ValueSet.class, data.valueSet()),
                 getReference(ValueEntity.class, data.defaultValue()),
-                data.isMultiSelect());
+                data.isMultiSelect(),
+                data.codeSet());
     }
 
     private AddNumericQuestion asAdd(long userId, QuestionRequest.NumericQuestionData data) {
@@ -103,7 +106,8 @@ class QuestionCreator {
                 data.minValue(),
                 data.maxValue(),
                 data.defaultValue(),
-                getReference(ValueSet.class, data.unitValueSet()));
+                getReference(ValueSet.class, data.unitValueSet()),
+                data.codeSet());
     }
 
     private <T> T getReference(Class<T> clazz, Object primaryKey) {

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/command/QuestionCommand.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/command/QuestionCommand.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.questionbank.question.command;
 import java.time.Instant;
 import gov.cdc.nbs.questionbank.entities.ValueEntity;
 import gov.cdc.nbs.questionbank.entities.ValueSet;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 
 public sealed interface QuestionCommand {
     Long question();
@@ -19,7 +20,8 @@ public sealed interface QuestionCommand {
             String tooltip,
             Integer maxLength,
             String placeholder,
-            String defaultValue) implements QuestionCommand {
+            String defaultValue,
+            CodeSet codeSet) implements QuestionCommand {
     }
 
     record AddDateQuestion(
@@ -28,7 +30,8 @@ public sealed interface QuestionCommand {
             Instant requestedOn,
             String label,
             String tooltip,
-            boolean allowFutureDates) implements QuestionCommand {
+            boolean allowFutureDates,
+            CodeSet codeSet) implements QuestionCommand {
 
     }
 
@@ -40,7 +43,8 @@ public sealed interface QuestionCommand {
             String tooltip,
             ValueSet valueSet,
             ValueEntity defaultValue,
-            boolean isMultiSelect) implements QuestionCommand {
+            boolean isMultiSelect,
+            CodeSet codeSet) implements QuestionCommand {
 
     }
 
@@ -53,7 +57,8 @@ public sealed interface QuestionCommand {
             Integer minValue,
             Integer maxValue,
             Integer defaultValue,
-            ValueSet unitsOptions) implements QuestionCommand {
+            ValueSet unitsOptions,
+            CodeSet codeSet) implements QuestionCommand {
     }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/DateQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/DateQuestionRepository.java
@@ -2,8 +2,8 @@ package gov.cdc.nbs.questionbank.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import gov.cdc.nbs.questionbank.entities.DateQuestionEntity;
-import gov.cdc.nbs.questionbank.entities.DisplayElementId;
+import gov.cdc.nbs.questionbank.entities.VersionId;
 
-public interface DateQuestionRepository extends JpaRepository<DateQuestionEntity, DisplayElementId> {
+public interface DateQuestionRepository extends JpaRepository<DateQuestionEntity, VersionId> {
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/DisplayElementRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/DisplayElementRepository.java
@@ -2,8 +2,8 @@ package gov.cdc.nbs.questionbank.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import gov.cdc.nbs.questionbank.entities.DisplayElementEntity;
-import gov.cdc.nbs.questionbank.entities.DisplayElementId;
+import gov.cdc.nbs.questionbank.entities.VersionId;
 
-public interface DisplayElementRepository extends JpaRepository<DisplayElementEntity, DisplayElementId> {
+public interface DisplayElementRepository extends JpaRepository<DisplayElementEntity, VersionId> {
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/DropdownQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/DropdownQuestionRepository.java
@@ -1,9 +1,9 @@
 package gov.cdc.nbs.questionbank.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import gov.cdc.nbs.questionbank.entities.DisplayElementId;
+import gov.cdc.nbs.questionbank.entities.VersionId;
 import gov.cdc.nbs.questionbank.entities.DropdownQuestionEntity;
 
-public interface DropdownQuestionRepository extends JpaRepository<DropdownQuestionEntity, DisplayElementId> {
+public interface DropdownQuestionRepository extends JpaRepository<DropdownQuestionEntity, VersionId> {
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/NumericQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/NumericQuestionRepository.java
@@ -1,9 +1,9 @@
 package gov.cdc.nbs.questionbank.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import gov.cdc.nbs.questionbank.entities.DisplayElementId;
+import gov.cdc.nbs.questionbank.entities.VersionId;
 import gov.cdc.nbs.questionbank.entities.NumericQuestionEntity;
 
-public interface NumericQuestionRepository extends JpaRepository<NumericQuestionEntity, DisplayElementId> {
+public interface NumericQuestionRepository extends JpaRepository<NumericQuestionEntity, VersionId> {
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/TextElementRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/TextElementRepository.java
@@ -1,9 +1,9 @@
 package gov.cdc.nbs.questionbank.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import gov.cdc.nbs.questionbank.entities.DisplayElementId;
+import gov.cdc.nbs.questionbank.entities.VersionId;
 import gov.cdc.nbs.questionbank.entities.TextEntity;
 
-public interface TextElementRepository extends JpaRepository<TextEntity, DisplayElementId> {
+public interface TextElementRepository extends JpaRepository<TextEntity, VersionId> {
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/TextQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/TextQuestionRepository.java
@@ -1,9 +1,9 @@
 package gov.cdc.nbs.questionbank.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import gov.cdc.nbs.questionbank.entities.DisplayElementId;
+import gov.cdc.nbs.questionbank.entities.VersionId;
 import gov.cdc.nbs.questionbank.entities.TextQuestionEntity;
 
-public interface TextQuestionRepository extends JpaRepository<TextQuestionEntity, DisplayElementId> {
+public interface TextQuestionRepository extends JpaRepository<TextQuestionEntity, VersionId> {
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/questionnaire/QuestionnaireMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/questionnaire/QuestionnaireMapper.java
@@ -8,7 +8,8 @@ import gov.cdc.nbs.questionbank.entities.DisplayGroupRef;
 import gov.cdc.nbs.questionbank.entities.DropdownQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.NumericQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.QuestionnaireEntity;
-import gov.cdc.nbs.questionbank.entities.Reference;
+import gov.cdc.nbs.questionbank.entities.ReferenceEntity;
+import gov.cdc.nbs.questionbank.entities.TabEntity;
 import gov.cdc.nbs.questionbank.entities.TextEntity;
 import gov.cdc.nbs.questionbank.entities.TextQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.ValueEntity;
@@ -28,11 +29,15 @@ class QuestionnaireMapper {
         return new Questionnaire(
                 entity.getId(),
                 entity.getConditionCodes(),
-                entity.getReferences().stream().map(this::toElement).toList());
+                entity.getTabs().stream().map(this::toTab).toList());
+    }
+
+    Questionnaire.Tab toTab(TabEntity entity) {
+        return new Questionnaire.Tab(entity.getName(), entity.getReferences().stream().map(this::toElement).toList());
     }
 
     /**
-     * Accepts a {@link gov.cdc.nbs.questionbank.entities.Reference Reference} and converts it into a
+     * Accepts a {@link gov.cdc.nbs.questionbank.entities.ReferenceEntity Reference} and converts it into a
      * {@link gov.cdc.nbs.questionbank.questionnaire.model.Questionnaire.Element Questionnaire.Element}.
      * 
      * A reference can be either a DisplayElementRef that references a
@@ -42,7 +47,7 @@ class QuestionnaireMapper {
      * @param ref
      * @return
      */
-    Questionnaire.Element toElement(Reference ref) {
+    Questionnaire.Element toElement(ReferenceEntity ref) {
         if (ref instanceof DisplayElementRef displayElementRef) {
             return toDisplayElement(displayElementRef.getDisplayElementEntity());
         } else if (ref instanceof DisplayGroupRef displayGroupRef) {

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/questionnaire/model/Questionnaire.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/questionnaire/model/Questionnaire.java
@@ -7,8 +7,10 @@ import java.util.UUID;
 public record Questionnaire(
         UUID id,
         List<String> conditions,
-        List<Element> elements) {
+        List<Tab> tabs) {
 
+    public record Tab(String name, List<Element> elements) {
+    }
     public sealed interface Element permits Section, DisplayElement {
 
     }

--- a/apps/question-bank/src/main/resources/db/migration/V0001__init.sql
+++ b/apps/question-bank/src/main/resources/db/migration/V0001__init.sql
@@ -1,4 +1,3 @@
-
     create table question_bank.dbo.display_element (
        display_type varchar(31) not null,
         id uniqueidentifier not null,
@@ -9,35 +8,36 @@
         last_update_user bigint not null,
         status varchar(20) not null,
         status_time datetime2 not null,
+        code_set varchar(20) not null,
         allow_future_dates bit,
         label varchar(300),
-        tooltip varchar(255),
-        default_text_value varchar(255),
+        tooltip varchar(200),
         multiselect bit,
+        default_numeric_value int,
         max_value int,
         min_value int,
-        default_numeric_value int,
         text varchar(255),
+        default_text_value varchar(255),
         max_length int,
-        placeholder varchar(255),
+        placeholder varchar(100),
         default_answer_id uniqueidentifier,
         value_set_id uniqueidentifier,
         units_set uniqueidentifier,
-        primary key nonclustered (id, version)
+        primary key (id, version)
     );
 
     create table question_bank.dbo.display_element_group (
        version int not null,
         id uniqueidentifier not null,
         label varchar(255) not null,
-        primary key nonclustered (version, id)
+        primary key (version, id)
     );
 
     create table question_bank.dbo.group_or_element_ref (
        reference_type varchar(31) not null,
         id bigint identity not null,
         display_order int not null,
-        questionnaire_id uniqueidentifier not null,
+        tab_id uniqueidentifier not null,
         display_element_id uniqueidentifier,
         display_element_version int,
         group_id int,
@@ -47,15 +47,26 @@
 
     create table question_bank.dbo.questionnaire (
        id uniqueidentifier not null,
+        version int not null,
         description varchar(500),
         name varchar(255),
-        primary key nonclustered (id)
+        primary key (id, version)
     );
 
     create table question_bank.dbo.questionnaire_rule (
        id uniqueidentifier not null,
-        questionnaire_id uniqueidentifier,
-        primary key nonclustered (id)
+        questionnaire_id uniqueidentifier not null,
+        version int not null,
+        primary key (id)
+    );
+
+    create table question_bank.dbo.tab (
+       id uniqueidentifier not null,
+        display_order int not null,
+        name varchar(100) not null,
+        questionnaire_id uniqueidentifier not null,
+        version int not null,
+        primary key (id)
     );
 
     create table question_bank.dbo.[value] (
@@ -66,7 +77,7 @@
         display_order int not null,
         [value] varchar(255) not null,
         value_set_id uniqueidentifier,
-        primary key nonclustered (id)
+        primary key (id)
     );
 
     create table question_bank.dbo.value_set (
@@ -74,8 +85,8 @@
         code varchar(255) not null,
         description varchar(300),
         name varchar(255) not null,
-        type varchar(255) not null,
-        primary key nonclustered (id)
+        code_set varchar(20) not null,
+        primary key (id)
     );
 
     create table dbo.display_element_group_elements (
@@ -84,11 +95,12 @@
         element_id uniqueidentifier not null,
         element_version int not null,
         display_order int not null,
-        primary key nonclustered (group_id, group_version, display_order)
+        primary key (group_id, group_version, display_order)
     );
 
     create table dbo.questionnaire_conditions (
        questionnaire_id uniqueidentifier not null,
+        questionnaire_version int not null,
         condition_codes varchar(255)
     );
 
@@ -111,9 +123,9 @@
        references question_bank.dbo.value_set;
 
     alter table question_bank.dbo.group_or_element_ref 
-       add constraint FKhombk3318f2gjg7rj2gw63r3h 
-       foreign key (questionnaire_id) 
-       references question_bank.dbo.questionnaire;
+       add constraint FKj4xcdcd32serk2e9sbamkcfte 
+       foreign key (tab_id) 
+       references question_bank.dbo.tab;
 
     alter table question_bank.dbo.group_or_element_ref 
        add constraint FK98f1j618ub117an4ovl5y6jv2 
@@ -126,8 +138,13 @@
        references question_bank.dbo.display_element_group;
 
     alter table question_bank.dbo.questionnaire_rule 
-       add constraint FK2m2g4ebe8m5ejl29cktnehj2b 
-       foreign key (questionnaire_id) 
+       add constraint FKhh0hnrxhvrkg00mdj8joul74o 
+       foreign key (questionnaire_id, version) 
+       references question_bank.dbo.questionnaire;
+
+    alter table question_bank.dbo.tab 
+       add constraint FK1yfpk1pgtssw29pmejyw14et7 
+       foreign key (questionnaire_id, version) 
        references question_bank.dbo.questionnaire;
 
     alter table question_bank.dbo.[value] 
@@ -146,6 +163,6 @@
        references question_bank.dbo.display_element_group;
 
     alter table dbo.questionnaire_conditions 
-       add constraint FK8bhsllvenpcqne8qk5s1grebn 
-       foreign key (questionnaire_id) 
+       add constraint FKtkfc1ypw3m4xffsp9f9mxw11v 
+       foreign key (questionnaire_id, questionnaire_version) 
        references question_bank.dbo.questionnaire;

--- a/apps/question-bank/src/main/resources/db/migration/V0001__init.sql
+++ b/apps/question-bank/src/main/resources/db/migration/V0001__init.sql
@@ -23,14 +23,14 @@
         default_answer_id uniqueidentifier,
         value_set_id uniqueidentifier,
         units_set uniqueidentifier,
-        primary key (id, version)
+        primary key nonclustered (id, version)
     );
 
     create table question_bank.dbo.display_element_group (
        version int not null,
         id uniqueidentifier not null,
         label varchar(255) not null,
-        primary key (version, id)
+        primary key nonclustered (version, id)
     );
 
     create table question_bank.dbo.group_or_element_ref (
@@ -50,14 +50,14 @@
         version int not null,
         description varchar(500),
         name varchar(255),
-        primary key (id, version)
+        primary key nonclustered (id, version)
     );
 
     create table question_bank.dbo.questionnaire_rule (
        id uniqueidentifier not null,
         questionnaire_id uniqueidentifier not null,
         version int not null,
-        primary key (id)
+        primary key nonclustered (id)
     );
 
     create table question_bank.dbo.tab (
@@ -66,7 +66,7 @@
         name varchar(100) not null,
         questionnaire_id uniqueidentifier not null,
         version int not null,
-        primary key (id)
+        primary key nonclustered (id)
     );
 
     create table question_bank.dbo.[value] (
@@ -77,7 +77,7 @@
         display_order int not null,
         [value] varchar(255) not null,
         value_set_id uniqueidentifier,
-        primary key (id)
+        primary key nonclustered (id)
     );
 
     create table question_bank.dbo.value_set (
@@ -86,7 +86,7 @@
         description varchar(300),
         name varchar(255) not null,
         code_set varchar(20) not null,
-        primary key (id)
+        primary key nonclustered (id)
     );
 
     create table dbo.display_element_group_elements (
@@ -95,7 +95,7 @@
         element_id uniqueidentifier not null,
         element_version int not null,
         display_order int not null,
-        primary key (group_id, group_version, display_order)
+        primary key nonclustered (group_id, group_version, display_order)
     );
 
     create table dbo.questionnaire_conditions (

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entities/VersionIdTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entities/VersionIdTest.java
@@ -1,0 +1,24 @@
+package gov.cdc.nbs.questionbank.entities;
+
+import static org.junit.Assert.assertEquals;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class VersionIdTest {
+
+    @Test
+    void should_set_version_to_1() {
+        VersionId versionId = new VersionId();
+        assertEquals(1, versionId.getVersion().intValue());
+    }
+
+    @Test
+    void should_set_version_and_uuid() {
+        UUID uuid = UUID.randomUUID();
+        Integer version = 9;
+
+        VersionId versionId = new VersionId(uuid, version);
+        assertEquals(version, versionId.getVersion());
+        assertEquals(uuid, versionId.getId());
+    }
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/kafka/producer/KafkaProducerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/kafka/producer/KafkaProducerTest.java
@@ -18,6 +18,7 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.SettableListenableFuture;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import gov.cdc.nbs.questionbank.kafka.message.QuestionBankRequest;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest;
 
@@ -44,7 +45,8 @@ class KafkaProducerTest {
                         "a tooltip",
                         11,
                         "a placeholder",
-                        "some default text"));
+                        "some default text",
+                        CodeSet.LOCAL));
         ListenableFuture<SendResult<String, QuestionBankRequest>> future = new SettableListenableFuture<>();
         Mockito.when(kafkaEnvelopeTemplate.send(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(future);
 
@@ -79,7 +81,8 @@ class KafkaProducerTest {
                         "a tooltip",
                         11,
                         "a placeholder",
-                        "default"));
+                        "default",
+                        CodeSet.LOCAL));
 
         ListenableFutureCallback<SendResult<String, QuestionBankRequest>> callback =
                 Mockito.mock(ListenableFutureCallback.class);
@@ -108,7 +111,8 @@ class KafkaProducerTest {
                         "a tooltip",
                         11,
                         "a placeholder",
-                        "default"));
+                        "default",
+                        CodeSet.LOCAL));
 
         ListenableFutureCallback<SendResult<String, QuestionBankRequest>> callback =
                 Mockito.mock(ListenableFutureCallback.class);

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/CreateQuestionResolverTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/CreateQuestionResolverTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -14,11 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import gov.cdc.nbs.authentication.NbsUserDetails;
 import gov.cdc.nbs.authentication.UserDetailsProvider;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DateQuestionData;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DropdownQuestionData;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.NumericQuestionData;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.TextQuestionData;
 import gov.cdc.nbs.questionbank.kafka.producer.KafkaProducer;
+import gov.cdc.nbs.questionbank.support.QuestionDataMother;
 
 @ExtendWith(MockitoExtension.class)
 class CreateQuestionResolverTest {
@@ -38,7 +34,7 @@ class CreateQuestionResolverTest {
         when(userDetailsProvider.getCurrentUserDetails()).thenReturn(userDetails());
 
         // given I submit a create text question request
-        var data = textQuestionData();
+        var data = QuestionDataMother.textQuestionData();
         resolver.createTextQuestion(data);
 
         // then the request is send to kafka
@@ -57,7 +53,7 @@ class CreateQuestionResolverTest {
         when(userDetailsProvider.getCurrentUserDetails()).thenReturn(userDetails());
 
         // given I submit a create text question request
-        var data = dateQuestionData();
+        var data = QuestionDataMother.dateQuestionData();
         resolver.createDateQuestion(data);
 
         // then the request is send to kafka
@@ -76,7 +72,7 @@ class CreateQuestionResolverTest {
         when(userDetailsProvider.getCurrentUserDetails()).thenReturn(userDetails());
 
         // given I submit a create text question request
-        var data = numericQuestionData();
+        var data = QuestionDataMother.numericQuestionData();
         resolver.createNumericQuestion(data);
 
         // then the request is send to kafka
@@ -95,7 +91,7 @@ class CreateQuestionResolverTest {
         when(userDetailsProvider.getCurrentUserDetails()).thenReturn(userDetails());
 
         // given I submit a create text question request
-        var data = dropdownQuestionData();
+        var data = QuestionDataMother.dropdownQuestionData();
         resolver.createDropdownQuestion(data);
 
         // then the request is send to kafka
@@ -119,41 +115,6 @@ class CreateQuestionResolverTest {
                 null,
                 null,
                 null,
-                true);
-    }
-
-    private TextQuestionData textQuestionData() {
-        return new TextQuestionData(
-                "test label",
-                "test tooltip",
-                13,
-                "test placeholder",
-                "some default value");
-    }
-
-    private DateQuestionData dateQuestionData() {
-        return new DateQuestionData(
-                "test label",
-                "test tooltip",
-                true);
-    }
-
-    private NumericQuestionData numericQuestionData() {
-        return new NumericQuestionData(
-                "test label",
-                "test tooltip",
-                -3,
-                543,
-                -2,
-                null);
-    }
-
-    private DropdownQuestionData dropdownQuestionData() {
-        return new DropdownQuestionData(
-                "test label",
-                "test tooltip",
-                UUID.randomUUID(),
-                UUID.randomUUID(),
                 true);
     }
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/CreateQuestionSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/CreateQuestionSteps.java
@@ -19,16 +19,13 @@ import gov.cdc.nbs.questionbank.entities.DropdownQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.NumericQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.TextQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.ValueSet;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DateQuestionData;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DropdownQuestionData;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.NumericQuestionData;
-import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.TextQuestionData;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionResponse;
 import gov.cdc.nbs.questionbank.question.repository.DateQuestionRepository;
 import gov.cdc.nbs.questionbank.question.repository.DisplayElementRepository;
 import gov.cdc.nbs.questionbank.question.repository.DropdownQuestionRepository;
 import gov.cdc.nbs.questionbank.question.repository.NumericQuestionRepository;
 import gov.cdc.nbs.questionbank.question.repository.TextQuestionRepository;
+import gov.cdc.nbs.questionbank.support.QuestionDataMother;
 import gov.cdc.nbs.questionbank.support.UserMother;
 import gov.cdc.nbs.questionbank.support.ValueSetMother;
 import io.cucumber.java.en.Given;
@@ -95,19 +92,22 @@ public class CreateQuestionSteps {
         try {
             switch (requestType) {
                 case "text": {
-                    response = resolver.createTextQuestion(textQuestionData());
+                    response = resolver.createTextQuestion(QuestionDataMother.textQuestionData());
                     break;
                 }
                 case "numeric": {
-                    response = resolver.createNumericQuestion(numericQuestionData());
+                    response = resolver.createNumericQuestion(QuestionDataMother.numericQuestionData(valueSet.getId()));
                     break;
                 }
                 case "date": {
-                    response = resolver.createDateQuestion(dateQuestionData());
+                    response = resolver.createDateQuestion(QuestionDataMother.dateQuestionData());
                     break;
                 }
                 case "dropdown": {
-                    response = resolver.createDropdownQuestion(dropdownQuestionData());
+                    response = resolver.createDropdownQuestion(
+                            QuestionDataMother.dropdownQuestionData(
+                                    valueSet.getId(),
+                                    valueSet.getValues().get(0).getId()));
                     break;
                 }
                 default: {
@@ -163,7 +163,7 @@ public class CreateQuestionSteps {
         List<TextQuestionEntity> results = textQuestionRepository.findAll();
         assertEquals(1, results.size());
         var created = results.get(0);
-        var actual = textQuestionData();
+        var actual = QuestionDataMother.textQuestionData();
 
         assertEquals(actual.label(), created.getLabel());
         assertEquals(actual.tooltip(), created.getTooltip());
@@ -178,7 +178,7 @@ public class CreateQuestionSteps {
         List<NumericQuestionEntity> results = numericQuestionRepository.findAll();
         assertEquals(1, results.size());
         var created = results.get(0);
-        var actual = numericQuestionData();
+        var actual = QuestionDataMother.numericQuestionData(valueSet.getId());
 
         assertEquals(actual.label(), created.getLabel());
         assertEquals(actual.tooltip(), created.getTooltip());
@@ -194,7 +194,9 @@ public class CreateQuestionSteps {
         List<DropdownQuestionEntity> results = dropdownQuestionRepository.findAll();
         assertEquals(1, results.size());
         var created = results.get(0);
-        var actual = dropdownQuestionData();
+        var actual = QuestionDataMother.dropdownQuestionData(
+                valueSet.getId(),
+                valueSet.getValues().get(0).getId());
 
         assertEquals(actual.label(), created.getLabel());
         assertEquals(actual.tooltip(), created.getTooltip());
@@ -209,7 +211,7 @@ public class CreateQuestionSteps {
         List<DateQuestionEntity> results = dateQuestionRepository.findAll();
         assertEquals(1, results.size());
         var created = results.get(0);
-        var actual = dateQuestionData();
+        var actual = QuestionDataMother.dateQuestionData();
 
         assertEquals(actual.label(), created.getLabel());
         assertEquals(actual.tooltip(), created.getTooltip());
@@ -225,42 +227,6 @@ public class CreateQuestionSteps {
         assertTrue(auditInfo.getAddTime().getEpochSecond() > thirtySecondsAgo);
         assertEquals(userId, auditInfo.getLastUpdateUserId());
         assertTrue(auditInfo.getLastUpdate().getEpochSecond() > thirtySecondsAgo);
-    }
-
-
-    private TextQuestionData textQuestionData() {
-        return new TextQuestionData(
-                "test label",
-                "test tooltip",
-                13,
-                "test placeholder",
-                "some default value");
-    }
-
-    private DateQuestionData dateQuestionData() {
-        return new DateQuestionData(
-                "test label",
-                "test tooltip",
-                true);
-    }
-
-    private NumericQuestionData numericQuestionData() {
-        return new NumericQuestionData(
-                "test label",
-                "test tooltip",
-                -3,
-                543,
-                -2,
-                valueSet.getId());
-    }
-
-    private DropdownQuestionData dropdownQuestionData() {
-        return new DropdownQuestionData(
-                "test label",
-                "test tooltip",
-                valueSet.getId(),
-                valueSet.getValues().get(0).getId(),
-                true);
     }
 
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionCreatorTest.java
@@ -22,6 +22,7 @@ import gov.cdc.nbs.questionbank.entities.NumericQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.TextQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.ValueEntity;
 import gov.cdc.nbs.questionbank.entities.ValueSet;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DateQuestionData;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DropdownQuestionData;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.NumericQuestionData;
@@ -145,14 +146,16 @@ class QuestionCreatorTest {
                 "test tooltip",
                 13,
                 "test placeholder",
-                "some default value");
+                "some default value",
+                CodeSet.LOCAL);
     }
 
     private DateQuestionData dateQuestionData() {
         return new DateQuestionData(
                 "test label",
                 "test tooltip",
-                true);
+                true,
+                CodeSet.LOCAL);
     }
 
     private NumericQuestionData numericQuestionData() {
@@ -162,7 +165,8 @@ class QuestionCreatorTest {
                 -3,
                 543,
                 -2,
-                null);
+                null,
+                CodeSet.LOCAL);
     }
 
     private DropdownQuestionData dropdownQuestionData() {
@@ -171,7 +175,8 @@ class QuestionCreatorTest {
                 "test tooltip",
                 UUID.randomUUID(),
                 UUID.randomUUID(),
-                true);
+                true,
+                CodeSet.LOCAL);
     }
 
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionHandlerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionHandlerTest.java
@@ -19,6 +19,7 @@ import gov.cdc.nbs.questionbank.entities.DateQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.DropdownQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.NumericQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.TextQuestionEntity;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import gov.cdc.nbs.questionbank.kafka.exception.UserNotAuthorizedException;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest;
 import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DateQuestionData;
@@ -136,7 +137,8 @@ class QuestionHandlerTest {
                         "tooltip",
                         25,
                         "placeholder",
-                        "defaultValue"));
+                        "defaultValue",
+                        CodeSet.LOCAL));
     }
 
     private QuestionRequest.CreateDateQuestionRequest createDateQuestionRequest() {
@@ -146,7 +148,8 @@ class QuestionHandlerTest {
                 new DateQuestionData(
                         "label",
                         "tooltip",
-                        true));
+                        true,
+                        CodeSet.LOCAL));
     }
 
     private QuestionRequest.CreateDropdownQuestionRequest createDropdownQuestionRequest() {
@@ -158,7 +161,8 @@ class QuestionHandlerTest {
                         "tooltip",
                         UUID.randomUUID(),
                         UUID.randomUUID(),
-                        true));
+                        true,
+                        CodeSet.LOCAL));
     }
 
     private QuestionRequest.CreateNumericQuestionRequest createNumericQuestionRequest() {
@@ -171,7 +175,8 @@ class QuestionHandlerTest {
                         1,
                         3,
                         2,
-                        UUID.randomUUID()));
+                        UUID.randomUUID(),
+                        CodeSet.LOCAL));
     }
 
     private TextQuestionEntity textEntity() {

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/questionnaire/QuestionnaireMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/questionnaire/QuestionnaireMapperTest.java
@@ -19,12 +19,13 @@ import gov.cdc.nbs.questionbank.entities.DisplayGroupRef;
 import gov.cdc.nbs.questionbank.entities.DropdownQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.NumericQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.QuestionnaireEntity;
-import gov.cdc.nbs.questionbank.entities.Reference;
+import gov.cdc.nbs.questionbank.entities.ReferenceEntity;
+import gov.cdc.nbs.questionbank.entities.TabEntity;
 import gov.cdc.nbs.questionbank.entities.TextEntity;
 import gov.cdc.nbs.questionbank.entities.TextQuestionEntity;
 import gov.cdc.nbs.questionbank.entities.ValueEntity;
 import gov.cdc.nbs.questionbank.entities.ValueSet;
-import gov.cdc.nbs.questionbank.entities.ValueSet.ValueSetType;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import gov.cdc.nbs.questionbank.questionnaire.model.Questionnaire;
 import gov.cdc.nbs.questionbank.questionnaire.model.Questionnaire.DateQuestion;
 import gov.cdc.nbs.questionbank.questionnaire.model.Questionnaire.DropDownQuestion;
@@ -42,19 +43,20 @@ class QuestionnaireMapperTest {
     void should_return_questionnaire() {
         Questionnaire q = questionnaireMapper.toQuestionnaire(emptyEntity());
         assertNotNull(q);
-        assertEquals(0, q.elements().size());
+        assertEquals(0, q.tabs().size());
     }
 
     @Test
     void should_return_questionnaire_with_content() {
         Questionnaire q = questionnaireMapper.toQuestionnaire(fullEntity());
         assertNotNull(q);
-        assertEquals(6, q.elements().size());
+        assertEquals(1, q.tabs().size());
+        assertEquals(6, q.tabs().get(0).elements().size());
     }
 
     @Test
     void toElement_should_throw_exception_for_invalid_type() {
-        Reference ref = new Reference() {
+        ReferenceEntity ref = new ReferenceEntity() {
             @Override
             public String getReferenceType() {
                 return "invalid type";
@@ -181,7 +183,7 @@ class QuestionnaireMapperTest {
         QuestionnaireEntity entity = new QuestionnaireEntity();
         entity.setId(UUID.randomUUID());
         entity.setConditionCodes(Arrays.asList("condition"));
-        entity.setReferences(new ArrayList<>());
+        entity.setTabs(new ArrayList<>());
         entity.setRules(new ArrayList<>());
         return entity;
     }
@@ -190,12 +192,21 @@ class QuestionnaireMapperTest {
         QuestionnaireEntity entity = new QuestionnaireEntity();
         entity.setId(UUID.randomUUID());
         entity.setConditionCodes(Arrays.asList("condition"));
-        entity.setReferences(allReferenceTypes());
+        entity.setTabs(Arrays.asList(tab(allReferenceTypes())));
         return entity;
     }
 
-    private List<Reference> allReferenceTypes() {
-        var references = new ArrayList<Reference>();
+    private TabEntity tab(List<ReferenceEntity> references) {
+        TabEntity entity = new TabEntity();
+        entity.setName("test tab");
+        entity.setId(UUID.randomUUID());
+        entity.setReferences(references);
+        entity.setDisplayOrder(0);
+        return entity;
+    }
+
+    private List<ReferenceEntity> allReferenceTypes() {
+        var references = new ArrayList<ReferenceEntity>();
         references.add(displayRef(textEntity(), 1));
         references.add(displayRef(textQuestionEntity(), 2));
         references.add(displayRef(numericQuestionEntity(), 3));
@@ -286,7 +297,7 @@ class QuestionnaireMapperTest {
         v.setCode("unit-code");
         v.setDescription("Value set for units");
         v.setName("Units");
-        v.setType(ValueSetType.LOCAL);
+        v.setCodeSet(CodeSet.LOCAL);
         v.setValues(unitValues(v));
         return v;
     }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionDataMother.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionDataMother.java
@@ -1,0 +1,58 @@
+package gov.cdc.nbs.questionbank.support;
+
+import java.util.UUID;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
+import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DateQuestionData;
+import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.DropdownQuestionData;
+import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.NumericQuestionData;
+import gov.cdc.nbs.questionbank.kafka.message.question.QuestionRequest.TextQuestionData;
+
+public class QuestionDataMother {
+    public static TextQuestionData textQuestionData() {
+        return new TextQuestionData(
+                "test label",
+                "test tooltip",
+                13,
+                "test placeholder",
+                "some default value",
+                CodeSet.LOCAL);
+    }
+
+    public static DateQuestionData dateQuestionData() {
+        return new DateQuestionData(
+                "test label",
+                "test tooltip",
+                true,
+                CodeSet.LOCAL);
+    }
+
+    public static NumericQuestionData numericQuestionData() {
+        return QuestionDataMother.numericQuestionData(UUID.randomUUID());
+    }
+
+    public static NumericQuestionData numericQuestionData(UUID unitsValueSet) {
+        return new NumericQuestionData(
+                "test label",
+                "test tooltip",
+                -3,
+                543,
+                -2,
+                unitsValueSet,
+                CodeSet.LOCAL);
+    }
+
+
+    public static DropdownQuestionData dropdownQuestionData() {
+        return QuestionDataMother.dropdownQuestionData(UUID.randomUUID(), UUID.randomUUID());
+    }
+
+    public static DropdownQuestionData dropdownQuestionData(UUID valueSet, UUID defaultValue) {
+        return new DropdownQuestionData(
+                "test label",
+                "test tooltip",
+                valueSet,
+                defaultValue,
+                true,
+                CodeSet.LOCAL);
+    }
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionnaireMother.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionnaireMother.java
@@ -17,6 +17,7 @@ public class QuestionnaireMother {
     public QuestionnaireEntity questionnaire(
             List<String> conditions) {
         var q = new QuestionnaireEntity();
+        q.setVersion(1);
         q.setConditionCodes(conditions);
         return repository.save(q);
     }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/ValueSetMother.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/ValueSetMother.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import gov.cdc.nbs.questionbank.entities.ValueEntity;
 import gov.cdc.nbs.questionbank.entities.ValueSet;
-import gov.cdc.nbs.questionbank.entities.ValueSet.ValueSetType;
+import gov.cdc.nbs.questionbank.entities.enums.CodeSet;
 import gov.cdc.nbs.questionbank.valueset.repository.ValueSetRepository;
 
 @Component
@@ -32,7 +32,7 @@ public class ValueSetMother {
         valueSet.setCode("yesNoUnknownCode");
         valueSet.setDescription("yesNoUnknown value set used for testing");
         valueSet.setName(YES_NO_UNKNOWN);
-        valueSet.setType(ValueSetType.LOCAL);
+        valueSet.setCodeSet(CodeSet.LOCAL);
         valueSet.setValues(values);
 
         return repository.save(valueSet);


### PR DESCRIPTION
Adds support for multiple "tabs" in a questionnaire. This is accomplished by adding a `tab` database table that has a `ManyToOne` relationship with the `questionnaire` table.

A questionnaire has tabs, each tab contains a list of elements.

Also adds a `CodeSet` field to questions to hold either `LOCAL` or `PHIN`.

