### PR TITLE
enhances the log message created when directly invoking the classic a…

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicContext.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicContext.java
@@ -1,5 +1,7 @@
 package gov.cdc.nbs.redirect.outgoing;
 
 public interface ClassicContext {
+    String host();
+    String user();
     String session();
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicContextConfiguration.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicContextConfiguration.java
@@ -11,11 +11,16 @@ import javax.servlet.http.HttpServletRequest;
 @Configuration
 class ClassicContextConfiguration {
 
+    private static final String SESSION_COOKIE_NAME = "JSESSIONID";
+    private static final String NBS_USER_COOKIE_NAME = "nbs_user";
+
     @Bean
     @RequestScope
     ClassicContext classicContext(final HttpServletRequest request) {
+        String host = request.getRemoteHost();
         String session = resolveSessionIdentifier(request.getCookies());
-        return new DefaultClassicContext(session);
+        String user = resolveUser(request.getCookies());
+        return new DefaultClassicContext(host, user, session);
     }
 
     private String resolveSessionIdentifier(final Cookie[] cookies) {
@@ -23,10 +28,23 @@ class ClassicContextConfiguration {
             return null;
         }
         for (var cookie : cookies) {
-            if (cookie.getName().equals("JSESSIONID")) {
-                return cookie.getName() + "=" + cookie.getValue() + "; ";
+            if (cookie.getName().equals(SESSION_COOKIE_NAME)) {
+                return cookie.getValue();
             }
         }
         return null;
     }
+
+    private String resolveUser(final Cookie[] cookies) {
+        if (cookies == null) {
+            return null;
+        }
+        for (var cookie : cookies) {
+            if (cookie.getName().equals(NBS_USER_COOKIE_NAME)) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+    
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicOutgoingAuthenticationRequestInterceptor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicOutgoingAuthenticationRequestInterceptor.java
@@ -10,11 +10,11 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
-class ClassicOutgoingRequestInterceptor implements ClientHttpRequestInterceptor {
+class ClassicOutgoingAuthenticationRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private final ClassicContext context;
 
-    ClassicOutgoingRequestInterceptor(final ClassicContext context) {
+    ClassicOutgoingAuthenticationRequestInterceptor(final ClassicContext context) {
         this.context = context;
     }
 
@@ -25,7 +25,11 @@ class ClassicOutgoingRequestInterceptor implements ClientHttpRequestInterceptor 
         final ClientHttpRequestExecution execution
     )
         throws IOException {
-        request.getHeaders().add(HttpHeaders.COOKIE, context.session());
+        request.getHeaders().add(HttpHeaders.COOKIE, resolveSessionCookie(context));
         return execution.execute(request, body);
+    }
+
+    private String resolveSessionCookie(final ClassicContext context) {
+        return "JSESSIONID=" + context.session() + ";";
     }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicOutgoingLoggingHttpRequestInterceptor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicOutgoingLoggingHttpRequestInterceptor.java
@@ -2,10 +2,12 @@ package gov.cdc.nbs.redirect.outgoing;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
@@ -13,9 +15,16 @@ import java.io.IOException;
  * A {@link ClientHttpRequestInterceptor} that adds basic logging to any requests made to the classic NBS application to
  * the {@code nbs.classic.outgoing} Logger.
  */
+@Component
 class ClassicOutgoingLoggingHttpRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private static final Logger LOG = LoggerFactory.getLogger("nbs.classic.outgoing");
+
+    private final ClassicContext context;
+
+    ClassicOutgoingLoggingHttpRequestInterceptor(final ClassicContext context) {
+        this.context = context;
+    }
 
     @Override
     public ClientHttpResponse intercept(
@@ -28,13 +37,18 @@ class ClassicOutgoingLoggingHttpRequestInterceptor implements ClientHttpRequestI
 
         if (LOG.isDebugEnabled()) {
 
+            String host = request.getURI().getHost();
             String path = request.getURI().getRawPath();
 
             LOG.debug(
-                "{} {}\tResponse: {}",
+                "\n\t{}\n\t{} {} {}\n\tHeaders:\n\t\t{}\n\tResponse: {}\n\tHeaders:\n\t\t{}",
+                context,
+                host,
                 request.getMethodValue(),
                 path,
-                response.getStatusCode()
+                request.getHeaders(),
+                response.getStatusCode(),
+                response.getHeaders()
             );
         }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicRestTemplateConfiguration.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicRestTemplateConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.MalformedURLException;
@@ -21,6 +22,7 @@ class ClassicRestTemplateConfiguration {
 
         return new RestTemplateBuilder()
             .rootUri(resolver.base().toURL().toString())
+            .defaultHeader(HttpHeaders.CONNECTION, "Close")
             .additionalInterceptors(loggingInterceptor, authenticationInterceptor)
             .build();
     }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicRestTemplateConfiguration.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/ClassicRestTemplateConfiguration.java
@@ -15,12 +15,13 @@ class ClassicRestTemplateConfiguration {
     @Qualifier("classic")
     RestTemplate classicRestTemplate(
         final ClassicPathResolver resolver,
-        final ClassicOutgoingRequestInterceptor interceptor
+        final ClassicOutgoingAuthenticationRequestInterceptor authenticationInterceptor,
+        final ClassicOutgoingLoggingHttpRequestInterceptor loggingInterceptor
     ) throws MalformedURLException {
 
         return new RestTemplateBuilder()
             .rootUri(resolver.base().toURL().toString())
-            .additionalInterceptors(new ClassicOutgoingLoggingHttpRequestInterceptor(), interceptor)
+            .additionalInterceptors(loggingInterceptor, authenticationInterceptor)
             .build();
     }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/DefaultClassicContext.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/outgoing/DefaultClassicContext.java
@@ -1,4 +1,4 @@
 package gov.cdc.nbs.redirect.outgoing;
 
-public record DefaultClassicContext(String session) implements ClassicContext {
+public record DefaultClassicContext(String host, String user, String session) implements ClassicContext {
 }


### PR DESCRIPTION
Adds more information to the log message produced when the modernized-api is communicating directly with the classic application.  This communication only occurs when "preparing" the session in the classic application to be able to navigate seamlessly from the modernized application to the desired page in the classic application.

The log message will now look as follows;

```text
2023-07-27 10:32:29.005 DEBUG 46656 --- [nio-9080-exec-7] nbs.classic.outgoing                     : 
        DefaultClassicContext[host=127.0.0.1, user=aloup, session=SzxfUTfkDtnL2UO0dzGv4kZwctuKE68Ks_szsxxd.ff08180b3365]
        GET /nbs/PatientSearchResults1.do
        Headers:
                [JSESSIONID=SzxfUTfkDtnL2UO0dzGv4kZwctuKE68Ks_szsxxd.ff08180b3365;]
        Response: 200 OK
```