### PR TITLE
Removes the routing rules that prevent navigation to Manual Merge

### DIFF
--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/search/PatientSearchRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/search/PatientSearchRouteLocatorConfiguration.java
@@ -11,7 +11,8 @@ import org.springframework.core.Ordered;
 
 /**
  * Configures the NBS Home Page to route searches and the advanced search link to the patient-search service.  The
- * routes are only enabled when the {@code routes.patient.search.enabled} property is {@code true} and any of the following criteria is satisfied.
+ * routes are only enabled when the {@code routes.patient.search.enabled} property is {@code true} and any of the
+ * following criteria is satisfied.
  *
  * <ul>
  *     <li>Path equal to {@code /nbs/MyTaskList1.do}</li>
@@ -19,16 +20,9 @@ import org.springframework.core.Ordered;
  * </ul>
  *
  * <ul>
- *     <li>Path equal to {@code /nbs/MyTaskList1.do}</li>
- *     <li>Query Parameter {@code ContextAction} equal to {@code GlobalMP_ManualSearch}</li>
- *     <li>Query Parameter {@code Mode1} equal to {@code ManualMerge}</li>
- * </ul>
- *
- * <ul>
  *     <li>Path equal to {@code /nbs/HomePage.do}</li>
  *     <li>Query Parameter {@code method} equal to {@code patientSearchSubmit}</li>
  * </ul>
- *
  */
 @Configuration
 @ConditionalOnProperty(prefix = "nbs.gateway.patient.search", name = "enabled", havingValue = "true")
@@ -48,21 +42,6 @@ class PatientSearchRouteLocatorConfiguration {
                     .path("/nbs/MyTaskList1.do")
                     .and()
                     .query("ContextAction", "GlobalPatient")
-                    .filters(
-                        filter -> filter.setPath("/nbs/redirect/advancedSearch")
-                            .filter(globalFilter)
-                    )
-                    .uri(parameters.uri())
-            )
-            .route(
-                "merge-patient-manual-search",
-                route -> route
-                    .order(Ordered.HIGHEST_PRECEDENCE)
-                    .path("/nbs/MyTaskList1.do")
-                    .and()
-                    .query("ContextAction", "GlobalMP_ManualSearch")
-                    .and()
-                    .query("Mode1", "ManualMerge")
                     .filters(
                         filter -> filter.setPath("/nbs/redirect/advancedSearch")
                             .filter(globalFilter)

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/search/PatientSearchServiceLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/search/PatientSearchServiceLocatorConfigurationTest.java
@@ -54,24 +54,6 @@ class PatientSearchServiceLocatorConfigurationTest {
     }
 
     @Test
-    void should_route_modernization_api_for_merge_patient_manual_search_link() {
-
-        service.stubFor(get(urlPathMatching("/nbs/redirect/advancedSearch\\\\?.*")).willReturn(ok()));
-
-        webClient
-            .get().uri(
-                builder -> builder
-                    .path("/nbs/MyTaskList1.do")
-                    .queryParam("ContextAction", "GlobalMP_ManualSearch")
-                    .queryParam("Mode1", "ManualMerge")
-                    .build()
-            )
-            .exchange()
-            .expectStatus()
-            .isOk();
-    }
-
-    @Test
     void should_not_route_to_modernization_when_context_action_is_not_present() {
 
         classic.stubFor(get("/nbs/MyTaskList1.do").willReturn(ok()));

--- a/documentation/Routing.md
+++ b/documentation/Routing.md
@@ -27,8 +27,6 @@ The following routes should be proxied to the `modernization-api` service.
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|----------------------------------------------------------------------------------|
 | Path is exactly `/nbs/HomePage.do` containing the Query Parameter `method` with a value of `mergeSubmit` and the Query Parameter `ContextAction` with a value of `Submit`                  | `/nbs/redirect/simpleSearch`   | Transforms a classic simple search request into a modernized search request URL. |
 | Path is exactly `/nbs/MyTaskList.do` containing the Query Parameter `ContextAction` with a value of `GlobalPatient`                                                                        | `/nbs/redirect/advancedSearch` | Routes the Classic Advanced search to the Modernized UI                          |
-| Path is exactly `/nbs/MyTaskList.do` containing the Query Parameter `ContextAction` with a value of `GlobalMP_ManualSearch` and the Query Parameter `Model1` with a value of `ManualMerge` | `/nbs/redirect/advancedSearch` | Routes the Classic Advanced search to the Modernized UI                          |
-
 ### Patient Profile Routes
 
 Transforms requests to a Classic Patient Profile into an authenticated request that redirects to the Modernized Patient


### PR DESCRIPTION
Removes the routing rule that is preventing navigation to Manual Merge.

 Path is exactly `/nbs/MyTaskList.do` containing the Query Parameter `ContextAction` with a value of `GlobalMP_ManualSearch` and the Query Parameter `Model1` with a value of `ManualMerge` >>
 `/nbs/redirect/advancedSearch` 