### PR TITLE
[FIX] removes max-age

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/web/AddCookie.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/web/AddCookie.java
@@ -1,12 +1,22 @@
 package gov.cdc.nbs.web;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
 public class AddCookie {
 
     public static void to(final String name, final String value, final HttpHeaders headers) {
-        String cookie = name + "=" + value + "; SameSite=Strict; HttpOnly; Secure; Max-Age=-1";
+        String cookie = ResponseCookie.from(name, value)
+            .path("/nbs/")
+            .sameSite("Strict")
+            .httpOnly(true)
+            .secure(true)
+            .build()
+            .toString();
         headers.add(HttpHeaders.SET_COOKIE, cookie);
+
+
+
     }
 
     private AddCookie() {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/web/RemoveCookie.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/web/RemoveCookie.java
@@ -1,13 +1,21 @@
 package gov.cdc.nbs.web;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
 import java.util.function.Consumer;
 
 public class RemoveCookie {
 
     public static void from(final String name, final HttpHeaders headers) {
-        String cookie = name + "=; SameSite=Strict; HttpOnly; Secure; Max-Age=0";
+        String cookie = ResponseCookie.from(name,"")
+            .path("/nbs/")
+            .sameSite("Strict")
+            .httpOnly(true)
+            .secure(true)
+            .maxAge(0)
+            .build()
+            .toString();
         headers.add(HttpHeaders.SET_COOKIE, cookie);
     }
 


### PR DESCRIPTION
## Description

The `Return-Patient` cookie is being deleted immediately by the browser due to the `max-age` being set to `-1`.  This is causing the returning links to modernized patient profile to not resolve the patient to return to resulting in navigation to the advanced-search page.

## Steps to verify

1. Navigate to a Patient Profile
2. In the Events tab
3. Click `Add Investigation`
4. On the add Investigations screen click `Cancel`
5. The correct Patient Profile should display

This can also be tested if a Patient already linked to an Investigation by clicking the Investigation Id, and then clicking the `Return to File Summary` link in the upper right hand corner of the classic Investigation page.