### PR TITLE
CNFT2-728 Allow user to specify Id for LOCAL question

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionCreator.java
@@ -190,14 +190,14 @@ class QuestionCreator {
 
 
     /**
-     * If the request is of 'LOCAL' type, generate the next available Id from the database. Else, return the specified
-     * request.uniqueId
+     * If the request is of 'LOCAL' type and no Id is specified, generate the next available Id from the database. Else,
+     * return the specified request.uniqueId
      * 
      * @param request
      * @return
      */
     String getLocalId(CreateQuestionRequest request) {
-        if (request.codeSet().equals("LOCAL")) {
+        if (request.codeSet().equals("LOCAL") && (request.uniqueId() == null || request.uniqueId().isBlank())) {
             // Question Ids are a combination of the 
             // `NBS_ODSE.NBS_configuration NBS_CLASS_CODE config value + the next valid Id 
             // Ex. GA13004

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionCreatorTest.java
@@ -61,16 +61,49 @@ class QuestionCreatorTest {
     private QuestionCreator creator;
 
     @Test
-    void should_return_proper_local_id() {
+    void should_return_user_specified_local_id() {
+        // given a "LOCAL" create question request with an Id specified
+        CreateQuestionRequest.Text request = QuestionRequestMother.localTextRequest();
+
+        // when I generate the localId
+        String localId = creator.getLocalId(request);
+
+        // then I am returned the specified Id
+        assertEquals(request.uniqueId(), localId);
+    }
+
+    @Test
+    void should_return_generated_local_id_null() {
         // given the idGenerator will return a generated Id
         when(idGenerator.getNextValidId(Mockito.any())).thenReturn(new GeneratedId(1000L, "PREFIX","SUFFIX"));
+        
         // and the configRepository will return a NBS_CLASS_CODE
         NbsConfiguration configEntry = new NbsConfiguration();
         configEntry.setConfigValue("GA");
         when(configRepository.findById("NBS_CLASS_CODE")).thenReturn(Optional.of(configEntry));
 
-        // given a "LOCAL" create question request
-        CreateQuestionRequest.Text request = QuestionRequestMother.localTextRequest();
+        // given a "LOCAL" create question request with null uniqueId
+        CreateQuestionRequest.Text request = QuestionRequestMother.localWithUniqueId(null);
+
+        // when I generate the localId
+        String localId = creator.getLocalId(request);
+
+        // then I am returned the datbaases next available Id
+        assertEquals(configEntry.getConfigValue() + "1000", localId);
+    }
+
+    @Test
+    void should_return_generated_local_id_empty() {
+        // given the idGenerator will return a generated Id
+        when(idGenerator.getNextValidId(Mockito.any())).thenReturn(new GeneratedId(1000L, "PREFIX","SUFFIX"));
+        
+        // and the configRepository will return a NBS_CLASS_CODE
+        NbsConfiguration configEntry = new NbsConfiguration();
+        configEntry.setConfigValue("GA");
+        when(configRepository.findById("NBS_CLASS_CODE")).thenReturn(Optional.of(configEntry));
+
+        // given a "LOCAL" create question request with null uniqueId
+        CreateQuestionRequest.Text request = QuestionRequestMother.localWithUniqueId("  ");
 
         // when I generate the localId
         String localId = creator.getLocalId(request);

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionRequestMother.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionRequestMother.java
@@ -191,4 +191,23 @@ public class QuestionRequestMother {
         return update(QuestionType.TEXT);
     }
 
+    public static CreateQuestionRequest.Text localWithUniqueId(String uniqueId) {
+        return new CreateQuestionRequest.Text(
+                "LOCAL",
+                uniqueId,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                QuestionType.TEXT,
+                null,
+                null,
+                null);
+    }
+
 }


### PR DESCRIPTION
[CNFT2-728](https://cdc-nbs.atlassian.net/browse/CNFT2-728)

If the user specifies an Id when creating a 'LOCAL' question, use the specified Id.

[CNFT2-728]: https://cdc-nbs.atlassian.net/browse/CNFT2-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ