### PR TITLE
add-error-handling-to-page-library

### DIFF
--- a/apps/modernization-ui/package-lock.json
+++ b/apps/modernization-ui/package-lock.json
@@ -14,6 +14,7 @@
                 "@trussworks/react-uswds": "^5.3.1",
                 "@types/jest": "^28.1.6",
                 "@types/react": "^18.0.15",
+                "@types/react-beautiful-dnd": "^13.1.5",
                 "@types/react-dom": "^18.0.6",
                 "classnames": "^2.3.2",
                 "date-fns": "^2.30.0",
@@ -21,6 +22,7 @@
                 "lodash.debounce": "^4.0.8",
                 "multiselect-react-dropdown": "^2.0.25",
                 "react": "^17",
+                "react-beautiful-dnd": "^13.1.1",
                 "react-dom": "^17",
                 "react-hook-form": "^7.36.1",
                 "react-refresh": "^0.14.0",
@@ -6838,6 +6840,15 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/hoist-non-react-statics": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
+            "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
+            "dependencies": {
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0"
+            }
+        },
         "node_modules/@types/html-minifier-terser": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -7003,12 +7014,31 @@
                 "csstype": "^3.0.2"
             }
         },
+        "node_modules/@types/react-beautiful-dnd": {
+            "version": "13.1.6",
+            "resolved": "https://registry.npmjs.org/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.6.tgz",
+            "integrity": "sha512-FXAuaa52ux7HWQDumi3MFSAAsW8OKfDImy1pSZPKe85nV9mZ1f4spVzW0a2boYvkIhphjbWUi5EwUiRG8Rq/Qg==",
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
         "node_modules/@types/react-dom": {
             "version": "18.2.14",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
             "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
             "dependencies": {
                 "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-redux": {
+            "version": "7.1.28",
+            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.28.tgz",
+            "integrity": "sha512-EQr7cChVzVUuqbA+J8ArWK1H0hLAHKOs21SIMrskKZ3nHNeE+LFYA+IsoZGhVOT8Ktjn3M20v4rnZKN3fLbypw==",
+            "dependencies": {
+                "@types/hoist-non-react-statics": "^3.3.0",
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0",
+                "redux": "^4.0.0"
             }
         },
         "node_modules/@types/react-test-renderer": {
@@ -9544,6 +9574,14 @@
             },
             "peerDependencies": {
                 "postcss": "^8.4"
+            }
+        },
+        "node_modules/css-box-model": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+            "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+            "dependencies": {
+                "tiny-invariant": "^1.0.6"
             }
         },
         "node_modules/css-declaration-sorter": {
@@ -20925,6 +20963,11 @@
                 "performance-now": "^2.1.0"
             }
         },
+        "node_modules/raf-schd": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+            "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -21003,6 +21046,29 @@
             "version": "0.13.11",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
             "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        },
+        "node_modules/react-beautiful-dnd": {
+            "version": "13.1.1",
+            "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+            "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.9.2",
+                "css-box-model": "^1.2.0",
+                "memoize-one": "^5.1.1",
+                "raf-schd": "^4.0.2",
+                "react-redux": "^7.2.0",
+                "redux": "^4.0.4",
+                "use-memo-one": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/react-beautiful-dnd/node_modules/memoize-one": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+            "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
         },
         "node_modules/react-day-picker": {
             "version": "8.9.1",
@@ -21214,6 +21280,35 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-redux": {
+            "version": "7.2.9",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+            "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.15.4",
+                "@types/react-redux": "^7.1.20",
+                "hoist-non-react-statics": "^3.3.2",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.7.2",
+                "react-is": "^17.0.2"
+            },
+            "peerDependencies": {
+                "react": "^16.8.3 || ^17 || ^18"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-redux/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "node_modules/react-refresh": {
             "version": "0.14.0",
@@ -21488,6 +21583,14 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/redux": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+            "dependencies": {
+                "@babel/runtime": "^7.9.2"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -23380,6 +23483,11 @@
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+            "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+        },
         "node_modules/title-case": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -23926,6 +24034,14 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/use-memo-one": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+            "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/util-deprecate": {

--- a/apps/modernization-ui/src/apps/page-builder/context/ConditionsContext.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/context/ConditionsContext.tsx
@@ -1,24 +1,8 @@
 /* eslint-disable camelcase */
-import { createContext, useState, Dispatch, SetStateAction } from 'react';
+import { createContext, useState } from 'react';
+import { ContextData } from './contextData';
 
-interface ConditionContextData {
-    filter: any;
-    setFilter: (filter: any) => void;
-    searchQuery: string;
-    setSearchQuery: (query: string) => void;
-    currentPage: number;
-    setCurrentPage?: (page: number) => void;
-    sortBy: string;
-    setSortBy: (name: string) => void;
-    sortDirection: string;
-    setSortDirection: (direction: string) => void;
-    pageSize: number;
-    setPageSize: Dispatch<SetStateAction<number>>;
-    isLoading: boolean;
-    setIsLoading: (status: boolean) => void;
-}
-
-const conditionContextDefaultValue: ConditionContextData = {
+const conditionContextDefaultValue: ContextData = {
     filter: {},
     setFilter: () => {},
     searchQuery: '',
@@ -35,7 +19,7 @@ const conditionContextDefaultValue: ConditionContextData = {
     setIsLoading: () => {}
 };
 
-export const ConditionsContext = createContext<ConditionContextData>(conditionContextDefaultValue);
+export const ConditionsContext = createContext<ContextData>(conditionContextDefaultValue);
 
 export const ConditionProvider = ({ children }: any) => {
     const [searchQuery, setSearchQuery] = useState(conditionContextDefaultValue.searchQuery);

--- a/apps/modernization-ui/src/apps/page-builder/context/PagesContext.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/context/PagesContext.tsx
@@ -1,22 +1,10 @@
 /* eslint-disable camelcase */
-import { createContext, useState, Dispatch, SetStateAction } from 'react';
+import { createContext, useState } from 'react';
+import { ContextData } from './contextData';
 
-interface PagesContextData {
-    searchQuery: string;
-    setSearchQuery: (query: string) => void;
-    currentPage: number;
-    setCurrentPage?: (page: number) => void;
-    sortBy: string;
-    setSortBy: (name: string) => void;
-    sortDirection: string;
-    setSortDirection: (direction: string) => void;
-    pageSize: number;
-    setPageSize: Dispatch<SetStateAction<number>>;
-    isLoading: boolean;
-    setIsLoading: (status: boolean) => void;
-}
-
-const pagesContextDefaultValue: PagesContextData = {
+const pagesContextDefaultValue: ContextData = {
+    filter: '',
+    setFilter: () => {},
     searchQuery: '',
     setSearchQuery: () => {},
     currentPage: 1,
@@ -31,9 +19,10 @@ const pagesContextDefaultValue: PagesContextData = {
     setIsLoading: () => {}
 };
 
-export const PagesContext = createContext<PagesContextData>(pagesContextDefaultValue);
+export const PagesContext = createContext<ContextData>(pagesContextDefaultValue);
 
 export const PagesProvider = ({ children }: any) => {
+    const [filter, setFilter] = useState(pagesContextDefaultValue.filter);
     const [searchQuery, setSearchQuery] = useState(pagesContextDefaultValue.searchQuery);
     const [currentPage, setCurrentPage] = useState(pagesContextDefaultValue.currentPage);
     const [sortBy, setSortBy] = useState(pagesContextDefaultValue.sortBy);
@@ -44,6 +33,8 @@ export const PagesProvider = ({ children }: any) => {
     return (
         <PagesContext.Provider
             value={{
+                filter,
+                setFilter,
                 currentPage,
                 sortBy,
                 setSortBy,

--- a/apps/modernization-ui/src/apps/page-builder/context/QuestionsContext.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/context/QuestionsContext.tsx
@@ -1,24 +1,8 @@
 /* eslint-disable camelcase */
-import { createContext, useState, Dispatch, SetStateAction } from 'react';
+import { createContext, useState } from 'react';
+import { ContextData } from './contextData';
 
-interface QuestionContextData {
-    filter: any;
-    setFilter: (filter: any) => void;
-    searchQuery: string;
-    setSearchQuery: (query: string) => void;
-    currentPage: number;
-    setCurrentPage?: (page: number) => void;
-    sortBy: string;
-    setSortBy: (name: string) => void;
-    sortDirection: string;
-    setSortDirection: (direction: string) => void;
-    pageSize: number;
-    setPageSize: Dispatch<SetStateAction<number>>;
-    isLoading: boolean;
-    setIsLoading: (status: boolean) => void;
-}
-
-const questionContextDefaultValue: QuestionContextData = {
+const questionContextDefaultValue: ContextData = {
     filter: {},
     setFilter: () => {},
     searchQuery: '',
@@ -35,7 +19,7 @@ const questionContextDefaultValue: QuestionContextData = {
     setIsLoading: () => {}
 };
 
-export const QuestionsContext = createContext<QuestionContextData>(questionContextDefaultValue);
+export const QuestionsContext = createContext<ContextData>(questionContextDefaultValue);
 
 export const QuestionProvider = ({ children }: any) => {
     const [searchQuery, setSearchQuery] = useState(questionContextDefaultValue.searchQuery);

--- a/apps/modernization-ui/src/apps/page-builder/context/ValueSetContext.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/context/ValueSetContext.tsx
@@ -1,24 +1,8 @@
 /* eslint-disable camelcase */
-import { createContext, useState, Dispatch, SetStateAction } from 'react';
+import { createContext, useState } from 'react';
+import { ContextData } from './contextData';
 
-interface ValueSetsContextData {
-    filter: any;
-    setFilter: (filter: any) => void;
-    searchQuery: string;
-    setSearchQuery: (query: string) => void;
-    currentPage: number;
-    setCurrentPage?: (page: number) => void;
-    sortBy: string;
-    setSortBy: (name: string) => void;
-    sortDirection: string;
-    setSortDirection: (direction: string) => void;
-    pageSize: number;
-    setPageSize: Dispatch<SetStateAction<number>>;
-    isLoading: boolean;
-    setIsLoading: (status: boolean) => void;
-}
-
-const valueSetsDefaultValue: ValueSetsContextData = {
+const valueSetsDefaultValue: ContextData = {
     filter: {},
     setFilter: () => {},
     searchQuery: '',
@@ -35,7 +19,7 @@ const valueSetsDefaultValue: ValueSetsContextData = {
     setIsLoading: () => {}
 };
 
-export const ValueSetsContext = createContext<ValueSetsContextData>(valueSetsDefaultValue);
+export const ValueSetsContext = createContext<ContextData>(valueSetsDefaultValue);
 
 export const ValueSetsProvider = ({ children }: any) => {
     const [searchQuery, setSearchQuery] = useState(valueSetsDefaultValue.searchQuery);

--- a/apps/modernization-ui/src/apps/page-builder/context/contextData.ts
+++ b/apps/modernization-ui/src/apps/page-builder/context/contextData.ts
@@ -1,0 +1,18 @@
+import { Dispatch, SetStateAction } from 'react';
+
+export interface ContextData {
+    filter: any;
+    setFilter: (filter: any) => void;
+    searchQuery: string;
+    setSearchQuery: (query: string) => void;
+    currentPage: number;
+    setCurrentPage?: (page: number) => void;
+    sortBy: string;
+    setSortBy: (name: string) => void;
+    sortDirection: string;
+    setSortDirection: (direction: string) => void;
+    pageSize: number;
+    setPageSize: Dispatch<SetStateAction<number>>;
+    isLoading: boolean;
+    setIsLoading: (status: boolean) => void;
+}

--- a/apps/modernization-ui/src/apps/page-builder/generated/services/PageControllerService.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/services/PageControllerService.ts
@@ -15,7 +15,6 @@ import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 
 export class PageControllerService {
-
     /**
      * getAllPageSummary
      * @returns Page_PageSummary_ OK
@@ -25,29 +24,29 @@ export class PageControllerService {
         authorization,
         page,
         size,
-        sort,
+        sort
     }: {
-        authorization: any,
-        page?: number,
-        size?: number,
-        sort?: string,
+        authorization: any;
+        page?: number;
+        size?: number;
+        sort?: string;
     }): CancelablePromise<Page_PageSummary_> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/nbs/page-builder/api/v1/pages',
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             query: {
-                'page': page,
-                'size': size,
-                'sort': sort,
+                page: page,
+                size: size,
+                sort: sort
             },
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,
-                404: `Not Found`,
-            },
+                404: `Not Found`
+            }
         });
     }
 
@@ -59,26 +58,26 @@ export class PageControllerService {
      */
     public static createPageUsingPost({
         authorization,
-        request,
+        request
     }: {
-        authorization: any,
+        authorization: any;
         /**
          * request
          */
-        request: PageCreateRequest,
+        request: PageCreateRequest;
     }): CancelablePromise<PageCreateResponse | any> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/nbs/page-builder/api/v1/pages',
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             body: request,
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,
-                404: `Not Found`,
-            },
+                404: `Not Found`
+            }
         });
     }
 
@@ -87,22 +86,18 @@ export class PageControllerService {
      * @returns Resource OK
      * @throws ApiError
      */
-    public static downloadPageLibraryUsingGet({
-        authorization,
-    }: {
-        authorization: any,
-    }): CancelablePromise<Resource> {
+    public static downloadPageLibraryUsingGet({ authorization }: { authorization: any }): CancelablePromise<Resource> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/nbs/page-builder/api/v1/pages/download',
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,
-                404: `Not Found`,
-            },
+                404: `Not Found`
+            }
         });
     }
 
@@ -111,22 +106,18 @@ export class PageControllerService {
      * @returns string OK
      * @throws ApiError
      */
-    public static downloadPageLibraryPdfUsingGet({
-        authorization,
-    }: {
-        authorization: any,
-    }): CancelablePromise<string> {
+    public static downloadPageLibraryPdfUsingGet({ authorization }: { authorization: any }): CancelablePromise<string> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/nbs/page-builder/api/v1/pages/downloadPDF',
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,
-                404: `Not Found`,
-            },
+                404: `Not Found`
+            }
         });
     }
 
@@ -141,35 +132,39 @@ export class PageControllerService {
         request,
         page,
         size,
-        sort,
+        sort
     }: {
-        authorization: any,
+        authorization: any;
         /**
          * request
          */
-        request: PageSummaryRequest,
-        page?: number,
-        size?: number,
-        sort?: string,
-    }): CancelablePromise<Page_PageSummary_ | any> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/nbs/page-builder/api/v1/pages/search',
-            headers: {
-                'Authorization': authorization,
-            },
-            query: {
-                'page': page,
-                'size': size,
-                'sort': sort,
-            },
-            body: request,
-            errors: {
-                401: `Unauthorized`,
-                403: `Forbidden`,
-                404: `Not Found`,
-            },
-        });
+        request: PageSummaryRequest;
+        page?: number;
+        size?: number;
+        sort?: string;
+    }): CancelablePromise<Page_PageSummary_> {
+        try {
+            return __request(OpenAPI, {
+                method: 'POST',
+                url: '/nbs/page-builder/api/v1/pages/search',
+                headers: {
+                    Authorization: authorization
+                },
+                query: {
+                    page: page,
+                    size: size,
+                    sort: sort
+                },
+                body: request,
+                errors: {
+                    401: `Unauthorized`,
+                    403: `Forbidden`,
+                    404: `Not Found`
+                }
+            });
+        } catch (error: any) {
+            throw new Error(error);
+        }
     }
 
     /**
@@ -179,27 +174,27 @@ export class PageControllerService {
      */
     public static deletePageDraftUsingDelete({
         authorization,
-        id,
+        id
     }: {
-        authorization: any,
+        authorization: any;
         /**
          * id
          */
-        id: number,
+        id: number;
     }): CancelablePromise<PageStateResponse> {
         return __request(OpenAPI, {
             method: 'DELETE',
             url: '/nbs/page-builder/api/v1/pages/{id}/delete-draft',
             path: {
-                'id': id,
+                id: id
             },
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             errors: {
                 401: `Unauthorized`,
-                403: `Forbidden`,
-            },
+                403: `Forbidden`
+            }
         });
     }
 
@@ -212,33 +207,33 @@ export class PageControllerService {
     public static updatePageDetailsUsingPut({
         authorization,
         id,
-        request,
+        request
     }: {
-        authorization: any,
+        authorization: any;
         /**
          * id
          */
-        id: number,
+        id: number;
         /**
          * request
          */
-        request: UpdatePageDetailsRequest,
+        request: UpdatePageDetailsRequest;
     }): CancelablePromise<PageSummary | any> {
         return __request(OpenAPI, {
             method: 'PUT',
             url: '/nbs/page-builder/api/v1/pages/{id}/details',
             path: {
-                'id': id,
+                id: id
             },
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             body: request,
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,
-                404: `Not Found`,
-            },
+                404: `Not Found`
+            }
         });
     }
 
@@ -250,29 +245,28 @@ export class PageControllerService {
      */
     public static savePageDraftUsingPut({
         authorization,
-        id,
+        id
     }: {
-        authorization: any,
+        authorization: any;
         /**
          * id
          */
-        id: number,
+        id: number;
     }): CancelablePromise<PageStateResponse | any> {
         return __request(OpenAPI, {
             method: 'PUT',
             url: '/nbs/page-builder/api/v1/pages/{id}/draft',
             path: {
-                'id': id,
+                id: id
             },
             headers: {
-                'Authorization': authorization,
+                Authorization: authorization
             },
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,
-                404: `Not Found`,
-            },
+                404: `Not Found`
+            }
         });
     }
-
 }

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePages.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePages.tsx
@@ -16,13 +16,21 @@ export const ManagePages = () => {
     useEffect(() => {
         setIsLoading(true);
         // get Pages
-        fetchPageSummaries(token, searchQuery, sortBy.toLowerCase() + ',' + sortDirection, currentPage, pageSize).then(
-            (data: any) => {
+        try {
+            fetchPageSummaries(
+                token,
+                searchQuery,
+                sortBy.toLowerCase() + ',' + sortDirection,
+                currentPage,
+                pageSize
+            ).then((data: any) => {
                 setPages(data.content);
                 setTotalElements(data.totalElements);
                 setIsLoading(false);
-            }
-        );
+            });
+        } catch (error) {
+            console.log(error);
+        }
     }, [searchQuery, currentPage, pageSize, sortBy, sortDirection]);
 
     return (

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePagesTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePagesTable.spec.tsx
@@ -18,7 +18,7 @@ describe('when rendered', () => {
 
         expect(tableHeads[0].innerHTML).toBe('Page name');
         expect(tableHeads[1].innerHTML).toBe('Event name');
-        expect(tableHeads[2].innerHTML).toBe('Related conditions');
+        expect(tableHeads[2].innerHTML).toBe('Related condition(s)');
         expect(tableHeads[3].innerHTML).toBe('Status');
         expect(tableHeads[4].innerHTML).toBe('Last updated');
         expect(tableHeads[5].innerHTML).toBe('Last updated by');

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePagesTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePagesTable.tsx
@@ -15,7 +15,7 @@ import { downloadPageLibraryPdf } from 'utils/ExportUtil';
 export enum Column {
     PageName = 'Page name',
     EventType = 'Event name',
-    RelatedConditions = 'Related conditions',
+    RelatedConditions = 'Related condition(s)',
     Status = 'Status',
     LastUpdate = 'Last updated',
     LastUpdatedBy = 'Last updated by'
@@ -90,6 +90,9 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
                     break;
                 case Column.Status:
                     setSortBy('status');
+                    break;
+                case Column.RelatedConditions:
+                    setSortBy('conditions');
                     break;
                 case Column.LastUpdate:
                     setSortBy('lastUpdate');

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/usePageSummaryAPI.ts
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/usePageSummaryAPI.ts
@@ -1,22 +1,21 @@
 /* eslint-disable camelcase */
 import { PageControllerService, Page_PageSummary_ } from 'apps/page-builder/generated';
 
-export const fetchPageSummaries = (
+export const fetchPageSummaries = async (
     token: string,
     search?: string,
     sort?: string,
     currentPage?: number,
     pageSize?: number
 ): Promise<Page_PageSummary_> => {
-    return PageControllerService.searchUsingPost({
+    const response = await PageControllerService.searchUsingPost({
         authorization: token,
         request: { search },
         page: currentPage && currentPage > 1 ? currentPage - 1 : 0,
         size: pageSize,
         sort
-    }).then((response: Page_PageSummary_) => {
-        return response;
     });
+    return response;
 };
 
 export const fetchSinglePageSummary = {};

--- a/apps/modernization-ui/src/apps/page-builder/services/pagesAPI.ts
+++ b/apps/modernization-ui/src/apps/page-builder/services/pagesAPI.ts
@@ -14,9 +14,13 @@ export const fetchPageSummaries = (
         page: currentPage && currentPage > 1 ? currentPage - 1 : 0,
         size: pageSize,
         sort
-    }).then((response: Page_PageSummary_) => {
-        return response;
-    });
+    })
+        .then((response: Page_PageSummary_) => {
+            return response;
+        })
+        .catch((error) => {
+            return error;
+        });
 };
 
 export const createPage = (

--- a/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.tsx
+++ b/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.tsx
@@ -1,32 +1,40 @@
 import { PagesContext } from 'apps/page-builder/context/PagesContext';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { Context, useContext, useEffect, useState } from 'react';
 import { SelectInput } from 'components/FormInputs/SelectInput';
 import './RangeToggle.scss';
 import { ConditionsContext } from 'apps/page-builder/context/ConditionsContext';
 import { QuestionsContext } from 'apps/page-builder/context/QuestionsContext';
 import { ValueSetsContext } from 'apps/page-builder/context/ValueSetContext';
+import { ContextData } from 'apps/page-builder/context/contextData';
 
 interface RangeToggleProps {
     contextName?: 'pages' | 'conditions' | 'questions' | 'valuesets' | 'templates';
 }
 
 export const RangeToggle = ({ contextName }: RangeToggleProps) => {
-    const context = useMemo(() => {
+    const [context, setContext] = useState<Context<ContextData>>(PagesContext);
+
+    useEffect(() => {
         switch (contextName) {
             case 'pages':
-                return useContext(PagesContext);
+                setContext(PagesContext);
+                break;
             case 'conditions':
-                return useContext(ConditionsContext);
+                setContext(ConditionsContext);
+                break;
             case 'questions':
-                return useContext(QuestionsContext);
+                setContext(QuestionsContext);
+                break;
             case 'valuesets':
-                return useContext(ValueSetsContext);
+                setContext(ValueSetsContext);
+                break;
             default:
-                return useContext(PagesContext);
+                setContext(PagesContext);
+                break;
         }
     }, [contextName]);
 
-    const { pageSize, setPageSize, currentPage, setCurrentPage } = context;
+    const { pageSize, setPageSize, currentPage, setCurrentPage } = useContext(context);
     const [range, setRange] = useState(10);
     const options = [
         { name: '10', value: '10' },


### PR DESCRIPTION
## Description
This PR adds error handling to the page library api requests.  It also cleans up some of the copy/paste related to the pagination contexts for each table, and cleans up some errors from using a hook inside of a hook within the RangeToggle component.

## Tickets



## Steps to verify

1. Use the page size toggle on any table and ensure there are no errors in the console.
2. Manually hard code something into the page search api call that will cause an error. Ensure that the page does not crash and the error is logged in the console.  We will need to add a banner or something in the future for displaying an error to the user.
