### PR TITLE
Fix 'act_id_seq' value in state case id investigation searches

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilder.java
@@ -107,7 +107,7 @@ public class InvestigationQueryBuilder {
                 case STATE_CASE_ID:
                     var stateCountryCaseId = QueryBuilders.boolQuery()
                             .must(QueryBuilders.matchQuery(Investigation.ACT_IDS + "." + ElasticsearchActId.ACT_ID_SEQ,
-                                    2))
+                                    1))
                             .must(QueryBuilders.matchQuery(Investigation.ACT_IDS + "." + ElasticsearchActId.TYPE_CD,
                                     "STATE"))
                             .must(QueryBuilders.matchQuery(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilderTest.java
@@ -372,7 +372,7 @@ class InvestigationQueryBuilderTest {
 
         var clause1 =
                 findMatchQueryBuilder(Investigation.ACT_IDS + "." + ElasticsearchActId.ACT_ID_SEQ, nestedBuilders);
-        assertEquals(2, clause1.value());
+        assertEquals(1, clause1.value());
 
         var clause2 =
                 findMatchQueryBuilder(Investigation.ACT_IDS + "." + ElasticsearchActId.TYPE_CD,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/EventMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/EventMother.java
@@ -72,7 +72,7 @@ public class EventMother {
                 .personParentUid(personId)
                 .build());
         var actIds = Arrays.asList(ElasticsearchActId.builder()
-                .actIdSeq(2)
+                .actIdSeq(1)
                 .typeCd("STATE")
                 .rootExtensionTxt("StateRootExtensionText")
                 .build());


### PR DESCRIPTION
A `State Case Id` investigation search should query where the `act_id_seq` is 1, not 2. See Classic™ code below. 
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/4467892a-46e7-44e0-90c1-3675f896d1b9)

A state case id in my local dev environment
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/a1163039-6e6b-4e71-9894-9d1ddc96f195)

A successful search after making the change
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/07f35903-03b1-4bd8-9d97-9cdefae62fcf)
