### PR TITLE
adding date of birth to the sex and birth in the demographics tab

### DIFF
--- a/apps/modernization-ui/src/pages/patient/profile/sexBirth/SexBirth.tsx
+++ b/apps/modernization-ui/src/pages/patient/profile/sexBirth/SexBirth.tsx
@@ -18,6 +18,7 @@ const asView = (birth?: PatientBirth, gender?: PatientGender): Data[] => [
         text: internalizeDate(birth?.asOf)
     },
     { title: 'Current age:', text: birth?.age?.toString() },
+    { title: 'Date of birth:', text: internalizeDate(birth?.bornOn) },
     { title: 'Current sex:', text: gender?.current?.description },
     { title: 'Unknown reason:', text: maybeDescription(gender?.unknownReason) },
     { title: 'Transgender information:', text: maybeDescription(gender?.preferred) },


### PR DESCRIPTION
## Description

Added a DOB for display to the Sex&Birth card in the demographics tab.

## Tickets

CNFT1-1558

## Steps to verify


1. Login
2. Search for any patient 
3. Navigate to patient profile 
4. navigate towards demographics tab and then towards the sex&birth card and see the DOB added.
