### PR TITLE
call codeCoverageReport directly due to bad task ordering

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -17,7 +17,7 @@ on:
   pull_request:
     paths:
       - "apps/**"
-      - "!apps/modernization-ui"
+      - "!apps/modernization-ui/**"
       - "libs/**"
       - "build.gradle"
       - "settings.gradle"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -89,7 +89,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.passed_github_token }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ env.sonar_token }}
-        run: ./gradlew clean build sonar -Dtesting.database.image=${{ env.accountid }}.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/modernization-test-db:latest-SNAPSHOT.e914c35
+        run: ./gradlew clean build codeCoverageReport sonar -Dtesting.database.image=${{ env.accountid }}.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/modernization-test-db:latest-SNAPSHOT.e914c35
 
       - name: Zip test report
         run: zip -r test-report.zip ./build/reports/*

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -47,8 +47,3 @@ subprojects {
         }
     }
 }
-
-// Automatically generate the code coverage report following a build
-tasks.named('test') {
-   finalizedBy tasks.named('codeCoverageReport', JacocoReport)
-}


### PR DESCRIPTION
## Description

There is an issue with the ordering of the `codeCoverageReport` gradle task. It is being executed prior to the modernization-api tests which is greatly reducing the sonar code coverage metrics. 

This updates the way in which we trigger the `codeCoverageReport` task to ensure it goes last.

## Tickets

NA

## Steps to verify

1. Ensure build succeeds
