### PR TITLE
Display middle name and suffix in patient profile

### DIFF
--- a/apps/modernization-ui/src/pages/patient/profile/summary/PatientProfileSummary.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/summary/PatientProfileSummary.tsx
@@ -86,7 +86,12 @@ export const PatientProfileSummary = ({ patient, summary }: Props) => {
             ) : (
                 <>
                     <div className="border-bottom border-base-lighter patient-summary-title">
-                        <h2>{`${formattedName(summary?.legalName?.last, summary?.legalName?.first)}`}</h2>
+                        <h2>{`${formattedName(
+                            `${summary?.legalName?.first || ''} ${summary?.legalName?.middle || ''}  ${
+                                summary?.legalName?.last || ''
+                            }`,
+                            summary?.legalName?.suffix
+                        )}`}</h2>
                         <span>
                             Patient ID: {patient.shortId}
                             {patient.status != 'ACTIVE' && (


### PR DESCRIPTION
## Description

Display middle name and suffix in patient profile

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT1-1436

## Steps to verify

1. Navigate to Patient profile it should display first, middle, last and suffix in the name field if they are present in summary field
2. create new patient and click view Patient it should display first, middle, last and suffix in the name field if they are present in Summary field
