### PR TITLE
CNFT1-1548 search local and other

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/CodedResultFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/CodedResultFinder.java
@@ -1,44 +1,69 @@
 package gov.cdc.nbs.event.search.labreport;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
+import org.elasticsearch.core.Map;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
 import gov.cdc.nbs.event.search.labreport.model.CodedResult;
-import gov.cdc.nbs.repository.LabResultRepository;
-import gov.cdc.nbs.repository.SnomedCodeRepository;
 
 @Component
 public class CodedResultFinder {
     private final Integer maxPageSize;
-    private final LabResultRepository labResultRepository;
-    private final SnomedCodeRepository snomedCodeRepository;
+    private final NamedParameterJdbcTemplate namedTemplate;
+
+    private static final String QUERY = """
+              SELECT
+              TOP 50 search.coded_result FROM
+              (
+                SELECT
+                  lr.lab_result_desc_txt coded_result
+                FROM
+                  [NBS_SRTE].[dbo].[Lab_result] lr
+                WHERE
+                  lr.organism_name_ind = 'N'
+                  AND(
+                    lr.lab_result_desc_txt LIKE :searchText
+                    OR lr.lab_result_cd LIKE :searchText
+                  )
+                UNION
+                SELECT
+                  sc.snomed_desc_txt coded_result
+                FROM
+                  [NBS_SRTE].[dbo].[Snomed_code] sc
+                WHERE
+                  sc.snomed_desc_txt LIKE :searchText
+                  OR sc.snomed_cd LIKE :searchText
+              ) AS search
+            ORDER BY
+              search.coded_result
+                       """;
 
     public CodedResultFinder(
-            final LabResultRepository labResultRepository,
-            final SnomedCodeRepository snomedCodeRepository,
+            final JdbcTemplate template,
             @Value("${nbs.max-page-size: 50}") final Integer maxPageSize) {
-        this.labResultRepository = labResultRepository;
-        this.snomedCodeRepository = snomedCodeRepository;
+        this.namedTemplate = new NamedParameterJdbcTemplate(template);
         this.maxPageSize = maxPageSize;
     }
 
-    public List<CodedResult> findDistinctCodedResults(String searchText, boolean snomed) {
-        if (snomed) {
-            Pageable pageable = PageRequest.of(0, maxPageSize, Direction.ASC, "snomedDescTxt");
-            return snomedCodeRepository.findDistinctSnomedCodes(searchText, pageable)
-                    .stream()
-                    .map(CodedResult::new)
-                    .toList();
-        } else {
-            Pageable pageable = PageRequest.of(0, maxPageSize, Direction.ASC, "labResultDescTxt");
-            return labResultRepository.findDistinctLabResults(searchText, pageable)
-                    .stream()
-                    .map(CodedResult::new)
-                    .toList();
-        }
+    public List<CodedResult> findDistinctCodedResults(String searchText) {
+        SqlParameterSource namedParameters = new MapSqlParameterSource(
+                Map.of("maxPageSize", maxPageSize, "searchText", "%" + searchText + "%"));
+
+        return namedTemplate.query(QUERY, namedParameters, new RowMapper<CodedResult>() {
+
+            @Override
+            public CodedResult mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new CodedResult(rs.getString(1));
+            }
+
+        });
     }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabResultController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabResultController.java
@@ -16,8 +16,8 @@ public class LabResultController {
     }
 
     @QueryMapping
-    public List<CodedResult> findDistinctCodedResults(@Argument String searchText, @Argument boolean snomed) {
-        return finder.findDistinctCodedResults(searchText, snomed);
+    public List<CodedResult> findDistinctCodedResults(@Argument String searchText) {
+        return finder.findDistinctCodedResults(searchText);
     }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestController.java
@@ -17,8 +17,8 @@ public class LabTestController {
     }
 
     @QueryMapping
-    public List<ResultedTest> findDistinctResultedTest(@Argument String searchText, @Argument boolean loinc) {
-        return resultedTestFinder.findDistinctResultedTest(searchText, loinc);
+    public List<ResultedTest> findDistinctResultedTest(@Argument String searchText) {
+        return resultedTestFinder.findDistinctResultedTests(searchText);
     }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/ResultedTestFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/ResultedTestFinder.java
@@ -54,28 +54,8 @@ public class ResultedTestFinder {
                 [NBS_SRTE].[dbo].[LOINC_code] lc
             WHERE
                 lc.related_class_cd in (:relatedClassCodes)
-                AND(lc.component_name LIKE '%:searchText%'
-                    OR lc.loinc_cd LIKE '%:searchText%')
-            UNION
-            SELECT
-                lt.lab_test_desc_txt
-            FROM
-                [NBS_SRTE].[dbo].[Lab_test] lt
-            WHERE
-                lt.test_type_cd = 'R'
-                AND(lt.lab_test_desc_txt LIKE '%:searchText%'
-                    OR lt.lab_test_cd LIKE '%:searchText%')
-            ORDER BY
-                resulted_test
-                                    """;
-    private static final String TEST = """
-            SELECT TOP (:maxPageSize)
-                lc.component_name resulted_test
-            FROM
-                [NBS_SRTE].[dbo].[LOINC_code] lc
-            WHERE
-                lc.component_name LIKE :searchText
-                    OR lc.loinc_cd LIKE :searchText
+                AND(lc.component_name LIKE :searchText
+                    OR lc.loinc_cd LIKE :searchText)
             UNION
             SELECT TOP (:maxPageSize)
                 lt.lab_test_desc_txt
@@ -104,7 +84,7 @@ public class ResultedTestFinder {
                 Map.of("maxPageSize", maxPageSize, "relatedClassCodes", relatedClassCodes, "searchText",
                         "%" + searchText + "%"));
 
-        return namedTemplate.query(TEST, namedParameters, new RowMapper<ResultedTest>() {
+        return namedTemplate.query(QUERY, namedParameters, new RowMapper<ResultedTest>() {
 
             @Override
             public ResultedTest mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/apps/modernization-api/src/main/resources/graphql/labResult.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/labResult.graphqls
@@ -1,8 +1,5 @@
 extend type Query {
-  findDistinctCodedResults(
-    searchText: String!
-    snomed: Boolean!
-  ): [CodedResult!]!
+  findDistinctCodedResults(searchText: String!): [CodedResult!]!
 }
 
 type CodedResult {

--- a/apps/modernization-api/src/main/resources/graphql/labTest.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/labTest.graphqls
@@ -1,8 +1,5 @@
 extend type Query {
-  findDistinctResultedTest(
-    searchText: String!
-    loinc: Boolean!
-  ): [ResultedTest!]!
+  findDistinctResultedTest(searchText: String!): [ResultedTest!]!
 }
 
 type ResultedTest {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/CodedResultsSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/CodedResultsSearchSteps.java
@@ -41,8 +41,7 @@ public class CodedResultsSearchSteps {
     @Autowired
     private SnomedCodeRepository snomedCodeRepository;
 
-    private List<CodedResult> localResponse;
-    private List<CodedResult> snomedResponse;
+    private List<CodedResult> response;
 
     @Given("local coded results exist")
     public void local_coded_results_exist() {
@@ -56,38 +55,19 @@ public class CodedResultsSearchSteps {
         createSnomedResultIfNotExists(LabResultMother.snomedNoGrowth());
     }
 
-    @When("I search for local coded results by {string}")
+    @When("I search for coded results by {string}")
     public void i_search_for_local_coded_results_by_(String searchText) {
-        localResponse = labResultController.findDistinctCodedResults(searchText, false);
+        response = labResultController.findDistinctCodedResults(searchText);
     }
 
-    @Then("A local coded result is {string}")
+    @Then("A coded result is {string}")
     public void a_local_coded_result_is(String expectedResult) {
         switch (expectedResult) {
             case "found":
-                assertTrue(localResponse.size() > 0);
+                assertTrue(response.size() > 0);
                 break;
             case "not found":
-                assertEquals(0, localResponse.size());
-                break;
-            default:
-                throw new IllegalArgumentException("Inavlid expected result type: " + expectedResult);
-        }
-    }
-
-    @When("I search for snomed coded results by {string}")
-    public void i_search_for_snomed_coded_results_by_(String searchText) {
-        snomedResponse = labResultController.findDistinctCodedResults(searchText, true);
-    }
-
-    @Then("A snomed coded results is {string}")
-    public void a_snomed_coded_result_is(String expectedResult) {
-        switch (expectedResult) {
-            case "found":
-                assertTrue(snomedResponse.size() > 0);
-                break;
-            case "not found":
-                assertEquals(0, snomedResponse.size());
+                assertEquals(0, response.size());
                 break;
             default:
                 throw new IllegalArgumentException("Inavlid expected result type: " + expectedResult);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/ResultedTestSearchSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/ResultedTestSearchSteps.java
@@ -40,8 +40,7 @@ public class ResultedTestSearchSteps {
     @Autowired
     private LabTestController labTestController;
 
-    private List<ResultedTest> localTestResponse;
-    private List<ResultedTest> loincTestResponse;
+    private List<ResultedTest> response;
 
     @Given("local resulted tests exist")
     public void resulted_tests_exist() {
@@ -55,38 +54,19 @@ public class ResultedTestSearchSteps {
         createLoincTestIfNotExists(LabTestMother.loincTestAmdinocillin());
     }
 
-    @When("I search for local resulted tests by {string}")
+    @When("I search for resulted tests by {string}")
     public void i_search_for_resulted_test(String searchText) {
-        localTestResponse = labTestController.findDistinctResultedTest(searchText, false);
+        response = labTestController.findDistinctResultedTest(searchText);
     }
 
-    @When("I search for loinc resulted tests by {string}")
-    public void i_search_for_loinc_test(String searchText) {
-        loincTestResponse = labTestController.findDistinctResultedTest(searchText, true);
-    }
-
-    @Then("A local test is {string}")
+    @Then("A test is {string}")
     public void a_local_test_is(String expectedResult) {
         switch (expectedResult) {
             case "found":
-                assertTrue(localTestResponse.size() > 0);
+                assertTrue(response.size() > 0);
                 break;
             case "not found":
-                assertEquals(0, localTestResponse.size());
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid expected result: " + expectedResult);
-        }
-    }
-
-    @Then("A loinc test is {string}")
-    public void a_loinc_test_is(String expectedResult) {
-        switch (expectedResult) {
-            case "found":
-                assertTrue(loincTestResponse.size() > 0);
-                break;
-            case "not found":
-                assertEquals(0, loincTestResponse.size());
+                assertEquals(0, response.size());
                 break;
             default:
                 throw new IllegalArgumentException("Invalid expected result: " + expectedResult);

--- a/apps/modernization-api/src/test/resources/features/CodedResultsSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/CodedResultsSearch.feature
@@ -1,30 +1,20 @@
 @coded_results
 Feature: I can search for coded results
 
-  Scenario: I can search for local coded results
-    Given local coded results exist
-    When I search for local coded results by "<searchText>"
-    Then A local coded result is "<result>"
+    Scenario: I can search for coded results
+        Given local coded results exist
+        And snomed coded results exist
+        When I search for coded results by "<searchText>"
+        Then A coded result is "<result>"
 
-    Examples:
-      | searchText    | result    |
-      | ANOMRES       | found     |
-      | ANOM          | found     |
-      | abnormal      | found     |
-      | ormal         | found     |
-      | zzzzzzzzzzzz  | not found |
-      | 9123213123123 | not found |
-
-  Scenario: I can search for snomed coded results
-    Given snomed coded results exist
-    When I search for snomed coded results by "<searchText>"
-    Then A snomed coded results is "<result>"
-
-    Examples:
-      | searchText    | result    |
-      | No growth     | found     |
-      | growth        | found     |
-      | Abnormal      | found     |
-      | ormal         | found     |
-      | zzzzzzzzzzzz  | not found |
-      | 9123213123123 | not found |
+        Examples:
+            | searchText    | result    |
+            | ANOMRES       | found     |
+            | ANOM          | found     |
+            | abnormal      | found     |
+            | AbNoRmAl      | found     |
+            | ormal         | found     |
+            | No growth     | found     |
+            | growth        | found     |
+            | zzzzzzzzzzzz  | not found |
+            | 9123213123123 | not found |

--- a/apps/modernization-api/src/test/resources/features/ResultedTestSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/ResultedTestSearch.feature
@@ -1,30 +1,23 @@
 @resulted_test
 Feature: I can search for resulted tests
 
-  Scenario: I can search for local resulted tests
-    Given local resulted tests exist
-    When I search for local resulted tests by "<searchText>"
-    Then A local test is "<result>"
+    Scenario: I can search for local resulted tests
+        Given local resulted tests exist
+        And loinc resulted tests exist
+        When I search for resulted tests by "<searchText>"
+        Then A test is "<result>"
 
-    Examples:
-      | searchText      | result    |
-      | Thyroxine       | found     |
-      | Thyr            | found     |
-      | oxine           | found     |
-      | HIV-1 ABS, QUAL | found     |
-      | zzzzzzzzzzzz    | not found |
-      | 9123213123123   | not found |
+        Examples:
+            | searchText      | result    |
+            | Thyroxine       | found     |
+            | Thyr            | found     |
+            | oxine           | found     |
+            | HIV-1 ABS, QUAL | found     |
+            | ACYCLOVIR       | found     |
+            | ACYCL           | found     |
+            | AMDINOCILLIN    | found     |
+            | NOCILLIN        | found     |
+            | NoCiLlIn        | found     |
+            | zzzzzzzzzzzz    | not found |
+            | 9123213123123   | not found |
 
-  Scenario: I can search for loinc resulted tests
-    Given loinc resulted tests exist
-    When I search for loinc resulted tests by "<searchText>"
-    Then A loinc test is "<result>"
-
-    Examples:
-      | searchText    | result    |
-      | ACYCLOVIR     | found     |
-      | ACYCL         | found     |
-      | AMDINOCILLIN  | found     |
-      | NOCILLIN      | found     |
-      | zzzzzzzzzzzz  | not found |
-      | 9123213123123 | not found |

--- a/apps/modernization-ui/src/generated/gql/queries/findDistinctCodedResults.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findDistinctCodedResults.gql
@@ -1,5 +1,5 @@
-query findDistinctCodedResults($searchText: String!, $snomed: Boolean!){
-    findDistinctCodedResults(searchText: $searchText, snomed: $snomed){
+query findDistinctCodedResults($searchText: String!){
+    findDistinctCodedResults(searchText: $searchText){
         name
     }
 }

--- a/apps/modernization-ui/src/generated/gql/queries/findDistinctResultedTest.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findDistinctResultedTest.gql
@@ -1,5 +1,5 @@
-query findDistinctResultedTest($searchText: String!, $loinc: Boolean!){
-    findDistinctResultedTest(searchText: $searchText, loinc: $loinc){
+query findDistinctResultedTest($searchText: String!){
+    findDistinctResultedTest(searchText: $searchText){
         name
     }
 }

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -299,8 +299,8 @@ export type GroupedCodedValue = {
 
 export type IdentificationCriteria = {
   assigningAuthority?: InputMaybe<Scalars['String']>;
-  identificationNumber: Scalars['String'];
-  identificationType: Scalars['String'];
+  identificationNumber?: InputMaybe<Scalars['String']>;
+  identificationType?: InputMaybe<Scalars['String']>;
 };
 
 export type IdentificationType = {
@@ -2281,12 +2281,10 @@ export type QueryFindContactsNamedByPatientArgs = {
 
 export type QueryFindDistinctCodedResultsArgs = {
   searchText: Scalars['String'];
-  snomed: Scalars['Boolean'];
 };
 
 
 export type QueryFindDistinctResultedTestArgs = {
-  loinc: Scalars['Boolean'];
   searchText: Scalars['String'];
 };
 
@@ -3052,7 +3050,6 @@ export type FindContactsNamedByPatientQuery = { __typename?: 'Query', findContac
 
 export type FindDistinctCodedResultsQueryVariables = Exact<{
   searchText: Scalars['String'];
-  snomed: Scalars['Boolean'];
 }>;
 
 
@@ -3060,7 +3057,6 @@ export type FindDistinctCodedResultsQuery = { __typename?: 'Query', findDistinct
 
 export type FindDistinctResultedTestQueryVariables = Exact<{
   searchText: Scalars['String'];
-  loinc: Scalars['Boolean'];
 }>;
 
 
@@ -5570,8 +5566,8 @@ export type FindContactsNamedByPatientQueryHookResult = ReturnType<typeof useFin
 export type FindContactsNamedByPatientLazyQueryHookResult = ReturnType<typeof useFindContactsNamedByPatientLazyQuery>;
 export type FindContactsNamedByPatientQueryResult = Apollo.QueryResult<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>;
 export const FindDistinctCodedResultsDocument = gql`
-    query findDistinctCodedResults($searchText: String!, $snomed: Boolean!) {
-  findDistinctCodedResults(searchText: $searchText, snomed: $snomed) {
+    query findDistinctCodedResults($searchText: String!) {
+  findDistinctCodedResults(searchText: $searchText) {
     name
   }
 }
@@ -5590,7 +5586,6 @@ export const FindDistinctCodedResultsDocument = gql`
  * const { data, loading, error } = useFindDistinctCodedResultsQuery({
  *   variables: {
  *      searchText: // value for 'searchText'
- *      snomed: // value for 'snomed'
  *   },
  * });
  */
@@ -5606,8 +5601,8 @@ export type FindDistinctCodedResultsQueryHookResult = ReturnType<typeof useFindD
 export type FindDistinctCodedResultsLazyQueryHookResult = ReturnType<typeof useFindDistinctCodedResultsLazyQuery>;
 export type FindDistinctCodedResultsQueryResult = Apollo.QueryResult<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>;
 export const FindDistinctResultedTestDocument = gql`
-    query findDistinctResultedTest($searchText: String!, $loinc: Boolean!) {
-  findDistinctResultedTest(searchText: $searchText, loinc: $loinc) {
+    query findDistinctResultedTest($searchText: String!) {
+  findDistinctResultedTest(searchText: $searchText) {
     name
   }
 }
@@ -5626,7 +5621,6 @@ export const FindDistinctResultedTestDocument = gql`
  * const { data, loading, error } = useFindDistinctResultedTestQuery({
  *   variables: {
  *      searchText: // value for 'searchText'
- *      loinc: // value for 'loinc'
  *   },
  * });
  */

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -602,20 +602,14 @@ enum LaboratoryReportStatus {
   UNPROCESSED
 }
 extend type Query {
-  findDistinctCodedResults(
-    searchText: String!
-    snomed: Boolean!
-  ): [CodedResult!]!
+  findDistinctCodedResults(searchText: String!): [CodedResult!]!
 }
 
 type CodedResult {
   name: String!
 }
 extend type Query {
-  findDistinctResultedTest(
-    searchText: String!
-    loinc: Boolean!
-  ): [ResultedTest!]!
+  findDistinctResultedTest(searchText: String!): [ResultedTest!]!
 }
 
 type ResultedTest {
@@ -1289,8 +1283,8 @@ extend type Query {
 }
 
 input IdentificationCriteria {
-    identificationNumber: String!
-    identificationType: String!
+    identificationNumber: String
+    identificationType: String
     assigningAuthority: String
 }
 

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/EventSearch.tsx
@@ -56,7 +56,6 @@ export const EventSearch = ({ investigationFilter, labReportFilter, onSearch }: 
     const handleClearAll = () => {
         investigationForm.reset({}, { keepDefaultValues: true });
         labReportForm.reset(initialLabForm(), { keepDefaultValues: true });
-        setSearchType(undefined);
     };
 
     /**

--- a/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/labReportSearch/LabReportCriteria.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/components/eventSearch/labReportSearch/LabReportCriteria.tsx
@@ -133,7 +133,7 @@ export const LabReportCriteria = ({ form }: LabReportCriteriaProps) => {
     const [resultedTestOptions, setResultedTestOptions] = useState<{ label: string; value: string }[]>();
 
     const debouncedCodedSearchResults = debounce(async (criteria: string) => {
-        getCodedResultedTests({ variables: { searchText: criteria, snomed: false } });
+        getCodedResultedTests({ variables: { searchText: criteria } });
     }, 300);
 
     const codedResultToComboOption = (codedResult: CodedResult): ComboBoxOption => {
@@ -141,7 +141,7 @@ export const LabReportCriteria = ({ form }: LabReportCriteriaProps) => {
     };
 
     const debounceResultedTestSearch = debounce(async (criteria: string) => {
-        getLocalResultedTests({ variables: { searchText: criteria, loinc: false } });
+        getLocalResultedTests({ variables: { searchText: criteria } });
     }, 300);
 
     const labTestToComboOption = (resultedTest: ResultedTest): ComboBoxOption => {

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/repository/LabResultRepository.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/repository/LabResultRepository.java
@@ -15,7 +15,4 @@ public interface LabResultRepository extends JpaRepository<LabResult, LabResultI
     @Query("SELECT lr FROM LabResult lr WHERE lr.organismNameInd = 'N' AND (lr.labResultDescTxt like %:searchString% OR lr.id.labResultCd like %:searchString%)")
     Page<LabResult> findLabResults(@Param("searchString") String searchString, Pageable pageable);
 
-    @Query("SELECT DISTINCT lr.labResultDescTxt FROM LabResult lr WHERE lr.organismNameInd = 'N' AND (lr.labResultDescTxt like %:searchString% OR lr.id.labResultCd like %:searchString%)")
-    Page<String> findDistinctLabResults(@Param("searchString") String searchString, Pageable pageable);
-
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/repository/LabTestRepository.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/repository/LabTestRepository.java
@@ -15,7 +15,4 @@ public interface LabTestRepository extends JpaRepository<LabTest, LabTestId> {
     @Query("SELECT lt FROM LabTest lt WHERE lt.testTypeCd = 'R' AND (UPPER(lt.labTestDescTxt) like %:searchString% OR UPPER(lt.id.labTestCd) like %:searchString%)")
     Page<LabTest> findTests(@Param("searchString") String searchString, Pageable pageable);
 
-    @Query("SELECT DISTINCT lt.labTestDescTxt FROM LabTest lt WHERE lt.testTypeCd = 'R' AND (UPPER(lt.labTestDescTxt) like %:searchString% OR UPPER(lt.id.labTestCd) like %:searchString%)")
-    Page<String> findDistinctTestNames(@Param("searchString") String searchString, Pageable pageable);
-
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/repository/LoincCodeRepository.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/repository/LoincCodeRepository.java
@@ -19,9 +19,4 @@ public interface LoincCodeRepository extends JpaRepository<LoincCode, String> {
             @Param("relatedClassCodes") List<String> relatedClassCodes,
             Pageable pageable);
 
-    @Query("SELECT DISTINCT lc.componentName FROM LoincCode lc WHERE lc.relatedClassCd IN (:relatedClassCodes) AND (UPPER(lc.componentName) like %:searchString% OR UPPER(lc.id) like %:searchString%)")
-    Page<String> findDistinctTestNames(
-            @Param("searchString") String searchString,
-            @Param("relatedClassCodes") List<String> relatedClassCodes,
-            Pageable pageable);
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/repository/SnomedCodeRepository.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/repository/SnomedCodeRepository.java
@@ -13,7 +13,5 @@ public interface SnomedCodeRepository extends JpaRepository<SnomedCode, String> 
     @Query("SELECT sc FROM SnomedCode sc WHERE sc.snomedDescTxt LIKE %:searchString% OR sc.id LIKE %:searchString%")
     Page<SnomedCode> findSnomedCodes(@Param("searchString") String searchString, Pageable pageable);
 
-    @Query("SELECT DISTINCT sc.snomedDescTxt FROM SnomedCode sc WHERE sc.snomedDescTxt LIKE %:searchString% OR sc.id LIKE %:searchString%")
-    Page<String> findDistinctSnomedCodes(@Param("searchString") String searchString, Pageable pageable);
 
 }


### PR DESCRIPTION
## Description

When searching for Resulted Tests in classic you are able to search on both `local` and `LOINC` codes.
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/1ba6a41a-39a5-44c8-af2a-20be35757106)

When searching for Coded Results in classic, you are able to search on both `local` and `SNOMED` codes
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/16313240-ca78-476d-a0f2-6d204744f169)

This PR updates the APIs to search on `Lab_test`, and `LOINC_code` for Resulted Tests, `Lab_result` and `Snomed_code` for Coded Results.

## Tickets

* [CNFT1-1548](https://cdc-nbs.atlassian.net/browse/CNFT1-1548)

## Steps to verify

1. Log in to NBS
1. Navigate to Advanced search -> Event Search -> Event type `Laboratory report`
1. Under `Resulted Test`, search for `Acid-Fast Stain` -> Verify results
1. Under `Resulted Test`, search for `AMDINOCILLIN` -> Verify results
1. Under `Coded result`, search for `abnormal` -> Verify results
1. Under `Coded result`, search for `No growth` -> Verify results


[CNFT1-1548]: https://cdc-nbs.atlassian.net/browse/CNFT1-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ