### PR TITLE
[FIX] Ensures that patients are cleaned up after everything else in tests

### DIFF
--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSteps.java
@@ -11,7 +11,8 @@ public class PatientSteps {
     @Autowired
     PatientMother mother;
 
-    @Before
+    //  Make sure that patients are cleaned up after everything else
+    @Before(order = 15000)
     public void clean() {
         mother.reset();
     }


### PR DESCRIPTION
Some Cucumber tests in `modernization-api` were randomly failing due to the clean-up steps happening out of order.  This ensures that patients are cleaned up last. 