### PR TITLE
fix build pipeline and create dependency on sonar running first

### DIFF
--- a/.github/workflows/Build-and-deploy-modernization-api.yaml
+++ b/.github/workflows/Build-and-deploy-modernization-api.yaml
@@ -15,7 +15,10 @@ jobs:
     uses: ./.github/workflows/sonar.yaml
     secrets:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}  
   call-build-microservice-container-workflow:
+    needs: sonar_scan
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
     with:
       microservice_name: modernization-api

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -7,7 +7,13 @@ on:
     secrets:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID:
         description: "Secret named CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID where ECR resides."
-        required: true      
+        required: true
+      GITHUB_TOKEN:
+        description: "Secret named GITHUB_TOKEN that references the github token for this repository."
+        required: true
+      SONAR_TOKEN:
+        description: "Secret named SONAR_TOKEN that references the sonar token secret corresponding to the project in sonarcloud."
+        required: true        
   pull_request:
     paths:
       - "apps/**"
@@ -15,7 +21,9 @@ on:
       - ".github/workflows/sonar.yaml"
 env:
   deployment_env: dev
-  accountid: ${{secrets.cdc_nbs_sandbox_shared_services_accountid}}
+  accountid: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+  github_token: ${{secrets.GITHUB_TOKEN}}
+  sonar_token: ${{secrets.SONAR_TOKEN}}
 
 jobs:
   pipeline:
@@ -82,8 +90,8 @@ jobs:
       - name: Build and analyze
         working-directory: ./
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ env.github_token }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ env.sonar_token }}
         run: ./gradlew build jacocoTestReport sonar -Dtesting.database.image=${{ env.accountid }}.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/modernization-test-db:1.0.7-SNAPSHOT.f1ef4c0
 
       - name: Publish Testing Reports


### PR DESCRIPTION
This change is similar to the previous one that passes in secrets that are otherwise missing. This should be the last of them.

One more significant change is to solidify the intention behind this change. If sonar does not run or fails, then the container build will fail. 