### PR TITLE
Page info panel metadata fix

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/repository/WaTemplateRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/repository/WaTemplateRepository.java
@@ -18,29 +18,19 @@ public interface WaTemplateRepository extends JpaRepository<WaTemplate, Long> {
     public Boolean existsByDatamartNmAndIdNot(String dataMartName, Long id);
 
     public Boolean existsByTemplateNmAndIdNot(String templateNm, Long id);
-
+    
     public Optional<WaTemplate> findFirstByTemplateNm(String templateNm);
-
+    
     public WaTemplate findByTemplateNmAndTemplateType(String templateNm, String templateType);
-
+    
     public Optional<WaTemplate> findFirstByDatamartNm(String dataMartNm);
-
+    
     @Query("SELECT v from WaTemplate v WHERE v.id=:id OR v.templateNm LIKE %:templateNm% OR v.conditionCd LIKE %:conditionCd% OR v.datamartNm LIKE %:dataMartNm% OR v.recordStatusCd LIKE %:recordStatusCd% OR v.templateType IN :templateType")
-    Page<WaTemplate> searchTemplate(
-            @Param("id") Long id,
-            @Param("templateNm") String templateNm,
-            @Param("conditionCd") String conditionCd,
-            @Param("dataMartNm") String dataMartNm,
-            @Param("recordStatusCd") String recordStatusCd,
-            @Param("templateType") List<String> templateType,
-            Pageable pageable);
-
+    Page<WaTemplate> searchTemplate(@Param("id") Long id, @Param("templateNm") String templateNm, @Param("conditionCd") String conditionCd , @Param("dataMartNm") String dataMartNm, @Param("recordStatusCd") String recordStatusCd,  @Param("templateType") List<String> templateType, Pageable pageable);
+    
     @Query("SELECT MAX(id) from WaTemplate")
     Long getMaxTemplateID();
-
+    
     @Query("SELECT v from WaTemplate v WHERE v.formCd LIKE '%PG_%'  order by v.templateNm asc")
     List<WaTemplate> getAllPagesOrderedByName();
-
-    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM WaTemplate t WHERE t.templateType = 'Draft' AND t.id =:id")
-    boolean isPageDraft(@Param("id") Long id);
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/repository/WaUiMetadataRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/repository/WaUiMetadataRepository.java
@@ -2,8 +2,7 @@ package gov.cdc.nbs.questionbank.entity.repository;
 
 import java.util.List;
 
-import gov.cdc.nbs.questionbank.page.util.PageConstants;
-import gov.cdc.nbs.questionbank.page.util.QueryStore;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -41,8 +40,7 @@ public interface WaUiMetadataRepository extends JpaRepository<WaUiMetadata, Long
     
     public void deleteByWaTemplateUid(WaTemplate page);
 
-    @Query(value = QueryStore.FIND_PAGE_METADATA_BY_TEMPLATE_SQL,nativeQuery = true)
-    List<Object[]> findPageMetadataByWaTemplateUid(@Param("waTemplateUid") Long waTemplateUid);
+
 
 
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/repository/WaUiMetadataRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/repository/WaUiMetadataRepository.java
@@ -1,7 +1,9 @@
 package gov.cdc.nbs.questionbank.entity.repository;
 
 import java.util.List;
-import java.util.Optional;
+
+import gov.cdc.nbs.questionbank.page.util.PageConstants;
+import gov.cdc.nbs.questionbank.page.util.QueryStore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,30 +16,20 @@ public interface WaUiMetadataRepository extends JpaRepository<WaUiMetadata, Long
 
     List<WaUiMetadata> findAllByQuestionIdentifier(String questionIdentifier);
 
-
     List<WaUiMetadata> findAllByWaTemplateUid(WaTemplate templateId);
-
-
+    
+    
     @Query("SELECT ui FROM WaUiMetadata ui WHERE ui.waTemplateUid.id =:pageId AND ui.nbsUiComponentUid =:nbsUiComponentUid order by ui.orderNbr asc")
-    List<WaUiMetadata> findOrderedTabsForPage(
-            @Param("pageId") Long pageId,
-            @Param("nbsUiComponentUid") Long nbsUiComponentUid);
+    List<WaUiMetadata> findOrderedTabsForPage(@Param("pageId") Long pageId, @Param("nbsUiComponentUid") Long nbsUiComponentUid);
 
     @Query("SELECT ui FROM WaUiMetadata ui WHERE ui.waTemplateUid.id =:pageId AND ui.nbsUiComponentUid =:nbsUiComponentUid AND ( ui.orderNbr > :orderNmbrMin AND ui.orderNbr <= :orderNmbrMax) order by ui.orderNbr asc")
-    List<WaUiMetadata> findOrderedChildComponents(
-            @Param("pageId") Long pageId,
-            @Param("nbsUiComponentUid") Long nbsUiComponentUid,
-            @Param("orderNmbrMin") Integer orderNmbrMin,
-            @Param("orderNmbrMax") Integer orderNmbrMax);
+    List<WaUiMetadata> findOrderedChildComponents(@Param("pageId") Long pageId, @Param("nbsUiComponentUid") Long nbsUiComponentUid, @Param("orderNmbrMin") Integer orderNmbrMin, @Param("orderNmbrMax") Integer orderNmbrMax   );
 
-
+    
     @Modifying
-    @Query("UPDATE WaUiMetadata ui SET ui.orderNbr = ui.orderNbr + 1 WHERE ui.waTemplateUid.id = :pageId AND ui.orderNbr >= :start")
-    void incrementOrderNbrGreaterThanOrEqualTo(@Param("pageId") Long pageId, @Param("start") Integer start);
+    @Query("Update WaUiMetadata ui SET ui.orderNbr = ui.orderNbr + 1 WHERE ui.waTemplateUid.id = :pageId AND ui.orderNbr >= :orderNumber")
+    void incrementOrderNbrGreaterThanOrEqualTo(@Param("pageId") Long pageId, @Param("orderNumber") Integer orderNumber);
 
-    @Modifying
-    @Query(value = "UPDATE WaUiMetadata w SET w.orderNbr = w.orderNbr - 1 WHERE w.orderNbr >=:start AND w.waTemplateUid.id =:page")
-    void decrementOrderNumbers(@Param("start") Integer start, @Param("page") Long page);
 
     @Query("SELECT COUNT(ui) FROM WaUiMetadata ui WHERE ui.waTemplateUid.id =:pageId AND ui.questionIdentifier =:questionIdentifier")
     Long countByPageAndQuestionIdentifier(
@@ -46,17 +38,12 @@ public interface WaUiMetadataRepository extends JpaRepository<WaUiMetadata, Long
 
     @Query("Select COALESCE(Max(ui.orderNbr),0) FROM WaUiMetadata ui WHERE ui.waTemplateUid.id =:pageId")
     Integer findMaxOrderNbrForPage(@Param("pageId") Long pageId);
+    
+    public void deleteByWaTemplateUid(WaTemplate page);
 
-    public void deleteAllByWaTemplateUid(WaTemplate template);
+    @Query(value = QueryStore.FIND_PAGE_METADATA_BY_TEMPLATE_SQL,nativeQuery = true)
+    List<Object[]> findPageMetadataByWaTemplateUid(@Param("waTemplateUid") Long waTemplateUid);
 
-    @Query(value = "SELECT w.orderNbr FROM WaUiMetadata w WHERE w.id = :id")
-    Optional<Integer> findOrderNumber(@Param("id") Long id);
 
-    @Query(value = "SELECT w.nbsUiComponentUid FROM WaUiMetadata w WHERE w.orderNbr =:orderNbr AND w.waTemplateUid.id =:pageId")
-    Optional<Long> findNbsUiComponentUid(@Param("orderNbr") Integer orderNbr, @Param("pageId") Long pageId);
 
-    @Query("SELECT MIN(m.orderNbr) FROM WaUiMetadata m WHERE m.waTemplateUid.id =:page AND m.orderNbr > :orderNbr AND m.nbsUiComponentUid IN (1015, 1010)")
-    Integer findOrderNbrOfNextSectionOrTab(
-            @Param("orderNbr") Integer orderNbr,
-            @Param("page") long page);
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageController.java
@@ -101,12 +101,6 @@ public class PageController {
         Long userId = userDetailsProvider.getCurrentUserDetails().getId();
         return creator.createPage(request, userId);
     }
-    
-    @GetMapping("{id}/details")
-    public PageDetailResponse.PagedDetail getPageDetails(@PathVariable("id") Long pageId) {
-    	return pageFinder.getPageDetails(pageId);
-    }
-
 
     @PutMapping("{id}/draft")
     public PageStateResponse savePageDraft(@PathVariable("id") Long pageId) {
@@ -141,8 +135,7 @@ public class PageController {
         return stateChange.deletePageDraft(pageId);
     }
 
-
-    @GetMapping("downloadPageMetadata/{waTemplateUid}")
+    @GetMapping("{waTemplateUid}/download-metadata")
     public ResponseEntity<Resource> downloadPageMetadata(@PathVariable("waTemplateUid") Long waTemplateUid) throws IOException {
         String fileName = "PageMetadata.csv";
         InputStreamResource file = new InputStreamResource(pageMetaDataDownloader.downloadPageMetadataByWaTemplateUid(waTemplateUid));

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageController.java
@@ -45,6 +45,8 @@ public class PageController {
     private final PageCreator creator;
     private final PageStateChanger stateChange;
     private final PageDownloader pageDownloader;
+    private final PageMetaDataDownloader pageMetaDataDownloader;
+
     private final UserDetailsProvider userDetailsProvider;
     public PageController(
             final PageUpdater pageUpdater,
@@ -53,6 +55,7 @@ public class PageController {
             final PageCreator creator,
             final PageStateChanger stateChange,
             final PageDownloader pageDownloader,
+            final PageMetaDataDownloader pageMetaDataDownloader,
             final UserDetailsProvider userDetailsProvider) {
         this.pageUpdater = pageUpdater;
         this.finder = finder;
@@ -60,6 +63,7 @@ public class PageController {
         this.creator = creator;
         this.stateChange = stateChange;
         this.pageDownloader = pageDownloader;
+        this.pageMetaDataDownloader = pageMetaDataDownloader;
         this.userDetailsProvider = userDetailsProvider;
     }
 
@@ -141,7 +145,7 @@ public class PageController {
     @GetMapping("downloadPageMetadata/{waTemplateUid}")
     public ResponseEntity<Resource> downloadPageMetadata(@PathVariable("waTemplateUid") Long waTemplateUid) throws IOException {
         String fileName = "PageMetadata.csv";
-        InputStreamResource file = new InputStreamResource(pageDownloader.downloadPageMetadataByWaTemplateUid(waTemplateUid));
+        InputStreamResource file = new InputStreamResource(pageMetaDataDownloader.downloadPageMetadataByWaTemplateUid(waTemplateUid));
         return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
                 .contentType(MediaType.parseMediaType("application/csv")).body(file);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageDownloader.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageDownloader.java
@@ -54,9 +54,6 @@ public class PageDownloader {
     @Autowired
     private UserProfileRepository userProfileRepository;
 
-    @Autowired
-    private WaUiMetadataRepository waUiMetadataRepository;
-
     private static final List<String> PAGE_LIBRARY_HEADERS = Arrays.asList("Event Type",
             "Page Name", "Page State", "Related Conditions(s)", "Last Updated", "Last Updated By ");
     private static final Font helvetica = new Font(FontFamily.HELVETICA, 7, Font.NORMAL);
@@ -210,26 +207,5 @@ public class PageDownloader {
                     header.setPhrase(new Phrase(columnTitle, helvetica));
                     table.addCell(header);
                 });
-    }
-
-    public ByteArrayInputStream downloadPageMetadataByWaTemplateUid(Long waTemplateUid) throws IOException {
-        final CSVFormat format = CSVFormat.Builder.create().setQuoteMode(QuoteMode.MINIMAL).
-                setHeader(PageConstants.PAGE_METADATA_CSV_HEADER.split(",")).build();
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-             CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format)) {
-            List<Object[]> pageMetadata = waUiMetadataRepository.findPageMetadataByWaTemplateUid(waTemplateUid);
-            String temp = "";
-            for (Object[] data : pageMetadata) {
-                for (Object element : data) {
-                    temp = temp + ",";
-                }
-                temp = "";
-                csvPrinter.printRecord(data);
-            }
-            csvPrinter.flush();
-            return new ByteArrayInputStream(out.toByteArray());
-        } catch (IOException e) {
-            throw new IOException("Error downloading Page Metadata: " + e.getMessage());
-        }
     }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageMetaDataDownloader.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageMetaDataDownloader.java
@@ -1,10 +1,39 @@
-package gov.cdc.nbs.questionbank.page.util;
+package gov.cdc.nbs.questionbank.page;
 
-public interface QueryStore {
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.QuoteMode;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
 
-    String FIND_PAGE_METADATA_BY_TEMPLATE_SQL =
+
+@Service
+@RequiredArgsConstructor
+public class PageMetaDataDownloader {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    String PageMetadataHeader = "page_nm, order_nbr, question_identifier, question_nm, question_label, question_type, desc_txt," +
+            "question_tool_tip, data_type, ui_display_type, code_set_nm, value_set_code, value_set_nm, enable_ind," +
+            "display_ind, required_ind, publish_ind_cd, repeats_ind_cd, field_size, max_length, mask, min_value," +
+            "max_value, default_value, other_value_ind_cd, future_date_ind_cd, unit_type_cd, unit_code_set_nm," +
+            "unit_value, question_unit_identifier, unit_parent_identifier, data_location, part_type_cd, participation_type," +
+            "data_cd, data_use_cd, standard_question_ind_cd, standard_nnd_ind_cd, coinfection_ind_cd, repeat_group_seq_nbr," +
+            " question_group_seq_nbr, batch_table_appear_ind_cd, batch_table_column_width, batch_table_header, block_nm," +
+            "block_pivot_nbr, question_identifier_nnd, question_label_nnd, question_required_nnd, question_data_type_nnd," +
+            "hl7_segment_field, order_group_id, question_map, indicator_cd, group_nm, sub_group_nm, rdb_table_nm, " +
+            "rdb_column_nm, data_mart_column_nm, rpt_admin_column_nm, admin_comment";
+
+
+    private static final String QUERY =
             "SELECT " +
-                    "NBS_ODSE.dbo.WA_template.template_nm AS \"page_nm\", " +
+                    "NBS_ODSE.dbo.WA_template.template_nm AS page_nm, " +
                     "NBS_ODSE.dbo.WA_UI_metadata.order_nbr," +
                     "NBS_ODSE.dbo.WA_UI_metadata.question_identifier," +
                     "NBS_ODSE.dbo.WA_UI_metadata.question_nm," +
@@ -13,7 +42,7 @@ public interface QueryStore {
                     "NBS_ODSE.dbo.WA_UI_metadata.desc_txt," +
                     "NBS_ODSE.dbo.WA_UI_metadata.question_tool_tip," +
                     "NBS_ODSE.dbo.WA_UI_metadata.data_type," +
-                    "NBS_ODSE.dbo.NBS_ui_component.type_cd_desc AS \"ui_display_type\"," +
+                    "NBS_ODSE.dbo.NBS_ui_component.type_cd_desc AS ui_display_type," +
                     "NBS_SRTE.dbo.Codeset.code_set_nm code_set_nm," +
                     "NBS_SRTE.dbo.Codeset.value_set_code," +
                     "NBS_SRTE.dbo.Codeset.value_set_nm," +
@@ -31,13 +60,13 @@ public interface QueryStore {
                     "NBS_ODSE.dbo.WA_UI_metadata.other_value_ind_cd," +
                     "NBS_ODSE.dbo.WA_UI_metadata.future_date_ind_cd," +
                     "NBS_ODSE.dbo.WA_UI_metadata.unit_type_cd," +
-                    "NBS_SRTE.dbo.Codeset.code_set_nm code_set_name," +
+                    "NBS_SRTE.dbo.Codeset.code_set_nm code_set_nm," +
                     "NBS_ODSE.dbo.WA_UI_metadata.unit_value," +
                     "NBS_ODSE.dbo.WA_UI_metadata.question_unit_identifier," +
                     "NBS_ODSE.dbo.WA_UI_metadata.unit_parent_identifier," +
                     "NBS_ODSE.dbo.WA_UI_metadata.data_location," +
                     "NBS_ODSE.dbo.WA_UI_metadata.part_type_cd," +
-                    "NBS_SRTE.dbo.Participation_type.type_desc_txt AS \"participation_type\"," +
+                    "NBS_SRTE.dbo.Participation_type.type_desc_txt AS participation_type," +
                     "NBS_ODSE.dbo.WA_UI_metadata.data_cd," +
                     "NBS_ODSE.dbo.WA_UI_metadata.data_use_cd," +
                     "NBS_ODSE.dbo.WA_UI_metadata.standard_question_ind_cd," +
@@ -62,10 +91,9 @@ public interface QueryStore {
                     "NBS_ODSE.dbo.WA_UI_metadata.sub_group_nm," +
                     "NBS_ODSE.dbo.WA_RDB_metadata.rdb_table_nm," +
                     "NBS_ODSE.dbo.WA_RDB_metadata.rdb_column_nm," +
-                    "NBS_ODSE.dbo.WA_RDB_metadata.user_defined_column_nm AS \"data_mart_column_nm\"," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.user_defined_column_nm AS data_mart_column_nm," +
                     "NBS_ODSE.dbo.WA_RDB_metadata.rpt_admin_column_nm," +
                     "NBS_ODSE.dbo.WA_UI_metadata.admin_comment " +
-
                     " FROM " +
                     "NBS_ODSE.dbo.WA_UI_metadata WITH (nolock) " +/* ON Code_value_general.code_desc_txt = NBS_ODSE.dbo.WA_UI_metadata.question_oid */" LEFT OUTER JOIN " +
                     "NBS_ODSE.dbo.WA_template WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_template_uid = NBS_ODSE.dbo.WA_template.wa_template_uid LEFT OUTER JOIN " +
@@ -77,7 +105,7 @@ public interface QueryStore {
                     "NBS_SRTE.dbo.Codeset WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.code_set_group_id = Codeset.code_set_group_id LEFT OUTER JOIN " +
                     "NBS_SRTE.dbo.Code_value_general WITH (nolock) ON NBS_SRTE.dbo.Code_value_general.code_set_nm = Codeset.code_set_nm " +
 
-                    "WHERE  (NBS_ODSE.dbo.WA_ui_metadata.wa_template_uid =:waTemplateUid " +
+                    "WHERE  (NBS_ODSE.dbo.WA_ui_metadata.wa_template_uid =? " +
                     "AND WA_UI_metadata.question_identifier NOT LIKE '%_UI_%' AND WA_UI_metadata.question_identifier NOT LIKE 'MSG%' ) " +
 
                     "GROUP BY NBS_ODSE.dbo.WA_template.template_nm , NBS_ODSE.dbo.WA_UI_metadata.order_nbr, NBS_ODSE.dbo.WA_UI_metadata.question_identifier," +
@@ -120,8 +148,41 @@ public interface QueryStore {
                     "NBS_ODSE.dbo.WA_UI_metadata.entry_method," +
                     "NBS_ODSE.dbo.WA_UI_metadata.question_oid," +
                     "NBS_ODSE.dbo.WA_UI_metadata.question_oid_system_txt" +
-
                     " ORDER BY participation_type, NBS_ODSE.dbo.WA_UI_metadata.order_nbr";
+
+
+    public ByteArrayInputStream downloadPageMetadataByWaTemplateUid(Long waTemplateUid) throws IOException {
+        final CSVFormat format = CSVFormat.Builder.create().setQuoteMode(QuoteMode.MINIMAL).
+                setHeader(PageMetadataHeader.split(",")).build();
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format)) {
+            List<Object[]> pageMetadata = findPageMetadataByWaTemplateUid(waTemplateUid);
+            String temp = "";
+            for (Object[] data : pageMetadata) {
+                for (Object element : data) {
+                    temp = temp + ",";
+                }
+                temp = "";
+                csvPrinter.printRecord(data);
+            }
+            csvPrinter.flush();
+            return new ByteArrayInputStream(out.toByteArray());
+        } catch (IOException e) {
+            throw new IOException("Error downloading Page Metadata: " + e.getMessage());
+        }
+    }
+
+    public List<Object[]> findPageMetadataByWaTemplateUid(Long waTemplateUid) {
+        List<Object[]> result = jdbcTemplate.query(QUERY, new Object[]{waTemplateUid}, (rs, rowNum) -> {
+            int columnCount = rs.getMetaData().getColumnCount();
+            Object[] row = new Object[columnCount];
+            for (int i = 1; i <= columnCount; i++) {
+                row[i - 1] = rs.getObject(i);
+            }
+            return row;
+        });
+        return result;
+    }
 
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/PageConstants.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/PageConstants.java
@@ -1,47 +1,55 @@
 package gov.cdc.nbs.questionbank.page.util;
 
 public class PageConstants {
-	
-	private PageConstants() {}
-	
-	// Page State Change
-	public static final String SAVE_DRAFT_SUCCESS = "Draft was saved successfully.";
-	public static final String SAVE_DRAFT_NOCHANGE = "Page already has draft.";
-	public static final String SAVE_DRAFT_FAIL = " Failed to update to draft status: ";
-	public static final String DELETE_DRAFT_FAIL = " Failed to delete page draft. ";
-	public static final String PAGE_NOT_FOUND = " Could not find page with given id.";
-	public static final String DRAFT_NOT_FOUND = " Page does not have draft.";
-	public static final String DRAFT_DELETE_SUCCESS = "page draft has been successfully deleted.";
-	public static final String PUBLISHED_WITH_DRAFT = "Published With Draft";
-	public static final String DRAFT = "Draft";
-	public static final String PUBLISHED = "Published";
-	
-	//Page Create
-	public static final String ADD_PAGE_MESSAGE= " page has been successfully added"; 
-	public static final String ADD_PAGE_FAIL = "could not successfully add page";
-	public static final String ADD_PAGE_NAME_EMPTY = "Page name is required.";
-	public static final String ADD_PAGE_TEMPLATENAME_EXISTS = "A Template  with Template Name %s already exists in the system";
-	public static final String ADD_PAGE_CONDITION_EMPTY = "At least one condition is required.";
-	public static final String ADD_PAGE_EVENTTYPE_EMPTY = "EventType is required.";
-	public static final String ADD_PAGE_TEMPLATE_EMPTY = "Template is required.";
-	public static final String ADD_PAGE_DATAMART_NAME_EXISTS = "A Page with Data Mart Name %s already exists in the system";
-	public static final String ADD_PAGE_MMG_EMPTY = "MMG is required.";
-	
-	//Page Details
-	public static final Long PAGE_COMPONENT = 1002L;
-	public static final Long TAB_COMPONENT = 1010L;
-	public static final Long SECTION_COMPONENT= 1015L;
-	public static final Long SUB_SECTION_COMPONENT= 1016L;
-	public static final Long GEN_QUESTION_COMPONENT=1007L;
-	public static final Long SPE_QUESTION_COMPONENT=1008L;
-	
-	
-	
-	
-	// General
-	public static final String NOT_EXISTS= "Could not find template with given Id";
-	public static final String PAGE_NOT_EXISTS= "Could not find page with given Id: ";
-	public static final String BAD_REQUEST= "Could not process request. ";
-	
+
+    private PageConstants() {
+    }
+
+    // Page State Change
+    public static final String SAVE_DRAFT_SUCCESS = "Draft was saved successfully.";
+    public static final String SAVE_DRAFT_FAIL = " Failed to update to draft status: ";
+    public static final String DELETE_DRAFT_FAIL = " Failed to delete page draft. ";
+    public static final String PAGE_NOT_FOUND = " Could not find page with given id.";
+    public static final String DRAFT_NOT_FOUND = " Page does not have draft.";
+    public static final String DRAFT_DELETE_SUCCESS = "page draft has been successfully deleted.";
+    public static final String PUBLISHED_WITH_DRAFT = "Published With Draft";
+    public static final String DRAFT = "Draft";
+    public static final String PUBLISHED = "Published";
+
+    //Page Create
+    public static final String ADD_PAGE_MESSAGE = " page has been successfully added";
+    public static final String ADD_PAGE_FAIL = "could not successfully add page";
+    public static final String ADD_PAGE_NAME_EMPTY = "Page name is required.";
+    public static final String ADD_PAGE_TEMPLATENAME_EXISTS = "A Template  with Template Name %s already exists in the system";
+    public static final String ADD_PAGE_CONDITION_EMPTY = "At least one condition is required.";
+    public static final String ADD_PAGE_EVENTTYPE_EMPTY = "EventType is required.";
+    public static final String ADD_PAGE_TEMPLATE_EMPTY = "Template is required.";
+    public static final String ADD_PAGE_DATAMART_NAME_EXISTS = "A Page with Data Mart Name %s already exists in the system";
+    public static final String ADD_PAGE_MMG_EMPTY = "MMG is required.";
+
+    //Page Details
+    public static final Long TAB_COMPONENT = 1010L;
+    public static final Long SECTION_COMPONENT = 1015L;
+    public static final Long SUB_SECTION_COMPONENT = 1016L;
+    public static final Long GEN_QUESTION_COMPONENT = 1007L;
+    public static final Long SPE_QUESTION_COMPONENT = 1008L;
+
+
+    // General
+    public static final String NOT_EXISTS = "Could not find template with given Id";
+    public static final String PAGE_NOT_EXISTS = "Could not find page with given Id: ";
+    public static final String BAD_REQUEST = "Could not process request. ";
+
+    public static final String PAGE_METADATA_CSV_HEADER =
+                   "page_nm, order_nbr, question_identifier, question_nm, question_label, question_type, desc_txt,"+
+                    "question_tool_tip, data_type, ui_display_type, code_set_nm, value_set_code, value_set_nm, enable_ind,"+
+                    "display_ind, required_ind, publish_ind_cd, repeats_ind_cd, field_size, max_length, mask, min_value,"+
+                    "max_value, default_value, other_value_ind_cd, future_date_ind_cd, unit_type_cd, unit_code_set_nm,"+
+                    "unit_value, question_unit_identifier, unit_parent_identifier, data_location, part_type_cd, participation_type,"+
+                    "data_cd, data_use_cd, standard_question_ind_cd, standard_nnd_ind_cd, coinfection_ind_cd, repeat_group_seq_nbr,"+
+                    " question_group_seq_nbr, batch_table_appear_ind_cd, batch_table_column_width, batch_table_header, block_nm,"+
+                    "block_pivot_nbr, question_identifier_nnd, question_label_nnd, question_required_nnd, question_data_type_nnd,"+
+                    "hl7_segment_field, order_group_id, question_map, indicator_cd, group_nm, sub_group_nm, rdb_table_nm, "+
+                    "rdb_column_nm, data_mart_column_nm, rpt_admin_column_nm, admin_comment";
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/PageConstants.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/PageConstants.java
@@ -40,16 +40,5 @@ public class PageConstants {
     public static final String PAGE_NOT_EXISTS = "Could not find page with given Id: ";
     public static final String BAD_REQUEST = "Could not process request. ";
 
-    public static final String PAGE_METADATA_CSV_HEADER =
-                   "page_nm, order_nbr, question_identifier, question_nm, question_label, question_type, desc_txt,"+
-                    "question_tool_tip, data_type, ui_display_type, code_set_nm, value_set_code, value_set_nm, enable_ind,"+
-                    "display_ind, required_ind, publish_ind_cd, repeats_ind_cd, field_size, max_length, mask, min_value,"+
-                    "max_value, default_value, other_value_ind_cd, future_date_ind_cd, unit_type_cd, unit_code_set_nm,"+
-                    "unit_value, question_unit_identifier, unit_parent_identifier, data_location, part_type_cd, participation_type,"+
-                    "data_cd, data_use_cd, standard_question_ind_cd, standard_nnd_ind_cd, coinfection_ind_cd, repeat_group_seq_nbr,"+
-                    " question_group_seq_nbr, batch_table_appear_ind_cd, batch_table_column_width, batch_table_header, block_nm,"+
-                    "block_pivot_nbr, question_identifier_nnd, question_label_nnd, question_required_nnd, question_data_type_nnd,"+
-                    "hl7_segment_field, order_group_id, question_map, indicator_cd, group_nm, sub_group_nm, rdb_table_nm, "+
-                    "rdb_column_nm, data_mart_column_nm, rpt_admin_column_nm, admin_comment";
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/QueryStore.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/QueryStore.java
@@ -1,0 +1,127 @@
+package gov.cdc.nbs.questionbank.page.util;
+
+public interface QueryStore {
+
+    String FIND_PAGE_METADATA_BY_TEMPLATE_SQL =
+            "SELECT " +
+                    "NBS_ODSE.dbo.WA_template.template_nm AS \"page_nm\", " +
+                    "NBS_ODSE.dbo.WA_UI_metadata.order_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_label," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_type," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.desc_txt," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_tool_tip," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_type," +
+                    "NBS_ODSE.dbo.NBS_ui_component.type_cd_desc AS \"ui_display_type\"," +
+                    "NBS_SRTE.dbo.Codeset.code_set_nm code_set_nm," +
+                    "NBS_SRTE.dbo.Codeset.value_set_code," +
+                    "NBS_SRTE.dbo.Codeset.value_set_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.enable_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.display_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.required_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.publish_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.repeats_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.field_size," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.max_length," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.mask," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.min_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.max_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.default_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.other_value_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.future_date_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_type_cd," +
+                    "NBS_SRTE.dbo.Codeset.code_set_nm code_set_name," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_unit_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_parent_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_location," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.part_type_cd," +
+                    "NBS_SRTE.dbo.Participation_type.type_desc_txt AS \"participation_type\"," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_use_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.standard_question_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.standard_nnd_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.coinfection_ind_cd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.repeat_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_appear_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_column_width," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_header," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.block_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.block_pivot_nbr," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_identifier_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_label_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_required_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_data_type_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.hl7_segment_field," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.order_group_id," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_map," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.indicator_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.group_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.sub_group_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rdb_table_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rdb_column_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.user_defined_column_nm AS \"data_mart_column_nm\"," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rpt_admin_column_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.admin_comment " +
+
+                    " FROM " +
+                    "NBS_ODSE.dbo.WA_UI_metadata WITH (nolock) " +/* ON Code_value_general.code_desc_txt = NBS_ODSE.dbo.WA_UI_metadata.question_oid */" LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.WA_template WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_template_uid = NBS_ODSE.dbo.WA_template.wa_template_uid LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.WA_RDB_metadata WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_ui_metadata_uid = NBS_ODSE.dbo.WA_RDB_metadata.wa_ui_metadata_uid LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.WA_NND_metadata WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_ui_metadata_uid = NBS_ODSE.dbo.WA_NND_metadata.wa_ui_metadata_uid LEFT OUTER JOIN " +
+                    "NBS_SRTE.dbo.Participation_type WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.part_type_cd = Participation_type.type_cd LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.NBS_ui_component WITH (nolock) ON  " +
+                    "NBS_ODSE.dbo.WA_UI_metadata.nbs_ui_component_uid = NBS_ODSE.dbo.NBS_ui_component.nbs_ui_component_uid LEFT OUTER JOIN " +
+                    "NBS_SRTE.dbo.Codeset WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.code_set_group_id = Codeset.code_set_group_id LEFT OUTER JOIN " +
+                    "NBS_SRTE.dbo.Code_value_general WITH (nolock) ON NBS_SRTE.dbo.Code_value_general.code_set_nm = Codeset.code_set_nm " +
+
+                    "WHERE  (NBS_ODSE.dbo.WA_ui_metadata.wa_template_uid =:waTemplateUid " +
+                    "AND WA_UI_metadata.question_identifier NOT LIKE '%_UI_%' AND WA_UI_metadata.question_identifier NOT LIKE 'MSG%' ) " +
+
+                    "GROUP BY NBS_ODSE.dbo.WA_template.template_nm , NBS_ODSE.dbo.WA_UI_metadata.order_nbr, NBS_ODSE.dbo.WA_UI_metadata.question_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_nm, NBS_ODSE.dbo.WA_UI_metadata.desc_txt, NBS_ODSE.dbo.WA_UI_metadata.question_oid," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_label," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_tool_tip, NBS_ODSE.dbo.WA_UI_metadata.data_location, NBS_ODSE.dbo.WA_UI_metadata.data_type, NBS_SRTE.dbo.Codeset.code_set_nm," +
+                    "NBS_ODSE.dbo.NBS_ui_component.type_cd_desc , NBS_ODSE.dbo.WA_UI_metadata.group_nm, NBS_SRTE.dbo.Participation_type.type_desc_txt ," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_cd, NBS_ODSE.dbo.WA_UI_metadata.data_use_cd, NBS_ODSE.dbo.WA_UI_metadata.sub_group_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.display_ind, NBS_ODSE.dbo.WA_UI_metadata.enable_ind, NBS_ODSE.dbo.WA_UI_metadata.required_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.other_value_ind_cd, NBS_ODSE.dbo.WA_UI_metadata.future_date_ind_cd, NBS_ODSE.dbo.WA_UI_metadata.publish_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.default_value, NBS_ODSE.dbo.WA_UI_metadata.max_length, NBS_ODSE.dbo.WA_UI_metadata.field_size," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.mask, NBS_ODSE.dbo.WA_UI_metadata.min_value, NBS_ODSE.dbo.WA_UI_metadata.max_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_type_cd, NBS_ODSE.dbo.WA_UI_metadata.unit_value, NBS_ODSE.dbo.WA_UI_metadata.question_unit_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_parent_identifier, NBS_ODSE.dbo.WA_UI_metadata.block_nm, NBS_ODSE.dbo.WA_RDB_metadata.block_pivot_nbr," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rdb_table_nm, NBS_ODSE.dbo.WA_RDB_metadata.rdb_column_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.user_defined_column_nm , NBS_ODSE.dbo.WA_RDB_metadata.rpt_admin_column_nm," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_identifier_nnd, NBS_ODSE.dbo.WA_NND_metadata.question_label_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_required_nnd, NBS_ODSE.dbo.WA_NND_metadata.question_data_type_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.hl7_segment_field, NBS_ODSE.dbo.WA_NND_metadata.order_group_id, NBS_ODSE.dbo.WA_UI_metadata.admin_comment, " +
+                    "NBS_SRTE.dbo.Codeset.value_set_code," +
+                    "NBS_SRTE.dbo.Codeset.value_set_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.repeats_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.part_type_cd," +
+                    "WA_UI_metadata.standard_question_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.standard_nnd_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.coinfection_ind_cd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.repeat_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_appear_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_column_width," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_header," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_map," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.desc_txt," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_type," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.indicator_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.nbs_ui_component_uid," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.code_set_group_id," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.version_ctrl_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.legacy_data_location," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.entry_method," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_oid," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_oid_system_txt" +
+
+                    " ORDER BY participation_type, NBS_ODSE.dbo.WA_UI_metadata.order_nbr";
+
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageControllerTest.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.questionbank.page.download;
 
 import static org.junit.Assert.assertNotNull;
+
+import gov.cdc.nbs.questionbank.page.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,11 +10,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import gov.cdc.nbs.authentication.UserDetailsProvider;
-import gov.cdc.nbs.questionbank.page.PageController;
-import gov.cdc.nbs.questionbank.page.PageCreator;
-import gov.cdc.nbs.questionbank.page.PageDownloader;
-import gov.cdc.nbs.questionbank.page.PageFinder;
-import gov.cdc.nbs.questionbank.page.PageStateChanger;
 import gov.cdc.nbs.questionbank.page.services.PageSummaryFinder;
 import gov.cdc.nbs.questionbank.page.services.PageUpdater;
 
@@ -33,12 +30,14 @@ class PageControllerTest {
     private PageDownloader pageDownloader;
     @Mock
     private UserDetailsProvider userDetailsProvider;
+    @Mock
+    private  PageMetaDataDownloader pageMetaDataDownloader;
 
     @Test
     void downloadPageLibraryPDFTest() throws Exception {
 
-        PageController pageController = new PageController(pageUpdater, finder, creator, stateChange,
-                pageDownloader, userDetailsProvider);
+        PageController pageController = new PageController(pageUpdater, finder, pageFinder, creator, stateChange,
+                pageDownloader, pageMetaDataDownloader,userDetailsProvider);
 
         byte[] resp = "pagedownloader".getBytes();
         Mockito.when(pageDownloader.downloadLibraryPDF())

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageDownloaderSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageDownloaderSteps.java
@@ -22,78 +22,102 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class PageDownloaderSteps {
-	
-	    @Autowired
-	    private UserMother userMother;
 
-	    @Autowired
-	    private PageController pageController;
+    @Autowired
+    private UserMother userMother;
 
-	    @Autowired
-	    private ExceptionHolder exceptionHolder;
-	    
-	    private ResponseEntity<Resource> download;
-	private ResponseEntity<byte[]> downloadPdf;
+    @Autowired
+    private PageController pageController;
 
-	    
-	    @Given("I am an admin user make an download page library request")
-	    public  void i_am_an_admin_user_make_an_download_page_library_request() {
-	    	 try {
-	    		 download = new ResponseEntity<Resource>(HttpStatus.OK);
-	             userMother.adminUser();
-	         } catch (AccessDeniedException e) {
-	             exceptionHolder.setException(e);
-	         } catch (AuthenticationCredentialsNotFoundException e) {
-	             exceptionHolder.setException(e);
-	         }	
-	    }
-	    
-	    @When("I make a request to download page library")
-	    public void i_make_a_request_to_download_page_library() {
-	    	 try {
-	    		 download  = pageController.downloadPageLibrary();
-	         } catch (AccessDeniedException e) {
-	             exceptionHolder.setException(e);
-	         } catch (AuthenticationCredentialsNotFoundException e) {
-	             exceptionHolder.setException(e);
-	         } catch (IOException e) {
-	        	 exceptionHolder.setException(e);
-	         }
-	    	 
-	    }
-	    
-	    @Then("Page library is downloaded")
-	    public void  page_library_is_downloaded() {
-	    	assertNotNull( download);
-	    	assertEquals(HttpStatus.OK, download.getStatusCode());
-	    	assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
-	    	assertTrue(download.getHeaders().getContentType().toString().contains("application/csv"));
-	    	
-	    }
+    @Autowired
+    private ExceptionHolder exceptionHolder;
 
-	@When("I make a request to download page library as pdf")
-	public void i_make_a_request_to_download_page_library_pdf() {
-		try {
-			downloadPdf = pageController.downloadPageLibraryPDF();
-		} catch (AccessDeniedException e) {
-			exceptionHolder.setException(e);
-		} catch (AuthenticationCredentialsNotFoundException e) {
-			exceptionHolder.setException(e);
-		} catch (IOException e) {
-			exceptionHolder.setException(e);
-		} catch (DocumentException e) {
-			exceptionHolder.setException(e);
-		}
+    private ResponseEntity<Resource> download;
+    private ResponseEntity<byte[]> downloadPdf;
 
-	}
-	@Then("Page library is downloaded file as pdf")
-	public void  page_library_is_downloadedpdf() {
-		assertNotNull( downloadPdf);
-		assertEquals(HttpStatus.OK, download.getStatusCode());
-		assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
-		assertTrue(download.getHeaders().getContentType().toString().contains("application/pdf"));
 
-	}
-	    
+    @Given("I am an admin user make an download page library request")
+    public void i_am_an_admin_user_make_an_download_page_library_request() {
+        try {
+            download = new ResponseEntity<Resource>(HttpStatus.OK);
+            userMother.adminUser();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        }
+    }
+
+    @When("I make a request to download page library")
+    public void i_make_a_request_to_download_page_library() {
+        try {
+            download = pageController.downloadPageLibrary();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        } catch (IOException e) {
+            exceptionHolder.setException(e);
+        }
+
+    }
+
+    @Then("Page library is downloaded")
+    public void page_library_is_downloaded() {
+        assertNotNull(download);
+        assertEquals(HttpStatus.OK, download.getStatusCode());
+        assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
+        assertTrue(download.getHeaders().getContentType().toString().contains("application/csv"));
+
+    }
+
+    @When("I make a request to download page metadata")
+    public void i_make_a_request_to_download_page_metadata() {
+        try {
+            download = pageController.downloadPageMetadata(100l);
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        } catch (IOException e) {
+            exceptionHolder.setException(e);
+        }
+
+    }
+
+    @Then("Page metadata is downloaded")
+    public void page_metadata_is_downloaded() {
+        assertNotNull(download);
+        assertEquals(HttpStatus.OK, download.getStatusCode());
+        assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
+        assertTrue(download.getHeaders().getContentType().toString().contains("application/csv"));
+
+    }
+
+    @When("I make a request to download page library as pdf")
+    public void i_make_a_request_to_download_page_library_pdf() {
+        try {
+            downloadPdf = pageController.downloadPageLibraryPDF();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        } catch (IOException e) {
+            exceptionHolder.setException(e);
+        } catch (DocumentException e) {
+            exceptionHolder.setException(e);
+        }
+
+    }
+
+    @Then("Page library is downloaded file as pdf")
+    public void page_library_is_downloadedpdf() {
+        assertNotNull(downloadPdf);
+        assertEquals(HttpStatus.OK, download.getStatusCode());
+        assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
+        assertTrue(download.getHeaders().getContentType().toString().contains("application/pdf"));
+
+    }
+
 
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageDownloaderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageDownloaderTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 import gov.cdc.nbs.questionbank.entity.repository.WaUiMetadataRepository;
+import gov.cdc.nbs.questionbank.page.PageMetaDataDownloader;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -31,6 +32,7 @@ import gov.cdc.nbs.questionbank.entity.repository.UserProfileRepository;
 import gov.cdc.nbs.questionbank.entity.repository.WaTemplateRepository;
 import gov.cdc.nbs.questionbank.exception.QueryException;
 import gov.cdc.nbs.questionbank.page.PageDownloader;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 class PageDownloaderTest {
 
@@ -46,11 +48,14 @@ class PageDownloaderTest {
     @Mock
     private UserProfileRepository userProfileRepository;
 
-    @Mock
-    WaUiMetadataRepository waUiMetadataRepository;
 
     @InjectMocks
     private PageDownloader pageDownloader;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @InjectMocks
+    private PageMetaDataDownloader pageMetaDataDownloader;
 
     public PageDownloaderTest() {
         MockitoAnnotations.openMocks(this);
@@ -168,10 +173,10 @@ class PageDownloaderTest {
     }
 
     @Test
-    void downloadPageMetaData() throws IOException {
+    void downloadPageMetadata() throws IOException {
         Long waTemplateUid = 100l;
-        when(waUiMetadataRepository.findPageMetadataByWaTemplateUid(waTemplateUid)).thenReturn(getPageMetaData());
-        ByteArrayInputStream response = pageDownloader.downloadPageMetadataByWaTemplateUid(waTemplateUid);
+        when(pageMetaDataDownloader.findPageMetadataByWaTemplateUid(waTemplateUid)).thenReturn(getPageMetadata());
+        ByteArrayInputStream response = pageMetaDataDownloader.downloadPageMetadataByWaTemplateUid(waTemplateUid);
         byte[] content = response.readAllBytes();
         assertNotNull(content);
         response.read(content, 0, content.length);
@@ -180,17 +185,17 @@ class PageDownloaderTest {
 
     }
 
-    List<Object[]> getPageMetaData() {
-        List<Object[]> pageMetaData = new ArrayList<>();
-        pageMetaData.add(new Object[]{"col1_val", "col2_val", "col3_val", "col4_val", "col5_val", "col6_val", "col7_val"});
-        pageMetaData.add(new Object[]{"col1_val", "col2_val", "col3_val", "col4_val", "col5_val", "col6_val", "col7_val"});
-        return pageMetaData;
+    List<Object[]> getPageMetadata() {
+        List<Object[]> pageMetadata = new ArrayList<>();
+        pageMetadata.add(new Object[]{"col1_val", "col2_val", "col3_val", "col4_val", "col5_val", "col6_val", "col7_val"});
+        pageMetadata.add(new Object[]{"col1_val", "col2_val", "col3_val", "col4_val", "col5_val", "col6_val", "col7_val"});
+        return pageMetadata;
     }
 
     @Test
-    void downloadPageMetaDataException() {
-        when(waUiMetadataRepository.findPageMetadataByWaTemplateUid(100l)).thenThrow(new QueryException("Error downloading Page Metadata"));
-        var exception = assertThrows(RuntimeException.class, () -> pageDownloader.downloadPageMetadataByWaTemplateUid(100l));
+    void downloadPageMetadataException() {
+        when(pageMetaDataDownloader.findPageMetadataByWaTemplateUid(100l)).thenThrow(new QueryException("Error downloading Page Metadata"));
+        var exception = assertThrows(RuntimeException.class, () -> pageMetaDataDownloader.downloadPageMetadataByWaTemplateUid(100l));
         assertTrue(exception.getMessage().contains("Error downloading Page Metadata"));
 
     }

--- a/apps/question-bank/src/test/resources/features/page/PageDownload.feature
+++ b/apps/question-bank/src/test/resources/features/page/PageDownload.feature
@@ -15,3 +15,8 @@ Feature: Download Pages
          Given I am a user without permissions
          When I make a request to download page library
          Then an accessdenied exception is thrown
+
+    Scenario: As an admin I can download page metadata
+           Given I am an admin user make an download page library request
+           When I make a request to download page metadata
+           Then Page metadata is downloaded


### PR DESCRIPTION
## Description

In the Classic NBS, the Excel File gets downloaded when the user taps on the “Page Metadata” button. The code change in Modern followed the same interaction, and the same data and column will be generated. 

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1127

## Steps to verify

1. From Classic, click on button "Page Metadata" in page "PreviewPage" to get the CSV.
2. From Modern API, use this endpoint to generate the same CSV: http://localhost:9095/nbs/page-builder/swagger-ui/#/page-controller/downloadPageMetadataUsingGET
3. The two CSV's should match.

