### PR TITLE
Remove test-db docker-compose

### DIFF
--- a/cdc-sandbox/docker-compose.yml
+++ b/cdc-sandbox/docker-compose.yml
@@ -99,11 +99,6 @@ services:
     #   - ./nifi/nifi_conf/conf:/opt/nifi/nifi-current/conf:rw
     networks:
       - nbs
-  test-db:
-    build: ./test-db
-    container_name: test-db
-    ports:
-      - 1434:1433
 volumes:
   nbs-mssql-data:
 networks:


### PR DESCRIPTION
## Description

With the change to use the dev database container instead of a test-db, the `test-db` folder was removed. However, the docker-compose entry for `test-db` was not removed. 

This PR removes the unused `test-db` entry.

## Tickets

NA

## Steps to verify

1. Rebuild everything
2. Run tests
3. Verify all is working as intended
