### PR TITLE
BUG/CNFT2-1335/Add New Page cancel button doesn't function

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.tsx
@@ -95,6 +95,10 @@ export const AddNewPage = () => {
         setValue('conditionIds', [condition.id].concat(getValues('conditionIds')));
     };
 
+    const handleCancel = () => {
+        navigate(-1);
+    };
+
     return (
         <PageBuilder page="add-new-page">
             <div className="add-new-page">
@@ -239,7 +243,7 @@ export const AddNewPage = () => {
                             />
                         </div>
                         <div className="add-new-page__buttons">
-                            <Button type="button" outline>
+                            <Button type="button" outline onClick={handleCancel}>
                                 Cancel
                             </Button>
                             <Button type="submit">Create page</Button>


### PR DESCRIPTION
## Description
Cancel button was missing a handler on the AddNewPage component.  Created one that will navigate back to the previous page.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1335)

## Steps to verify

1. Navigate to /page-builder/manage/pages
2. Click "Create new page" in the upper right
3. Click cancel at the bottom of the Create New Page form.
4. You should return to the previous page.
