### PR TITLE
[FIX] Message Modal Display

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/ManageTabs/ManageTabs.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/ManageTabs/ManageTabs.scss
@@ -4,7 +4,3 @@
     justify-content: center;
     align-items: center;
 }
-
-.usa-modal__close {
-    display: none;
-}


### PR DESCRIPTION
## Description

When attempting to delete a patient from the Patient Profile a message appears in a modal if the Patient cannot be deleted.  A change to the `.usa-modal__close` style was causing an error that lead to a blank page being shown.  The cause of the error was that there was no component in the modal to focus on since the only component in the `MessageModal` that could have focus was the `X` icon in the upper right.

## Steps to verify

1. Search for a Patient associated with events
1. Go to the Patient Profile
1. Attempt to delete the Patient
