### PR TITLE
Add `programJurisdictionOid` check to investigation query

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/SecurityService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/SecurityService.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import gov.cdc.nbs.authentication.NbsUserDetails;
+import gov.cdc.nbs.config.security.SecurityUtil;
 import gov.cdc.nbs.repository.JurisdictionCodeRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -13,6 +14,10 @@ import lombok.RequiredArgsConstructor;
 public class SecurityService {
     private static final String ALL = "ALL";
     private final JurisdictionCodeRepository jurisdictionCodeRepository;
+
+    public Set<Long> getCurrentUserProgramAreaJurisdictionOids() {
+        return getProgramAreaJurisdictionOids(SecurityUtil.getUserDetails());
+    }
 
     /**
      * Returns a Set of Ids that are a combination of ProgramAreas and Jurisdictions the user has access to. These are

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/service/SecurityService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/service/SecurityService.java
@@ -21,18 +21,19 @@ public class SecurityService {
     public Set<Long> getProgramAreaJurisdictionOids(NbsUserDetails userDetails) {
         var jurisdictionCodes = jurisdictionCodeRepository.findAll();
         var oidsUserHasAccessTo = new HashSet<Long>();
-        userDetails.getAuthorities().forEach(e -> {
-            if (e.getJurisdiction().equals(ALL)) {
+        userDetails.getAuthorities().forEach(authority -> {
+            if (authority.getJurisdiction().equals(ALL)) {
                 // for each existing jurisdiction, create an Oid with the program area
                 oidsUserHasAccessTo
-                        .addAll(jurisdictionCodes.stream().map(jc -> generateOid(jc.getNbsUid(), e.getProgramAreaUid()))
+                        .addAll(jurisdictionCodes.stream()
+                                .map(jc -> generateOid(jc.getNbsUid(), authority.getProgramAreaUid()))
                                 .collect(Collectors.toSet()));
             } else {
                 // generate an Oid for the jurisdiction and program area
                 jurisdictionCodes.stream()
-                        .filter(jc -> jc.getId().equals(e.getJurisdiction()))
+                        .filter(jc -> jc.getId().equals(authority.getJurisdiction()))
                         .findFirst()
-                        .map(jc -> generateOid(jc.getNbsUid(), e.getProgramAreaUid()))
+                        .map(jc -> generateOid(jc.getNbsUid(), authority.getProgramAreaUid()))
                         .ifPresent(oidsUserHasAccessTo::add);
             }
         });

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/investigation/InvestigationMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/investigation/InvestigationMother.java
@@ -25,12 +25,11 @@ public class InvestigationMother {
     private final TestInvestigationCleaner cleaner;
 
     public InvestigationMother(
-        final MotherSettings settings,
-        final TestUniqueIdGenerator idGenerator,
-        final EntityManager entityManager,
-        final TestInvestigations investigations,
-        final TestInvestigationCleaner cleaner
-    ) {
+            final MotherSettings settings,
+            final TestUniqueIdGenerator idGenerator,
+            final EntityManager entityManager,
+            final TestInvestigations investigations,
+            final TestInvestigationCleaner cleaner) {
         this.idGenerator = idGenerator;
         this.settings = settings;
         this.entityManager = entityManager;
@@ -53,8 +52,9 @@ public class InvestigationMother {
         investigation.setAddTime(settings.createdOn());
         investigation.setAddUserId(settings.createdBy());
 
-        investigation.setCd("42060");   // other injury
-        investigation.setJurisdictionCd("999999");    // out of system
+        investigation.setCd("42060"); // other injury
+        investigation.setJurisdictionCd("999999"); // out of system
+        investigation.setProgramJurisdictionOid(1300600015L); // Clayton county + STD
 
         subjectOf(investigation.getAct(), subject);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigationResolverTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigationResolverTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.patient.profile.investigation;
 
 import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.patient.profile.investigation.PatientInvestigationFinder.Criteria;
+import gov.cdc.nbs.service.SecurityService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.Page;
@@ -22,6 +23,7 @@ class PatientInvestigationResolverTest {
     void should_find_paginated_investigations_for_the_provided_patient_using_the_finder() {
 
         PatientInvestigationFinder finder = mock(PatientInvestigationFinder.class);
+        SecurityService securityService = mock(SecurityService.class);
 
         when(finder.find(any(), any()))
             .thenAnswer(args -> new PageImpl<>(
@@ -31,7 +33,7 @@ class PatientInvestigationResolverTest {
                 )
             );
 
-        PatientInvestigationResolver resolver = new PatientInvestigationResolver(25, finder);
+        PatientInvestigationResolver resolver = new PatientInvestigationResolver(25, finder, securityService);
 
         GraphQLPage page = new GraphQLPage(25, 2);
 
@@ -67,6 +69,7 @@ class PatientInvestigationResolverTest {
     void should_find_paginated_open_investigations_for_the_provided_patient_using_the_finder() {
 
         PatientInvestigationFinder finder = mock(PatientInvestigationFinder.class);
+        SecurityService securityService = mock(SecurityService.class);
 
         when(finder.find(any(), any()))
             .thenAnswer(args -> new PageImpl<>(
@@ -76,7 +79,7 @@ class PatientInvestigationResolverTest {
                 )
             );
 
-        PatientInvestigationResolver resolver = new PatientInvestigationResolver(25, finder);
+        PatientInvestigationResolver resolver = new PatientInvestigationResolver(25, finder, securityService);
 
         GraphQLPage page = new GraphQLPage(25, 2);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/service/SecurityServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/service/SecurityServiceTest.java
@@ -1,0 +1,163 @@
+package gov.cdc.nbs.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import gov.cdc.nbs.authentication.NbsAuthority;
+import gov.cdc.nbs.authentication.NbsUserDetails;
+import gov.cdc.nbs.entity.srte.JurisdictionCode;
+import gov.cdc.nbs.repository.JurisdictionCodeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityServiceTest {
+
+    @Mock
+    private JurisdictionCodeRepository jurisdictionCodeRepository;
+
+    @InjectMocks
+    private SecurityService securityService;
+
+
+    @Test
+    void should_return_oids_for_all_jurisdiction() {
+        // given two jurisdictions exist
+        when(jurisdictionCodeRepository.findAll()).thenReturn(Arrays.asList(fultonCounty(), gwinnettCounty()));
+
+        // and the program area id 1 and the jurisdiciton "ALL"
+        NbsUserDetails userDetails = userDetails(allProgramAreas());
+
+        // when compiling program_jurisdiction_oids
+        Set<Long> oids = securityService.getProgramAreaJurisdictionOids(userDetails);
+
+        // then the expected oids are returned
+        assertNotNull(oids);
+        assertTrue(oids.size() == 2);
+        assertTrue(oids.contains(1300100095L));
+        assertTrue(oids.contains(1300300095L));
+    }
+
+    @Test
+    void should_return_oids_for_specific_jurisdiction() {
+        // given two jurisdictions exist
+        when(jurisdictionCodeRepository.findAll()).thenReturn(Arrays.asList(fultonCounty(), gwinnettCounty()));
+
+        // and the program area id 1 and the jurisdiciton "ALL"
+        NbsUserDetails userDetails = userDetails(oneProgramArea());
+
+        // when compiling program_jurisdiction_oids
+        Set<Long> oids = securityService.getProgramAreaJurisdictionOids(userDetails);
+
+        // then the expected oids are returned
+        assertNotNull(oids);
+        assertTrue(oids.size() == 1);
+        assertTrue(oids.contains(1300100095L));
+    }
+
+    private JurisdictionCode fultonCounty() {
+        Instant now = Instant.now();
+        return new JurisdictionCode(
+                "130001",
+                "ALL",
+                "GA",
+                "GA State",
+                "Fulton County",
+                "Fulton County",
+                now,
+                null,
+                (short) 1,
+                'Y',
+                null,
+                "13",
+                "A",
+                now,
+                "S_JURDIC_C",
+                (short) 1,
+                13001,
+                null,
+                "L",
+                "Local",
+                null,
+                null);
+    }
+
+    private JurisdictionCode gwinnettCounty() {
+        Instant now = Instant.now();
+        return new JurisdictionCode(
+                "130002",
+                "ALL",
+                "GA",
+                "GA State",
+                "Gwinnett County",
+                "Gwinnett County",
+                now,
+                null,
+                (short) 1,
+                'Y',
+                null,
+                "13",
+                "A",
+                now,
+                "S_JURDIC_C",
+                (short) 1,
+                13003,
+                null,
+                "L",
+                "Local",
+                null,
+                null);
+    }
+
+    private NbsUserDetails userDetails(Set<NbsAuthority> authorities) {
+        return new NbsUserDetails(
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                null,
+                null,
+                authorities,
+                null,
+                false);
+    }
+
+
+    private Set<NbsAuthority> allProgramAreas() {
+        Set<NbsAuthority> authorities = new HashSet<>();
+
+        authorities.add(new NbsAuthority(
+                null,
+                null,
+                null,
+                95,
+                "ALL",
+                null));
+
+        return authorities;
+    }
+
+    private Set<NbsAuthority> oneProgramArea() {
+        Set<NbsAuthority> authorities = new HashSet<>();
+
+        authorities.add(new NbsAuthority(
+                null,
+                null,
+                null,
+                95,
+                "130001",
+                null));
+
+        return authorities;
+    }
+
+}


### PR DESCRIPTION
[BBJ12-3](https://cdc-nbs.atlassian.net/browse/BBJ12-3)

Investigations displayed on a patient profile do not check for user program area / jurisdictions. This was causing Classic™ to throw an error when trying to view the investigation details for an investigation the user should not have access to.


Pertusis Investigation:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/88d8e6ba-c828-4823-8397-5cfaf2547afd)


After fix:

User lacks `VPD` program area:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/8f4b53cd-9737-4d26-a9e3-5c63d5be828a)


After adding `VPD` program area to user:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/116ae919-a8cf-4ef5-bca0-997cd58ea312)


[BBJ12-3]: https://cdc-nbs.atlassian.net/browse/BBJ12-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ