### PR TITLE
Ab sandbox readme update

### DIFF
--- a/cdc-sandbox/README.md
+++ b/cdc-sandbox/README.md
@@ -35,7 +35,7 @@ The steps outlined in this README should get the system up and running quickly f
    placed within the wildfly server directory with the relative path wildfly-10.0.0.Final/nedssdomain/Nedss/pagemanagement.
 3. Database restore files are taken from a point-in-time backup from provided the dev server on date 9-20-2022 and zipped in [db-restore.zip](db/restore/restore.d/db-restore.zip). They contain updates from 6.0.12-GA release and
    should only be used until a proper solution is implemented. The build scripts automatically unzip contents into the correct directory.
-   a) If database container is not successful when running, put contents of the db-restore.zip into the path .../NEDSS-Modernization/cdc-sandbox/db/restore/restore.d, make sure to only put the contents of the unzipped folder and the folder itself.
+   a) If database container is not successful when running, put contents of the db-restore.zip into the path .../NEDSS-Modernization/cdc-sandbox/db/restore/restore.d, make sure to only put the contents of the unzipped folder and not the folder itself.
 
 ## Build
 

--- a/cdc-sandbox/README.md
+++ b/cdc-sandbox/README.md
@@ -36,6 +36,9 @@ The steps outlined in this README should get the system up and running quickly f
 3. Database restore files are taken from a point-in-time backup from provided the dev server on date 9-20-2022 and zipped in [db-restore.zip](db/restore/restore.d/db-restore.zip). They contain updates from 6.0.12-GA release and
    should only be used until a proper solution is implemented. The build scripts automatically unzip contents into the correct directory.
    a) If database container is not successful when running, put contents of the db-restore.zip into the path .../NEDSS-Modernization/cdc-sandbox/db/restore/restore.d, make sure to only put the contents of the unzipped folder and not the folder itself.
+   ```
+   $ unzip -j ~/Downloads/db-restore.zip -d {location}/NEDSS-Modernization/cdc-sandbox/db/restore/restore.d
+   ```
 
 ## Build
 

--- a/cdc-sandbox/README.md
+++ b/cdc-sandbox/README.md
@@ -35,6 +35,7 @@ The steps outlined in this README should get the system up and running quickly f
    placed within the wildfly server directory with the relative path wildfly-10.0.0.Final/nedssdomain/Nedss/pagemanagement.
 3. Database restore files are taken from a point-in-time backup from provided the dev server on date 9-20-2022 and zipped in [db-restore.zip](db/restore/restore.d/db-restore.zip). They contain updates from 6.0.12-GA release and
    should only be used until a proper solution is implemented. The build scripts automatically unzip contents into the correct directory.
+   a) If database container is not successful when running, put contents of the db-restore.zip into the path .../NEDSS-Modernization/cdc-sandbox/db/restore/restore.d, make sure to only put the contents of the unzipped folder and the folder itself.
 
 ## Build
 


### PR DESCRIPTION
Small addition to the README file within the cdc_sandbox, for better understanding of how to store the db restore files in the correct path. 