### PR TITLE
aligning fields in data entry and ensuring tabs in search don't move

### DIFF
--- a/apps/modernization-ui/src/components/FormInputs/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/apps/modernization-ui/src/components/FormInputs/PhoneNumberInput/PhoneNumberInput.tsx
@@ -29,7 +29,7 @@ export const PhoneNumberInput = ({
     return (
         <div className={`phone-number-input ${error ? 'input--error' : ''}`}>
             <Label htmlFor={id || 'phoneNumber'}>{label}</Label>
-            <ErrorMessage id={`${error}-message`}>{error}</ErrorMessage>
+            {error && <ErrorMessage id={`${error}-message`}>{error}</ErrorMessage>}
             {mask ? (
                 <TextInputMask
                     {...props}

--- a/apps/modernization-ui/src/pages/addPatient/components/contactFields/ContactFields.tsx
+++ b/apps/modernization-ui/src/pages/addPatient/components/contactFields/ContactFields.tsx
@@ -144,7 +144,7 @@ export default function ContactFields({ id, title }: Props) {
                             }
                             className="text-bold"
                             unstyled
-                            style={{ margin: '0', padding: '0' }}>
+                            style={{ margin: '10px 0 0 0', padding: '0' }}>
                             + Add another phone number
                         </Button>
                     </Grid>
@@ -190,7 +190,7 @@ export default function ContactFields({ id, title }: Props) {
                             }
                             className="text-bold"
                             unstyled
-                            style={{ margin: '0', padding: '0' }}>
+                            style={{ margin: '10px 0 0 0', padding: '0' }}>
                             + Add another email address
                         </Button>
                     </Grid>

--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.scss
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.scss
@@ -23,7 +23,7 @@ button {
 }
 
 .type {
-    border-bottom: 5px solid transparent;
+    border-bottom: 7px solid transparent;
 }
 .type.active {
     border-bottom: 7px solid #005ea2;

--- a/apps/modernization-ui/src/pages/patient/search/result/PatientResult.scss
+++ b/apps/modernization-ui/src/pages/patient/search/result/PatientResult.scss
@@ -28,3 +28,7 @@
         }
     }
 }
+
+.font-sans-3xs {
+    font-size: 13px !important;
+}

--- a/apps/modernization-ui/src/pages/patient/search/result/PatientResult.tsx
+++ b/apps/modernization-ui/src/pages/patient/search/result/PatientResult.tsx
@@ -119,7 +119,7 @@ const ResultItem = ({ label, orientation = 'horizontal', children }: ResultItemP
 type ResultItemLabelProps = { children: string };
 
 const ResultItemLabel = ({ children }: ResultItemLabelProps) => (
-    <span className="patient-search-result-item-label">{children}</span>
+    <span className="patient-search-result-item-label font-sans-3xs">{children}</span>
 );
 
 type ResultValueProps = {


### PR DESCRIPTION
https://cdc-nbs.atlassian.net/browse/CNFT1-1583
In advanced search page the patient search and event search tabs for visual consistency the highlight should not lead to the text being lifted, but instead the text should remain consistent across the line
Increasing transparent border in Advanced Search to ensure the switching of tabs does not cause a movement of the rest of the elements, that is because by increasing the transparent border that was previously 5px to 7px it ensures that when you click between patient search and event search that no visible movement is created.
 
Aligning Data Entry - Fields should be horizontally aligned -> https://cdc-nbs.atlassian.net/browse/CNFT1-1612


## Steps to verify


1 .Login 
2. Navigate to advanced search
3. Click repeatedly between Patient search and Event search tabs
4. Observe no movement with the change of the two tabs


