### PR TITLE
BBJ12-40 Returns Investigation started on as a LocalDate

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigation.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigation.java
@@ -1,10 +1,10 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
-import java.time.Instant;
+import java.time.LocalDate;
 
 record PatientInvestigation(
     long investigation,
-    Instant startedOn,
+    LocalDate startedOn,
     String condition,
     String status,
     String caseStatus,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigationTupleMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigationTupleMapper.java
@@ -9,6 +9,8 @@ import gov.cdc.nbs.entity.srte.QJurisdictionCode;
 import gov.cdc.nbs.patient.NameRenderer;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Objects;
 
 class PatientInvestigationTupleMapper {
@@ -50,7 +52,7 @@ class PatientInvestigationTupleMapper {
             "An investigation identifier is required."
         );
 
-        Instant startedOn = tuple.get(tables.investigation().activityFromTime);
+        LocalDate startedOn = resolveStartedOn(tuple);
         String condition = tuple.get(tables.condition().conditionShortNm);
         String status = tuple.get(tables.status().codeShortDescTxt);
         String caseStatus = tuple.get(tables.caseStatus().codeShortDescTxt);
@@ -73,6 +75,16 @@ class PatientInvestigationTupleMapper {
             notification,
             investigator
         );
+    }
+
+    private LocalDate resolveStartedOn(final Tuple tuple) {
+
+        Instant value = tuple.get(tables.investigation().activityFromTime);
+
+        return value == null
+            ? null
+            : LocalDate.ofInstant(value, ZoneId.of("UTC"));
+
     }
 
     private String mapInvestigator(final Tuple tuple) {

--- a/apps/modernization-api/src/main/resources/graphql/patient-investigation.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-investigation.graphqls
@@ -1,6 +1,6 @@
 type PatientInvestigation {
     investigation: ID!
-    startedOn: DateTime
+    startedOn: Date
     condition: String!
     status: String!
     caseStatus: String

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigationTupleMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientInvestigationTupleMapperTest.java
@@ -44,7 +44,7 @@ class PatientInvestigationTupleMapperTest {
         PatientInvestigation actual = mapper.map(tuple);
 
         assertThat(actual.investigation()).isEqualTo(1787L);
-        assertThat(actual.startedOn()).isEqualTo("2022-06-07T12:01:47Z");
+        assertThat(actual.startedOn()).isEqualTo("2022-06-07");
         assertThat(actual.condition()).isEqualTo("condition");
         assertThat(actual.status()).isEqualTo("status");
         assertThat(actual.caseStatus()).isEqualTo("case-status");

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -1372,7 +1372,7 @@ export type PatientInvestigation = {
   investigator?: Maybe<Scalars['String']>;
   jurisdiction: Scalars['String'];
   notification?: Maybe<Scalars['String']>;
-  startedOn?: Maybe<Scalars['DateTime']>;
+  startedOn?: Maybe<Scalars['Date']>;
   status: Scalars['String'];
 };
 

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -835,7 +835,7 @@ extend type Query {
 }
 type PatientInvestigation {
     investigation: ID!
-    startedOn: DateTime
+    startedOn: Date
     condition: String!
     status: String!
     caseStatus: String

--- a/apps/modernization-ui/src/pages/patient/profile/investigation/PatientInvestigationTransformer.spec.ts
+++ b/apps/modernization-ui/src/pages/patient/profile/investigation/PatientInvestigationTransformer.spec.ts
@@ -65,7 +65,7 @@ describe('when the result has content', () => {
                 }),
                 expect.objectContaining({
                     investigation: '829',
-                    startedOn: new Date('2023-03-27T00:00:00Z'),
+                    startedOn: new Date('2023-03-27T05:00:00Z'),
                     condition: 'condition-829',
                     status: 'status-829',
                     caseStatus: 'case-status-829',

--- a/apps/modernization-ui/src/pages/patient/profile/investigation/PatientInvestigationTransformer.ts
+++ b/apps/modernization-ui/src/pages/patient/profile/investigation/PatientInvestigationTransformer.ts
@@ -1,3 +1,4 @@
+import { asLocalDate } from 'date';
 import { Investigation } from './PatientInvestigation';
 import { FindInvestigationsForPatientQuery } from 'generated/graphql/schema';
 
@@ -21,7 +22,7 @@ const internalized = (content: Content): Investigation | null => {
     return (
         content && {
             ...content,
-            startedOn: content.startedOn && new Date(content.startedOn)
+            startedOn: content.startedOn && asLocalDate(content.startedOn)
         }
     );
 };

--- a/apps/modernization-ui/src/pages/patient/profile/investigation/PatientInvestigationsTable.spec.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/investigation/PatientInvestigationsTable.spec.tsx
@@ -105,7 +105,7 @@ describe('when at least one investigation is available for a patient', () => {
                     content: [
                         {
                             investigation: 'investigation-id',
-                            startedOn: '2023-03-27T00:00:00Z',
+                            startedOn: '2023-03-27',
                             condition: 'condition',
                             status: 'status',
                             caseStatus: 'case-status',
@@ -136,7 +136,7 @@ describe('when at least one investigation is available for a patient', () => {
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toContainElement(await findByText('03/26/2023'));
+        expect(tableData[0]).toContainElement(await findByText('03/27/2023'));
         expect(tableData[1]).toHaveTextContent('condition');
         expect(tableData[2]).toHaveTextContent('status');
         expect(tableData[3]).toHaveTextContent('case-status');

--- a/apps/modernization-ui/src/pages/patient/profile/investigation/PatientOpenInvestigationsTable.spec.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/investigation/PatientOpenInvestigationsTable.spec.tsx
@@ -81,7 +81,7 @@ describe('when at least one investigation is available for a patient', () => {
                     content: [
                         {
                             investigation: 'investigation-id',
-                            startedOn: '2023-03-27T00:00:00Z',
+                            startedOn: '2023-03-27',
                             condition: 'condition',
                             status: 'status',
                             caseStatus: 'case-status',
@@ -112,7 +112,7 @@ describe('when at least one investigation is available for a patient', () => {
 
         const tableData = container.getElementsByClassName('table-data');
 
-        expect(tableData[0]).toHaveTextContent('03/26/2023');
+        expect(tableData[0]).toHaveTextContent('03/27/2023');
         expect(tableData[1]).toHaveTextContent('condition');
         expect(tableData[2]).toHaveTextContent('case-status');
         expect(tableData[3]).toHaveTextContent('notification');


### PR DESCRIPTION
Resolves [BBJ12-40](https://cdc-nbs.atlassian.net/browse/BBJ12-40) by returning the Investigation started on date as a local date from the API and applies the `asLocalDate` function on the UI.  

[BBJ12-40]: https://cdc-nbs.atlassian.net/browse/BBJ12-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ