### PR TITLE
[CNFT1-1560] fix phone number in search results

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultPhoneFinder.java
@@ -8,21 +8,23 @@ import java.util.Collection;
 @Component
 class PatientSearchResultPhoneFinder {
 
-  private static final String QUERY = """
-            select distinct
-          [phone_number].phone_nbr_txt    as [phone_number]
-      from Entity_locator_participation [locators]
+  private static final String QUERY =
+      """
+          select distinct
+              [phone_number].phone_nbr_txt    as [phone_number]
+          from Entity_locator_participation [locators]
 
-          join Tele_locator [phone_number] on
-                  [phone_number].[tele_locator_uid] = [locators].[locator_uid]
-              and [phone_number].record_status_cd = [locators].[record_status_cd]
+              join Tele_locator [phone_number] on
+                      [phone_number].[tele_locator_uid] = [locators].[locator_uid]
+                  and [phone_number].record_status_cd   = [locators].[record_status_cd]
+                  and [phone_number].phone_nbr_txt is not null
 
 
-      where   [locators].entity_uid = ?
-          and [locators].[class_cd] = 'TELE'
-          and [locators].cd <> 'NET'
-          and [locators].record_status_cd = 'ACTIVE'
-            """;
+          where   [locators].entity_uid = ?
+              and [locators].[class_cd] = 'TELE'
+              and [locators].cd <> 'NET'              
+              and [locators].record_status_cd = 'ACTIVE'
+      """;
   private static final int PATIENT_PARAMETER = 1;
   private static final int PHONE_COLUMN = 1;
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
@@ -2,7 +2,6 @@ package gov.cdc.nbs.patient;
 
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.identity.MotherSettings;
-import gov.cdc.nbs.testing.identity.SequentialIdentityGenerator;
 import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
@@ -10,9 +9,10 @@ import gov.cdc.nbs.patient.identifier.PatientLocalIdentifierGenerator;
 import gov.cdc.nbs.patient.identifier.PatientShortIdentifierResolver;
 import gov.cdc.nbs.support.IdentificationMother;
 import gov.cdc.nbs.support.RaceMother;
+import gov.cdc.nbs.support.util.RandomUtil;
+import gov.cdc.nbs.testing.identity.SequentialIdentityGenerator;
 import gov.cdc.nbs.testing.support.Active;
 import gov.cdc.nbs.testing.support.Available;
-import gov.cdc.nbs.support.util.RandomUtil;
 import net.datafaker.Faker;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -125,14 +125,14 @@ public class PatientMother {
       final String state,
       final String zip
   ) {
-   withAddress(
-       identifier,
-       "H",
-       address,
-       city,
-       state,
-       zip
-   );
+    withAddress(
+        identifier,
+        "H",
+        address,
+        city,
+        state,
+        zip
+    );
   }
 
   public void withAddress(
@@ -339,6 +339,15 @@ public class PatientMother {
       final PatientIdentifier identifier,
       final String number
   ) {
+    withPhone(identifier, null, number, null);
+  }
+
+  public void withPhone(
+      final PatientIdentifier identifier,
+      final String countryCode,
+      final String number,
+      final String extension
+  ) {
     Person patient = managed(identifier);
 
     patient.add(
@@ -348,9 +357,9 @@ public class PatientMother {
             "PH",
             "H",
             RandomUtil.getRandomDateInPast(),
-            null,
+            countryCode,
             number,
-            null,
+            extension,
             null,
             null,
             null,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientSteps.java
@@ -72,6 +72,20 @@ public class PatientSteps {
           value
       );
 
+      case "country code" -> mother.withPhone(
+          identifier,
+          value,
+          null,
+          null
+      );
+
+      case "extension" -> mother.withPhone(
+          identifier,
+          null,
+          null,
+          value
+      );
+
       case "email", "email address" -> mother.withEmail(
           identifier,
           value
@@ -109,5 +123,23 @@ public class PatientSteps {
       case "multi-race", "multi" -> "M";
       default -> "U";
     };
+  }
+
+  @Given("the patient has the phone number {string}-{string} x{string}")
+  public void the_patient_has_the_phone_number(
+      final String countryCode,
+      final String number,
+      final String extension
+  ) {
+
+    PatientIdentifier identifier = this.patient.active();
+
+    mother.withPhone(
+        identifier,
+        countryCode,
+        number,
+        extension
+    );
+
   }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -106,6 +106,14 @@ Feature: Patient Search
     And the search results have a patient with a "first name" equal to "Al"
     And the search results have a patient with a "last name" equal to "Lias"
 
+  Scenario: I can search for a Patient using a phone number
+    Given the patient has the phone number "1"-"888-240-2200" x"1009"
+    And I have another patient
+    And the patient has a "phone number" of "613-240-2200"
+    And I add the patient criteria for an "phone number" equal to "888-240-2200"
+    When I search for patients
+    Then the search results have a patient with a "phone number" equal to "888-240-2200"
+
   Scenario: I can search for a Patient using a partial phone number
     Given the patient has a "phone number" of "888-240-2200"
     And I have another patient
@@ -153,3 +161,17 @@ Feature: Patient Search
     And I add the patient criteria for an "identification value" equal to "4099"
     When I search for patients
     Then the patient is not in the search results
+
+  Scenario: BUG: CNFT1-1560 Patients with only a country code are searchable
+    Given the patient has a "country code" of "+32"
+    And the patient has a "first name" of "Eva"
+    And I add the patient criteria for an "first name" equal to "Eva"
+    When I search for patients
+    Then the search results have a patient with a "first name" equal to "Eva"
+
+  Scenario: BUG: CNFT1-1560 Patients only an extension are searchable
+    Given the patient has an "extension" of "3943"
+    And the patient has a "first name" of "Liam"
+    And I add the patient criteria for an "first name" equal to "Liam"
+    When I search for patients
+    Then the search results have a patient with a "first name" equal to "Liam"


### PR DESCRIPTION
## Description

Patients that have a phone entry that does not contain a number causes an error that prevents Patient Search Results from loading.  The finder for Patient Search Result phone numbers are adjusted to exclude phone entries without a number value.

## Tickets

* [CNFT1-1560](https://cdc-nbs.atlassian.net/browse/CNFT1-1560)

## Steps to verify

1. Create a Patient with a name
2. View the Patient Profile
3. Navigate to the Demographics tabs
4. Add a Phone & email entry that contains either a country code or an extension.  (no phone number value)
5. Return to Patient Search
6. Search for the Patient
7. The Patient Search Results should be visible.


[CNFT1-1560]: https://cdc-nbs.atlassian.net/browse/CNFT1-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ