### PR TITLE
NiFi remove default password from Dockerfile

### DIFF
--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -89,6 +89,7 @@ services:
     environment:
       - NIFI_JVM_HEAP_INIT=1g
       - NIFI_JVM_HEAP_MAX=2g
+      - ENV SINGLE_USER_CREDENTIALS_PASSWORD=fake.fake.fake.1234
     # volumes:
     #   - ./nifi/nifi_drivers:/var/opt/nifi_drivers:ro
     #   - ./nifi/nifi_conf/conf:/opt/nifi/nifi-current/conf:rw

--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -89,7 +89,12 @@ services:
     environment:
       - NIFI_JVM_HEAP_INIT=1g
       - NIFI_JVM_HEAP_MAX=2g
-      - ENV SINGLE_USER_CREDENTIALS_PASSWORD=fake.fake.fake.1234
+      - SINGLE_USER_CREDENTIALS_USERNAME=admin
+      - SINGLE_USER_CREDENTIALS_PASSWORD=fake.fake.fake.1234
+      - NIFI_SENSITIVE_PROPS_KEY=12345678901234567890A
+      - JDBC_CONNECTION_STRING=jdbc:sqlserver://nbs-mssql:1433;integratedSecurity=false;encrypt=false;databaseName=NBS_ODSE;user=sa;password=fake.fake.fake.1234;authenticationScheme=nativeAuthentication;
+      - JDBC_DRIVER=/var/opt/nifi_drivers/mssql-jdbc-11.2.0.jre8.jar
+      - ELASTICSEARCH_HTTP_HOSTS=http://elasticsearch:9200
     # volumes:
     #   - ./nifi/nifi_drivers:/var/opt/nifi_drivers:ro
     #   - ./nifi/nifi_conf/conf:/opt/nifi/nifi-current/conf:rw

--- a/cdc-sandbox/nifi/Dockerfile
+++ b/cdc-sandbox/nifi/Dockerfile
@@ -1,13 +1,6 @@
 # Dockerfile to build nifi image
 FROM apache/nifi:1.19.0
 
-# Set environment variables
-ENV NIFI_SENSITIVE_PROPS_KEY='12345678901234567890A'
-ENV SINGLE_USER_CREDENTIALS_USERNAME=admin
-ENV JDBC_CONNECTION_STRING='jdbc:sqlserver://nbs-mssql:1433;integratedSecurity=false;encrypt=false;databaseName=NBS_ODSE;user=sa;password=fake.fake.fake.1234;authenticationScheme=nativeAuthentication;'
-ENV JDBC_DRIVER=/var/opt/nifi_drivers/mssql-jdbc-11.2.0.jre8.jar
-ENV ELASTICSEARCH_HTTP_HOSTS=http://elasticsearch:9200
-
 COPY ./nifi_drivers/ /var/opt/nifi_drivers/
 COPY ./nifi_conf/conf/ /opt/nifi/nifi-current/conf/
 

--- a/cdc-sandbox/nifi/Dockerfile
+++ b/cdc-sandbox/nifi/Dockerfile
@@ -4,7 +4,6 @@ FROM apache/nifi:1.19.0
 # Set environment variables
 ENV NIFI_SENSITIVE_PROPS_KEY='12345678901234567890A'
 ENV SINGLE_USER_CREDENTIALS_USERNAME=admin
-ENV SINGLE_USER_CREDENTIALS_PASSWORD=fake.fake.fake.1234
 ENV JDBC_CONNECTION_STRING='jdbc:sqlserver://nbs-mssql:1433;integratedSecurity=false;encrypt=false;databaseName=NBS_ODSE;user=sa;password=fake.fake.fake.1234;authenticationScheme=nativeAuthentication;'
 ENV JDBC_DRIVER=/var/opt/nifi_drivers/mssql-jdbc-11.2.0.jre8.jar
 ENV ELASTICSEARCH_HTTP_HOSTS=http://elasticsearch:9200

--- a/cdc-sandbox/nifi/nifi_conf/conf/login-identity-providers.xml
+++ b/cdc-sandbox/nifi/nifi_conf/conf/login-identity-providers.xml
@@ -29,8 +29,8 @@
     <provider>
         <identifier>single-user-provider</identifier>
         <class>org.apache.nifi.authentication.single.user.SingleUserLoginIdentityProvider</class>
-        <property name="Username">admin</property>
-        <property name="Password">$2b$12$8rPQ5u9M6h9rT.qL1ClIt.lQxmT9xAIJeYQNPmAiYKSUt7J5Y9YGi</property>
+        <property name="Username"></property>
+        <property name="Password"></property>
     </provider>
     <!--
         Identity Provider for users logging in with username/password against an LDAP server.


### PR DESCRIPTION
## Description

The foundations team requested we move the environment variables from the NiFi dockerfile and place them into the docker-compose. This prevents these default environment variables from being present in the NiFi image.

## Tickets

* [CNFT2-1255](https://cdc-nbs.atlassian.net/browse/CNFT2-1255)

## Steps to verify

1. Manually inspect Dockerfile, verify env vars are removed
2. Run `docker-compose up nifi --build -d` from the cdc-sandbox directory
3. Verify NiFI starts and runs without issue


[CNFT2-1255]: https://cdc-nbs.atlassian.net/browse/CNFT2-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ