### PR TITLE
Hide new login page. Redirect to NBS logout page

### DIFF
--- a/apps/modernization-ui/src/config.js
+++ b/apps/modernization-ui/src/config.js
@@ -3,13 +3,15 @@ const prod = {
         ? process.env.REACT_APP_NBS_URL
         : `${window.location.protocol}//${window.location.host}/nbs`,
     modernizationUrl: `${window.location.protocol}//${window.location.host}`,
-    pageBuilderUrl: `${window.location.protocol}//${window.location.host}`
+    pageBuilderUrl: `${window.location.protocol}//${window.location.host}`,
+    enableLogin: false
 };
 
 const dev = {
     nbsUrl: `${window.location.protocol}//${window.location.host}/nbs`,
     modernizationUrl: `${window.location.protocol}//${window.location.host}`,
-    pageBuilderUrl: `${window.location.protocol}//${window.location.host}`
+    pageBuilderUrl: `${window.location.protocol}//${window.location.host}`,
+    enableLogin: true
 };
 
 // eslint-disable-next-line no-undef

--- a/apps/modernization-ui/src/index.tsx
+++ b/apps/modernization-ui/src/index.tsx
@@ -12,19 +12,19 @@ import NavBar from './shared/header/NavBar';
 
 ReactDOM.render(
     <React.StrictMode>
-        <UserContextProvider>
-            <ApolloWrapper>
-                <SearchCriteriaProvider>
-                    <BrowserRouter>
+        <BrowserRouter>
+            <UserContextProvider>
+                <ApolloWrapper>
+                    <SearchCriteriaProvider>
                         {/* <TopBanner /> */}
                         <NavBar />
                         <div className="route-content">
                             <AppRoutes />
                         </div>
-                    </BrowserRouter>
-                </SearchCriteriaProvider>
-            </ApolloWrapper>
-        </UserContextProvider>
+                    </SearchCriteriaProvider>
+                </ApolloWrapper>
+            </UserContextProvider>
+        </BrowserRouter>
     </React.StrictMode>,
     document.getElementById('root')
 );

--- a/apps/modernization-ui/src/providers/UserContext.tsx
+++ b/apps/modernization-ui/src/providers/UserContext.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
 import { ApiError } from '../generated';
 import { UserControllerService } from '../generated/services/UserControllerService';
+import { Config } from 'config';
+import { useNavigate } from 'react-router-dom';
 const USER_ID = 'nbs_user=';
 const TOKEN = 'nbs_token=';
 
@@ -57,6 +59,7 @@ export const UserContext = React.createContext<{
 });
 
 export const UserContextProvider = (props: any) => {
+    const nav = useNavigate();
     const [state, setState] = React.useState({ ...initialState });
     const setLoginPending = (isLoginPending: boolean) => setState({ ...state, isLoginPending, loginError: undefined });
     const setLoginSuccess = (userId: string, displayName: string) =>
@@ -86,8 +89,15 @@ export const UserContextProvider = (props: any) => {
         // delete cookies
         document.cookie = USER_ID + '=; Max-Age=0; path=/;';
         document.cookie = TOKEN + '=; Max-Age=0; path=/;';
-        // reset state
-        setState({ ...initialState });
+        // load appropriate page
+        if (Config.enableLogin) {
+            // reset state
+            setState({ ...initialState });
+            nav('/dev/login');
+        } else {
+            // loading external page will clear state
+            window.location.href = `${Config.nbsUrl}/logOut`;
+        }
     };
 
     // on init attempt to login using USER_ID cookie

--- a/apps/modernization-ui/src/routes/AppRoutes.tsx
+++ b/apps/modernization-ui/src/routes/AppRoutes.tsx
@@ -11,6 +11,7 @@ import { Spinner } from 'components/Spinner/Spinner';
 import { CompareInvestigations } from 'pages/CompareInvestigations/CompareInvestigations';
 import { AddedPatient } from 'pages/addPatient/components/SuccessForm/AddedPatient';
 import PageBuilderContextProvider from 'apps/page-builder/context/PageBuilderContext';
+import { Config } from 'config';
 
 const ScrollToTop = ({ children }: { children: ReactNode }) => {
     const location = useLocation();
@@ -24,7 +25,7 @@ const ScrollToTop = ({ children }: { children: ReactNode }) => {
 export const AppRoutes = () => {
     const { state } = useContext(UserContext);
     const location = useLocation();
-    const [loading, setLoading] = useState(location.pathname !== '/login'); // allow login page to load immediately
+    const [loading, setLoading] = useState(location.pathname !== '/dev/login'); // allow login page to load immediately
     const [initializing, setInitializing] = useState(true);
 
     useEffect(() => {
@@ -73,10 +74,24 @@ export const AppRoutes = () => {
                             <Route path="/" element={<Navigate to="/advanced-search" />} />
                         </>
                     )}
-                    {!state.isLoggedIn && !state.isLoginPending && !loading && (
-                        <Route path="*" element={<Navigate to="/login" />} />
+
+                    {Config.enableLogin && (
+                        <>
+                            {!state.isLoggedIn && !state.isLoginPending && !loading && (
+                                <>
+                                    <Route path="/dev/login" element={<Login />} />
+                                    <Route path="*" element={<Navigate to="/dev/login" />} />
+                                </>
+                            )}
+                        </>
                     )}
-                    <Route path="/login" element={<Login />} />
+                    {!Config.enableLogin && (
+                        <>
+                            {!state.isLoggedIn && !state.isLoginPending && !loading && (
+                                <Route path="*" element={<>{(window.location.href = `${Config.nbsUrl}/login`)}</>} />
+                            )}
+                        </>
+                    )}
                 </Routes>
             </ScrollToTop>
         </>

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Config } from '../../config';
 import { UserContext } from '../../providers/UserContext';
 import './NavBar.scss';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 // eslint-disable-next-line no-undef
 const NBS_URL = Config.nbsUrl;
@@ -10,9 +10,7 @@ const NBS_URL = Config.nbsUrl;
 export default function NavBar() {
     const { state, logout } = useContext(UserContext);
     const location = useLocation();
-    const nav = useNavigate();
     const logoutClick = () => {
-        nav('/login');
         logout();
     };
     return (

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/config/WebSecurityConfig.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/config/WebSecurityConfig.java
@@ -1,6 +1,5 @@
 package gov.cdc.nbs.questionbank.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
@@ -25,9 +24,6 @@ import lombok.RequiredArgsConstructor;
 @EntityScan({"gov.cdc.nbs.questionbank"})
 public class WebSecurityConfig {
     private final JWTFilter jwtFilter;
-
-    @Value("${server.servlet.context-path:}")
-    private String contextPath;
 
     @Bean
     @SuppressWarnings("squid:S4502")


### PR DESCRIPTION
1. Hide modernized login page behind config.
2. When logout is clicked, redirect to `/nbs/logOut` to match legacy
