### PR TITLE
Cnft1 1032 emit a patient create event on kafka

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/PatientCreatedEmitter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/PatientCreatedEmitter.java
@@ -1,0 +1,168 @@
+package gov.cdc.nbs.patient.create;
+
+import gov.cdc.nbs.entity.odse.EntityId;
+import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.entity.odse.PersonName;
+import gov.cdc.nbs.entity.odse.PersonRace;
+import gov.cdc.nbs.entity.odse.PostalEntityLocatorParticipation;
+import gov.cdc.nbs.entity.odse.PostalLocator;
+import gov.cdc.nbs.entity.odse.TeleEntityLocatorParticipation;
+import gov.cdc.nbs.entity.odse.TeleLocator;
+import gov.cdc.nbs.message.enums.Deceased;
+import gov.cdc.nbs.message.enums.Gender;
+import gov.cdc.nbs.message.patient.event.PatientEvent;
+import gov.cdc.nbs.patient.event.PatientEventEmitter;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.List;
+
+@Component
+class PatientCreatedEmitter {
+
+    private final PatientEventEmitter emitter;
+
+    PatientCreatedEmitter(final PatientEventEmitter emitter) {
+        this.emitter = emitter;
+    }
+
+    void created(final Person person) {
+        PatientEvent.Created created = asCreated(person);
+
+        this.emitter.emit(created);
+    }
+
+    private PatientEvent.Created asCreated(final Person patient) {
+
+        LocalDate birthday = resolveBirthday(patient);
+
+        return new PatientEvent.Created(
+            patient.getId(),
+            patient.getLocalId(),
+            birthday,
+            resolveGender(patient.getBirthGenderCd()),
+            resolveGender(patient.getCurrSexCd()),
+            resolveDeceased(patient.getDeceasedIndCd()),
+            patient.getDeceasedTime(),
+            patient.getMaritalStatusCd(),
+            patient.getEthnicity().ethnicGroup(),
+            patient.getAsOfDateGeneral(),
+            patient.getDescription(),
+            patient.getEharsId(),
+            resolveNames(patient.getNames()),
+            resolveRaces(patient.getRaces()),
+            resolveAddresses(patient.addresses()),
+            resolvePhones(patient.phoneNumbers()),
+            resolveEmails(patient.emailAddresses()),
+            resolveIdentifications(patient.identifications()),
+            patient.getAddUserId(),
+            patient.getAddTime()
+        );
+    }
+
+    private LocalDate resolveBirthday(final Person patient) {
+        Instant value = patient.getBirthTime();
+
+        return value == null
+            ? null
+            : value.atZone(ZoneOffset.UTC).toLocalDate();
+    }
+
+    private String resolveGender(final Gender gender) {
+        return gender == null ? null : gender.value();
+    }
+
+    private String resolveDeceased(final Deceased deceased) {
+        return deceased == null ? null : deceased.value();
+    }
+
+    private List<PatientEvent.Created.Name> resolveNames(final Collection<PersonName> names) {
+        return names.stream()
+            .map(this::asName)
+            .toList();
+    }
+
+    private PatientEvent.Created.Name asName(final PersonName name) {
+        String suffix = name.getNmSuffix() == null ? null : name.getNmSuffix().name();
+
+        return new PatientEvent.Created.Name(
+            name.getNmUseCd(),
+            name.getFirstNm(),
+            name.getMiddleNm(),
+            name.getLastNm(),
+            suffix
+        );
+    }
+
+    private List<String> resolveRaces(final Collection<PersonRace> races) {
+        return races.stream().map(PersonRace::getRaceCategoryCd).toList();
+    }
+
+    private List<PatientEvent.Created.Address> resolveAddresses(
+        final Collection<PostalEntityLocatorParticipation> addresses
+    ) {
+        return addresses.stream().map(this::asAddress).toList();
+    }
+
+    private PatientEvent.Created.Address asAddress(final PostalEntityLocatorParticipation address) {
+        PostalLocator locator = address.getLocator();
+        return new PatientEvent.Created.Address(
+            address.getId().getLocatorUid(),
+            locator.getStreetAddr1(),
+            locator.getStreetAddr2(),
+            locator.getCityDescTxt(),
+            locator.getStateCd(),
+            locator.getZipCd(),
+            locator.getCntyCd(),
+            locator.getCntryCd(),
+            locator.getCensusTract()
+        );
+    }
+
+    private List<PatientEvent.Created.Phone> resolvePhones(final Collection<TeleEntityLocatorParticipation> phones) {
+        return phones.stream().map(this::asPhone).toList();
+    }
+
+    private PatientEvent.Created.Phone asPhone(final TeleEntityLocatorParticipation phone) {
+        TeleLocator locator = phone.getLocator();
+
+        return new PatientEvent.Created.Phone(
+            phone.getId().getLocatorUid(),
+            phone.getCd(),
+            phone.getUseCd(),
+            locator.getPhoneNbrTxt(),
+            locator.getExtensionTxt()
+        );
+    }
+
+    private List<PatientEvent.Created.Email> resolveEmails(final Collection<TeleEntityLocatorParticipation> emails) {
+        return emails.stream().map(this::asEmail).toList();
+    }
+
+    private PatientEvent.Created.Email asEmail(final TeleEntityLocatorParticipation email) {
+        TeleLocator locator = email.getLocator();
+
+        return new PatientEvent.Created.Email(
+            email.getId().getLocatorUid(),
+            email.getCd(),
+            email.getUseCd(),
+            locator.getEmailAddress()
+        );
+    }
+
+    private List<PatientEvent.Created.Identification> resolveIdentifications(final Collection<EntityId> identifications) {
+        return identifications.stream().map(this::asIdentification).toList();
+    }
+
+    private PatientEvent.Created.Identification asIdentification(final EntityId identification) {
+        return new PatientEvent.Created.Identification(
+            identification.getId().getEntityIdSeq(),
+            identification.getTypeCd(),
+            identification.getAssigningAuthorityCd(),
+            identification.getRootExtensionTxt()
+        );
+    }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/PatientCreator.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/PatientCreator.java
@@ -21,15 +21,18 @@ public class PatientCreator {
     private final PatientIdentifierGenerator patientIdentifierGenerator;
     private final IdGeneratorService idGeneratorService;
     private final EntityManager entityManager;
+    private final PatientCreatedEmitter emitter;
 
     PatientCreator(
         final PatientIdentifierGenerator patientIdentifierGenerator,
         final IdGeneratorService idGenerator,
-        final EntityManager entityManager
+        final EntityManager entityManager,
+        final PatientCreatedEmitter emitter
     ) {
         this.patientIdentifierGenerator = patientIdentifierGenerator;
         this.idGeneratorService = idGenerator;
         this.entityManager = entityManager;
+        this.emitter = emitter;
     }
 
     @Transactional
@@ -63,6 +66,8 @@ public class PatientCreator {
             .forEach(person::add);
 
         this.entityManager.persist(person);
+
+        this.emitter.created(person);
 
         return identifier;
     }
@@ -195,4 +200,5 @@ public class PatientCreator {
         var generatedId = idGeneratorService.getNextValidId(IdGeneratorService.EntityType.NBS);
         return generatedId.getId();
     }
+
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientCreateAssertions.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientCreateAssertions.java
@@ -14,7 +14,7 @@ import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PatientAssertions {
+public class PatientCreateAssertions {
 
     public static Consumer<PersonName> containsNames(final Collection<PatientInput.Name> names) {
         return names.stream()
@@ -133,6 +133,6 @@ public class PatientAssertions {
             ;
     }
 
-    private PatientAssertions() {
+    private PatientCreateAssertions() {
     }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/create/PatientCreatedEmitterTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/create/PatientCreatedEmitterTest.java
@@ -1,0 +1,426 @@
+package gov.cdc.nbs.patient.create;
+
+import gov.cdc.nbs.address.City;
+import gov.cdc.nbs.address.Country;
+import gov.cdc.nbs.address.County;
+import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.message.enums.Deceased;
+import gov.cdc.nbs.message.enums.Gender;
+import gov.cdc.nbs.message.enums.Suffix;
+import gov.cdc.nbs.message.patient.event.PatientEvent;
+import gov.cdc.nbs.message.patient.input.PatientInput;
+import gov.cdc.nbs.patient.PatientCommand;
+import gov.cdc.nbs.patient.event.PatientEventEmitter;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PatientCreatedEmitterTest {
+
+    @Test
+    void should_emit_person_as_created_event() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created actual = captor.getValue();
+
+        assertThat(actual)
+            .returns(117L, PatientEvent.Created::patient)
+            .returns("patient-local-id", PatientEvent.Created::localId)
+            .returns(LocalDate.parse("2000-09-03"), PatientEvent.Created::dateOfBirth)
+            .returns("M", PatientEvent.Created::birthGender)
+            .returns("F", PatientEvent.Created::currentGender)
+            .returns("Y", PatientEvent.Created::deceased)
+            .returns(Instant.parse("2085-09-07T13:09:07Z"), PatientEvent.Created::deceasedOn)
+            .returns("Marital Status", PatientEvent.Created::maritalStatus)
+            .returns("EthCode", PatientEvent.Created::ethnicGroup)
+            .returns(Instant.parse("2019-03-03T10:15:30Z"), PatientEvent.Created::asOf)
+            .returns("comments", PatientEvent.Created::comments)
+            .returns("HIV-Case", PatientEvent.Created::stateHIVCase)
+            .returns(131L, PatientEvent.Created::createdBy)
+            .returns(Instant.parse("2020-03-03T10:15:30.00Z"), PatientEvent.Created::createdOn)
+            ;
+
+        assertThat(actual.names()).isEmpty();
+        assertThat(actual.races()).isEmpty();
+        assertThat(actual.addresses()).isEmpty();
+        assertThat(actual.phoneNumbers()).isEmpty();
+        assertThat(actual.emails()).isEmpty();
+        assertThat(actual.identifications()).isEmpty();
+    }
+
+    @Test
+    void should_emit_person_as_created_event_with_names() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        patient.add(
+            new PatientCommand.AddName(
+                117L,
+                "First",
+                "Middle",
+                "Last",
+                Suffix.JR,
+                PatientInput.NameUseCd.L,
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created created = captor.getValue();
+
+        assertThat(created.names())
+            .satisfiesExactly(
+                actual -> assertThat(actual)
+                    .returns("L", PatientEvent.Created.Name::use)
+                    .returns("First", PatientEvent.Created.Name::first)
+                    .returns("Middle", PatientEvent.Created.Name::middle)
+                    .returns("Last", PatientEvent.Created.Name::last)
+                    .returns("JR", PatientEvent.Created.Name::suffix)
+            );
+    }
+
+    @Test
+    void should_emit_person_as_created_event_with_races() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        patient.add(
+            new PatientCommand.AddRace(
+                117L,
+                Instant.parse("2022-05-12T11:15:17Z"),
+                "race-code-value",
+                "race-category-value",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created created = captor.getValue();
+
+        assertThat(created.races())
+            .contains("race-category-value");
+    }
+
+    @Test
+    void should_emit_person_as_created_event_with_addresses() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        patient.add(
+            new PatientCommand.AddAddress(
+                117L,
+                4861L,
+                "SA1",
+                "SA2",
+                new City("city-code", "city-description"),
+                "State",
+                "Zip",
+                new County("county-code", "county-description"),
+                new Country("country-code", "country-description"),
+                "Census Tract",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created created = captor.getValue();
+
+        assertThat(created.addresses())
+            .satisfiesExactly(
+                actual -> assertThat(actual)
+                    .returns(4861L, PatientEvent.Created.Address::identifier)
+                    .returns("SA1", PatientEvent.Created.Address::streetAddress1)
+                    .returns("SA2", PatientEvent.Created.Address::streetAddress2)
+                    .returns("city-description", PatientEvent.Created.Address::city)
+                    .returns("State", PatientEvent.Created.Address::state)
+                    .returns("Zip", PatientEvent.Created.Address::zip)
+                    .returns("county-code", PatientEvent.Created.Address::county)
+                    .returns("country-code", PatientEvent.Created.Address::country)
+                    .returns("Census Tract", PatientEvent.Created.Address::censusTract)
+            );
+    }
+
+    @Test
+    void should_emit_person_as_created_event_with_phones() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        patient.add(
+            new PatientCommand.AddPhoneNumber(
+                117L,
+                5347L,
+                "Phone Number",
+                "Extension",
+                "CP",
+                "MC",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created created = captor.getValue();
+
+        assertThat(created.phoneNumbers())
+            .satisfiesExactly(
+                actual -> assertThat(actual)
+                    .returns(5347L, PatientEvent.Created.Phone::identifier)
+                    .returns("CP", PatientEvent.Created.Phone::type)
+                    .returns("MC", PatientEvent.Created.Phone::use)
+                    .returns("Phone Number", PatientEvent.Created.Phone::number)
+                    .returns("Extension", PatientEvent.Created.Phone::extension)
+            );
+    }
+
+    @Test
+    void should_emit_person_as_created_event_with_email() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        patient.add(
+            new PatientCommand.AddEmailAddress(
+                117L,
+                5333L,
+                "AnEmail@email.com",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created created = captor.getValue();
+
+        assertThat(created.emails())
+            .satisfiesExactly(
+                actual -> assertThat(actual)
+                    .returns(5333L, PatientEvent.Created.Email::identifier)
+                    .returns("NET", PatientEvent.Created.Email::type)
+                    .returns("H", PatientEvent.Created.Email::use)
+                    .returns("AnEmail@email.com", PatientEvent.Created.Email::address)
+            );
+    }
+
+    @Test
+    void should_emit_person_as_created_event_with_identifications() {
+
+        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+        Person patient = new Person(
+            new PatientCommand.AddPatient(
+                117L,
+                "patient-local-id",
+                LocalDate.parse("2000-09-03"),
+                Gender.M,
+                Gender.F,
+                Deceased.Y,
+                Instant.parse("2085-09-07T13:09:07Z"),
+                "Marital Status",
+                "EthCode",
+                Instant.parse("2019-03-03T10:15:30Z"),
+                "comments",
+                "HIV-Case",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        patient.add(
+            new PatientCommand.AddIdentification(
+                117L,
+                "identification-value",
+                "authority-value",
+                "identification-type",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        createdEmitter.created(patient);
+
+        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+        verify(emitter).emit(captor.capture());
+
+        PatientEvent.Created created = captor.getValue();
+
+        assertThat(created.identifications())
+            .satisfiesExactly(
+                actual -> assertThat(actual)
+                    .returns(1, PatientEvent.Created.Identification::identifier)
+                    .returns("identification-type", PatientEvent.Created.Identification::type)
+                    .returns("authority-value", PatientEvent.Created.Identification::authority)
+                    .returns("identification-value", PatientEvent.Created.Identification::value)
+            );
+    }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/event/PatientEventSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/event/PatientEventSteps.java
@@ -34,6 +34,24 @@ public class PatientEventSteps {
         consumer.isEmpty();
     }
 
+    @Then("the patient create event is emitted")
+    public void the_patient_create_event_is_emitted() {
+        PatientIdentifier patient = patients.one();
+        ActiveUser user = activeUser.active();
+
+        consumer.satisfies(
+            actual -> assertThat(actual).satisfiesExactly(
+                actual_event -> assertThat(actual_event)
+                    .returns(patient.local(), PatientKafkaTestConsumer.Message::key)
+                    .extracting(PatientKafkaTestConsumer.Message::event)
+                    .asInstanceOf(type(PatientEvent.Created.class))
+                    .returns(patient.id(), PatientEvent::patient)
+                    .returns(patient.local(), PatientEvent::localId)
+                    .returns(user.id(), PatientEvent.Created::createdBy)
+            )
+        );
+    }
+
     @Then("the patient delete event is emitted")
     public void the_patient_delete_event_is_emitted() {
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
@@ -5,7 +5,7 @@ import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.entity.odse.PostalEntityLocatorParticipation;
 import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.PatientAssertions;
+import gov.cdc.nbs.patient.PatientCreateAssertions;
 import gov.cdc.nbs.patient.PatientMother;
 import gov.cdc.nbs.patient.TestPatient;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
@@ -81,7 +81,7 @@ public class PatientProfileAddressSteps {
         if (!addresses.isEmpty()) {
 
             assertThat(addresses)
-                .satisfiesExactlyInAnyOrder(PatientAssertions.containsAddresses(input.active().getAddresses()));
+                .satisfiesExactlyInAnyOrder(PatientCreateAssertions.containsAddresses(input.active().getAddresses()));
         }
 
     }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/identification/PatientProfileIdentificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/identification/PatientProfileIdentificationSteps.java
@@ -5,7 +5,7 @@ import gov.cdc.nbs.entity.odse.EntityId;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.PatientAssertions;
+import gov.cdc.nbs.patient.PatientCreateAssertions;
 import gov.cdc.nbs.patient.PatientMother;
 import gov.cdc.nbs.patient.TestPatient;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
@@ -84,7 +84,7 @@ public class PatientProfileIdentificationSteps {
 
             assertThat(identifications)
                 .satisfiesExactlyInAnyOrder(
-                    PatientAssertions.containsIdentifications(input.active().getIdentifications()));
+                    PatientCreateAssertions.containsIdentifications(input.active().getIdentifications()));
         }
 
     }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/PatientProfileNameSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/PatientProfileNameSteps.java
@@ -3,7 +3,7 @@ package gov.cdc.nbs.patient.profile.names;
 import com.github.javafaker.Faker;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.PatientAssertions;
+import gov.cdc.nbs.patient.PatientCreateAssertions;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -38,7 +38,7 @@ public class PatientProfileNameSteps {
 
         if (!actual.getNames().isEmpty()) {
             assertThat(actual.getNames())
-                .satisfiesExactly(PatientAssertions.containsNames(this.input.active().getNames()));
+                .satisfiesExactly(PatientCreateAssertions.containsNames(this.input.active().getNames()));
         }
     }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/phone/PatientProfileEmailSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/phone/PatientProfileEmailSteps.java
@@ -4,7 +4,7 @@ import com.github.javafaker.Faker;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.entity.odse.TeleEntityLocatorParticipation;
 import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.PatientAssertions;
+import gov.cdc.nbs.patient.PatientCreateAssertions;
 import gov.cdc.nbs.patient.TestPatient;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.en.Given;
@@ -41,7 +41,7 @@ public class PatientProfileEmailSteps {
         if(!emails.isEmpty()) {
 
             assertThat(emails)
-                .satisfiesExactlyInAnyOrder(PatientAssertions.containsEmailAddresses(input.active().getEmailAddresses()));
+                .satisfiesExactlyInAnyOrder(PatientCreateAssertions.containsEmailAddresses(input.active().getEmailAddresses()));
 
 
         }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/phone/PatientProfilePhoneSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/phone/PatientProfilePhoneSteps.java
@@ -4,7 +4,7 @@ import com.github.javafaker.Faker;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.entity.odse.TeleEntityLocatorParticipation;
 import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.PatientAssertions;
+import gov.cdc.nbs.patient.PatientCreateAssertions;
 import gov.cdc.nbs.patient.TestPatient;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.en.Given;
@@ -48,7 +48,7 @@ public class PatientProfilePhoneSteps {
         if(!phoneNumbers.isEmpty()) {
 
             assertThat(phoneNumbers)
-                .satisfiesExactlyInAnyOrder(PatientAssertions.containsPhoneNumbers(input.active().getPhoneNumbers()));
+                .satisfiesExactlyInAnyOrder(PatientCreateAssertions.containsPhoneNumbers(input.active().getPhoneNumbers()));
 
 
         }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/race/PatientProfileRaceSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/race/PatientProfileRaceSteps.java
@@ -3,7 +3,7 @@ package gov.cdc.nbs.patient.profile.race;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.PatientAssertions;
+import gov.cdc.nbs.patient.PatientCreateAssertions;
 import gov.cdc.nbs.patient.PatientMother;
 import gov.cdc.nbs.patient.TestPatient;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
@@ -57,7 +57,7 @@ public class PatientProfileRaceSteps {
 
         if (!actual.getRaces().isEmpty()) {
             assertThat(actual.getRaces())
-                .satisfiesExactly(PatientAssertions.containsRaceCategories(this.input.active().getRaces()));
+                .satisfiesExactly(PatientCreateAssertions.containsRaceCategories(this.input.active().getRaces()));
         }
     }
 

--- a/apps/modernization-api/src/test/resources/features/patient/PatientCreate.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientCreate.feature
@@ -7,6 +7,7 @@ Feature: Patient create
     And I am adding a new patient
     When I submit the patient
     Then the patient is created
+    And the patient create event is emitted
 
   Scenario: I can create a patient with birth
     Given I am logged into NBS
@@ -109,3 +110,4 @@ Feature: Patient create
     And I am adding a new patient
     When I submit the patient
     Then I am not allowed to create a patient
+    And a patient event is not emitted

--- a/apps/patient-listener/src/test/java/gov/cdc/nbs/patientlistener/request/update/PatientUpdaterTest.java
+++ b/apps/patient-listener/src/test/java/gov/cdc/nbs/patientlistener/request/update/PatientUpdaterTest.java
@@ -818,7 +818,7 @@ class PatientUpdaterTest {
 
         var data = new DeleteIdentificationData(
                 123L,
-                (short) 0,
+                (short) 1,
                 "RequestId",
                 321L,
                 Instant.now());

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/NBSEntity.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/NBSEntity.java
@@ -68,7 +68,7 @@ public class NBSEntity {
     public EntityId add(final PatientCommand.AddIdentification added) {
 
         Collection<EntityId> existing = ensureEntityIds();
-        EntityIdId identifier = new EntityIdId(this.id, (short) existing.size());
+        EntityIdId identifier = new EntityIdId(this.id, (short) (existing.size() + 1));
 
         EntityId entityId = new EntityId(
             this,

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
@@ -491,6 +491,10 @@ public class Person {
         return this.names;
     }
 
+    public List<PersonName> getNames() {
+        return this.names == null ? List.of() : List.copyOf(this.names);
+    }
+
     public EntityId add(final PatientCommand.AddIdentification added) {
         return this.nbsEntity.add(added);
     }
@@ -511,6 +515,10 @@ public class Person {
             this.races = new ArrayList<>();
         }
         return this.races;
+    }
+
+    public List<PersonRace> getRaces() {
+        return this.races == null ? List.of() : List.copyOf(this.races);
     }
 
     public EntityLocatorParticipation add(final PatientCommand.AddAddress address) {

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -3,6 +3,9 @@ package gov.cdc.nbs.entity.odse;
 import gov.cdc.nbs.address.City;
 import gov.cdc.nbs.address.Country;
 import gov.cdc.nbs.address.County;
+import gov.cdc.nbs.audit.Added;
+import gov.cdc.nbs.audit.Audit;
+import gov.cdc.nbs.audit.Changed;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.message.enums.Gender;
@@ -111,7 +114,9 @@ class PersonTest {
                 "race-code-value",
                 "race-category-value",
                 131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")));
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
 
         assertThat(actual.getRaces()).satisfiesExactly(
             actual_race -> assertThat(actual_race)
@@ -225,7 +230,9 @@ class PersonTest {
                 new Country("country-code", "country-description"),
                 "Census Tract",
                 131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")));
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
 
         assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
             .satisfiesExactly(
@@ -261,7 +268,9 @@ class PersonTest {
                 5333L,
                 "AnEmail@email.com",
                 131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")));
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
 
         assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
             .satisfiesExactly(
@@ -292,7 +301,9 @@ class PersonTest {
                 "CP",
                 "MC",
                 131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")));
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
 
         assertThat(actual.getNbsEntity().getEntityLocatorParticipations())
             .satisfiesExactly(
@@ -648,6 +659,51 @@ class PersonTest {
                     .returns("ethnicity-value", PersonEthnicGroupId::getEthnicGroupCd)
             );
 
+    }
+
+    @Test
+    void should_add_identity_with_sequence_one() {
+        Person patient = new Person(117L, "local-id-value");
+
+        patient.add(
+            new PatientCommand.AddIdentification(
+                117L,
+                "identification-value",
+                "authority-value",
+                "identification-type",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        assertThat(patient.identifications()).satisfiesExactly(
+            actual -> assertThat(actual)
+                .satisfies(
+                    identification -> assertThat(identification)
+                        .extracting(EntityId::getAudit)
+                        .satisfies(
+                            added -> assertThat(added)
+                                .extracting(Audit::getAdded)
+                                .returns(131L, Added::getAddUserId)
+                                .returns(Instant.parse("2020-03-03T10:15:30.00Z"), Added::getAddTime)
+                        )
+                        .satisfies(
+                        changed -> assertThat(changed)
+                            .extracting(Audit::getChanged)
+                            .returns(131L, Changed::getLastChgUserId)
+                            .returns(Instant.parse("2020-03-03T10:15:30.00Z"), Changed::getLastChgTime)
+                    )
+                )
+                .returns("identification-type", EntityId::getTypeCd)
+                .returns("authority-value", EntityId::getAssigningAuthorityCd)
+                .returns("identification-value", EntityId::getRootExtensionTxt)
+                .satisfies(
+                    identification -> assertThat(identification)
+                        .extracting(EntityId::getId)
+                        .returns((short)1, EntityIdId::getEntityIdSeq)
+                )
+
+        );
     }
 
 }

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -341,12 +341,14 @@ class PersonTest {
 
         Person actual = new Person(117L, "local-id-value");
 
+        Instant deletedOn = Instant.parse("2020-03-03T10:15:30.00Z");
+
         assertThatThrownBy(() ->
             actual.delete(
                 new PatientCommand.Delete(
                     117L,
                     131L,
-                    Instant.now()
+                    deletedOn
                 ),
                 finder
             )

--- a/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Deceased.java
+++ b/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Deceased.java
@@ -1,16 +1,22 @@
 package gov.cdc.nbs.message.enums;
 
 public enum Deceased {
-    Y("Yes"),
-    N("No"),
-    UNK("Unknown"),
+    Y("Y", "Yes"),
+    N("N", "No"),
+    UNK("UNK", "Unknown"),
 
-    FALSE("false") // this value may be bad data in the db restore
+    FALSE("false", "false") // this value may be bad data in the db restore
     ;
+    private final String value;
     private final String display;
 
-    Deceased(final String display) {
+    Deceased(String value, final String display) {
+        this.value = value;
         this.display = display;
+    }
+
+    public String value() {
+        return value;
     }
 
     public String display() {

--- a/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Gender.java
+++ b/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Gender.java
@@ -1,17 +1,23 @@
 package gov.cdc.nbs.message.enums;
 
 public enum Gender {
-    M("Male"),
-    F("Female"),
-    U("Unknown");
+    M("M", "Male"),
+    F("F", "Female"),
+    U("U", "Unknown");
 
+    private final String value;
     private final String display;
 
-    Gender(String display) {
+    Gender(String value, String display) {
+        this.value = value;
         this.display = display;
     }
 
     public String display() {
         return this.display;
+    }
+
+    public String value() {
+        return value;
     }
 }

--- a/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Suffix.java
+++ b/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/Suffix.java
@@ -1,21 +1,27 @@
 package gov.cdc.nbs.message.enums;
 
 public enum Suffix {
-    ESQ("Esquire"),
-    II("II / The Second"),
-    III("III / The Third"),
-    IV("IV / The Fourth"),
-    JR("Jr."),
-    SR("Sr."),
-    V("V / The Fifth");
+    ESQ("ESQ", "Esquire"),
+    II("II", "II / The Second"),
+    III("III", "III / The Third"),
+    IV("IV", "IV / The Fourth"),
+    JR("JR", "Jr."),
+    SR("SR", "Sr."),
+    V("V", "V / The Fifth");
 
+    private final String value;
     private final String display;
 
-    Suffix(final String display) {
+    Suffix(final String value, final String display) {
+        this.value = value;
         this.display = display;
     }
 
     public String display() {
         return display;
+    }
+
+    public String value() {
+        return value;
     }
 }

--- a/libs/event-schema/src/main/java/gov/cdc/nbs/message/patient/event/PatientEvent.java
+++ b/libs/event-schema/src/main/java/gov/cdc/nbs/message/patient/event/PatientEvent.java
@@ -2,8 +2,6 @@ package gov.cdc.nbs.message.patient.event;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import gov.cdc.nbs.message.enums.Deceased;
-import gov.cdc.nbs.message.enums.Gender;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -11,6 +9,7 @@ import java.util.List;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
+    @JsonSubTypes.Type(PatientEvent.Created.class),
     @JsonSubTypes.Type(PatientEvent.Deleted.class),
     @JsonSubTypes.Type(PatientEvent.EthnicityChanged.class)
 })
@@ -28,20 +27,54 @@ public sealed interface PatientEvent {
         long patient,
         String localId,
         LocalDate dateOfBirth,
-        Gender birthGender,
-        Gender currentGender,
-        Deceased deceased,
-        Instant deceasedTime,
+        String birthGender,
+        String currentGender,
+        String deceased,
+        Instant deceasedOn,
         String maritalStatus,
-        String ethnicity,
+        String ethnicGroup,
         Instant asOf,
         String comments,
         String stateHIVCase,
+        List<Name> names,
+        List<String> races,
+        List<Address> addresses,
+        List<Phone> phoneNumbers,
+        List<Email> emails,
+        List<Identification> identifications,
         long createdBy,
         Instant createdOn
     ) implements PatientEvent {
+        public record Name(String use, String first, String middle, String last, String suffix) {
+        }
 
+
+        public record Address(
+            long identifier,
+            String streetAddress1,
+            String streetAddress2,
+            String city,
+            String state,
+            String zip,
+            String county,
+            String country,
+            String censusTract
+        ) {
+        }
+
+
+        public record Phone(long identifier, String type, String use, String number, String extension) {
+        }
+
+
+        public record Email(long identifier, String type, String use, String address) {
+        }
+
+
+        public record Identification(int identifier, String type, String authority, String value) {
+        }
     }
+
 
     record Deleted(
         long patient,


### PR DESCRIPTION
Implements the features requested in [CNFT1-1032](https://cdc-nbs.atlassian.net/browse/CNFT1-1032) by emitting an event when a patient is created. The event is only emitted if Kafka is enabled on the `modernization-api`.

The emitted event will have the key set to the patient localId and the value is the Patient Created Event serialized into a JSON format.

A Patient created via the mutation

```json
{
  "query": "mutation createPatient($patient:PersonInput!){createPatient(patient:$patient){id shortId}}",
  "variables": {
    "patient": {
      "comments": "Created for Development testing",
      "asOf": "2022-05-05T00:01:02Z",
      "names": [
        {
          "use": "L",
          "first": "Cory",
          "last": "Wolf-Hart"
        }
      ]
    }
  }
}
```

Will result in a `PatientEvent$Created` in the following format;

```json
{
	"type": "PatientEvent$Created",
	"patient": 10058305,
	"localId": "PSN10095017GA01",
	"dateOfBirth": null,
	"birthGender": null,
	"currentGender": null,
	"deceased": null,
	"deceasedOn": null,
	"maritalStatus": null,
	"ethnicGroup": null,
	"asOf": "2022-05-05T00:01:02Z",
	"comments": "Created for Development testing",
	"stateHIVCase": null,
	"names": [
		{
			"use": "L",
			"first": "Cory",
			"middle": null,
			"last": "Wolf-Hart",
			"suffix": null
		}
	],
	"races": [],
	"addresses": [],
	"phoneNumbers": [],
	"emails": [],
	"identifications": [],
	"createdBy": 29,
	"createdOn": "2023-06-07T20:04:56.939837Z"
}
```

[CNFT1-1032]: https://cdc-nbs.atlassian.net/browse/CNFT1-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ