### PR TITLE
changing menuItem names and route for link to match flow of NBS

### DIFF
--- a/apps/modernization-ui/src/pages/addPatient/components/LeftBar/LeftBar.tsx
+++ b/apps/modernization-ui/src/pages/addPatient/components/LeftBar/LeftBar.tsx
@@ -3,9 +3,9 @@ import { MenuItem } from './MenuItem';
 
 export enum ACTIVE_TAB {
     PATIENT = 'patient',
-    ORGANIZATION = 'organization',
-    PROVIDER = 'provider',
-    MORBIDITY = 'morbidity'
+    ORGANIZATION = 'Organization',
+    PROVIDER = 'Provider',
+    MORBIDITY = 'Morbidity'
 }
 
 export const LeftBar = ({ activeTab }: any) => {
@@ -20,9 +20,12 @@ export const LeftBar = ({ activeTab }: any) => {
                     New patient
                 </h6>
             </div>
-            <MenuItem name={`New ${ACTIVE_TAB.ORGANIZATION}`} link={`nbs/OrgSearchResults1.do?ContextAction=Add`} />
-            <MenuItem name={`New ${ACTIVE_TAB.MORBIDITY}`} link={`nbs/MyTaskList1.do?ContextAction=AddMorbDataEntry`} />
-            <MenuItem name={`New ${ACTIVE_TAB.PROVIDER}`} link={`nbs/ProvSearchResults1.do?ContextAction=Add`} />
+            <MenuItem
+                name={`${ACTIVE_TAB.ORGANIZATION}`}
+                link={`nbs/MyTaskList1.do?ContextAction=GlobalOrganization`}
+            />
+            <MenuItem name={`${ACTIVE_TAB.MORBIDITY}`} link={`nbs/MyTaskList1.do?ContextAction=AddMorbDataEntry`} />
+            <MenuItem name={`${ACTIVE_TAB.PROVIDER}`} link={`nbs/MyTaskList1.do?ContextAction=GlobalProvider`} />
         </Grid>
     );
 };


### PR DESCRIPTION
## Description

Changing the link in menuItems for Organization and Provider and changing spelling to match with the intention of the action item for clicking on the "Organization", "Provider", and "Morbidity".
Upon receiving feedback from the Design team to rename the menu items in the add patient page due to the fact that the actual "add" portion of the process of navigating to those menu items and adding in the case of "Provider" and "Organization" requires the user to search a provider and select one before actually adding a "Provider" or "Organization".


## Steps to verify

1. Login
2. Navigate to advanced search
3. Click on add new patient button after making a search
4. click on any of the menu items on the left navbar within the add patient page
5. route to NBS classic as expected.
