### PR TITLE
[FIX] Fix authorization from classic -> modernization

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/config/security/WebSecurityConfig.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/config/security/WebSecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.cdc.nbs.authentication.JWTFilter;
+import gov.cdc.nbs.authentication.token.JWTFilter;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
 import lombok.RequiredArgsConstructor;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/UserController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/UserController.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.controller;
 import gov.cdc.nbs.authentication.NBSToken;
 import gov.cdc.nbs.authentication.NbsAuthority;
 import gov.cdc.nbs.authentication.NbsUserDetails;
+import gov.cdc.nbs.authentication.TokenCreator;
 import gov.cdc.nbs.authentication.UserService;
 import gov.cdc.nbs.authentication.config.SecurityProperties;
 import gov.cdc.nbs.authentication.entity.AuthUser;
@@ -30,6 +31,8 @@ public class UserController {
     SecurityProperties securityProperties;
     @Autowired
     AuthUserRepository userRepository;
+    @Autowired
+    TokenCreator creator;
 
     @Value("${nbs.max-page-size: 50}")
     private Integer maxPageSize;
@@ -38,7 +41,9 @@ public class UserController {
     public LoginResponse login(@RequestBody LoginRequest request, HttpServletResponse response) {
         var userDetails = userService.loadUserByUsername(request.getUsername());
 
-        userDetails.getToken().apply(
+        NBSToken token = this.creator.forUser(request.getUsername());
+
+        token.apply(
             securityProperties,
             response
         );
@@ -47,7 +52,7 @@ public class UserController {
             userDetails.getId(),
             userDetails.getUsername(),
             userDetails.getFirstName() + " " + userDetails.getLastName(),
-            userDetails.getToken().value()
+            token.value()
         );
     }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/UserController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
     public LoginResponse login(@RequestBody LoginRequest request, HttpServletResponse response) {
         var userDetails = userService.loadUserByUsername(request.getUsername());
 
-        new NBSToken(userDetails.getToken()).apply(
+        userDetails.getToken().apply(
             securityProperties,
             response
         );
@@ -47,7 +47,7 @@ public class UserController {
             userDetails.getId(),
             userDetails.getUsername(),
             userDetails.getFirstName() + " " + userDetails.getLastName(),
-            userDetails.getToken()
+            userDetails.getToken().value()
         );
     }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthenticationFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthenticationFilter.java
@@ -21,7 +21,8 @@ class ClassicIncomingAuthenticationFilter implements Filter {
 
     ClassicIncomingAuthenticationFilter(
             final ClassicIncomingContextResolver resolver,
-            final SecurityProperties securityProperties) {
+            final SecurityProperties securityProperties
+    ) {
         this.resolver = resolver;
         this.securityProperties = securityProperties;
     }
@@ -30,7 +31,8 @@ class ClassicIncomingAuthenticationFilter implements Filter {
     public void doFilter(
             final ServletRequest request,
             final ServletResponse response,
-            final FilterChain chain)
+            final FilterChain chain
+    )
             throws IOException, ServletException {
 
         if (request instanceof HttpServletRequest incoming

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthenticationFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package gov.cdc.nbs.redirect.incoming;
 
+import gov.cdc.nbs.authentication.config.SecurityProperties;
+import gov.cdc.nbs.authentication.token.NBSTokenCookieEnsurer;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -7,7 +10,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import gov.cdc.nbs.authentication.config.SecurityProperties;
 import java.io.IOException;
 
 /**
@@ -17,31 +19,35 @@ import java.io.IOException;
 class ClassicIncomingAuthenticationFilter implements Filter {
 
     private final ClassicIncomingContextResolver resolver;
+    private final NBSTokenCookieEnsurer ensurer;
     private final SecurityProperties securityProperties;
 
     ClassicIncomingAuthenticationFilter(
-            final ClassicIncomingContextResolver resolver,
-            final SecurityProperties securityProperties
+        final ClassicIncomingContextResolver resolver,
+        final NBSTokenCookieEnsurer ensurer,
+        final SecurityProperties securityProperties
     ) {
         this.resolver = resolver;
+        this.ensurer = ensurer;
         this.securityProperties = securityProperties;
     }
 
     @Override
     public void doFilter(
-            final ServletRequest request,
-            final ServletResponse response,
-            final FilterChain chain
+        final ServletRequest request,
+        final ServletResponse response,
+        final FilterChain chain
     )
-            throws IOException, ServletException {
+        throws IOException, ServletException {
 
         if (request instanceof HttpServletRequest incoming
-                && response instanceof HttpServletResponse outgoing) {
+            && response instanceof HttpServletResponse outgoing) {
 
             ClassicIncomingAuthorization context = resolver.resolve(incoming);
 
             if (context instanceof ClassicIncomingAuthorization.Authorized authorized) {
                 authorized.apply(securityProperties).accept(outgoing);
+                this.ensurer.ensure(authorized.user().user(), outgoing);
                 chain.doFilter(incoming, outgoing);
             } else if (context instanceof ClassicIncomingAuthorization.Unauthorized unauthorized) {
                 unauthorized.apply(securityProperties).accept(outgoing);

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthenticationFilterConfiguration.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthenticationFilterConfiguration.java
@@ -1,10 +1,11 @@
 package gov.cdc.nbs.redirect.incoming;
 
 
+import gov.cdc.nbs.authentication.config.SecurityProperties;
+import gov.cdc.nbs.authentication.token.NBSTokenCookieEnsurer;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import gov.cdc.nbs.authentication.config.SecurityProperties;
 
 @Configuration
 class ClassicIncomingAuthenticationFilterConfiguration {
@@ -15,14 +16,17 @@ class ClassicIncomingAuthenticationFilterConfiguration {
      */
     @Bean
     FilterRegistrationBean<ClassicIncomingAuthenticationFilter> classicIncomingAuthenticationFilterRegistration(
-            final ClassicIncomingContextResolver resolver,
-            final SecurityProperties securityProperties) {
+        final ClassicIncomingContextResolver resolver,
+        final NBSTokenCookieEnsurer ensurer,
+        final SecurityProperties securityProperties
+    ) {
 
         ClassicIncomingAuthenticationFilter filter =
-                new ClassicIncomingAuthenticationFilter(resolver, securityProperties);
+            new ClassicIncomingAuthenticationFilter(resolver, ensurer, securityProperties);
 
         FilterRegistrationBean<ClassicIncomingAuthenticationFilter> registration =
-                new FilterRegistrationBean<>(filter);
+            new FilterRegistrationBean<>(filter);
+
         registration.addUrlPatterns("/nbs/redirect/*");
 
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthorization.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingAuthorization.java
@@ -1,8 +1,8 @@
 package gov.cdc.nbs.redirect.incoming;
 
 import gov.cdc.nbs.authentication.config.SecurityProperties;
-import gov.cdc.nbs.authorization.NBSUserCookie;
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.NBSUserCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingContextResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/redirect/incoming/ClassicIncomingContextResolver.java
@@ -1,8 +1,8 @@
 package gov.cdc.nbs.redirect.incoming;
 
 import gov.cdc.nbs.authentication.AuthorizedUserResolver;
-import gov.cdc.nbs.authorization.NBSUserCookie;
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.NBSUserCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/Authenticated.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/Authenticated.java
@@ -39,7 +39,7 @@ public class Authenticated {
 
         AuthUser authUser = this.entityManager.find(AuthUser.class, activeUser.id());
 
-        NbsUserDetails details = resolver.resolve(authUser, activeUser.token());
+        NbsUserDetails details = resolver.resolve(authUser);
 
         PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
                 details,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/Authenticated.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/Authenticated.java
@@ -15,18 +15,16 @@ import javax.persistence.EntityManager;
 import java.util.function.Supplier;
 
 @Component
-public class TestAuthentication {
-
+public class Authenticated {
 
     private final TestActive<ActiveUser> active;
     private final NBSUserDetailsResolver resolver;
     private final EntityManager entityManager;
 
-    public TestAuthentication(
-        final TestActive<ActiveUser> active,
-        final NBSUserDetailsResolver resolver,
-        final EntityManager entityManager
-    ) {
+    public Authenticated(
+            final TestActive<ActiveUser> active,
+            final NBSUserDetailsResolver resolver,
+            final EntityManager entityManager) {
         this.active = active;
         this.resolver = resolver;
         this.entityManager = entityManager;
@@ -36,27 +34,25 @@ public class TestAuthentication {
         SecurityContextHolder.getContext().setAuthentication(null);
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void apply() {
+    private void apply() {
         ActiveUser activeUser = this.active.active();
 
         AuthUser authUser = this.entityManager.find(AuthUser.class, activeUser.id());
 
-        NbsUserDetails details = resolver.resolve(authUser, activeUser.token().value());
+        NbsUserDetails details = resolver.resolve(authUser, activeUser.token());
 
-        PreAuthenticatedAuthenticationToken authentication =
-            new PreAuthenticatedAuthenticationToken(
+        PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
                 details,
                 null,
-                details.getAuthorities()
-            );
+                details.getAuthorities());
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
     }
 
     /**
-     * Executes the given {@code action} ensuring that the {@link SecurityContextHolder} is configured to be
+     * Executes the given {@code action} ensuring that the
+     * {@link SecurityContextHolder} is configured to be
      * authenticated with the Active User.
      *
      * @param action The action to perform while authenticated.
@@ -64,7 +60,7 @@ public class TestAuthentication {
      * @return The result of the action
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public <T> T authenticated(final Supplier<T> action) {
+    public <T> T perform(final Supplier<T> action) {
         apply();
 
         try {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/FindUsersSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/FindUsersSteps.java
@@ -1,18 +1,12 @@
 package gov.cdc.nbs;
 
-import gov.cdc.nbs.authentication.entity.AuthAudit;
-import gov.cdc.nbs.authentication.entity.AuthPermSet;
 import gov.cdc.nbs.authentication.entity.AuthPermSetRepository;
 import gov.cdc.nbs.authentication.entity.AuthUser;
 import gov.cdc.nbs.authentication.entity.AuthUserRepository;
-import gov.cdc.nbs.authentication.entity.AuthUserRole;
 import gov.cdc.nbs.authentication.entity.AuthUserRoleRepository;
 import gov.cdc.nbs.authorization.TestAuthorizedUser;
 import gov.cdc.nbs.controller.UserController;
-import gov.cdc.nbs.support.PermissionMother;
 import gov.cdc.nbs.support.TestAvailable;
-import gov.cdc.nbs.support.UserMother;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.junit.runner.RunWith;
@@ -23,7 +17,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.time.Instant;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,13 +40,13 @@ public class FindUsersSteps {
     TestAvailable<TestAuthorizedUser> availableUsers;
 
     @Autowired
-    TestAuthentication testAuthentication;
+    Authenticated authenticated;
 
     private Page<AuthUser> users;
 
     @When("I retrieve the user list")
     public void i_search_for_users() {
-        users = testAuthentication.authenticated(() -> userController.findAllUsers(null));
+        users = authenticated.perform(() -> userController.findAllUsers(null));
     }
 
     @Then("The {string} user is returned")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/PermissionSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/PermissionSteps.java
@@ -1,9 +1,7 @@
 package gov.cdc.nbs;
 
-import gov.cdc.nbs.authentication.NBSToken;
 import gov.cdc.nbs.authentication.NbsAuthority;
 import gov.cdc.nbs.authentication.NbsUserDetails;
-import gov.cdc.nbs.authentication.TokenCreator;
 import gov.cdc.nbs.authorization.ActiveUser;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.event.search.InvestigationFilter;
@@ -48,9 +46,6 @@ public class PermissionSteps {
 
     @Autowired
     TestActive<UserDetails> activeUserDetails;
-
-    @Autowired
-    TokenCreator tokenCreator;
 
     @Before
     public void clearAuth() {
@@ -98,7 +93,6 @@ public class PermissionSteps {
             var nbsUserDetails = NbsUserDetails.builder()
                 .id(id)
                 .username("MOCK-USER")
-                .token(createToken("MOCK-USER"))
                 .authorities(nbsAuthorities)
                 .isEnabled(true)
                 .build();
@@ -115,7 +109,6 @@ public class PermissionSteps {
             var nbsUserDetails = NbsUserDetails.builder()
                 .id(existingUserDetails.getId())
                 .username(existingUserDetails.getUsername())
-                .token(existingUserDetails.getToken())
                 .authorities(existingAuthorities)
                 .isEnabled(existingUserDetails.isEnabled())
                 .build();
@@ -169,10 +162,6 @@ public class PermissionSteps {
         } else {
             throw new RuntimeException("Invalid responseType specified: " + resultType);
         }
-    }
-
-    private NBSToken createToken(String username) {
-        return tokenCreator.forUser(username);
     }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/RedirectSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/RedirectSteps.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import javax.servlet.http.Cookie;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
@@ -202,10 +203,19 @@ public class RedirectSteps {
     @Then("the user Id is present in the redirect")
     public void the_user_id_is_present_in_the_redirect() {
         MockHttpServletResponse response = activeResponse.active();
-        var userIdCookie = response.getCookie("nbs_user");
-        assertNotNull(userIdCookie);
-        assertEquals(activeUser.active().username(), userIdCookie.getValue());
+        Cookie cookie = response.getCookie("nbs_user");
+
+        assertThat(cookie).extracting(Cookie::getValue).isEqualTo(activeUser.active().username());
+
     }
 
+    @Then("the token is present in the redirect")
+    public void the_token_is_present_in_the_redirect() {
+        MockHttpServletResponse response = activeResponse.active();
+
+        Cookie cookie = response.getCookie("nbs_token");
+
+        assertThat(cookie).extracting(Cookie::getValue).isNotNull();
+    }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/RedirectSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/RedirectSteps.java
@@ -1,7 +1,7 @@
 package gov.cdc.nbs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.authorization.TestActiveUser;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.graphql.GraphQLPage;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/TestAuthentication.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/TestAuthentication.java
@@ -42,7 +42,7 @@ public class TestAuthentication {
 
         AuthUser authUser = this.entityManager.find(AuthUser.class, activeUser.id());
 
-        NbsUserDetails details = resolver.resolve(authUser, activeUser.token());
+        NbsUserDetails details = resolver.resolve(authUser, activeUser.token().value());
 
         PreAuthenticatedAuthenticationToken authentication =
             new PreAuthenticatedAuthenticationToken(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/ActiveUser.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/ActiveUser.java
@@ -1,4 +1,6 @@
 package gov.cdc.nbs.authorization;
 
-public record ActiveUser(long id, String username, String token) {
+import gov.cdc.nbs.authentication.NBSToken;
+
+public record ActiveUser(long id, String username, NBSToken token) {
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/AuthorizationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/AuthorizationSteps.java
@@ -1,5 +1,7 @@
 package gov.cdc.nbs.authorization;
 
+import gov.cdc.nbs.authentication.NBSToken;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.authentication.TokenCreator;
 import gov.cdc.nbs.authentication.entity.AuthUser;
 import gov.cdc.nbs.authentication.entity.SecurityLog;
@@ -57,7 +59,7 @@ public class AuthorizationSteps {
         log.setLastNm(user.getUserLastNm());
         securityLogRepository.save(log);
 
-        String token = this.tokenCreator.forUser(user.getUserId());
+        NBSToken token = this.tokenCreator.forUser(user.getUserId());
 
         ActiveUser currentUser = new ActiveUser(user.getId(), user.getUserId(), token);
         activeUser.active(currentUser);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/TestActiveSessionCookieConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/TestActiveSessionCookieConfiguration.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.authorization;
 
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.support.TestActive;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/permission/ClientPermissionSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/authorization/permission/ClientPermissionSteps.java
@@ -29,7 +29,7 @@ public class ClientPermissionSteps {
         ActiveUser user = activeUser.active();
 
         activeResult.active(
-            mvc.perform(get("/nbs/api/me").header("Authorization", "Bearer " + user.token()))
+            mvc.perform(get("/nbs/api/me").header("Authorization", "Bearer " + user.token().value()))
                 .andExpect(status().isOk())
 
         );

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilderTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import gov.cdc.nbs.authentication.NBSToken;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
@@ -770,7 +772,7 @@ class InvestigationQueryBuilderTest {
         return NbsUserDetails.builder()
                 .id(1L)
                 .username("MOCK-USER")
-                .token("token")
+                .token(new NBSToken("token"))
                 .authorities(authorities())
                 .isEnabled(true)
                 .build();

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportQueryBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportQueryBuilderTest.java
@@ -1,39 +1,5 @@
 package gov.cdc.nbs.event.search.labreport;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import gov.cdc.nbs.authentication.NBSToken;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.query.TermsQueryBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import gov.cdc.nbs.authentication.NbsAuthority;
 import gov.cdc.nbs.authentication.NbsUserDetails;
 import gov.cdc.nbs.entity.elasticsearch.ElasticsearchActId;
@@ -55,6 +21,40 @@ import gov.cdc.nbs.message.enums.PregnancyStatus;
 import gov.cdc.nbs.service.SecurityService;
 import gov.cdc.nbs.support.util.RandomUtil;
 import gov.cdc.nbs.time.FlexibleInstantConverter;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 class LabReportQueryBuilderTest {
     @Mock
@@ -127,13 +127,13 @@ class LabReportQueryBuilderTest {
 
         // program_jurisdiction_oid clause was added
         var clause = must.stream()
-                .filter(m -> {
-                    if (m instanceof TermsQueryBuilder mq)
-                        return mq.fieldName().equals(LabReport.PROGRAM_JURISDICTION_OID);
-                    return false;
-                })
-                .findFirst()
-                .map(m -> (TermsQueryBuilder) m);
+            .filter(m -> {
+                if (m instanceof TermsQueryBuilder mq)
+                    return mq.fieldName().equals(LabReport.PROGRAM_JURISDICTION_OID);
+                return false;
+            })
+            .findFirst()
+            .map(m -> (TermsQueryBuilder) m);
         assertTrue(clause.isPresent());
         var oids = programAreaJurisdictionOids();
         oids.forEach(oid -> assertTrue(clause.get().values().contains(oid)));
@@ -295,7 +295,7 @@ class LabReportQueryBuilderTest {
 
         // method call
         var eds = new LabReportFilter.LaboratoryEventDateSearch(dateType, RandomUtil.dateInPast(),
-                LocalDate.now());
+            LocalDate.now());
         var filter = new LabReportFilter();
         filter.setEventDate(eds);
         var query = queryBuilder.buildLabReportQuery(filter, pageable);
@@ -330,7 +330,7 @@ class LabReportQueryBuilderTest {
 
         // method call
         var eds =
-                new LabReportFilter.LaboratoryEventDateSearch(LabReportDateType.DATE_OF_REPORT, null, LocalDate.now());
+            new LabReportFilter.LaboratoryEventDateSearch(LabReportDateType.DATE_OF_REPORT, null, LocalDate.now());
         var filter = new LabReportFilter();
         filter.setEventDate(eds);
         assertThrows(QueryException.class, () -> queryBuilder.buildLabReportQuery(filter, pageable));
@@ -490,7 +490,7 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var clause = findTermsQueryBuilder(LabReport.RECORD_STATUS_CD, must);
         Arrays.asList(ProcessingStatus.values()).stream()
-                .forEach(status -> assertTrue(clause.values().contains(status.toString())));
+            .forEach(status -> assertTrue(clause.values().contains(status.toString())));
     }
 
     @Test
@@ -554,10 +554,10 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var nested = findNestedQueryBuilders(must);
         var clause1 = findMatchQueryBuilder(
-                LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchPersonParticipation.TYPE_CD, nested);
+            LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchPersonParticipation.TYPE_CD, nested);
         assertEquals("PATSBJ", clause1.value());
         var clause2 = findMatchQueryBuilder(
-                LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchPersonParticipation.PERSON_PARENT_UID, nested);
+            LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchPersonParticipation.PERSON_PARENT_UID, nested);
         assertEquals(filter.getPatientId(), clause2.value());
     }
 
@@ -581,16 +581,16 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var nested = findNestedQueryBuilders(must);
         var clause1 = findMatchQueryBuilder(
-                LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.TYPE_CD,
-                nested);
+            LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.TYPE_CD,
+            nested);
         assertEquals("ORD", clause1.value());
         var clause2 = findMatchQueryBuilder(
-                LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.SUBJECT_CLASS_CD,
-                nested);
+            LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.SUBJECT_CLASS_CD,
+            nested);
         assertEquals("ORG", clause2.value());
         var clause3 = findMatchQueryBuilder(
-                LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.ENTITY_ID,
-                nested);
+            LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.ENTITY_ID,
+            nested);
         assertEquals(filter.getProviderSearch().getProviderId(), clause3.value());
     }
 
@@ -614,16 +614,16 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var nested = findNestedQueryBuilders(must);
         var clause1 = findMatchQueryBuilder(
-                LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.TYPE_CD,
-                nested);
+            LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.TYPE_CD,
+            nested);
         assertEquals("ORD", clause1.value());
         var clause2 = findMatchQueryBuilder(
-                LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.SUBJECT_CLASS_CD,
-                nested);
+            LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.SUBJECT_CLASS_CD,
+            nested);
         assertEquals("PSN", clause2.value());
         var clause3 = findMatchQueryBuilder(
-                LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.ENTITY_ID,
-                nested);
+            LabReport.PERSON_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.ENTITY_ID,
+            nested);
         assertEquals(filter.getProviderSearch().getProviderId(), clause3.value());
     }
 
@@ -647,12 +647,12 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var nested = findNestedQueryBuilders(must);
         var clause1 = findMatchQueryBuilder(
-                LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.SUBJECT_CLASS_CD,
-                nested);
+            LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.SUBJECT_CLASS_CD,
+            nested);
         assertEquals("AUT", clause1.value());
         var clause3 = findMatchQueryBuilder(
-                LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.ENTITY_ID,
-                nested);
+            LabReport.ORGANIZATION_PARTICIPATIONS + "." + ElasticsearchOrganizationParticipation.ENTITY_ID,
+            nested);
         assertEquals(filter.getProviderSearch().getProviderId(), clause3.value());
     }
 
@@ -675,7 +675,7 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var nested = findNestedQueryBuilders(must);
         var clause = findMatchQueryBuilder(LabReport.OBSERVATIONS_FIELD + "." + ElasticsearchObservation.CD_DESC_TXT,
-                nested);
+            nested);
         assertEquals(filter.getResultedTest(), clause.value());
     }
 
@@ -698,45 +698,45 @@ class LabReportQueryBuilderTest {
         // Case type clause added
         var nested = findNestedQueryBuilders(must);
         var clause = findMatchQueryBuilder(LabReport.OBSERVATIONS_FIELD + "." + ElasticsearchObservation.DISPLAY_NAME,
-                nested);
+            nested);
         assertEquals(filter.getCodedResult(), clause.value());
     }
 
     private RangeQueryBuilder findRangeQueryBuilder(String path, List<QueryBuilder> builders) {
         var optional = builders.stream()
-                .filter(m -> {
-                    if (m instanceof RangeQueryBuilder mq)
-                        return mq.fieldName().equals(path);
-                    return false;
-                })
-                .findFirst()
-                .map(m -> (RangeQueryBuilder) m);
+            .filter(m -> {
+                if (m instanceof RangeQueryBuilder mq)
+                    return mq.fieldName().equals(path);
+                return false;
+            })
+            .findFirst()
+            .map(m -> (RangeQueryBuilder) m);
         assertNotNull(optional);
         return optional.get();
     }
 
     private MatchQueryBuilder findMatchQueryBuilder(String path, List<QueryBuilder> builders) {
         var optional = builders.stream()
-                .filter(m -> {
-                    if (m instanceof MatchQueryBuilder mq)
-                        return mq.fieldName().equals(path);
-                    return false;
-                })
-                .findFirst()
-                .map(m -> (MatchQueryBuilder) m);
+            .filter(m -> {
+                if (m instanceof MatchQueryBuilder mq)
+                    return mq.fieldName().equals(path);
+                return false;
+            })
+            .findFirst()
+            .map(m -> (MatchQueryBuilder) m);
         assertNotNull(optional);
         return optional.get();
     }
 
     private TermsQueryBuilder findTermsQueryBuilder(String path, List<QueryBuilder> builders) {
         var optional = builders.stream()
-                .filter(m -> {
-                    if (m instanceof TermsQueryBuilder mq)
-                        return mq.fieldName().equals(path);
-                    return false;
-                })
-                .findFirst()
-                .map(m -> (TermsQueryBuilder) m);
+            .filter(m -> {
+                if (m instanceof TermsQueryBuilder mq)
+                    return mq.fieldName().equals(path);
+                return false;
+            })
+            .findFirst()
+            .map(m -> (TermsQueryBuilder) m);
         assertNotNull(optional);
         return optional.get();
     }
@@ -757,40 +757,39 @@ class LabReportQueryBuilderTest {
     private Set<NbsAuthority> authorities() {
         var authorities = new HashSet<NbsAuthority>();
         authorities.add(NbsAuthority.builder()
-                .authority("FIND-PATIENT")
-                .businessObject("PATIENT")
-                .businessOperation("FIND")
-                .programArea("STD")
-                .programAreaUid(1)
-                .jurisdiction("130001")
-                .build());
+            .authority("FIND-PATIENT")
+            .businessObject("PATIENT")
+            .businessOperation("FIND")
+            .programArea("STD")
+            .programAreaUid(1)
+            .jurisdiction("130001")
+            .build());
         authorities.add(NbsAuthority.builder()
-                .authority("VIEW-OBSERVATIONLABREPORT")
-                .businessObject("OBSERVATIONLABREPORT")
-                .businessOperation("VIEW")
-                .programArea("STD")
-                .programAreaUid(2)
-                .jurisdiction("130002")
-                .build());
+            .authority("VIEW-OBSERVATIONLABREPORT")
+            .businessObject("OBSERVATIONLABREPORT")
+            .businessOperation("VIEW")
+            .programArea("STD")
+            .programAreaUid(2)
+            .jurisdiction("130002")
+            .build());
         return authorities;
     }
 
     private void setAuthentication() {
         var userDetails = userDetails();
         var authentication = new PreAuthenticatedAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.getAuthorities());
+            userDetails,
+            null,
+            userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     private NbsUserDetails userDetails() {
         return NbsUserDetails.builder()
-                .id(1L)
-                .username("MOCK-USER")
-                .token(new NBSToken("token"))
-                .authorities(authorities())
-                .isEnabled(true)
-                .build();
+            .id(1L)
+            .username("MOCK-USER")
+            .authorities(authorities())
+            .isEnabled(true)
+            .build();
     }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportQueryBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportQueryBuilderTest.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import gov.cdc.nbs.authentication.NBSToken;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
@@ -786,7 +788,7 @@ class LabReportQueryBuilderTest {
         return NbsUserDetails.builder()
                 .id(1L)
                 .username("MOCK-USER")
-                .token("token")
+                .token(new NBSToken("token"))
                 .authorities(authorities())
                 .isEnabled(true)
                 .build();

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/contact/PatientProfileViewContactSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/contact/PatientProfileViewContactSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.contact;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatientIdentifier;
 import gov.cdc.nbs.patient.contact.TestContactTracings;
 import gov.cdc.nbs.support.TestActive;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/document/PatientProfileViewDocumentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/document/PatientProfileViewDocumentSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.document;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.patient.document.TestDocuments;
 import gov.cdc.nbs.support.TestActive;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/DeleteInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/DeleteInvestigationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/DeleteLegacyInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/DeleteLegacyInvestigationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileAddInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileAddInvestigationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileCompareInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileCompareInvestigationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.event.search.investigation.TestInvestigations;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileViewInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileViewInvestigationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.event.search.investigation.TestInvestigations;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/merge/PatientProfileMergeInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/merge/PatientProfileMergeInvestigationSteps.java
@@ -1,7 +1,7 @@
 package gov.cdc.nbs.patient.profile.investigation.merge;
 
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/redirect/incoming/PatientProfileIncomingRedirectionSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/redirect/incoming/PatientProfileIncomingRedirectionSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.redirect.incoming;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.support.TestActive;
 import gov.cdc.nbs.support.TestAvailable;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/redirect/incoming/PatientProfileReturningRedirectionSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/redirect/incoming/PatientProfileReturningRedirectionSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.redirect.incoming;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/lab/PatientProfileAddLabReportSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/lab/PatientProfileAddLabReportSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.report.lab;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/lab/PatientProfileViewLabReportSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/lab/PatientProfileViewLabReportSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.report.lab;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/lab/SubmitLabReportSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/lab/SubmitLabReportSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.report.lab;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/morbidity/PatientProfileAddMorbiditySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/morbidity/PatientProfileAddMorbiditySteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.report.morbidity;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/morbidity/PatientProfileViewMorbiditySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/morbidity/PatientProfileViewMorbiditySteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.report.morbidity;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.patient.morbidity.TestMorbidityReports;
 import gov.cdc.nbs.support.TestActive;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/morbidity/SubmitMorbidityReportSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/report/morbidity/SubmitMorbidityReportSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.report.morbidity;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/treatment/PatientProfileViewTreatmentSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/treatment/PatientProfileViewTreatmentSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.treatment;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.patient.treatment.TestTreatments;
 import gov.cdc.nbs.support.TestActive;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientProfileSubmitVaccinationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientProfileSubmitVaccinationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.vaccination;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatientIdentifier;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientProfileViewVaccinationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/vaccination/PatientProfileViewVaccinationSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.profile.vaccination;
 
-import gov.cdc.nbs.authorization.SessionCookie;
+import gov.cdc.nbs.authentication.SessionCookie;
 import gov.cdc.nbs.patient.TestPatientIdentifier;
 import gov.cdc.nbs.support.TestActive;
 import io.cucumber.java.Before;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchSteps.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.patient.search;
 
-import gov.cdc.nbs.TestAuthentication;
+import gov.cdc.nbs.Authenticated;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.exception.QueryException;
@@ -52,7 +52,7 @@ public class PatientSearchSteps {
     PatientController patientController;
 
     @Autowired
-    TestAuthentication testAuthentication;
+    Authenticated authenticated;
 
     private List<Person> available;
     private QueryException exception;
@@ -275,7 +275,7 @@ public class PatientSearchSteps {
             SortCriteria criteria = this.sorting.active();
             GraphQLPage page = new GraphQLPage(15, 0, criteria.direction(), criteria.field());
 
-            Page<Person> found = testAuthentication.authenticated(() ->
+            Page<Person> found = authenticated.perform(() ->
                 patientController.findPatientsByFilter(
                     this.filter.active(),
                     page

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/service/SecurityServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/service/SecurityServiceTest.java
@@ -155,8 +155,8 @@ class SecurityServiceTest {
                 null,
                 null,
                 authorities,
-                null,
-                false);
+                false
+        );
     }
 
 

--- a/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileIncomingRedirect.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileIncomingRedirect.feature
@@ -19,6 +19,7 @@ Feature: NBS Classic Patient Profile redirects to modernized Patient Profile
     When Redirecting a Classic Revision Patient Profile
     Then I am redirected to the Modernized Patient Profile
     And the user Id is present in the redirect
+    And the token is present in the redirect
 
   Scenario: A user in NBS Classic is navigating to a Patient Profile without an active session
     Given I have a patient

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/config/WebSecurityConfig.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/config/WebSecurityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
-import gov.cdc.nbs.authentication.JWTFilter;
+import gov.cdc.nbs.authentication.token.JWTFilter;
 import lombok.RequiredArgsConstructor;
 
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/services/PageUpdaterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/services/PageUpdaterTest.java
@@ -1,24 +1,5 @@
 package gov.cdc.nbs.questionbank.page.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import java.time.Instant;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import gov.cdc.nbs.authentication.NBSToken;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import gov.cdc.nbs.authentication.NbsUserDetails;
 import gov.cdc.nbs.authentication.UserDetailsProvider;
 import gov.cdc.nbs.questionbank.entity.PageCondMapping;
@@ -27,6 +8,24 @@ import gov.cdc.nbs.questionbank.entity.repository.WaTemplateRepository;
 import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
 import gov.cdc.nbs.questionbank.page.exception.PageUpdateException;
 import gov.cdc.nbs.questionbank.page.request.UpdatePageDetailsRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PageUpdaterTest {
@@ -266,7 +265,6 @@ class PageUpdaterTest {
             null,
             null,
             null,
-            new NBSToken("token"),
             true);
     }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/services/PageUpdaterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/services/PageUpdaterTest.java
@@ -4,12 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import gov.cdc.nbs.authentication.NBSToken;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -55,7 +58,7 @@ class PageUpdaterTest {
 
         // given a page exists
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Published", null)));
+            .thenReturn(Optional.of(template("Published", null)));
 
         // when an update request is sent
         UpdatePageDetailsRequest request = updateRequest();
@@ -74,7 +77,7 @@ class PageUpdaterTest {
 
         // given a page exists
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Draft", null)));
+            .thenReturn(Optional.of(template("Draft", null)));
 
         // when an update request is sent
         UpdatePageDetailsRequest request = updateRequest();
@@ -94,7 +97,7 @@ class PageUpdaterTest {
 
         // given a page exists
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Published", null)));
+            .thenReturn(Optional.of(template("Published", null)));
 
         // when an update request is sent
         UpdatePageDetailsRequest request = updateRequest();
@@ -113,7 +116,7 @@ class PageUpdaterTest {
 
         // given a page exists
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Draft", 1)));
+            .thenReturn(Optional.of(template("Draft", 1)));
 
         // when an update request is sent
         UpdatePageDetailsRequest request = updateRequest();
@@ -132,7 +135,7 @@ class PageUpdaterTest {
 
         // given a page exists with templateType of "Draft" and null publishVersionNbr
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Draft", null)));
+            .thenReturn(Optional.of(template("Draft", null)));
 
         // when an update request is sent
         UpdatePageDetailsRequest request = updateRequest();
@@ -151,15 +154,15 @@ class PageUpdaterTest {
 
         // given a page exists with templateType of "Draft" and null publishVersionNbr
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Draft", null)));
+            .thenReturn(Optional.of(template("Draft", null)));
 
         // when an update request is sent
         UpdatePageDetailsRequest request = new UpdatePageDetailsRequest(
-                "updated name",
-                "updated mmg",
-                "updated datamart",
-                "updated description",
-                Collections.singleton("conditionCd"));
+            "updated name",
+            "updated mmg",
+            "updated datamart",
+            "updated description",
+            Collections.singleton("conditionCd"));
         WaTemplate updatedTemplate = updater.update(1L, request);
 
         // then the condition is not changed
@@ -173,7 +176,7 @@ class PageUpdaterTest {
     void should_throw_bad_request_duplicate_name() {
         // given a page exists with templateType of "Draft" and null publishVersionNbr
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Draft", null)));
+            .thenReturn(Optional.of(template("Draft", null)));
 
         // the datamart name doesn't exist
         when(repository.existsByDatamartNmAndIdNot("updated datamart", 1L)).thenReturn(false);
@@ -183,12 +186,12 @@ class PageUpdaterTest {
 
         // when an update request is sent
         UpdatePageDetailsRequest request = new UpdatePageDetailsRequest(
-                "updated name",
-                "updated mmg",
-                "updated datamart",
-                "updated description",
-                Collections.singleton("conditionCd"));
-        PageUpdateException ex = assertThrows( PageUpdateException.class, () ->updater.update(1L, request));
+            "updated name",
+            "updated mmg",
+            "updated datamart",
+            "updated description",
+            Collections.singleton("conditionCd"));
+        PageUpdateException ex = assertThrows(PageUpdateException.class, () -> updater.update(1L, request));
         assertEquals("The specified Page Name already exists", ex.getMessage());
     }
 
@@ -196,19 +199,19 @@ class PageUpdaterTest {
     void should_throw_bad_request_duplicate_data_mart_name() {
         // given a page exists with templateType of "Draft" and null publishVersionNbr
         when(repository.findByIdAndTemplateTypeIn(1L, List.of("Draft", "Published")))
-                .thenReturn(Optional.of(template("Draft", null)));
+            .thenReturn(Optional.of(template("Draft", null)));
 
         // and a page with the updated name already exists
         when(repository.existsByDatamartNmAndIdNot("updated datamart", 1L)).thenReturn(true);
 
         // when an update request is sent
         UpdatePageDetailsRequest request = new UpdatePageDetailsRequest(
-                "updated name",
-                "updated mmg",
-                "updated datamart",
-                "updated description",
-                Collections.singleton("conditionCd"));
-        PageUpdateException ex = assertThrows( PageUpdateException.class, () ->updater.update(1L, request));
+            "updated name",
+            "updated mmg",
+            "updated datamart",
+            "updated description",
+            Collections.singleton("conditionCd"));
+        PageUpdateException ex = assertThrows(PageUpdateException.class, () -> updater.update(1L, request));
         assertEquals("The specified Data Mart Name already exists", ex.getMessage());
 
     }
@@ -232,38 +235,38 @@ class PageUpdaterTest {
         Instant now = Instant.now();
         Set<PageCondMapping> mappings = new HashSet<>();
         mappings.add(
-                new PageCondMapping(
-                        2L,
-                        template,
-                        "conditionCd",
-                        now,
-                        100L,
-                        now,
-                        100L));
+            new PageCondMapping(
+                2L,
+                template,
+                "conditionCd",
+                now,
+                100L,
+                now,
+                100L));
         return mappings;
     }
 
     private UpdatePageDetailsRequest updateRequest() {
         return new UpdatePageDetailsRequest(
-                "updated name",
-                "updated mmg",
-                "updated datamart",
-                "updated description",
-                Collections.singleton("new condition"));
+            "updated name",
+            "updated mmg",
+            "updated datamart",
+            "updated description",
+            Collections.singleton("new condition"));
     }
 
     private NbsUserDetails userDetails() {
         return new NbsUserDetails(
-                23L,
-                "test",
-                "test",
-                "test",
-                false,
-                false,
-                null,
-                null,
-                null,
-                "token",
-                true);
+            23L,
+            "test",
+            "test",
+            "test",
+            false,
+            false,
+            null,
+            null,
+            null,
+            new NBSToken("token"),
+            true);
     }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionControllerTest.java
@@ -3,6 +3,8 @@ package gov.cdc.nbs.questionbank.question;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+
+import gov.cdc.nbs.authentication.NBSToken;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -48,16 +50,16 @@ class QuestionControllerTest {
 
     private NbsUserDetails userDetails() {
         return new NbsUserDetails(
-                1L,
-                "test",
-                "test",
-                "test",
-                false,
-                false,
-                null,
-                null,
-                null,
-                "token",
-                true);
+            1L,
+            "test",
+            "test",
+            "test",
+            false,
+            false,
+            null,
+            null,
+            null,
+            new NBSToken("token"),
+            true);
     }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionControllerTest.java
@@ -1,21 +1,20 @@
 package gov.cdc.nbs.questionbank.question;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import gov.cdc.nbs.authentication.NBSToken;
+import gov.cdc.nbs.authentication.NbsUserDetails;
+import gov.cdc.nbs.authentication.UserDetailsProvider;
+import gov.cdc.nbs.questionbank.question.request.CreateQuestionRequest;
+import gov.cdc.nbs.questionbank.question.response.CreateQuestionResponse;
+import gov.cdc.nbs.questionbank.support.QuestionRequestMother;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import gov.cdc.nbs.authentication.NbsUserDetails;
-import gov.cdc.nbs.authentication.UserDetailsProvider;
-import gov.cdc.nbs.questionbank.question.request.CreateQuestionRequest;
-import gov.cdc.nbs.questionbank.question.response.CreateQuestionResponse;
-import gov.cdc.nbs.questionbank.support.QuestionRequestMother;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionControllerTest {
@@ -59,7 +58,6 @@ class QuestionControllerTest {
             null,
             null,
             null,
-            new NBSToken("token"),
             true);
     }
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/JWTFilter.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/JWTFilter.java
@@ -1,29 +1,30 @@
 package gov.cdc.nbs.authentication;
 
-import java.io.IOException;
-import java.util.Optional;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import gov.cdc.nbs.authentication.config.SecurityProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class JWTFilter extends OncePerRequestFilter {
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
-    private static final String TOKEN_COOKIE_NAME = "nbs_token";
+
     private final UserService userService;
     private final JWTVerifier verifier;
     private final SecurityProperties securityProperties;
@@ -33,29 +34,23 @@ public class JWTFilter extends OncePerRequestFilter {
      */
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain)
-            throws ServletException, IOException {
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain)
+        throws ServletException, IOException {
         verifyAndDecodeJWT(request)
-                .map(userService::findUserByToken)
-                .map(userDetails -> {
-                    response.addCookie(createJWTCookie(userDetails));
-                    return buildPreAuthenticatedToken(userDetails, request);
-                })
-                .ifPresent(preAuthToken -> SecurityContextHolder.getContext().setAuthentication(preAuthToken));
+            .map(userService::findUserByToken)
+            .map(userDetails -> {
+                response.addCookie(createJWTCookie(userDetails));
+                return buildPreAuthenticatedToken(userDetails, request);
+            })
+            .ifPresent(preAuthToken -> SecurityContextHolder.getContext().setAuthentication(preAuthToken));
         filterChain.doFilter(request, response);
     }
 
-    @SuppressWarnings({"squid:S2092", "squid:S3330"})
-    public Cookie createJWTCookie(NbsUserDetails userDetails) {
-        var cookie = new Cookie(TOKEN_COOKIE_NAME, userDetails.getToken());
-        // S2092 intra-container communication is currently not secure
-        cookie.setSecure(true);
-        // S3330 currently read by frontend codebase
-        cookie.setHttpOnly(false);
+    public Cookie createJWTCookie(final NbsUserDetails userDetails) {
+        Cookie cookie = userDetails.getToken().asCookie();
         cookie.setMaxAge(securityProperties.getTokenExpirationSeconds());
-        cookie.setPath("/");
         return cookie;
     }
 
@@ -66,8 +61,8 @@ public class JWTFilter extends OncePerRequestFilter {
     public Optional<DecodedJWT> verifyAndDecodeJWT(HttpServletRequest request) {
         try {
             return Optional.ofNullable(request.getHeader(AUTHORIZATION))
-                    .map(s -> !s.isBlank() ? s.substring(BEARER.length()) : s)
-                    .map(verifier::verify);
+                .map(s -> !s.isBlank() ? s.substring(BEARER.length()) : s)
+                .map(verifier::verify);
         } catch (JWTVerificationException | StringIndexOutOfBoundsException ex) {
             return Optional.empty();
         }
@@ -78,7 +73,7 @@ public class JWTFilter extends OncePerRequestFilter {
      * that notifies Spring Security that the request has been authorized
      */
     public PreAuthenticatedAuthenticationToken buildPreAuthenticatedToken(NbsUserDetails principal,
-            HttpServletRequest request) {
+        HttpServletRequest request) {
         var pat = new PreAuthenticatedAuthenticationToken(principal, null, principal.getAuthorities());
         pat.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         return pat;

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
@@ -24,6 +24,7 @@ public record NBSToken(String value) {
     public Cookie asCookie() {
         Cookie cookie = new Cookie(NBS_TOKEN_NAME, value());
         cookie.setPath("/");
+        cookie.setSecure(true);
         return cookie;
     }
 

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.authentication;
+
+import gov.cdc.nbs.authentication.config.SecurityProperties;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+public record NBSToken(String value) {
+
+    private static final String NBS_TOKEN_NAME = "nbs_token";
+
+    public void apply(
+        final SecurityProperties properties,
+        final HttpServletResponse response
+    ) {
+        Cookie cookie = asCookie();
+        cookie.setMaxAge(properties.getTokenExpirationSeconds());
+
+        response.addCookie(cookie);
+
+    }
+
+    @SuppressWarnings({"squid:S2092"})
+    public Cookie asCookie() {
+        Cookie cookie = new Cookie(NBS_TOKEN_NAME, value());
+        cookie.setPath("/");
+        return cookie;
+    }
+
+}

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
@@ -20,7 +20,7 @@ public record NBSToken(String value) {
 
     }
 
-    @SuppressWarnings({"squid:S2092"})
+    @SuppressWarnings({"squid:S3330"})
     public Cookie asCookie() {
         Cookie cookie = new Cookie(NBS_TOKEN_NAME, value());
         cookie.setPath("/");

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSUserCookie.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSUserCookie.java
@@ -1,4 +1,4 @@
-package gov.cdc.nbs.authorization;
+package gov.cdc.nbs.authentication;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSUserDetailsResolver.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSUserDetailsResolver.java
@@ -16,7 +16,7 @@ public class NBSUserDetailsResolver {
         this.finder = finder;
     }
 
-    public NbsUserDetails resolve(final AuthUser authUser, final String token) {
+    public NbsUserDetails resolve(final AuthUser authUser, final NBSToken token) {
         return NbsUserDetails
             .builder()
             .id(authUser.getNedssEntryId())

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSUserDetailsResolver.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSUserDetailsResolver.java
@@ -16,7 +16,7 @@ public class NBSUserDetailsResolver {
         this.finder = finder;
     }
 
-    public NbsUserDetails resolve(final AuthUser authUser, final NBSToken token) {
+    public NbsUserDetails resolve(final AuthUser authUser) {
         return NbsUserDetails
             .builder()
             .id(authUser.getNedssEntryId())
@@ -32,7 +32,6 @@ public class NBSUserDetailsResolver {
             .password(null)
             .authorities(finder.getUserPermissions(authUser))
             .isEnabled(authUser.getAudit().recordStatus().equals(AuthRecordStatus.ACTIVE))
-            .token(token)
             .build();
     }
 

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NbsUserDetails.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NbsUserDetails.java
@@ -20,7 +20,6 @@ public class NbsUserDetails implements UserDetails {
     private final Set<String> adminProgramAreas;
     private final String password;
     private final Set<NbsAuthority> authorities;
-    private final NBSToken token;
     private final boolean isEnabled;
 
     @Override

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NbsUserDetails.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NbsUserDetails.java
@@ -1,12 +1,11 @@
 package gov.cdc.nbs.authentication;
 
-import java.util.Set;
-
-import org.springframework.security.core.userdetails.UserDetails;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Set;
 
 @Getter
 @Builder
@@ -21,7 +20,7 @@ public class NbsUserDetails implements UserDetails {
     private final Set<String> adminProgramAreas;
     private final String password;
     private final Set<NbsAuthority> authorities;
-    private final String token;
+    private final NBSToken token;
     private final boolean isEnabled;
 
     @Override
@@ -41,8 +40,7 @@ public class NbsUserDetails implements UserDetails {
 
     /**
      * Checks if user has the specified permission
-     * 
-     * @param userDetails
+     *
      * @param businessObject
      * @param operation
      * @return
@@ -52,9 +50,9 @@ public class NbsUserDetails implements UserDetails {
             return false;
         }
         return getAuthorities()
-                .stream()
-                .anyMatch(a -> a.getBusinessObject().equals(businessObject)
-                        && a.getBusinessOperation().equals(operation));
+            .stream()
+            .anyMatch(a -> a.getBusinessObject().equals(businessObject)
+                && a.getBusinessOperation().equals(operation));
     }
 
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SessionCookie.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SessionCookie.java
@@ -1,4 +1,4 @@
-package gov.cdc.nbs.authorization;
+package gov.cdc.nbs.authentication;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/TokenCreator.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/TokenCreator.java
@@ -26,15 +26,16 @@ public class TokenCreator {
         this.properties = properties;
     }
 
-    public String forUser(final String username) {
+    public NBSToken forUser(final String username) {
         Instant now = Instant.now(clock);
         Instant expiry = now.plus(Duration.ofMillis(properties.getTokenExpirationMillis()));
-        return JWT
+        String token = JWT
             .create()
             .withIssuer(properties.getTokenIssuer())
             .withIssuedAt(now)
             .withExpiresAt(expiry)
             .withSubject(username)
             .sign(algorithm);
+        return new NBSToken(token);
     }
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/UserService.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/UserService.java
@@ -51,7 +51,7 @@ public class UserService implements UserDetailsService {
     }
 
     private String createToken(AuthUser user) {
-        return creator.forUser(user.getUserId());
+        return creator.forUser(user.getUserId()).value();
     }
 
 

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/UserService.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/UserService.java
@@ -1,10 +1,7 @@
 package gov.cdc.nbs.authentication;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import gov.cdc.nbs.authentication.entity.AuthUser;
 import gov.cdc.nbs.authentication.entity.AuthUserRepository;
-import gov.cdc.nbs.exception.BadTokenException;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -13,18 +10,25 @@ import org.springframework.transaction.annotation.Transactional;
 import static gov.cdc.nbs.authentication.NbsAuthorities.allowsAny;
 
 @Service
-@RequiredArgsConstructor
 public class UserService implements UserDetailsService {
 
     private final AuthUserRepository authUserRepository;
-    private final TokenCreator creator;
     private final NBSUserDetailsResolver resolver;
 
+    public UserService(
+        final AuthUserRepository authUserRepository,
+        final NBSUserDetailsResolver resolver
+    ) {
+        this.authUserRepository = authUserRepository;
+        this.resolver = resolver;
+    }
+
     @Override
+    @Transactional
     public NbsUserDetails loadUserByUsername(String username) {
         return authUserRepository
             .findByUserId(username)
-            .map(authUser -> buildUserDetails(authUser, createToken(authUser)))
+            .map(this::buildUserDetails)
             .orElseThrow(() -> new UsernameNotFoundException("Username not found"));
     }
 
@@ -35,25 +39,9 @@ public class UserService implements UserDetailsService {
             .anyMatch(allowsAny(permissions));
     }
 
-    /**
-     * Lookup AuthUser in database using the JWT subject. Convert database entity to a new JWTUserDetails and return
-     */
-    @Transactional
-    public NbsUserDetails findUserByToken(DecodedJWT jwt) {
-        return authUserRepository
-            .findByUserId(jwt.getSubject())
-            .map(authUser -> buildUserDetails(authUser, createToken(authUser)))
-            .orElseThrow(BadTokenException::new);
+    private NbsUserDetails buildUserDetails(AuthUser authUser) {
+        return resolver.resolve(authUser);
     }
-
-    private NbsUserDetails buildUserDetails(AuthUser authUser, NBSToken token) {
-        return resolver.resolve(authUser, token);
-    }
-
-    private NBSToken createToken(final AuthUser user) {
-        return creator.forUser(user.getUserId());
-    }
-
 
 
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/UserService.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/UserService.java
@@ -46,12 +46,12 @@ public class UserService implements UserDetailsService {
             .orElseThrow(BadTokenException::new);
     }
 
-    private NbsUserDetails buildUserDetails(AuthUser authUser, String token) {
+    private NbsUserDetails buildUserDetails(AuthUser authUser, NBSToken token) {
         return resolver.resolve(authUser, token);
     }
 
-    private String createToken(AuthUser user) {
-        return creator.forUser(user.getUserId()).value();
+    private NBSToken createToken(final AuthUser user) {
+        return creator.forUser(user.getUserId());
     }
 
 

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/token/NBSTokenCookieEnsurer.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/token/NBSTokenCookieEnsurer.java
@@ -1,0 +1,32 @@
+package gov.cdc.nbs.authentication.token;
+
+import gov.cdc.nbs.authentication.NBSToken;
+import gov.cdc.nbs.authentication.TokenCreator;
+import gov.cdc.nbs.authentication.config.SecurityProperties;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class NBSTokenCookieEnsurer {
+
+    private final TokenCreator creator;
+    private final SecurityProperties securityProperties;
+
+    NBSTokenCookieEnsurer(
+        final TokenCreator creator,
+        final SecurityProperties securityProperties
+    ) {
+        this.creator = creator;
+        this.securityProperties = securityProperties;
+    }
+
+    public void ensure(
+        final String username,
+        final HttpServletResponse outgoing
+    ) {
+        NBSToken token = creator.forUser(username);
+
+        token.apply(securityProperties, outgoing);
+    }
+}

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/JWTFilterTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/JWTFilterTest.java
@@ -1,101 +1,93 @@
 package gov.cdc.nbs.authentication;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import gov.cdc.nbs.authentication.config.JWTSecurityConfig;
+import gov.cdc.nbs.authentication.config.SecurityProperties;
+import gov.cdc.nbs.authentication.util.AuthObjectUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
-import org.springframework.security.core.context.SecurityContextHolder;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.JWTVerifier;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.DecodedJWT;
-import gov.cdc.nbs.authentication.config.JWTSecurityConfig;
-import gov.cdc.nbs.authentication.config.SecurityProperties;
-import gov.cdc.nbs.authentication.util.AuthObjectUtil;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class JWTFilterTest {
     @Mock
     private UserService userService;
 
-    @Spy
-    private SecurityProperties properties = new SecurityProperties(
-            "46z+oDurrJnxfaAz6h4Eg1saP7NSeHuQQ/Yq4vh+mbi4B4QYThc/M+22VtPO469Z",
-            "test-issuer",
-            60_000);
-
-    @Spy
     private Algorithm algorithm;
 
-    @Spy
-    private JWTVerifier verifier;
-
-    @InjectMocks
     private JWTFilter filter;
 
     @BeforeEach
     void setup() {
-        algorithm = buildAlgorithm();
-        verifier = buildVerifier();
+
+        SecurityProperties properties = new SecurityProperties(
+            "46z+oDurrJnxfaAz6h4Eg1saP7NSeHuQQ/Yq4vh+mbi4B4QYThc/M+22VtPO469Z",
+            "test-issuer",
+            60_000
+        );
+
+        JWTSecurityConfig config = new JWTSecurityConfig();
+
+        algorithm = config.jwtAlgorithm(properties);
+        JWTVerifier verifier = config.jwtVerifier(algorithm, properties);
+
+        TokenCreator creator = new TokenCreator(
+            Clock.systemDefaultZone(),
+            algorithm,
+            properties
+        );
         SecurityContextHolder.getContext().setAuthentication(null);
-        MockitoAnnotations.openMocks(this);
+
+        filter = new JWTFilter(userService, verifier, properties, creator);
     }
 
 
     @Test
     void should_validate() throws ServletException, IOException {
-        NbsUserDetails actual = AuthObjectUtil.userDetails();
+        NbsUserDetails details = mock(NbsUserDetails.class);
         // mocks
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        String token = "Bearer " + createToken(false);
+        String token = "Bearer " + createToken(Instant.now().plus(5, ChronoUnit.HOURS));
         when(request.getHeader("Authorization")).thenReturn(token);
 
-        when(userService.findUserByToken(Mockito.any())).thenReturn(actual);
+        when(userService.loadUserByUsername(any())).thenReturn(details);
 
         // method to test
         filter.doFilterInternal(request, response, filterChain);
 
         // validate
-        NbsUserDetails user = (NbsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        assertNotNull(user);
-        assertEquals(actual.getFirstName(), user.getFirstName());
-        assertEquals(actual.getLastName(), user.getLastName());
-        assertEquals(actual.getId(), user.getId());
-        assertEquals(actual.isEnabled(), user.isEnabled());
-        assertEquals(actual.isMasterSecurityAdmin(), user.isMasterSecurityAdmin());
-        assertEquals(actual.isProgramAreaAdmin(), user.isProgramAreaAdmin());
-        assertEquals(actual.getToken(), user.getToken());
-        assertEquals(actual.getUsername(), user.getUsername());
+        NbsUserDetails principal =
+            (NbsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        assertEquals(1, user.getAuthorities().size());
-        NbsAuthority actualAuthority = actual.getAuthorities().iterator().next();
-        NbsAuthority userAuthority = user.getAuthorities().iterator().next();
-        assertEquals(actualAuthority.getAuthority(), userAuthority.getAuthority());
-        assertEquals(actualAuthority.getBusinessObject(), userAuthority.getBusinessObject());
-        assertEquals(actualAuthority.getBusinessOperation(), userAuthority.getBusinessOperation());
-        assertEquals(actualAuthority.getJurisdiction(), userAuthority.getJurisdiction());
-        assertEquals(actualAuthority.getProgramArea(), userAuthority.getProgramArea());
-        assertEquals(actualAuthority.getProgramAreaUid(), userAuthority.getProgramAreaUid());
+        assertThat(principal).isSameAs(details);
 
-        verify(response).addCookie(Mockito.any());
+        verify(response).addCookie(any());
     }
 
     @Test
@@ -108,14 +100,12 @@ class JWTFilterTest {
         String token = "Bearer this-is-a-bad-token";
         when(request.getHeader("Authorization")).thenReturn(token);
 
-        when(userService.findUserByToken(Mockito.any(DecodedJWT.class))).thenReturn(AuthObjectUtil.userDetails());
-
         // method to test
         filter.doFilterInternal(request, response, filterChain);
 
         // validate
-        verify(userService, never()).findUserByToken(Mockito.any());
-        verify(response, never()).addCookie(Mockito.any());
+        verify(userService, never()).loadUserByUsername(any());
+        verify(response, never()).addCookie(any());
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
     }
@@ -127,17 +117,14 @@ class JWTFilterTest {
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        String token = "";
-        when(request.getHeader("Authorization")).thenReturn(token);
-
-        when(userService.findUserByToken(Mockito.any(DecodedJWT.class))).thenReturn(AuthObjectUtil.userDetails());
+        when(request.getHeader("Authorization")).thenReturn("");
 
         // method to test
         filter.doFilterInternal(request, response, filterChain);
 
         // validate
-        verify(userService, never()).findUserByToken(Mockito.any());
-        verify(response, never()).addCookie(Mockito.any());
+        verify(userService, never()).loadUserByUsername(any());
+        verify(response, never()).addCookie(any());
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
     }
@@ -149,46 +136,28 @@ class JWTFilterTest {
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        String token = "Bearer " + createToken(true);
+        String token = "Bearer " + createToken(Instant.now().minus(5, ChronoUnit.HOURS));
         when(request.getHeader("Authorization")).thenReturn(token);
-
-        when(userService.findUserByToken(Mockito.any(DecodedJWT.class))).thenReturn(AuthObjectUtil.userDetails());
 
         // method to test
         filter.doFilterInternal(request, response, filterChain);
 
         // validate
-        verify(userService, never()).findUserByToken(Mockito.any());
-        verify(response, never()).addCookie(Mockito.any());
+        verify(userService, never()).loadUserByUsername(any());
+        verify(response, never()).addCookie(any());
 
         assertNull(SecurityContextHolder.getContext().getAuthentication());
     }
 
 
-    private String createToken(boolean isExpired) {
-        Instant now = Instant.now();
-        Instant expiry;
-        if (isExpired) {
-            expiry = Instant.now().minus(Duration.ofMillis(properties.getTokenExpirationMillis() + 1000L));
-        } else {
-            expiry = Instant.now().plus(Duration.ofMillis(properties.getTokenExpirationMillis()));
-        }
+    private String createToken(final Instant expiringAt) {
         return JWT
-                .create()
-                .withIssuer(properties.getTokenIssuer())
-                .withIssuedAt(now)
-                .withExpiresAt(expiry)
-                .withSubject(AuthObjectUtil.userDetails().getUsername())
-                .sign(algorithm);
+            .create()
+            .withIssuer("test-issuer")
+            .withIssuedAt(Instant.now())
+            .withExpiresAt(expiringAt)
+            .withSubject(AuthObjectUtil.userDetails().getUsername())
+            .sign(algorithm);
     }
 
-    private Algorithm buildAlgorithm() {
-        JWTSecurityConfig config = new JWTSecurityConfig();
-        return config.jwtAlgorithm(properties);
-    }
-
-    private JWTVerifier buildVerifier() {
-        JWTSecurityConfig config = new JWTSecurityConfig();
-        return config.jwtVerifier(algorithm, properties);
-    }
 }

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSUserDetailsResolverTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSUserDetailsResolverTest.java
@@ -53,7 +53,7 @@ class NBSUserDetailsResolverTest {
             .returns("first-name-value", NbsUserDetails::getFirstName)
             .returns("last-name-value", NbsUserDetails::getLastName)
             .returns("user-id-value", NbsUserDetails::getUsername)
-            .returns("token-value", NbsUserDetails::getToken)
+            .returns("token-value", details -> details.getToken().value())
             .returns(false, NbsUserDetails::isMasterSecurityAdmin)
             .returns(false, NbsUserDetails::isProgramAreaAdmin)
             .returns(true, NbsUserDetails::isEnabled)

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSUserDetailsResolverTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSUserDetailsResolverTest.java
@@ -47,13 +47,12 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
+        NbsUserDetails resolved = resolver.resolve(user);
 
         assertThat(resolved)
             .returns("first-name-value", NbsUserDetails::getFirstName)
             .returns("last-name-value", NbsUserDetails::getLastName)
             .returns("user-id-value", NbsUserDetails::getUsername)
-            .returns("token-value", details -> details.getToken().value())
             .returns(false, NbsUserDetails::isMasterSecurityAdmin)
             .returns(false, NbsUserDetails::isProgramAreaAdmin)
             .returns(true, NbsUserDetails::isEnabled)
@@ -82,7 +81,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
+        NbsUserDetails resolved = resolver.resolve(user);
 
         assertThat(resolved.isMasterSecurityAdmin()).isTrue();
 
@@ -107,7 +106,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
+        NbsUserDetails resolved = resolver.resolve(user);
 
         assertThat(resolved.isProgramAreaAdmin()).isTrue();
 
@@ -151,7 +150,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
+        NbsUserDetails resolved = resolver.resolve(user);
 
         assertThat(resolved.getAdminProgramAreas()).contains("program-area-one", "program-area-two");
 
@@ -182,7 +181,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
+        NbsUserDetails resolved = resolver.resolve(user);
 
         assertThat(resolved.isEnabled()).isFalse();
 
@@ -219,7 +218,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
+        NbsUserDetails resolved = resolver.resolve(user);
 
         assertThat(resolved.getAuthorities())
             .satisfiesExactly(

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSUserDetailsResolverTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSUserDetailsResolverTest.java
@@ -47,7 +47,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, "token-value");
+        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
 
         assertThat(resolved)
             .returns("first-name-value", NbsUserDetails::getFirstName)
@@ -82,7 +82,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, "token-value");
+        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
 
         assertThat(resolved.isMasterSecurityAdmin()).isTrue();
 
@@ -107,7 +107,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, "token-value");
+        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
 
         assertThat(resolved.isProgramAreaAdmin()).isTrue();
 
@@ -151,7 +151,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, "token-value");
+        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
 
         assertThat(resolved.getAdminProgramAreas()).contains("program-area-one", "program-area-two");
 
@@ -182,7 +182,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, "token-value");
+        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
 
         assertThat(resolved.isEnabled()).isFalse();
 
@@ -219,7 +219,7 @@ class NBSUserDetailsResolverTest {
 
         NBSUserDetailsResolver resolver = new NBSUserDetailsResolver(finder);
 
-        NbsUserDetails resolved = resolver.resolve(user, "token-value");
+        NbsUserDetails resolved = resolver.resolve(user, new NBSToken("token-value"));
 
         assertThat(resolved.getAuthorities())
             .satisfiesExactly(

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/TokenCreatorTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/TokenCreatorTest.java
@@ -38,9 +38,9 @@ class TokenCreatorTest {
             properties
         );
 
-        String actual = creator.forUser("user-value");
+        NBSToken actual = creator.forUser("user-value");
 
-        DecodedJWT decoded = JWT.decode(actual);
+        DecodedJWT decoded = JWT.decode(actual.value());
 
         assertThat(decoded)
             .returns("test-issuer", DecodedJWT::getIssuer)

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/UserServiceTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/UserServiceTest.java
@@ -50,7 +50,7 @@ class UserServiceTest {
 
         when(resolver.resolve(any(), any())).thenReturn(details);
 
-        when(creator.forUser(any())).thenReturn("resolved-token");
+        when(creator.forUser(any())).thenReturn(new NBSToken("resolved-token"));
 
         // method in test
         NbsUserDetails userDetails = service.loadUserByUsername("test");
@@ -77,7 +77,7 @@ class UserServiceTest {
 
         when(resolver.resolve(any(), any())).thenReturn(details);
 
-        when(creator.forUser(any())).thenReturn("resolved-token");
+        when(creator.forUser(any())).thenReturn(new NBSToken("resolved-token"));
 
         DecodedJWT decodedJWT = mock(DecodedJWT.class);
         when(decodedJWT.getSubject()).thenReturn("test");

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/UserServiceTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/UserServiceTest.java
@@ -1,10 +1,8 @@
 package gov.cdc.nbs.authentication;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import gov.cdc.nbs.authentication.entity.AuthUser;
 import gov.cdc.nbs.authentication.entity.AuthUserRepository;
 import gov.cdc.nbs.authentication.util.AuthObjectUtil;
-import gov.cdc.nbs.exception.BadTokenException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,9 +28,6 @@ class UserServiceTest {
     AuthUserRepository repository;
 
     @Mock
-    TokenCreator creator;
-
-    @Mock
     NBSUserDetailsResolver resolver;
 
     @InjectMocks
@@ -42,15 +37,13 @@ class UserServiceTest {
     void should_return_user_details_by_username() {
         // Mock
         AuthUser authUser = mock(AuthUser.class);
-        when(authUser.getUserId()).thenReturn("authenticated-user");
 
         when(repository.findByUserId(any())).thenReturn(Optional.of(authUser));
 
         NbsUserDetails details = mock(NbsUserDetails.class);
 
-        when(resolver.resolve(any(), any())).thenReturn(details);
+        when(resolver.resolve(any())).thenReturn(details);
 
-        when(creator.forUser(any())).thenReturn(new NBSToken("resolved-token"));
 
         // method in test
         NbsUserDetails userDetails = service.loadUserByUsername("test");
@@ -60,50 +53,7 @@ class UserServiceTest {
 
         verify(repository).findByUserId("test");
 
-        verify(resolver).resolve(authUser, new NBSToken("resolved-token"));
-
-        verify(creator).forUser("authenticated-user");
-    }
-
-    @Test
-    void should_return_user_details_by_token() {
-        // Mock
-        AuthUser authUser = mock(AuthUser.class);
-        when(authUser.getUserId()).thenReturn("authenticated-user");
-
-        when(repository.findByUserId(any())).thenReturn(Optional.of(authUser));
-
-        NbsUserDetails details = mock(NbsUserDetails.class);
-
-        when(resolver.resolve(any(), any())).thenReturn(details);
-
-        when(creator.forUser(any())).thenReturn(new NBSToken("resolved-token"));
-
-        DecodedJWT decodedJWT = mock(DecodedJWT.class);
-        when(decodedJWT.getSubject()).thenReturn("test");
-
-        // method in test
-        NbsUserDetails userDetails = service.findUserByToken(decodedJWT);
-
-        // assertions
-        assertThat(userDetails).isSameAs(details);
-
-        verify(repository).findByUserId("test");
-
-        verify(resolver).resolve(authUser, new NBSToken("resolved-token"));
-
-        verify(creator).forUser("authenticated-user");
-    }
-
-    @Test
-    void should_not_return_user_details_by_token_when_user_not_found() {
-        // Mock
-        when(repository.findByUserId("test")).thenReturn(Optional.empty());
-        DecodedJWT decodedJWT = mock(DecodedJWT.class);
-        when(decodedJWT.getSubject()).thenReturn("test");
-
-        // method in test
-        assertThrows(BadTokenException.class, () -> service.findUserByToken(decodedJWT));
+        verify(resolver).resolve(authUser);
     }
 
     @Test

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/UserServiceTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/UserServiceTest.java
@@ -60,7 +60,7 @@ class UserServiceTest {
 
         verify(repository).findByUserId("test");
 
-        verify(resolver).resolve(authUser, "resolved-token");
+        verify(resolver).resolve(authUser, new NBSToken("resolved-token"));
 
         verify(creator).forUser("authenticated-user");
     }
@@ -90,7 +90,7 @@ class UserServiceTest {
 
         verify(repository).findByUserId("test");
 
-        verify(resolver).resolve(authUser, "resolved-token");
+        verify(resolver).resolve(authUser, new NBSToken("resolved-token"));
 
         verify(creator).forUser("authenticated-user");
     }

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/util/AuthObjectUtil.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/util/AuthObjectUtil.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.authentication.util;
 
+import gov.cdc.nbs.authentication.NBSToken;
 import gov.cdc.nbs.authentication.NbsAuthority;
 import gov.cdc.nbs.authentication.NbsUserDetails;
 import gov.cdc.nbs.authentication.entity.AuthAudit;
@@ -58,8 +59,9 @@ public class AuthObjectUtil {
                 null,
                 null,
                 authorities(),
-                "token",
-                true);
+                new NBSToken("token"),
+                true
+        );
     }
 
     public static Set<NbsAuthority> authorities() {

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/util/AuthObjectUtil.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/util/AuthObjectUtil.java
@@ -1,6 +1,5 @@
 package gov.cdc.nbs.authentication.util;
 
-import gov.cdc.nbs.authentication.NBSToken;
 import gov.cdc.nbs.authentication.NbsAuthority;
 import gov.cdc.nbs.authentication.NbsUserDetails;
 import gov.cdc.nbs.authentication.entity.AuthAudit;
@@ -39,40 +38,39 @@ public class AuthObjectUtil {
     public static List<AuthProgAreaAdmin> progAreaAdmins(AuthUser user) {
         var adminAreas = new ArrayList<AuthProgAreaAdmin>();
         adminAreas.add(
-                new AuthProgAreaAdmin(
-                        null,
-                        "progArea",
-                        user,
-                        'T',
-                        audit()));
+            new AuthProgAreaAdmin(
+                null,
+                "progArea",
+                user,
+                'T',
+                audit()));
         return adminAreas;
     }
 
     public static NbsUserDetails userDetails() {
         return new NbsUserDetails(
-                1L,
-                "test",
-                "test",
-                "test",
-                false,
-                false,
-                null,
-                null,
-                authorities(),
-                new NBSToken("token"),
-                true
+            1L,
+            "test",
+            "test",
+            "test",
+            false,
+            false,
+            null,
+            null,
+            authorities(),
+            true
         );
     }
 
     public static Set<NbsAuthority> authorities() {
         var authorities = new HashSet<NbsAuthority>();
         authorities.add(new NbsAuthority(
-                BUSINESS_OPERATION,
-                BUSINESS_OBJECT,
-                "programArea",
-                123,
-                "jurisdiction",
-                AUTHORITY));
+            BUSINESS_OPERATION,
+            BUSINESS_OBJECT,
+            "programArea",
+            123,
+            "jurisdiction",
+            AUTHORITY));
         return authorities;
     }
 }


### PR DESCRIPTION
The `modernization-api` is generating a token for users that are authenticated via NBS Classic™.  The Token was previously only applied when a call to the `/login` endpoint was made.  This endpoint is slowly being phased out as it only really applies for local development.  

The token is now generated for redirected requests from classic that are  have been authenticated through NBS Classic.