### PR TITLE
Fixed Incorrect spelling Superceded with Superseded in all variations

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/PatientProfile.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/PatientProfile.java
@@ -5,7 +5,7 @@ import gov.cdc.nbs.entity.enums.RecordStatus;
 public record PatientProfile(long id, String local, short version, String status) {
 
     public PatientProfile(long id, String local, short version) {
-        this(id, local, version, RecordStatus.ACTIVE.name());
+        this(id, local, version, RecordStatus.ACTIVE.display());
     }
 
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/RecordStatus.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/enums/RecordStatus.java
@@ -1,8 +1,18 @@
 package gov.cdc.nbs.entity.enums;
 
 public enum RecordStatus {
-    ACTIVE,
-    INACTIVE,
-    LOG_DEL,
-    SUPERCEDED
+    ACTIVE("ACTIVE"),
+    INACTIVE("INACTIVE"),
+    LOG_DEL("INACTIVE"),
+    SUPERCEDED("SUPERSEDED");
+
+    private final String display;
+
+    RecordStatus(final String display) {
+        this.display = display;
+    }
+
+    public String display() {
+        return display;
+    }
 }


### PR DESCRIPTION
## Summary

Incorrect spelling for "Superseded" in patient profile. Change "Superceded" to "Superseded". 
## Tickets

* [CNFT1-1546](https://cdc-nbs.atlassian.net/browse/CNFT1-1546)

## Steps to verify

1. Visit Advanced Search page
1. Click "Superseded" in the "Include records that are" section.
1. Click "Search" button.
2. Click Patient link to view patient profile and to see Superseded is spelled correctly. 


[CNFT1-1546]: https://cdc-nbs.atlassian.net/browse/CNFT1-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ