### PR TITLE
CNFT1-1049/ Removes standard formatting from Race list

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountryCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountryCodedValueFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QCountryCode;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,7 @@ class CountryCodedValueFinder {
                 values.id,
                 values.codeDescTxt
             ).from(values)
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountyCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountyCodedValueFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QStateCountyCodeValue;
 import org.springframework.stereotype.Component;
@@ -37,6 +39,7 @@ class CountyCodedValueFinder {
                 values.parentIsCd
             ).from(values)
             .where(values.parentIsCd.eq(category))
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/DetailedRaceFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/DetailedRaceFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QRaceCode;
 import org.springframework.stereotype.Component;
@@ -37,6 +39,7 @@ class DetailedRaceFinder {
                 values.parentIsCd
             ).from(values)
             .where(values.parentIsCd.eq(category))
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)
@@ -45,7 +48,7 @@ class DetailedRaceFinder {
 
     private GroupedCodedValue map(final Tuple tuple) {
         String value = tuple.get(values.id);
-        String name = StandardNameFormatter.formatted(tuple.get(values.codeShortDescTxt));
+        String name = tuple.get(values.codeShortDescTxt);
         String group = tuple.get(values.parentIsCd);
         return new GroupedCodedValue(value, name, group);
     }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/GeneralCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/GeneralCodedValueFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
 import org.springframework.stereotype.Component;
@@ -24,6 +26,7 @@ class GeneralCodedValueFinder {
                 values.codeShortDescTxt
             ).from(values)
             .where(values.id.codeSetNm.eq(set))
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/PrimaryLanguageValueSetFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/PrimaryLanguageValueSetFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QLanguageCode;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,7 @@ class PrimaryLanguageValueSetFinder {
                 values.id,
                 values.codeShortDescTxt
             ).from(values)
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/PrimaryOccupationValueSetFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/PrimaryOccupationValueSetFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QNaicsIndustryCode;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,7 @@ class PrimaryOccupationValueSetFinder {
                 values.id,
                 values.codeShortDescTxt
             ).from(values)
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/StateCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/StateCodedValueFinder.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.codes;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import gov.cdc.nbs.entity.srte.QStateCode;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,7 @@ class StateCodedValueFinder {
                 values.id,
                 values.codeDescTxt
             ).from(values)
+            .orderBy(new OrderSpecifier<>(Order.ASC, values.indentLevelNbr))
             .fetch()
             .stream()
             .map(this::map)

--- a/apps/modernization-api/src/main/resources/graphql/coded-values.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/coded-values.graphqls
@@ -8,12 +8,6 @@ type StateCountyCodeValueResults {
     total: Int!
 }
 
-type StateCountyCodeValue {
-    id: CodeValueGeneralId!
-    code_desc_txt: String!
-    state_cd: String!
-}
-
 type NaicsIndustryCode {
     id: ID!
     assigningAuthorityCd: String


### PR DESCRIPTION
Implements the feature defined by [CNFT1-1049](https://cdc-nbs.atlassian.net/browse/CNFT1-1049) by ensuring that the Race Category names have proper noun capitalization.  Also, ordering of the value sets is now controlled by the `indent_level_nbr`

[CNFT1-1049]: https://cdc-nbs.atlassian.net/browse/CNFT1-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ