### PR TITLE
CNFT2-1284 Add Section overlap Save as Draft

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.scss
@@ -2,11 +2,12 @@
 
 .alert-banner {
     width: 100%;
-    padding: 0.3rem 1.0rem 1.0rem;
+    padding: 0.6rem 1.0rem;
     display: flex;
     flex-direction: row;
     gap: 0.5rem;
     margin-bottom: 1.0rem;
+    align-items: center;
     &.success {
         background-color: $color-bg-alert-success;
         border-left: 8px solid $color-alert-success;
@@ -23,7 +24,8 @@
         background-color: $color-bg-alert-error;
         border-left: 8px solid $color-alert-error;
     }
-    &__right {
-        padding-top: 0.4rem;
+    &__left, &__right{
+        display: flex;
+        align-items: center;
     }
 }

--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
@@ -9,7 +9,7 @@ export type AlertBannerProps = {
 export const AlertBanner = ({ type, children }: AlertBannerProps) => {
     return (
         <div className={`alert-banner ${type}`}>
-            <div className="alert-banner-left">
+            <div className="alert-banner__left">
                 {type === 'success' && <Icon.CheckCircle size={3} />}
                 {type === 'warning' && <Icon.Warning size={3} />}
                 {type === 'prompt' && <Icon.Info size={3} />}

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPage.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPage.scss
@@ -18,7 +18,8 @@
         position: relative;
         .edit-page__content {
             display: flex;
-            justify-content: center;
+            flex-direction: column;
+            align-items: center;
             margin-top: 1.2rem;
             width: 100%;
             height: 100%;

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPage.tsx
@@ -61,6 +61,7 @@ export const EditPage = () => {
                 <DragDropProvider data={page.tabs?.[active]}>
                     <div className="edit-page">
                         <PagesBreadcrumb currentPage={page.name} />
+                        {alertMessage ? <AlertBanner type={alertType}>{alertMessage}</AlertBanner> : null}
                         <div className="edit-page__header">
                             <EditPageHeader page={page} handleSaveDraft={handleSaveDraft} />
                             {page.tabs ? (
@@ -74,8 +75,6 @@ export const EditPage = () => {
                         </div>
                         <div className="edit-page__container">
                             <div className="edit-page__content">
-                                {alertMessage ? <AlertBanner type={alertType}>{alertMessage}</AlertBanner> : null}
-
                                 {page.tabs?.[active] ? (
                                     <EditPageContentComponent
                                         content={page.tabs[active]}


### PR DESCRIPTION
This fixes a bug, where the alert banner does not display above the Edit Page content when Page is successfully saved as Draft.