### PR TITLE
Reorder Page builder left hand navigation

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/Navigation/Navigation.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Navigation/Navigation.tsx
@@ -20,25 +20,26 @@ export const Navigation = ({ active }: Props) => {
                 <div
                     className={`navigation__button ${active === 'manage-pages' ? 'active' : ''}`}
                     onClick={() => goBack('pages')}>
-                    <p>Pages</p>
+                    <p>Page Library</p>
                 </div>
-                <div className="navigation__button">
-                    <p>Templates</p>
-                </div>
+
                 <div
                     className={`navigation__button ${active === 'condition-library' ? 'active' : ''}`}
                     onClick={() => goBack('condition-library')}>
-                    <p>Conditions</p>
+                    <p>Condition Library</p>
                 </div>
                 <div
                     className={`navigation__button ${active === 'question-library' ? 'active' : ''}`}
                     onClick={() => goBack('question-library')}>
-                    <p>Questions</p>
+                    <p>Question Library</p>
+                </div>
+                <div className="navigation__button">
+                    <p>Template Library</p>
                 </div>
                 <div
                     className={`navigation__button ${active === 'valueset-library' ? 'active' : ''}`}
                     onClick={() => goBack('valueset-library')}>
-                    <p>Value sets</p>
+                    <p>Value set Library</p>
                 </div>
             </div>
         </div>

--- a/apps/modernization-ui/src/apps/page-builder/components/Navigation/Navigation.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Navigation/Navigation.tsx
@@ -20,26 +20,26 @@ export const Navigation = ({ active }: Props) => {
                 <div
                     className={`navigation__button ${active === 'manage-pages' ? 'active' : ''}`}
                     onClick={() => goBack('pages')}>
-                    <p>Page Library</p>
+                    <p>Page library</p>
                 </div>
 
                 <div
                     className={`navigation__button ${active === 'condition-library' ? 'active' : ''}`}
                     onClick={() => goBack('condition-library')}>
-                    <p>Condition Library</p>
+                    <p>Condition library</p>
                 </div>
                 <div
                     className={`navigation__button ${active === 'question-library' ? 'active' : ''}`}
                     onClick={() => goBack('question-library')}>
-                    <p>Question Library</p>
+                    <p>Question library</p>
                 </div>
                 <div className="navigation__button">
-                    <p>Template Library</p>
+                    <p>Template library</p>
                 </div>
                 <div
                     className={`navigation__button ${active === 'valueset-library' ? 'active' : ''}`}
                     onClick={() => goBack('valueset-library')}>
-                    <p>Value set Library</p>
+                    <p>Value set library</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Description

Corrects the copy and order of the navigation links to each page on the left side of page-builder
## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1328)

## Steps to verify

1. Verify the links on the left panel match the figma design (https://www.figma.com/file/Uz9YzHbHQAubHpQTcsibA2/NBS-PageBuilder-2.0?node-id=3398%3A197455&mode=dev)
