### PR TITLE
BBJ12-34 / ensure identifications are indexed when added to a patient

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatientConverter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatientConverter.java
@@ -4,9 +4,11 @@ package gov.cdc.nbs.patient.search;
 import gov.cdc.nbs.entity.elasticsearch.ElasticsearchPerson;
 import gov.cdc.nbs.entity.elasticsearch.NestedAddress;
 import gov.cdc.nbs.entity.elasticsearch.NestedEmail;
+import gov.cdc.nbs.entity.elasticsearch.NestedEntityId;
 import gov.cdc.nbs.entity.elasticsearch.NestedName;
 import gov.cdc.nbs.entity.elasticsearch.NestedPhone;
 import gov.cdc.nbs.entity.elasticsearch.NestedRace;
+import gov.cdc.nbs.entity.odse.EntityId;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.entity.odse.PostalEntityLocatorParticipation;
 import gov.cdc.nbs.entity.odse.PostalLocator;
@@ -55,6 +57,7 @@ class SearchablePatientConverter {
                 .asOfDateAdmin(person.getAsOfDateAdmin())
                 .asOfDateSex(person.getAsOfDateSex())
                 .description(person.getDescription())
+                .entityId(asIdentifications(person))
                 .build();
     }
 
@@ -163,6 +166,21 @@ class SearchablePatientConverter {
                 .cntyCd(locator.getCntyCd())
                 .cntryCd(locator.getCntryCd())
                 .build();
+    }
+
+    private static List<NestedEntityId> asIdentifications(final Person person) {
+        return person.identifications()
+            .stream()
+            .map(SearchablePatientConverter::asIdentification)
+            .toList();
+    }
+
+    private static NestedEntityId asIdentification(final EntityId identification) {
+        return new NestedEntityId(
+            identification.getRecordStatusCd(),
+            identification.getRootExtensionTxt(),
+            identification.getTypeCd()
+        );
     }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/SearchablePatientConverterTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/SearchablePatientConverterTest.java
@@ -1,0 +1,59 @@
+package gov.cdc.nbs.patient.search;
+
+import gov.cdc.nbs.entity.elasticsearch.ElasticsearchPerson;
+import gov.cdc.nbs.entity.elasticsearch.NestedEntityId;
+import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.patient.PatientCommand;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchablePatientConverterTest {
+
+    @Test
+    void should_convert_patient() {
+        Person patient = new Person(1157L, "local");
+
+        ElasticsearchPerson searchable = SearchablePatientConverter.toSearchable(patient);
+
+        assertThat(searchable)
+            .returns("1157", ElasticsearchPerson::getId)
+            .returns(1157L, ElasticsearchPerson::getPersonUid)
+            .returns("local", ElasticsearchPerson::getLocalId)
+            .satisfies(
+                actual -> assertThat(actual.getEntityId()).isEmpty()
+            )
+        ;
+    }
+
+    @Test
+    void should_convert_patient_with_identifications() {
+
+        Person patient = new Person(1157L, "local");
+
+        patient.add(
+            new PatientCommand.AddIdentification(
+                1157L,
+                Instant.parse("1999-09-09T11:59:13Z"),
+                "identification-value",
+                "authority-value",
+                "identification-type",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        ElasticsearchPerson searchable = SearchablePatientConverter.toSearchable(patient);
+
+        assertThat(searchable.getEntityId()).satisfiesExactlyInAnyOrder(
+            actual -> assertThat(actual)
+                .returns("identification-value", NestedEntityId::getRootExtensionTxt)
+                .returns("identification-type", NestedEntityId::getTypeCd)
+                .returns("ACTIVE", NestedEntityId::getRecordStatusCd)
+        );
+    }
+
+
+}


### PR DESCRIPTION
Resolves [BBJ12-34](https://cdc-nbs.atlassian.net/browse/BBJ12-34) by adding Identifications to the `SearchablePatietnConverter` so that changes to a patient's identifications are reflected when searching.

[BBJ12-34]: https://cdc-nbs.atlassian.net/browse/BBJ12-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ