### PR TITLE
CNFT1-1180 removes formatting from County, State, and Country lists

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountryCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountryCodedValueFinder.java
@@ -34,7 +34,7 @@ class CountryCodedValueFinder {
 
     private CodedValue map(final Tuple tuple) {
         String value = tuple.get(values.id);
-        String name = StandardNameFormatter.formatted(tuple.get(values.codeDescTxt));
+        String name = tuple.get(values.codeDescTxt);
         return new CodedValue(value, name);
     }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountyCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/CountyCodedValueFinder.java
@@ -48,7 +48,7 @@ class CountyCodedValueFinder {
 
     private GroupedCodedValue map(final Tuple tuple) {
         String value = tuple.get(values.id);
-        String name = StandardNameFormatter.formatted(tuple.get(values.codeDescTxt));
+        String name = tuple.get(values.codeDescTxt);
         String group = tuple.get(values.parentIsCd);
         return new GroupedCodedValue(value, name, group);
     }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/StateCodedValueFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/codes/StateCodedValueFinder.java
@@ -34,7 +34,7 @@ class StateCodedValueFinder {
 
     private CodedValue map(final Tuple tuple) {
         String value = tuple.get(values.id);
-        String name = StandardNameFormatter.formatted(tuple.get(values.codeDescTxt));
+        String name = tuple.get(values.codeDescTxt);
         return new CodedValue(value, name);
     }
 }


### PR DESCRIPTION
Addresses [CNFT1-1180](https://cdc-nbs.atlassian.net/browse/CNFT1-1180) by removing the `StandardNameFormatter` from the county, state, and country lists.  This will allow the lists to be returned the way they are entered in the database.

[CNFT1-1180]: https://cdc-nbs.atlassian.net/browse/CNFT1-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ