### PR TITLE
CNFT1-1518 Removes status criteria from PatientIdentifierFinder

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/identifier/PatientIdentifierFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/identifier/PatientIdentifierFinder.java
@@ -34,7 +34,6 @@ public class PatientIdentifierFinder {
             .from(this.tables.patient())
             .where(
                 this.tables.patient().cd.eq(PATIENT_CODE),
-                this.tables.patient().recordStatusCd.eq(RecordStatus.ACTIVE),
                 this.tables.patient().id.eq(identifier)
             )
             .fetch()

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/identifier/PatientIdentifierFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/identifier/PatientIdentifierFinder.java
@@ -1,7 +1,6 @@
 package gov.cdc.nbs.patient.identifier;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import gov.cdc.nbs.entity.enums.RecordStatus;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/redirect/incoming/IncomingPatientIdentifierResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/redirect/incoming/IncomingPatientIdentifierResolver.java
@@ -7,7 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
 @Component
-class IncomingPatientIdentifierResolver {
+public class IncomingPatientIdentifierResolver {
 
     private static Optional<Long> maybeLong(final String value) {
         if (value == null) {
@@ -25,12 +25,12 @@ class IncomingPatientIdentifierResolver {
     private static final String PATIENT_PARENT_ID = "MPRUid";
     private static final String PATIENT_ID = "uid";
 
-    Optional<Long> fromQueryParams(final HttpServletRequest request) {
+    public Optional<Long> fromQueryParams(final HttpServletRequest request) {
         return maybeLong(request.getParameter(PATIENT_PARENT_ID)).or(() -> maybeLong(request.getParameter(PATIENT_ID)));
 
     }
 
-    Optional<Long> fromReturningPatient(final HttpServletRequest request) {
+    public Optional<Long> fromReturningPatient(final HttpServletRequest request) {
         return ReturningPatientCookie.resolve(request.getCookies())
             .map(ReturningPatientCookie::patient)
             .flatMap(IncomingPatientIdentifierResolver::maybeLong);

--- a/apps/modernization-ui/src/pages/patient/profile/PatientProfile.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/PatientProfile.tsx
@@ -138,7 +138,6 @@ export const PatientProfile = () => {
                 </div>
             </div>
             <div className="main-body">
-                {/* {profile?.patient.status != 'ACTIVE' && <p className="text-red text-right">INACTIVE</p>} */}
                 {profile && profile.summary && (
                     <PatientProfileSummary patient={profile.patient} summary={profile.summary} />
                 )}

--- a/apps/modernization-ui/src/pages/patient/profile/summary/PatientProfileSummary.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/summary/PatientProfileSummary.tsx
@@ -35,7 +35,9 @@ export const PatientProfileSummary = ({ patient, summary }: Props) => {
                 <p className="font-sans-xl text-bold margin-0">{`${formattedName(summary.legalName)}`}</p>
                 <h5 className="font-sans-md text-medium margin-0">
                     Patient ID: {patient.shortId}
-                    {patient.status != 'ACTIVE' && <span className="text-red text-right margin-left-2">INACTIVE</span>}
+                    {patient.status != 'ACTIVE' && (
+                        <span className="text-red text-right margin-left-2">{patient.status}</span>
+                    )}
                 </h5>
             </div>
             <Grid row gap={3} className="padding-3">


### PR DESCRIPTION
Resolves [CNFT1-1518](https://cdc-nbs.atlassian.net/browse/CNFT1-1518) by removing the record status requirement on the `PatientIdentifierFinder`

- A `PatientIdentifier` can now be found for patients of any status.
- A Patient's status is displayed on the Patient Profile when the status is anything other than ACTIVE.

[CNFT1-1518]: https://cdc-nbs.atlassian.net/browse/CNFT1-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ