### PR TITLE
1164 - Remove any boost from soundex so it comes last in search results

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
@@ -57,10 +57,10 @@ import static gov.cdc.nbs.config.security.SecurityUtil.Operations.FINDINACTIVE;
 public class PatientService {
     private static final float FIRST_NAME_PRIMARY_BOOST = 2.0f;
     private static final float FIRST_NAME_NON_PRIMARY_BOOST = 1.0f;
-    private static final float FIRST_NAME_SOUNDEX_BOOST = 0.5f;
+    private static final float FIRST_NAME_SOUNDEX_BOOST = 0.0f;
     private static final float LAST_NAME_PRIMARY_BOOST = 2.0f;
     private static final float LAST_NAME_NON_PRIMARY_BOOST = 1.0f;
-    private static final float LAST_NAME_SOUNDEX_BOOST = 0.5f;
+    private static final float LAST_NAME_SOUNDEX_BOOST = 0.0f;
 
     @Value("${nbs.max-page-size: 50}")
     private Integer maxPageSize;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
@@ -55,10 +55,10 @@ import static gov.cdc.nbs.config.security.SecurityUtil.Operations.FINDINACTIVE;
 @Service
 @RequiredArgsConstructor
 public class PatientService {
-    private static final float FIRST_NAME_PRIMARY_BOOST = 2.0f;
+    private static final float FIRST_NAME_PRIMARY_BOOST = 10.0f;
     private static final float FIRST_NAME_NON_PRIMARY_BOOST = 1.0f;
     private static final float FIRST_NAME_SOUNDEX_BOOST = 0.0f;
-    private static final float LAST_NAME_PRIMARY_BOOST = 2.0f;
+    private static final float LAST_NAME_PRIMARY_BOOST = 10.0f;
     private static final float LAST_NAME_NON_PRIMARY_BOOST = 1.0f;
     private static final float LAST_NAME_SOUNDEX_BOOST = 0.0f;
 


### PR DESCRIPTION
**Why**: A patient's current legal name should always come first in the search results
**How**: 
1) Since soundex is not available on the Person table any soundex matches on Person_name are giving a cumulative boost to that patient.  In addition there is no need to ever boost soundex results currently.  We need to ensure that one soundex or an aggregate of soundex names will never override the patient legal name or secondary names in the search ordering.
2) We also don't want a secondary aggregate set of names to override legal name.  Make the boost on primary even greater to override the boost effects of secondary (10x greater)