### PR TITLE
CNFT1-1432 CNFT1-1230 Switch legal name search to query string query

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
@@ -149,7 +149,7 @@ public class PatientService {
             BoolQueryBuilder firstNameBuilder = QueryBuilders.boolQuery();
 
             firstNameBuilder.should(QueryBuilders.queryStringQuery(
-                    addWildcards(filter.getLastName()))
+                    addWildcards(filter.getFirstName()))
                     .defaultField(ElasticsearchPerson.FIRST_NM)
                     .defaultOperator(Operator.AND).boost(FIRST_NAME_PRIMARY_BOOST));
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
@@ -174,7 +174,7 @@ public class PatientService {
 
             lastNameBuilder.should(QueryBuilders.queryStringQuery(
                     addWildcards(filter.getLastName()))
-                    .defaultField(ElasticsearchPerson.LAST_NM_KEYWORD)
+                    .defaultField(ElasticsearchPerson.LAST_NM)
                     .defaultOperator(Operator.AND).boost(LAST_NAME_PRIMARY_BOOST));
 
             lastNameBuilder.should(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
@@ -415,7 +415,7 @@ public class PatientService {
                     sorts.add(SortBuilders.scoreSort());
                     break;
                 case "lastNm":
-                    sorts.add(SortBuilders.fieldSort(ElasticsearchPerson.LAST_NM_KEYWORD)
+                    sorts.add(SortBuilders.fieldSort(ElasticsearchPerson.LAST_NM)
                         .order(sort.getDirection() == Direction.DESC ? SortOrder.DESC : SortOrder.ASC));
                     break;
                 case "birthTime":

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/PatientService.java
@@ -148,8 +148,10 @@ public class PatientService {
         if (filter.getFirstName() != null && !filter.getFirstName().isEmpty()) {
             BoolQueryBuilder firstNameBuilder = QueryBuilders.boolQuery();
 
-            firstNameBuilder.should(QueryBuilders.matchQuery(ElasticsearchPerson.FIRST_NM,
-                filter.getFirstName().trim()).boost(FIRST_NAME_PRIMARY_BOOST));
+            firstNameBuilder.should(QueryBuilders.queryStringQuery(
+                    addWildcards(filter.getLastName()))
+                    .defaultField(ElasticsearchPerson.FIRST_NM)
+                    .defaultOperator(Operator.AND).boost(FIRST_NAME_PRIMARY_BOOST));
 
             firstNameBuilder.should(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
                 QueryBuilders.queryStringQuery(
@@ -170,8 +172,10 @@ public class PatientService {
         if (filter.getLastName() != null && !filter.getLastName().isEmpty()) {
             BoolQueryBuilder lastNameBuilder = QueryBuilders.boolQuery();
 
-            lastNameBuilder.should(QueryBuilders.matchQuery(ElasticsearchPerson.LAST_NM_KEYWORD,
-                filter.getLastName().trim()).boost(LAST_NAME_PRIMARY_BOOST));
+            lastNameBuilder.should(QueryBuilders.queryStringQuery(
+                    addWildcards(filter.getLastName()))
+                    .defaultField(ElasticsearchPerson.LAST_NM_KEYWORD)
+                    .defaultOperator(Operator.AND).boost(LAST_NAME_PRIMARY_BOOST));
 
             lastNameBuilder.should(QueryBuilders.nestedQuery(ElasticsearchPerson.NAME_FIELD,
                 QueryBuilders.queryStringQuery(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSearchSteps.java
@@ -57,9 +57,9 @@ public class PatientSearchSteps {
     private QueryException exception;
     private String searchText;
 
-    final long RELEVANCE_SEARCH_SOUNDEX_NAME_PERSON_ID = 20000000;
-    final long RELEVANCE_SEARCH_SECONDARY_NAME_PERSON_ID = 20000001;
-    final long RELEVANCE_SEARCH_LEGAL_NAME_PERSON_ID = 20000002;
+    public static final long RELEVANCE_SEARCH_SOUNDEX_NAME_PERSON_ID = 20000000;
+    public static final long RELEVANCE_SEARCH_SECONDARY_NAME_PERSON_ID = 20000001;
+    public static final long RELEVANCE_SEARCH_LEGAL_NAME_PERSON_ID = 20000002;
 
     @Given("there are {int} patients")
     public void there_are_patients(int patientCount) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSearchSteps.java
@@ -57,6 +57,10 @@ public class PatientSearchSteps {
     private QueryException exception;
     private String searchText;
 
+    final long RELEVANCE_SEARCH_SOUNDEX_NAME_PERSON_ID = 20000000;
+    final long RELEVANCE_SEARCH_SECONDARY_NAME_PERSON_ID = 20000001;
+    final long RELEVANCE_SEARCH_LEGAL_NAME_PERSON_ID = 20000002;
+
     @Given("there are {int} patients")
     public void there_are_patients(int patientCount) {
         // person data is randomly generated but the Ids are always the same.
@@ -116,7 +120,7 @@ public class PatientSearchSteps {
         var deletedRecord = PersonMother.janeDoe_deleted();
         personRepository.save(deletedRecord);
         elasticsearchPersonRepository
-            .saveAll(ElasticsearchPersonMapper.getElasticSearchPersons(Arrays.asList(deletedRecord)));
+                .saveAll(ElasticsearchPersonMapper.getElasticSearchPersons(Arrays.asList(deletedRecord)));
     }
 
     @When("I search patients by {string} {string}")
@@ -141,7 +145,7 @@ public class PatientSearchSteps {
 
     @When("I search patients by {string} {string} {string} {string} {string} {string}")
     public void i_search_patients_by_multiple_fields(String field, String qualifier, String field2, String qualifier2,
-        String field3, String qualifier3) {
+            String field3, String qualifier3) {
         PatientFilter filter = getPatientDataFilter(field, qualifier);
         updatePatientDataFilter(filter, field2, qualifier2);
         updatePatientDataFilter(filter, field3, qualifier3);
@@ -157,12 +161,12 @@ public class PatientSearchSteps {
 
     @When("I search for patients sorted by {string} {string} {string} {string}")
     public void i_search_for_ordered_patients(String field, String qualifier, String aSortField,
-        String aSortDirection) {
+            String aSortDirection) {
         PatientFilter filter = getPatientDataFilter(field, qualifier);
         sortDirection = aSortDirection.equalsIgnoreCase("desc") ? Direction.DESC : Direction.ASC;
         sortField = aSortField;
         searchResults = patientController
-            .findPatientsByFilter(filter, new GraphQLPage(1000, 0, sortDirection, sortField)).getContent();
+                .findPatientsByFilter(filter, new GraphQLPage(1000, 0, sortDirection, sortField)).getContent();
     }
 
     @When("I search for a patient by {string} and there is a space at the end")
@@ -208,7 +212,7 @@ public class PatientSearchSteps {
         Soundex soundex = new Soundex();
         String searchSoundex = soundex.encode(searchText.trim());
         switch (field) {
-            case "first name":                
+            case "first name":
                 searchResults.forEach(r -> {
                     assertTrue(r.getFirstNm().contains(searchText.trim())
                             || soundex.encode(r.getFirstNm()).contains(searchSoundex));
@@ -217,7 +221,7 @@ public class PatientSearchSteps {
             case "last name":
                 searchResults.forEach(r -> {
                     assertTrue(r.getLastNm().contains(searchText.trim())
-                     || soundex.encode(r.getLastNm()).contains(searchSoundex));
+                            || soundex.encode(r.getLastNm()).contains(searchSoundex));
                 });
                 break;
             case "address":
@@ -237,9 +241,9 @@ public class PatientSearchSteps {
         Comparator<Person> comparator = getPersonSortComparator(sortField, sortDirection);
         if (comparator == null) {
             // check relevance ordering manually (ie there is no simple comparator)
-            Assert.assertEquals(searchResults.get(0), generatedPersons.get(2));
-            Assert.assertEquals(searchResults.get(1), generatedPersons.get(1));
-            Assert.assertEquals(searchResults.get(2), generatedPersons.get(0));
+            Assert.assertEquals(searchResults.get(0).getId(), (Long) RELEVANCE_SEARCH_LEGAL_NAME_PERSON_ID);
+            Assert.assertEquals(searchResults.get(1).getId(), (Long) RELEVANCE_SEARCH_SECONDARY_NAME_PERSON_ID);
+            Assert.assertEquals(searchResults.get(2).getId(), (Long) RELEVANCE_SEARCH_SOUNDEX_NAME_PERSON_ID);
             return;
         }
         List<Person> sortedPersons = generatedPersons.stream().sorted(comparator).collect(Collectors.toList());
@@ -295,7 +299,7 @@ public class PatientSearchSteps {
             case "identification":
                 var patientId = searchPatient.identifications().get(0);
                 filter.setIdentification(
-                    new Identification(patientId.getRootExtensionTxt(), "GA", patientId.getTypeCd()));
+                        new Identification(patientId.getRootExtensionTxt(), "GA", patientId.getTypeCd()));
                 break;
             case "patient id":
                 filter.setId(searchPatient.getLocalId());
@@ -360,7 +364,7 @@ public class PatientSearchSteps {
             case "identification":
                 var patientId = searchPatient.identifications().get(0);
                 filter.setIdentification(
-                    new Identification(patientId.getRootExtensionTxt(), "GA", patientId.getTypeCd()));
+                        new Identification(patientId.getRootExtensionTxt(), "GA", patientId.getTypeCd()));
                 break;
             case "ssn":
                 filter.setSsn(RandomUtil.randomPartialDataSearchString(searchPatient.getSsn()));

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
@@ -69,7 +69,7 @@ public class ElasticsearchPersonMapper {
         address.setZip(pl.getZipCd());
 
         ElasticsearchInstantValueConverter instantConverter = new ElasticsearchInstantValueConverter();
-        boolean isLegalNameDifferent = id==20000001 && person.getFirstNm() == "John" && person.getLastNm() == "Smith";
+        boolean isLegalNameDifferent = id==20000002 && person.getFirstNm() == "John" && person.getLastNm() == "Smith";
         return ElasticsearchPerson.builder()
                 .id(String.valueOf(id))
                 .personUid(id)

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
@@ -69,7 +69,7 @@ public class ElasticsearchPersonMapper {
         address.setZip(pl.getZipCd());
 
         ElasticsearchInstantValueConverter instantConverter = new ElasticsearchInstantValueConverter();
-        boolean isLegalNameDifferent = id==20000002 && person.getFirstNm() == "John" && person.getLastNm() == "Smith";
+        boolean isLegalNameDifferent = id==20000001 && person.getFirstNm() == "John" && person.getLastNm() == "Smith";
         return ElasticsearchPerson.builder()
                 .id(String.valueOf(id))
                 .personUid(id)

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/util/ElasticsearchPersonMapper.java
@@ -22,6 +22,7 @@ import gov.cdc.nbs.entity.odse.PostalEntityLocatorParticipation;
 import gov.cdc.nbs.entity.odse.PostalLocator;
 import gov.cdc.nbs.entity.odse.TeleEntityLocatorParticipation;
 import gov.cdc.nbs.entity.odse.TeleLocator;
+import gov.cdc.nbs.patient.PatientSearchSteps;
 
 public class ElasticsearchPersonMapper {
 
@@ -57,7 +58,6 @@ public class ElasticsearchPersonMapper {
             nestedEntityIds.add(nestedEntityId);
         }
 
-
         var address = new NestedAddress();
         PostalLocator pl = PersonUtil.getPostalLocators(person).get(0);
         address.setStreetAddr1(pl.getStreetAddr1());
@@ -69,7 +69,8 @@ public class ElasticsearchPersonMapper {
         address.setZip(pl.getZipCd());
 
         ElasticsearchInstantValueConverter instantConverter = new ElasticsearchInstantValueConverter();
-        boolean isLegalNameDifferent = id==20000001 && person.getFirstNm() == "John" && person.getLastNm() == "Smith";
+        boolean isLegalNameDifferent = id == PatientSearchSteps.RELEVANCE_SEARCH_SECONDARY_NAME_PERSON_ID
+                && person.getFirstNm().equals("John") && person.getLastNm().equals("Smith");
         return ElasticsearchPerson.builder()
                 .id(String.valueOf(id))
                 .personUid(id)

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/elasticsearch/ElasticsearchPerson.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/elasticsearch/ElasticsearchPerson.java
@@ -76,7 +76,7 @@ public class ElasticsearchPerson {
     public static final String SURVIVED_IND_CD = "survived_ind_cd";
     public static final String USER_AFFILIATION_TXT = "user_affiliation_txt";
     public static final String FIRST_NM = "first_nm";
-    public static final String LAST_NM_KEYWORD = "last_nm";
+    public static final String LAST_NM = "last_nm";
     public static final String TEXT = "text";
     public static final String MIDDLE_NM = "middle_nm";
     public static final String NM_PREFIX = "nm_prefix";
@@ -293,7 +293,7 @@ public class ElasticsearchPerson {
     private String firstNm;
 
     // allows sorting
-    @MultiField(mainField = @Field(name = LAST_NM_KEYWORD, type = FieldType.Keyword), otherFields = {
+    @MultiField(mainField = @Field(name = LAST_NM, type = FieldType.Text), otherFields = {
             @InnerField(suffix = TEXT, type = FieldType.Text)
     })
     private String lastNm;

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/elasticsearch/ElasticsearchPerson.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/elasticsearch/ElasticsearchPerson.java
@@ -293,7 +293,7 @@ public class ElasticsearchPerson {
     private String firstNm;
 
     // allows sorting
-    @MultiField(mainField = @Field(name = LAST_NM, type = FieldType.Text), otherFields = {
+    @MultiField(mainField = @Field(name = LAST_NM, type = FieldType.Text, fielddata = true), otherFields = {
             @InnerField(suffix = TEXT, type = FieldType.Text)
     })
     private String lastNm;


### PR DESCRIPTION
**Why**: Legal name was doing an exact match previously.  So when we searched by prefix (ie "Smi" for "Smith") the legal name was not getting boosted unless it was an exact match.  Moreover the exact match was case sensitive.  Note the legal name always had a nested name so it would still get LAST_NAME_NON_PRIMARY_BOOST but that is significantly less than LAST_NAME_PRIMARY_BOOST.  Finally legal name was set for a keyword search and should have been a text search.
**How**: Use QueryBuilders.queryStringQuery w/wildcard and downcase similar to all the nested searches. 

NOTE1: to do partial searches on legal name we need to convert the field type to text and set fielddata to true.  It was set to keyword for performance purposes (heap space) for sorting - when alphabetical sort (vs relevance) used to be the default criteria.  If it turns out to be too much of a hog we can create two fields in elastic: the keyword name for sorting, and the text name for searching.

NOTE2: since the schema of the elastic documents changed (legal last name went from keyword to text) we will need an elastic index delete / reindex for deploy