### PR TITLE
Removes the push trigger for sonar

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -4,6 +4,9 @@ name: "Sonar Scanner"
 
 on:
   push:
+    paths:
+      - "apps/**"
+      - "libs/**"
     branches:
       - main
   pull_request:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -3,11 +3,6 @@
 name: "Sonar Scanner"
 
 on:
-  push:
-    paths:
-      - "apps/**"
-      - "libs/**"
-      - ".github/workflows/sonar.yaml"
   pull_request:
     paths:
       - "apps/**"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -3,6 +3,9 @@
 name: "Sonar Scanner"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - "apps/**"


### PR DESCRIPTION
Removes the push trigger from the Sonar workflow.  Frequent pushes (good practice!) with many developers is causing the workflow actions to queue for long periods of time.