### PR TITLE
CNFT1-1094 Logging calls to NBS Classic

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicOutgoingLoggingHttpRequestInterceptor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicOutgoingLoggingHttpRequestInterceptor.java
@@ -1,0 +1,45 @@
+package gov.cdc.nbs.redirect.outgoing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+/**
+ * A {@link ClientHttpRequestInterceptor} that adds basic logging to any requests made to the classic NBS application to
+ * the {@code nbs.classic.outgoing} Logger.
+ */
+class ClassicOutgoingLoggingHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger("nbs.classic.outgoing");
+
+    @Override
+    public ClientHttpResponse intercept(
+        final HttpRequest request,
+        final byte[] body,
+        final ClientHttpRequestExecution execution
+    ) throws IOException {
+
+        ClientHttpResponse response = execution.execute(request, body);
+
+        if (LOG.isDebugEnabled()) {
+
+            String path = request.getURI().getRawPath();
+
+            LOG.debug(
+                "{} {}\tResponse: {}",
+                request.getMethodValue(),
+                path,
+                response.getStatusCode()
+            );
+        }
+
+        return response;
+    }
+
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicRestTemplateConfiguration.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicRestTemplateConfiguration.java
@@ -17,9 +17,10 @@ class ClassicRestTemplateConfiguration {
         final ClassicPathResolver resolver,
         final ClassicOutgoingRequestInterceptor interceptor
     ) throws MalformedURLException {
+
         return new RestTemplateBuilder()
             .rootUri(resolver.base().toURL().toString())
-            .additionalInterceptors(interceptor)
+            .additionalInterceptors(new ClassicOutgoingLoggingHttpRequestInterceptor(), interceptor)
             .build();
     }
 

--- a/apps/modernization-api/src/main/resources/application.yml
+++ b/apps/modernization-api/src/main/resources/application.yml
@@ -27,6 +27,9 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
     org.springframework.data.elasticsearch.client.WIRE: trace
+    nbs:
+      classic:
+        outgoing: DEBUG
 
 spring:
   graphql:


### PR DESCRIPTION
Adds very basic logging to the outgoing requests to NBS Classic so that communication from `modernization-api` to NBS Class can be verified using the log.

Any request from `modernization-api` directly to NBS Classic will be logged to the `nbs.classic.outgoing` logger as ` {http-method} {path}       Response: {response-status}`.  For example;

```
2023-07-06 13:23:08.973 DEBUG 10388 --- [nio-9080-exec-9] nbs.classic.outgoing                     : GET /nbs/HomePage.do       Response: 200 OK
2023-07-06 13:23:09.094 DEBUG 10388 --- [nio-9080-exec-9] nbs.classic.outgoing                     : GET /nbs/PatientSearchResults1.do  Response: 200 OK
```

The level of the logging can be changed using the standard logging properties, the default level has been set to `DEBUG` for the meantime.

```yaml
logging:
  level:
    nbs:
      classic:
        outgoing: DEBUG
```