### PR TITLE
Update to use condition name in search instead of Id

### DIFF
--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
@@ -716,7 +716,7 @@ export const AdvancedSearch = () => {
             case 'Conditions':
                 return (
                     searchCriteria.conditions.find((element) => {
-                        return element.id === re.value;
+                        return element.conditionDescTxt === re.value;
                     })?.conditionDescTxt || ''
                 );
             case 'Created By':

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.tsx
@@ -184,7 +184,7 @@ export const EventSearch = ({ onSearch, investigationFilter, labReportFilter, cl
         let filterData: InvestigationFilter | LabReportFilter = {};
         if (eventSearchType === SEARCH_TYPE.INVESTIGATION) {
             filterData = {
-                conditions: body.conditon?.length > 0 ? body.conditon : undefined,
+                conditions: body.condition?.length > 0 ? body.condition : undefined,
                 jurisdictions: body.jurisdiction?.length > 0 ? body.jurisdiction : undefined,
                 pregnancyStatus:
                     body.pregnancyTest && body.pregnancyTest !== '- Select -' ? body.pregnancyTest : undefined,

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/GeneralSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/GeneralSearch.tsx
@@ -31,12 +31,12 @@ export const GeneralSearch = ({ control, filter }: GeneralSearchProps) => {
                         <MultiSelectControl
                             defaultValue={filter?.conditions}
                             control={control}
-                            name="conditon"
+                            name="condition"
                             label="Condition"
                             options={searchCriteria.conditions.map((c) => {
                                 return {
                                     label: c.conditionDescTxt,
-                                    value: c.id
+                                    value: c.conditionDescTxt
                                 };
                             })}
                         />


### PR DESCRIPTION
The condition names are indexed into ES:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/3d0af40e-d694-4dd3-80d2-11cfa0685790)

So we need to search by name not by Id for conditions. There is an ongoing effort to move away from Elasticsearch for Investigation queries so I did not update the indexing to include the Ids

Post fix:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/f1c3b368-76bc-4b56-88e3-28aae874083d)
