### PR TITLE
Workflows Modernization

### DIFF
--- a/.github/workflows/Build-and-deploy-modernization-api.yaml
+++ b/.github/workflows/Build-and-deploy-modernization-api.yaml
@@ -3,12 +3,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "cdc-sandbox/**"
-      - "docker-compose.yml"
-      - "**.md"
-      - ".github/workflows/**"
-      - "apps/nbs-gateway/**"
+    paths:
+      - "apps/modernization-api/**"
+      - "apps/modernization-ui/**"
+      - "libs/accumulation/**"
+      - "!libs/testing/**"
 
 jobs:
   sonar_scan:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -17,7 +17,11 @@ on:
   pull_request:
     paths:
       - "apps/**"
+      - "!apps/modernization-ui"
       - "libs/**"
+      - "build.gradle"
+      - "settings.gradle"
+      - "gradle/**"
       - ".github/workflows/sonar.yaml"
 env:
   deployment_env: dev


### PR DESCRIPTION
## Description

Updates the trigger for the Build and Deploy modernization api work flow to trigger only for changes to the `modernization-api` or any dependencies.

Updates the trigger for the sonar workflow to not trigger for PRs that only affect the `modernization-ui` due to our Sonar only being able to scan Java projects.
