### PR TITLE
CNFT1-1179 demo county name is displayed as coded numeric value in view details address

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapper.java
@@ -2,14 +2,14 @@ package gov.cdc.nbs.geo.county;
 
 import com.querydsl.core.Tuple;
 import gov.cdc.nbs.entity.odse.QPostalLocator;
-import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
+import gov.cdc.nbs.entity.srte.QStateCountyCodeValue;
 
 import java.util.Objects;
 import java.util.Optional;
 
 public class SimpleCountyTupleMapper {
 
-    public record Tables(QPostalLocator address, QCodeValueGeneral county) {
+    public record Tables(QPostalLocator address, QStateCountyCodeValue county) {
     }
 
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/PatientProfile.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/PatientProfile.java
@@ -1,4 +1,11 @@
 package gov.cdc.nbs.patient.profile;
 
+import gov.cdc.nbs.entity.enums.RecordStatus;
+
 public record PatientProfile(long id, String local, short version, String recordStatusCd) {
+
+    public PatientProfile(long id, String local, short version) {
+        this(id, local, version, RecordStatus.ACTIVE.name());
+    }
+
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
@@ -17,8 +17,6 @@ class PatientAddressFinder {
     private static final String ACTIVE_CODE = "ACTIVE";
     private static final String POSTAL_TYPE_CODE_SET = "EL_TYPE_PST_PAT";
     private static final String POSTAL_USE_CODE_SET = "EL_USE_PST_PAT";
-    private static final String COUNTY_CODE_SET = "PHVS_COUNTY_FIPS_6-4";
-
     private final JPAQueryFactory factory;
     private final PatientAddressTupleMapper.Tables tables;
     private final PatientAddressTupleMapper mapper;
@@ -83,8 +81,7 @@ class PatientAddressFinder {
     private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
         return applyBaseCriteria(query, patient)
             .leftJoin(this.tables.county()).on(
-                this.tables.county().id.codeSetNm.eq(COUNTY_CODE_SET),
-                this.tables.county().id.code.eq(this.tables.address().cntyCd)
+                this.tables.county().id.eq(this.tables.address().cntyCd)
             )
             .leftJoin(this.tables.state()).on(
                 this.tables.state().id.eq(this.tables.address().stateCd)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressTupleMapper.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.entity.odse.QPostalLocator;
 import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
 import gov.cdc.nbs.entity.srte.QCountryCode;
 import gov.cdc.nbs.entity.srte.QStateCode;
+import gov.cdc.nbs.entity.srte.QStateCountyCodeValue;
 import gov.cdc.nbs.geo.country.SimpleCountry;
 import gov.cdc.nbs.geo.country.SimpleCountryTupleMapper;
 import gov.cdc.nbs.geo.county.SimpleCounty;
@@ -26,7 +27,7 @@ class PatientAddressTupleMapper {
         QPostalLocator address,
         QCodeValueGeneral type,
         QCodeValueGeneral use,
-        QCodeValueGeneral county,
+        QStateCountyCodeValue county,
         QStateCode state,
         QCountryCode country
     ) {
@@ -38,7 +39,7 @@ class PatientAddressTupleMapper {
                 QPostalLocator.postalLocator,
                 new QCodeValueGeneral("type"),
                 new QCodeValueGeneral("use"),
-                new QCodeValueGeneral("county"),
+                QStateCountyCodeValue.stateCountyCodeValue,
                 QStateCode.stateCode,
                 QCountryCode.countryCode
             );

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthFinder.java
@@ -60,8 +60,7 @@ class PatientBirthFinder {
                 this.tables.state().id.eq(this.tables.address().stateCd)
             )
             .leftJoin(this.tables.county()).on(
-                this.tables.county().id.codeSetNm.eq(COUNTY_CODE_SET),
-                this.tables.county().id.code.eq(this.tables.address().cntyCd)
+                this.tables.county().id.eq(this.tables.address().cntyCd)
             )
             .leftJoin(this.tables.country()).on(
                 this.tables.country().id.eq(this.tables.address().cntryCd)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/PatientBirthTupleMapper.java
@@ -6,6 +6,7 @@ import gov.cdc.nbs.entity.odse.QPostalLocator;
 import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
 import gov.cdc.nbs.entity.srte.QCountryCode;
 import gov.cdc.nbs.entity.srte.QStateCode;
+import gov.cdc.nbs.entity.srte.QStateCountyCodeValue;
 import gov.cdc.nbs.geo.country.SimpleCountry;
 import gov.cdc.nbs.geo.country.SimpleCountryTupleMapper;
 import gov.cdc.nbs.geo.county.SimpleCounty;
@@ -27,7 +28,7 @@ class PatientBirthTupleMapper {
         QCodeValueGeneral multipleBirth,
         QPostalLocator address,
         QStateCode state,
-        QCodeValueGeneral county,
+        QStateCountyCodeValue county,
         QCountryCode country
     ) {
 
@@ -37,7 +38,7 @@ class PatientBirthTupleMapper {
                 new QCodeValueGeneral("multiple_birth"),
                 QPostalLocator.postalLocator,
                 QStateCode.stateCode,
-                new QCodeValueGeneral("county"),
+                QStateCountyCodeValue.stateCountyCodeValue,
                 QCountryCode.countryCode
             );
         }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 @Component
 class PatientMortalityFinder {
 
-    private static final String COUNTY_CODE_SET = "PHVS_COUNTY_FIPS_6-4";
     private static final String PATIENT_CODE = "PAT";
     private static final String DEATH_ADDRESS_CODE = "DTH";
     private static final String ACTIVE_CODE = "ACTIVE";

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityFinder.java
@@ -51,8 +51,7 @@ class PatientMortalityFinder {
                 this.tables.state().id.eq(this.tables.address().stateCd)
             )
             .leftJoin(this.tables.county()).on(
-                this.tables.county().id.codeSetNm.eq(COUNTY_CODE_SET),
-                this.tables.county().id.code.eq(this.tables.address().cntyCd)
+                this.tables.county().id.eq(this.tables.address().cntyCd)
             )
             .leftJoin(this.tables.country()).on(
                 this.tables.country().id.eq(this.tables.address().cntryCd)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/PatientMortalityTupleMapper.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.entity.odse.QPostalLocator;
 import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
 import gov.cdc.nbs.entity.srte.QCountryCode;
 import gov.cdc.nbs.entity.srte.QStateCode;
+import gov.cdc.nbs.entity.srte.QStateCountyCodeValue;
 import gov.cdc.nbs.geo.country.SimpleCountry;
 import gov.cdc.nbs.geo.country.SimpleCountryTupleMapper;
 import gov.cdc.nbs.geo.county.SimpleCounty;
@@ -28,7 +29,7 @@ class PatientMortalityTupleMapper {
         QPostalEntityLocatorParticipation locators,
         QPostalLocator address,
         QStateCode state,
-        QCodeValueGeneral county,
+        QStateCountyCodeValue county,
         QCountryCode country
     ) {
 
@@ -39,7 +40,7 @@ class PatientMortalityTupleMapper {
                 QPostalEntityLocatorParticipation.postalEntityLocatorParticipation,
                 QPostalLocator.postalLocator,
                 QStateCode.stateCode,
-                new QCodeValueGeneral("county"),
+                QStateCountyCodeValue.stateCountyCodeValue,
                 QCountryCode.countryCode
             );
         }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/geo/county/SimpleCountyTupleMapperTest.java
@@ -2,7 +2,7 @@ package gov.cdc.nbs.geo.county;
 
 import com.querydsl.core.Tuple;
 import gov.cdc.nbs.entity.odse.QPostalLocator;
-import gov.cdc.nbs.entity.srte.QCodeValueGeneral;
+import gov.cdc.nbs.entity.srte.QStateCountyCodeValue;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -18,7 +18,7 @@ class SimpleCountyTupleMapperTest {
     void should_map_known_county_from_tuple() {
         SimpleCountyTupleMapper.Tables tables = new SimpleCountyTupleMapper.Tables(
             QPostalLocator.postalLocator,
-            QCodeValueGeneral.codeValueGeneral
+            QStateCountyCodeValue.stateCountyCodeValue
         );
 
         Tuple tuple = mock(Tuple.class);
@@ -38,7 +38,7 @@ class SimpleCountyTupleMapperTest {
     void should_map_unknown_county_from_tuple() {
         SimpleCountyTupleMapper.Tables tables = new SimpleCountyTupleMapper.Tables(
             QPostalLocator.postalLocator,
-            QCodeValueGeneral.codeValueGeneral
+            QStateCountyCodeValue.stateCountyCodeValue
         );
 
         Tuple tuple = mock(Tuple.class);
@@ -57,7 +57,7 @@ class SimpleCountyTupleMapperTest {
     void should_not_map_county_without_identifier() {
         SimpleCountyTupleMapper.Tables tables = new SimpleCountyTupleMapper.Tables(
             QPostalLocator.postalLocator,
-            QCodeValueGeneral.codeValueGeneral
+            QStateCountyCodeValue.stateCountyCodeValue
         );
 
         Tuple tuple = mock(Tuple.class);
@@ -72,7 +72,7 @@ class SimpleCountyTupleMapperTest {
     void should_map_known_county_if_present() {
         SimpleCountyTupleMapper.Tables tables = new SimpleCountyTupleMapper.Tables(
             QPostalLocator.postalLocator,
-            QCodeValueGeneral.codeValueGeneral
+            QStateCountyCodeValue.stateCountyCodeValue
         );
 
         Tuple tuple = mock(Tuple.class);
@@ -93,7 +93,7 @@ class SimpleCountyTupleMapperTest {
     void should_map_unknown_county_if_present() {
         SimpleCountyTupleMapper.Tables tables = new SimpleCountyTupleMapper.Tables(
             QPostalLocator.postalLocator,
-            QCodeValueGeneral.codeValueGeneral
+            QStateCountyCodeValue.stateCountyCodeValue
         );
 
         Tuple tuple = mock(Tuple.class);
@@ -113,7 +113,7 @@ class SimpleCountyTupleMapperTest {
     void should_not_map_county_when_not_present() {
         SimpleCountyTupleMapper.Tables tables = new SimpleCountyTupleMapper.Tables(
             QPostalLocator.postalLocator,
-            QCodeValueGeneral.codeValueGeneral
+            QStateCountyCodeValue.stateCountyCodeValue
         );
 
         Tuple tuple = mock(Tuple.class);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
@@ -1,7 +1,6 @@
 package gov.cdc.nbs.patient.profile.address;
 
 import com.github.javafaker.Faker;
-
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.entity.odse.PostalEntityLocatorParticipation;
@@ -12,6 +11,8 @@ import gov.cdc.nbs.patient.PatientMother;
 import gov.cdc.nbs.patient.TestPatient;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.patient.profile.PatientProfile;
+import gov.cdc.nbs.patient.profile.address.change.NewPatientAddressInput;
+import gov.cdc.nbs.patient.profile.address.change.UpdatePatientAddressInput;
 import gov.cdc.nbs.support.TestActive;
 import gov.cdc.nbs.support.TestAvailable;
 import gov.cdc.nbs.support.util.RandomUtil;
@@ -47,6 +48,12 @@ public class PatientProfileAddressSteps {
     @Autowired
     TestPatient patient;
 
+    @Autowired
+    TestActive<NewPatientAddressInput> newRequest;
+
+    @Autowired
+    TestActive<UpdatePatientAddressInput> updateRequest;
+
     @Given("the patient has an address")
     public void the_patient_has_an_address() {
         mother.withAddress(patients.one());
@@ -81,7 +88,7 @@ public class PatientProfileAddressSteps {
             assertThat(addresses)
                 .satisfiesExactlyInAnyOrder(PatientCreateAssertions.containsAddresses(input.active().getAddresses()));
         }
-
+        
     }
 
     @Then("the profile has associated addresses")
@@ -90,10 +97,66 @@ public class PatientProfileAddressSteps {
 
         PatientProfile profile = new PatientProfile(patient, "local", (short) 1, RecordStatus.ACTIVE.toString());
 
-        GraphQLPage page = new GraphQLPage(1);
+        GraphQLPage page = new GraphQLPage(5);
 
         Page<PatientAddress> actual = this.resolver.resolve(profile, page);
         assertThat(actual).isNotEmpty();
+    }
+
+    @Then("the patient profile has the new address")
+    public void the_patient_profile_has_the_new_address() {
+        PatientIdentifier patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient.id(), patient.local(), (short) patient.shortId());
+
+        GraphQLPage page = new GraphQLPage(5);
+
+        NewPatientAddressInput input = newRequest.active();
+
+        Page<PatientAddress> found = this.resolver.resolve(profile, page);
+
+        assertThat(found).anySatisfy(
+            actual -> assertThat(actual)
+                .returns(input.type(), i -> i.type().id())
+                .returns(input.use(), i -> i.use().id())
+                .returns(input.asOf(), PatientAddress::asOf)
+                .returns(input.address1(), PatientAddress::address1)
+                .returns(input.address2(), PatientAddress::address2)
+                .returns(input.city(), PatientAddress::city)
+                .returns(input.state(), i -> i.state().id())
+                .returns(input.county(), i -> i.county().id())
+                .returns(input.zipcode(), PatientAddress::zipcode)
+                .returns(input.country(), i -> i.country().id())
+                .returns(input.censusTract(), PatientAddress::censusTract)
+        );
+    }
+
+    @Then("the patient profile has the expected address")
+    public void the_patient_profile_has_the_expected_address() {
+        PatientIdentifier patient = this.patients.one();
+
+        PatientProfile profile = new PatientProfile(patient.id(), patient.local(), (short) patient.shortId());
+
+        GraphQLPage page = new GraphQLPage(5);
+
+        UpdatePatientAddressInput input = updateRequest.active();
+
+        Page<PatientAddress> found = this.resolver.resolve(profile, page);
+
+        assertThat(found).anySatisfy(
+            actual -> assertThat(actual)
+                .returns(input.type(), i -> i.type().id())
+                .returns(input.use(), i -> i.use().id())
+                .returns(input.asOf(), PatientAddress::asOf)
+                .returns(input.address1(), PatientAddress::address1)
+                .returns(input.address2(), PatientAddress::address2)
+                .returns(input.city(), PatientAddress::city)
+                .returns(input.state(), i -> i.state().id())
+                .returns(input.county(), i -> i.county().id())
+                .returns(input.zipcode(), PatientAddress::zipcode)
+                .returns(input.country(), i -> i.country().id())
+                .returns(input.censusTract(), PatientAddress::censusTract)
+        );
     }
 
     @Then("the profile has no associated addresses")
@@ -102,7 +165,7 @@ public class PatientProfileAddressSteps {
 
         PatientProfile profile = new PatientProfile(patient, "local", (short) 1, RecordStatus.ACTIVE.toString());
 
-        GraphQLPage page = new GraphQLPage(1);
+        GraphQLPage page = new GraphQLPage(5);
 
         Page<PatientAddress> actual = this.resolver.resolve(profile, page);
         assertThat(actual).isEmpty();
@@ -115,7 +178,7 @@ public class PatientProfileAddressSteps {
 
         PatientProfile profile = new PatientProfile(patient, "local", (short) 1, RecordStatus.ACTIVE.toString());
 
-        GraphQLPage page = new GraphQLPage(1);
+        GraphQLPage page = new GraphQLPage(5);
 
         assertThatThrownBy(
             () -> this.resolver.resolve(profile, page)

--- a/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileAddressChange.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileAddressChange.feature
@@ -8,14 +8,14 @@ Feature: Patient Profile Address Changes
     Given I am logged into NBS
     And I have the authorities: "FIND-PATIENT,EDIT-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
     When a patient's address is added
-    Then the patient has the new address
+    Then the patient profile has the new address
 
   Scenario: I can update a patient's existing address
     Given I am logged into NBS
     And I have the authorities: "FIND-PATIENT,EDIT-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
     And the patient has an address
     When a patient's address is changed
-    Then the patient has the expected address
+    Then the patient profile has the expected address
 
   Scenario: I can remove a patient's existing address
     Given I am logged into NBS
@@ -23,6 +23,7 @@ Feature: Patient Profile Address Changes
     And the patient has an address
     When a patient's address is removed
     Then the patient does not have the expected address
+    And the profile has no associated addresses
 
   Scenario: I cannot add a patient's address without proper permission
     Given I am logged into NBS


### PR DESCRIPTION
Resolves [CNFT1-1179](https://cdc-nbs.atlassian.net/browse/CNFT1-1179) by ensuring that the Patient Address finder uses the same County list that is used when adding or updating a Patient's Address.  

The Patient Address finder was pulling county names from the `PHVS_COUNTY_FIPS_6-4` Code Set instead of the `State_County_Code_Value` table.