### PR TITLE
Add program_area_jurisdiction_oid where clause to document fetch

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/document/PatientDocumentByPatientResolver.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.patient.document;
 
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.graphql.GraphQLPage;
+import gov.cdc.nbs.service.SecurityService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,37 +13,41 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
+import java.util.Set;
 
 @Controller
 class PatientDocumentByPatientResolver {
 
     private final int maxPageSize;
     private final PatientDocumentFinder finder;
+    private final SecurityService securityService;
 
     PatientDocumentByPatientResolver(
-        @Value("${nbs.max-page-size}") final int maxPageSize,
-        final PatientDocumentFinder finder
-    ) {
+            @Value("${nbs.max-page-size}") final int maxPageSize,
+            final PatientDocumentFinder finder,
+            final SecurityService securityService) {
         this.maxPageSize = maxPageSize;
         this.finder = finder;
+        this.securityService = securityService;
     }
 
     @QueryMapping(name = "findDocumentsForPatient")
     @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-DOCUMENT')")
     Page<PatientDocument> find(
-        @Argument("patient") final long patient,
-        @Argument final GraphQLPage page
-    ) {
+            @Argument("patient") final long patient,
+            @Argument final GraphQLPage page) {
+        Set<Long> userOids = securityService.getCurrentUserProgramAreaJurisdictionOids();
         Pageable pageable = GraphQLPage.toPageable(page, maxPageSize);
         return this.finder.find(
-            patient,
-            pageable
-        );
+                patient,
+                userOids,
+                pageable);
     }
 
     @SchemaMapping("documents")
     @PreAuthorize("hasAuthority('FIND-PATIENT') and hasAuthority('VIEW-DOCUMENT')")
     List<PatientDocument> resolve(final Person patient) {
-        return this.finder.find(patient.getId());
+        Set<Long> userOids = securityService.getCurrentUserProgramAreaJurisdictionOids();
+        return this.finder.find(patient.getId(), userOids);
     }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/DocumentMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/DocumentMother.java
@@ -15,111 +15,151 @@ import javax.persistence.EntityManager;
 @Component
 class DocumentMother {
 
-  private static final String DOCUMENT_CLASS = "DOC";
-  private static final String PERSON_CLASS = "PSN";
+    private static final String DOCUMENT_CLASS = "DOC";
+    private static final String PERSON_CLASS = "PSN";
+    private static Long CLAYTON_STD_OID = 1300600015L; // Clayton count + STD
 
-  private final MotherSettings settings;
-  private final TestUniqueIdGenerator idGenerator;
-  private final EntityManager entityManager;
-  private final TestDocumentCleaner cleaner;
+    private final MotherSettings settings;
+    private final TestUniqueIdGenerator idGenerator;
+    private final EntityManager entityManager;
+    private final TestDocumentCleaner cleaner;
 
-  private final TestDocuments documents;
+    private final TestDocuments documents;
 
-  DocumentMother(
-      final MotherSettings settings,
-      final TestUniqueIdGenerator idGenerator,
-      final EntityManager entityManager,
-      final TestDocumentCleaner cleaner,
-      final TestDocuments documents
-  ) {
-    this.settings = settings;
-    this.idGenerator = idGenerator;
-    this.entityManager = entityManager;
-    this.cleaner = cleaner;
-    this.documents = documents;
-  }
+    DocumentMother(
+            final MotherSettings settings,
+            final TestUniqueIdGenerator idGenerator,
+            final EntityManager entityManager,
+            final TestDocumentCleaner cleaner,
+            final TestDocuments documents) {
+        this.settings = settings;
+        this.idGenerator = idGenerator;
+        this.entityManager = entityManager;
+        this.cleaner = cleaner;
+        this.documents = documents;
+    }
 
-  void reset() {
-    this.cleaner.clean(this.settings.starting());
-    this.documents.reset();
-  }
+    void reset() {
+        this.cleaner.clean(this.settings.starting());
+        this.documents.reset();
+    }
 
-  /**
-   * Creates a Case Report associated with the given {@code patient}
-   *
-   * @param patient The identifier of the patient.
-   * @return A {@link NbsDocument} representing a Case Report associated with a patient.
-   */
-  NbsDocument caseReport(final long patient) {
-    //  create a document
-    NbsDocument document = new NbsDocument();
-    long identifier = idGenerator.next();
+    /**
+     * Creates a Case Report associated with the given {@code patient} with the Clayton County and STD
+     * programJurisdictionOid
+     *
+     * @param patient The identifier of the patient.
+     * @return A {@link NbsDocument} representing a Case Report associated with a patient.
+     */
+    NbsDocument caseReport(final long patient) {
+        //  create a document
+        NbsDocument document = new NbsDocument();
+        long identifier = idGenerator.next();
 
-    document.setId(identifier);
-    document.setDocPayload("<?xml version=\"1.0\"?>");
-    document.setDocTypeCd("PHC236");
-    document.setLocalId(idGenerator.nextLocal(DOCUMENT_CLASS));
+        document.setId(identifier);
+        document.setDocPayload("<?xml version=\"1.0\"?>");
+        document.setDocTypeCd("PHC236");
+        document.setLocalId(idGenerator.nextLocal(DOCUMENT_CLASS));
 
-    document.setNbsInterfaceUid(227L);  // not sure what this refers to
+        document.setNbsInterfaceUid(227L); // not sure what this refers to
 
-    document.setSharedInd('F');
-    document.setVersionCtrlNbr((short) 1);
+        document.setSharedInd('F');
+        document.setVersionCtrlNbr((short) 1);
 
-    document.setRecordStatusCd("ACTIVE");
-    document.setRecordStatusTime(settings.createdOn());
-    document.setAddTime(settings.createdOn());
-    document.setAddUserId(settings.createdBy());
+        document.setRecordStatusCd("ACTIVE");
+        document.setRecordStatusTime(settings.createdOn());
+        document.setAddTime(settings.createdOn());
+        document.setAddUserId(settings.createdBy());
+        document.setProgramJurisdictionOid(CLAYTON_STD_OID); // Clayton
 
-    document.setNbsDocumentMetadataUid(metadatum());
+        document.setNbsDocumentMetadataUid(metadatum());
 
-    entityManager.persist(document);
+        entityManager.persist(document);
 
-    subjectOfDocument(patient, identifier);
+        subjectOfDocument(patient, identifier);
 
-    this.documents.available(document.getId());
+        this.documents.available(document.getId());
 
-    return document;
-  }
+        return document;
+    }
 
-  private Participation subjectOfDocument(final long patient, final long document) {
+    /**
+     * Creates a Case Report associated with the given {@code patient} with no programJurisdictionOid
+     *
+     * @param patient The identifier of the patient.
+     * @return A {@link NbsDocument} representing a Case Report associated with a patient.
+     */
+    NbsDocument caseReportWithoutJurisdiction(final long patient) {
+        //  create a document
+        NbsDocument document = new NbsDocument();
+        long identifier = idGenerator.next();
 
-    //  create the act
-    Act act = new Act();
-    act.setId(document);
-    act.setClassCd(DOCUMENT_CLASS);
-    act.setMoodCd("EVN");
+        document.setId(identifier);
+        document.setDocPayload("<?xml version=\"1.0\"?>");
+        document.setDocTypeCd("PHC236");
+        document.setLocalId(idGenerator.nextLocal(DOCUMENT_CLASS));
 
-    // create the participation
-    ParticipationId identifier = new ParticipationId(patient, document, "SubjOfDoc");
+        document.setNbsInterfaceUid(227L); // not sure what this refers to
 
-    Participation participation = new Participation();
-    participation.setId(identifier);
-    participation.setActClassCd(DOCUMENT_CLASS);
-    participation.setSubjectClassCd(PERSON_CLASS);
+        document.setSharedInd('F');
+        document.setVersionCtrlNbr((short) 1);
 
-    participation.setRecordStatusCd(RecordStatus.ACTIVE);
-    participation.setRecordStatusTime(settings.createdOn());
-    participation.setAddTime(settings.createdOn());
-    participation.setAddUserId(settings.createdBy());
-    participation.setActUid(act);
+        document.setRecordStatusCd("ACTIVE");
+        document.setRecordStatusTime(settings.createdOn());
+        document.setAddTime(settings.createdOn());
+        document.setAddUserId(settings.createdBy());
+        document.setProgramJurisdictionOid(null);
 
-    act.addParticipation(participation);
+        document.setNbsDocumentMetadataUid(metadatum());
 
-    entityManager.persist(act);
+        entityManager.persist(document);
 
-    return participation;
-  }
+        subjectOfDocument(patient, identifier);
 
-  private NbsDocumentMetadatum metadatum() {
-    var ref = entityManager.find(NbsDocumentMetadatum.class,1003L);
-  if (ref == null){
-    var metadatum = new NbsDocumentMetadatum();
-    metadatum.setId(1003L);
-    metadatum.setXmlSchemaLocation("schemaLocation");
-    metadatum.setDocumentViewXsl("docViewXsl");
-    entityManager.persist(metadatum);
-    return metadatum;
-  } 
-  return ref;
-}
+        this.documents.available(document.getId());
+
+        return document;
+    }
+
+    private Participation subjectOfDocument(final long patient, final long document) {
+
+        //  create the act
+        Act act = new Act();
+        act.setId(document);
+        act.setClassCd(DOCUMENT_CLASS);
+        act.setMoodCd("EVN");
+
+        // create the participation
+        ParticipationId identifier = new ParticipationId(patient, document, "SubjOfDoc");
+
+        Participation participation = new Participation();
+        participation.setId(identifier);
+        participation.setActClassCd(DOCUMENT_CLASS);
+        participation.setSubjectClassCd(PERSON_CLASS);
+
+        participation.setRecordStatusCd(RecordStatus.ACTIVE);
+        participation.setRecordStatusTime(settings.createdOn());
+        participation.setAddTime(settings.createdOn());
+        participation.setAddUserId(settings.createdBy());
+        participation.setActUid(act);
+
+        act.addParticipation(participation);
+
+        entityManager.persist(act);
+
+        return participation;
+    }
+
+    private NbsDocumentMetadatum metadatum() {
+        var ref = entityManager.find(NbsDocumentMetadatum.class, 1003L);
+        if (ref == null) {
+            var metadatum = new NbsDocumentMetadatum();
+            metadatum.setId(1003L);
+            metadatum.setXmlSchemaLocation("schemaLocation");
+            metadatum.setDocumentViewXsl("docViewXsl");
+            entityManager.persist(metadatum);
+            return metadatum;
+        }
+        return ref;
+    }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.patient.document;
 
+import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.graphql.GraphQLPage;
 import gov.cdc.nbs.patient.PatientMother;
 import gov.cdc.nbs.patient.TestPatientIdentifier;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.List;
 
 @Transactional
 public class PatientDocumentSteps {
@@ -54,6 +56,15 @@ public class PatientDocumentSteps {
         long patient = this.patients.one().id();
 
         Page<PatientDocument> actual = this.resolver.find(patient, new GraphQLPage(1));
+        assertThat(actual).isNotEmpty();
+    }
+
+    @Then("I can view the document when listing all documents for patient")
+    public void view_document_when_listing_all() {
+        long patient = this.patients.one().id();
+        Person person = new Person(patient, "local");
+
+        List<PatientDocument> actual = this.resolver.resolve(person);
         assertThat(actual).isNotEmpty();
     }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/document/PatientDocumentSteps.java
@@ -42,6 +42,12 @@ public class PatientDocumentSteps {
         this.mother.caseReport(revision.id());
     }
 
+    @When("the patient only has a Case Report with no program area or jurisdiction")
+    public void the_patient_only_has_a_report_with_no_program_area_or_jurisdiction() {
+        PatientIdentifier revision = patientMother.revise(patients.one());
+        this.mother.reset();
+        this.mother.caseReportWithoutJurisdiction(revision.id());
+    }
 
     @Then("the profile has an associated document")
     public void the_profile_has_an_associated_document() {
@@ -59,12 +65,10 @@ public class PatientDocumentSteps {
         GraphQLPage page = new GraphQLPage(1);
 
         assertThatThrownBy(
-            () -> this.resolver.find(
-                patient,
-                page
-            )
-        )
-            .isInstanceOf(AccessDeniedException.class);
+                () -> this.resolver.find(
+                        patient,
+                        page))
+                                .isInstanceOf(AccessDeniedException.class);
     }
 
     @Then("the profile has no associated document")

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
@@ -13,6 +13,10 @@ Feature: Patient Profile Documents
     Given I have the authorities: "FIND-PATIENT,VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"
     Then the profile has no associated document
 
+  Scenario: I can retrieve all documents for a patient
+    Given I have the authorities: "FIND-PATIENT,VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"
+    When the patient has a Case Report
+    Then I can view the document when listing all documents for patient
 
   Scenario: I cannot view documents that do not have a program area and jurisdiction assigned
     Given I have the authorities: "FIND-PATIENT,VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"

--- a/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientProfileDocuments.feature
@@ -14,6 +14,11 @@ Feature: Patient Profile Documents
     Then the profile has no associated document
 
 
+  Scenario: I cannot view documents that do not have a program area and jurisdiction assigned
+    Given I have the authorities: "FIND-PATIENT,VIEW-DOCUMENT" for the jurisdiction: "ALL" and program area: "STD"
+    When the patient only has a Case Report with no program area or jurisdiction
+    Then the profile has no associated document
+
   Scenario: I cannot retrieve documents without proper authorities
     Given I have the authorities: "FIND-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
     Then the profile documents are not returned

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/AddQuestionToPageSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/AddQuestionToPageSteps.java
@@ -15,6 +15,7 @@ import gov.cdc.nbs.questionbank.page.request.AddQuestionRequest;
 import gov.cdc.nbs.questionbank.support.ExceptionHolder;
 import gov.cdc.nbs.questionbank.support.PageMother;
 import gov.cdc.nbs.questionbank.support.QuestionMother;
+import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 
@@ -36,6 +37,11 @@ public class AddQuestionToPageSteps {
     private PageMother pageMother;
 
     private AddQuestionResponse response;
+
+    @Before
+    public void clearExceptions() {
+        exceptionHolder.clear();
+    }
 
     @Given("No questions are in use")
     public void no_questions_are_in_use() {

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/ExceptionHolder.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/ExceptionHolder.java
@@ -10,4 +10,8 @@ import lombok.Setter;
 public class ExceptionHolder {
 
     private Exception exception;
+
+    public void clear() {
+        this.exception = null;
+    }
 }


### PR DESCRIPTION
Fixes the issue outlined in [BBJ12-48](https://cdc-nbs.atlassian.net/browse/BBJ12-48) by adding the `program_area_jurisdiction` WHERE clause to the select statement for documents associated with a patient.

Classic™  documents listed for profile:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/405f4a8a-f6bb-4cc6-a46f-d1bdd108d86d)

Modernized documents listed for profile:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/e60587e1-f751-40d3-8a95-e1c5da6fe436)


Assigned another document a program area and jurisdiction for patient:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/b6715822-422f-4753-b6c5-7602ba4f4c40)

Classic™ documents now listed:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/27494870-f327-4ee2-9e44-5084aacac63c)


Modernized documents:
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/28d1e996-201e-4537-b6ee-7cd27eb8da10)



[BBJ12-48]: https://cdc-nbs.atlassian.net/browse/BBJ12-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ