### PR TITLE
1127 new branch

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageController.java
@@ -32,6 +32,7 @@ import gov.cdc.nbs.questionbank.page.services.PageSummaryFinder;
 import gov.cdc.nbs.questionbank.page.services.PageUpdater;
 import lombok.extern.slf4j.Slf4j;
 
+
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/pages")
@@ -44,19 +45,22 @@ public class PageController {
     private final PageStateChanger stateChange;
     private final PageDownloader pageDownloader;
     private final UserDetailsProvider userDetailsProvider;
+    private final PageMetaDataDownloader pageMetaDataDownloader;
     public PageController(
             final PageUpdater pageUpdater,
             final PageSummaryFinder finder,
             final PageCreator creator,
             final PageStateChanger stateChange,
             final PageDownloader pageDownloader,
-            final UserDetailsProvider userDetailsProvider) {
+            final UserDetailsProvider userDetailsProvider,
+            final PageMetaDataDownloader pageMetaDataDownloader) {
         this.pageUpdater = pageUpdater;
         this.finder = finder;
         this.creator = creator;
         this.stateChange = stateChange;
         this.pageDownloader = pageDownloader;
         this.userDetailsProvider = userDetailsProvider;
+        this.pageMetaDataDownloader = pageMetaDataDownloader;
     }
 
     @PutMapping("{id}/details")
@@ -125,6 +129,14 @@ public class PageController {
     @DeleteMapping("{id}/delete-draft")
     public PageStateResponse deletePageDraft(@PathVariable("id") Long pageId) {
         return stateChange.deletePageDraft(pageId);
+    }
+
+    @GetMapping("{waTemplateUid}/download-metadata")
+    public ResponseEntity<Resource> downloadPageMetadata(@PathVariable("waTemplateUid") Long waTemplateUid) throws IOException {
+        String fileName = "PageMetadata.csv";
+        InputStreamResource file = new InputStreamResource(pageMetaDataDownloader.downloadPageMetadataByWaTemplateUid(waTemplateUid));
+        return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
+                .contentType(MediaType.parseMediaType("application/csv")).body(file);
     }
 
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageMetaDataDownloader.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageMetaDataDownloader.java
@@ -1,0 +1,188 @@
+package gov.cdc.nbs.questionbank.page;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.QuoteMode;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class PageMetaDataDownloader {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    String PageMetadataHeader = "page_nm, order_nbr, question_identifier, question_nm, question_label, question_type, desc_txt," +
+            "question_tool_tip, data_type, ui_display_type, code_set_nm, value_set_code, value_set_nm, enable_ind," +
+            "display_ind, required_ind, publish_ind_cd, repeats_ind_cd, field_size, max_length, mask, min_value," +
+            "max_value, default_value, other_value_ind_cd, future_date_ind_cd, unit_type_cd, unit_code_set_nm," +
+            "unit_value, question_unit_identifier, unit_parent_identifier, data_location, part_type_cd, participation_type," +
+            "data_cd, data_use_cd, standard_question_ind_cd, standard_nnd_ind_cd, coinfection_ind_cd, repeat_group_seq_nbr," +
+            " question_group_seq_nbr, batch_table_appear_ind_cd, batch_table_column_width, batch_table_header, block_nm," +
+            "block_pivot_nbr, question_identifier_nnd, question_label_nnd, question_required_nnd, question_data_type_nnd," +
+            "hl7_segment_field, order_group_id, question_map, indicator_cd, group_nm, sub_group_nm, rdb_table_nm, " +
+            "rdb_column_nm, data_mart_column_nm, rpt_admin_column_nm, admin_comment";
+
+
+    private static final String QUERY =
+            "SELECT " +
+                    "NBS_ODSE.dbo.WA_template.template_nm AS page_nm, " +
+                    "NBS_ODSE.dbo.WA_UI_metadata.order_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_label," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_type," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.desc_txt," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_tool_tip," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_type," +
+                    "NBS_ODSE.dbo.NBS_ui_component.type_cd_desc AS ui_display_type," +
+                    "NBS_SRTE.dbo.Codeset.code_set_nm code_set_nm," +
+                    "NBS_SRTE.dbo.Codeset.value_set_code," +
+                    "NBS_SRTE.dbo.Codeset.value_set_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.enable_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.display_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.required_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.publish_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.repeats_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.field_size," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.max_length," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.mask," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.min_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.max_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.default_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.other_value_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.future_date_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_type_cd," +
+                    "NBS_SRTE.dbo.Codeset.code_set_nm code_set_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_unit_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_parent_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_location," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.part_type_cd," +
+                    "NBS_SRTE.dbo.Participation_type.type_desc_txt AS participation_type," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_use_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.standard_question_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.standard_nnd_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.coinfection_ind_cd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.repeat_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_appear_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_column_width," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_header," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.block_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.block_pivot_nbr," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_identifier_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_label_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_required_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_data_type_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.hl7_segment_field," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.order_group_id," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_map," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.indicator_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.group_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.sub_group_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rdb_table_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rdb_column_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.user_defined_column_nm AS data_mart_column_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rpt_admin_column_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.admin_comment " +
+                    " FROM " +
+                    "NBS_ODSE.dbo.WA_UI_metadata WITH (nolock) " +/* ON Code_value_general.code_desc_txt = NBS_ODSE.dbo.WA_UI_metadata.question_oid */" LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.WA_template WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_template_uid = NBS_ODSE.dbo.WA_template.wa_template_uid LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.WA_RDB_metadata WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_ui_metadata_uid = NBS_ODSE.dbo.WA_RDB_metadata.wa_ui_metadata_uid LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.WA_NND_metadata WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.wa_ui_metadata_uid = NBS_ODSE.dbo.WA_NND_metadata.wa_ui_metadata_uid LEFT OUTER JOIN " +
+                    "NBS_SRTE.dbo.Participation_type WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.part_type_cd = Participation_type.type_cd LEFT OUTER JOIN " +
+                    "NBS_ODSE.dbo.NBS_ui_component WITH (nolock) ON  " +
+                    "NBS_ODSE.dbo.WA_UI_metadata.nbs_ui_component_uid = NBS_ODSE.dbo.NBS_ui_component.nbs_ui_component_uid LEFT OUTER JOIN " +
+                    "NBS_SRTE.dbo.Codeset WITH (nolock) ON NBS_ODSE.dbo.WA_UI_metadata.code_set_group_id = Codeset.code_set_group_id LEFT OUTER JOIN " +
+                    "NBS_SRTE.dbo.Code_value_general WITH (nolock) ON NBS_SRTE.dbo.Code_value_general.code_set_nm = Codeset.code_set_nm " +
+
+                    "WHERE  (NBS_ODSE.dbo.WA_ui_metadata.wa_template_uid =? " +
+                    "AND WA_UI_metadata.question_identifier NOT LIKE '%_UI_%' AND WA_UI_metadata.question_identifier NOT LIKE 'MSG%' ) " +
+
+                    "GROUP BY NBS_ODSE.dbo.WA_template.template_nm , NBS_ODSE.dbo.WA_UI_metadata.order_nbr, NBS_ODSE.dbo.WA_UI_metadata.question_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_nm, NBS_ODSE.dbo.WA_UI_metadata.desc_txt, NBS_ODSE.dbo.WA_UI_metadata.question_oid," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_label," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_tool_tip, NBS_ODSE.dbo.WA_UI_metadata.data_location, NBS_ODSE.dbo.WA_UI_metadata.data_type, NBS_SRTE.dbo.Codeset.code_set_nm," +
+                    "NBS_ODSE.dbo.NBS_ui_component.type_cd_desc , NBS_ODSE.dbo.WA_UI_metadata.group_nm, NBS_SRTE.dbo.Participation_type.type_desc_txt ," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.data_cd, NBS_ODSE.dbo.WA_UI_metadata.data_use_cd, NBS_ODSE.dbo.WA_UI_metadata.sub_group_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.display_ind, NBS_ODSE.dbo.WA_UI_metadata.enable_ind, NBS_ODSE.dbo.WA_UI_metadata.required_ind," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.other_value_ind_cd, NBS_ODSE.dbo.WA_UI_metadata.future_date_ind_cd, NBS_ODSE.dbo.WA_UI_metadata.publish_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.default_value, NBS_ODSE.dbo.WA_UI_metadata.max_length, NBS_ODSE.dbo.WA_UI_metadata.field_size," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.mask, NBS_ODSE.dbo.WA_UI_metadata.min_value, NBS_ODSE.dbo.WA_UI_metadata.max_value," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_type_cd, NBS_ODSE.dbo.WA_UI_metadata.unit_value, NBS_ODSE.dbo.WA_UI_metadata.question_unit_identifier," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.unit_parent_identifier, NBS_ODSE.dbo.WA_UI_metadata.block_nm, NBS_ODSE.dbo.WA_RDB_metadata.block_pivot_nbr," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.rdb_table_nm, NBS_ODSE.dbo.WA_RDB_metadata.rdb_column_nm," +
+                    "NBS_ODSE.dbo.WA_RDB_metadata.user_defined_column_nm , NBS_ODSE.dbo.WA_RDB_metadata.rpt_admin_column_nm," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_identifier_nnd, NBS_ODSE.dbo.WA_NND_metadata.question_label_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_required_nnd, NBS_ODSE.dbo.WA_NND_metadata.question_data_type_nnd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.hl7_segment_field, NBS_ODSE.dbo.WA_NND_metadata.order_group_id, NBS_ODSE.dbo.WA_UI_metadata.admin_comment, " +
+                    "NBS_SRTE.dbo.Codeset.value_set_code," +
+                    "NBS_SRTE.dbo.Codeset.value_set_nm," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.repeats_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.part_type_cd," +
+                    "WA_UI_metadata.standard_question_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.standard_nnd_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.coinfection_ind_cd," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.repeat_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_group_seq_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_appear_ind_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_column_width," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.batch_table_header," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.question_map," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.desc_txt," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_type," +
+                    "NBS_ODSE.dbo.WA_NND_metadata.indicator_cd," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.nbs_ui_component_uid," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.code_set_group_id," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.version_ctrl_nbr," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.legacy_data_location," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.entry_method," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_oid," +
+                    "NBS_ODSE.dbo.WA_UI_metadata.question_oid_system_txt" +
+                    " ORDER BY participation_type, NBS_ODSE.dbo.WA_UI_metadata.order_nbr";
+
+
+    public ByteArrayInputStream downloadPageMetadataByWaTemplateUid(Long waTemplateUid) throws IOException {
+        final CSVFormat format = CSVFormat.Builder.create().setQuoteMode(QuoteMode.MINIMAL).
+                setHeader(PageMetadataHeader.split(",")).build();
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format)) {
+            List<Object[]> pageMetadata = findPageMetadataByWaTemplateUid(waTemplateUid);
+            String temp = "";
+            for (Object[] data : pageMetadata) {
+                for (Object element : data) {
+                    temp = temp + ",";
+                }
+                temp = "";
+                csvPrinter.printRecord(data);
+            }
+            csvPrinter.flush();
+            return new ByteArrayInputStream(out.toByteArray());
+        } catch (IOException e) {
+            throw new IOException("Error downloading Page Metadata: " + e.getMessage());
+        }
+    }
+
+    public List<Object[]> findPageMetadataByWaTemplateUid(Long waTemplateUid) {
+        List<Object[]> result = jdbcTemplate.query(QUERY, new Object[]{waTemplateUid}, (rs, rowNum) -> {
+            int columnCount = rs.getMetaData().getColumnCount();
+            Object[] row = new Object[columnCount];
+            for (int i = 1; i <= columnCount; i++) {
+                row[i - 1] = rs.getObject(i);
+            }
+            return row;
+        });
+        return result;
+    }
+
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageControllerTest.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.questionbank.page.download;
 
 import static org.junit.Assert.assertNotNull;
+
+import gov.cdc.nbs.questionbank.page.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,11 +10,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import gov.cdc.nbs.authentication.UserDetailsProvider;
-import gov.cdc.nbs.questionbank.page.PageController;
-import gov.cdc.nbs.questionbank.page.PageCreator;
-import gov.cdc.nbs.questionbank.page.PageDownloader;
-import gov.cdc.nbs.questionbank.page.PageFinder;
-import gov.cdc.nbs.questionbank.page.PageStateChanger;
 import gov.cdc.nbs.questionbank.page.services.PageSummaryFinder;
 import gov.cdc.nbs.questionbank.page.services.PageUpdater;
 
@@ -34,11 +31,14 @@ class PageControllerTest {
     @Mock
     private UserDetailsProvider userDetailsProvider;
 
+    @Mock
+    private PageMetaDataDownloader pageMetaDataDownloader;
+
     @Test
     void downloadPageLibraryPDFTest() throws Exception {
 
         PageController pageController = new PageController(pageUpdater, finder, creator, stateChange,
-                pageDownloader, userDetailsProvider);
+                pageDownloader, userDetailsProvider,pageMetaDataDownloader);
 
         byte[] resp = "pagedownloader".getBytes();
         Mockito.when(pageDownloader.downloadLibraryPDF())

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageDownloaderSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageDownloaderSteps.java
@@ -22,78 +22,112 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class PageDownloaderSteps {
-	
-	    @Autowired
-	    private UserMother userMother;
 
-	    @Autowired
-	    private PageController pageController;
+    @Autowired
+    private UserMother userMother;
 
-	    @Autowired
-	    private ExceptionHolder exceptionHolder;
-	    
-	    private ResponseEntity<Resource> download;
-	private ResponseEntity<byte[]> downloadPdf;
+    @Autowired
+    private PageController pageController;
 
-	    
-	    @Given("I am an admin user make an download page library request")
-	    public  void i_am_an_admin_user_make_an_download_page_library_request() {
-	    	 try {
-	    		 download = new ResponseEntity<Resource>(HttpStatus.OK);
-	             userMother.adminUser();
-	         } catch (AccessDeniedException e) {
-	             exceptionHolder.setException(e);
-	         } catch (AuthenticationCredentialsNotFoundException e) {
-	             exceptionHolder.setException(e);
-	         }	
-	    }
-	    
-	    @When("I make a request to download page library")
-	    public void i_make_a_request_to_download_page_library() {
-	    	 try {
-	    		 download  = pageController.downloadPageLibrary();
-	         } catch (AccessDeniedException e) {
-	             exceptionHolder.setException(e);
-	         } catch (AuthenticationCredentialsNotFoundException e) {
-	             exceptionHolder.setException(e);
-	         } catch (IOException e) {
-	        	 exceptionHolder.setException(e);
-	         }
-	    	 
-	    }
-	    
-	    @Then("Page library is downloaded")
-	    public void  page_library_is_downloaded() {
-	    	assertNotNull( download);
-	    	assertEquals(HttpStatus.OK, download.getStatusCode());
-	    	assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
-	    	assertTrue(download.getHeaders().getContentType().toString().contains("application/csv"));
-	    	
-	    }
+    @Autowired
+    private ExceptionHolder exceptionHolder;
 
-	@When("I make a request to download page library as pdf")
-	public void i_make_a_request_to_download_page_library_pdf() {
-		try {
-			downloadPdf = pageController.downloadPageLibraryPDF();
-		} catch (AccessDeniedException e) {
-			exceptionHolder.setException(e);
-		} catch (AuthenticationCredentialsNotFoundException e) {
-			exceptionHolder.setException(e);
-		} catch (IOException e) {
-			exceptionHolder.setException(e);
-		} catch (DocumentException e) {
-			exceptionHolder.setException(e);
-		}
+    private ResponseEntity<Resource> download;
+    private ResponseEntity<byte[]> downloadPdf;
 
-	}
-	@Then("Page library is downloaded file as pdf")
-	public void  page_library_is_downloadedpdf() {
-		assertNotNull( downloadPdf);
-		assertEquals(HttpStatus.OK, download.getStatusCode());
-		assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
-		assertTrue(download.getHeaders().getContentType().toString().contains("application/pdf"));
 
-	}
-	    
+    @Given("I am an admin user make an download page library request")
+    public void i_am_an_admin_user_make_an_download_page_library_request() {
+        try {
+            download = new ResponseEntity<Resource>(HttpStatus.OK);
+            userMother.adminUser();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        }
+    }
+
+    @Given("I am an admin user make an download page metadata request")
+    public void i_am_an_admin_user_make_an_download_page_metadata_request() {
+        try {
+            download = new ResponseEntity<Resource>(HttpStatus.OK);
+            userMother.adminUser();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        }
+    }
+
+    @When("I make a request to download page library")
+    public void i_make_a_request_to_download_page_library() {
+        try {
+            download = pageController.downloadPageLibrary();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        } catch (IOException e) {
+            exceptionHolder.setException(e);
+        }
+
+    }
+
+    @Then("Page library is downloaded")
+    public void page_library_is_downloaded() {
+        assertNotNull(download);
+        assertEquals(HttpStatus.OK, download.getStatusCode());
+        assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
+        assertTrue(download.getHeaders().getContentType().toString().contains("application/csv"));
+
+    }
+
+    @When("I make a request to download page library as pdf")
+    public void i_make_a_request_to_download_page_library_pdf() {
+        try {
+            downloadPdf = pageController.downloadPageLibraryPDF();
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        } catch (IOException e) {
+            exceptionHolder.setException(e);
+        } catch (DocumentException e) {
+            exceptionHolder.setException(e);
+        }
+
+    }
+
+    @Then("Page library is downloaded file as pdf")
+    public void page_library_is_downloadedpdf() {
+        assertNotNull(downloadPdf);
+        assertEquals(HttpStatus.OK, download.getStatusCode());
+        assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
+        assertTrue(download.getHeaders().getContentType().toString().contains("application/pdf"));
+
+    }
+
+    @When("I make a request to download page metadata")
+    public void i_make_a_request_to_download_page_metadata() {
+        try {
+            download = pageController.downloadPageMetadata(100l);
+        } catch (AccessDeniedException e) {
+            exceptionHolder.setException(e);
+        } catch (AuthenticationCredentialsNotFoundException e) {
+            exceptionHolder.setException(e);
+        } catch (IOException e) {
+            exceptionHolder.setException(e);
+        }
+    }
+
+    @Then("Page metadata is downloaded")
+    public void page_metadata_is_downloaded() {
+        assertNotNull(download);
+        assertEquals(HttpStatus.OK, download.getStatusCode());
+        assertTrue(download.getHeaders().getContentDisposition().toString().contains("attachment; filename="));
+        assertTrue(download.getHeaders().getContentType().toString().contains("application/csv"));
+    }
+
 
 }

--- a/apps/question-bank/src/test/resources/features/page/PageDownload.feature
+++ b/apps/question-bank/src/test/resources/features/page/PageDownload.feature
@@ -15,3 +15,8 @@ Feature: Download Pages
          Given I am a user without permissions
          When I make a request to download page library
          Then an accessdenied exception is thrown
+
+    Scenario: As an admin I can download page metadata
+         Given I am an admin user make an download page metadata request
+         When I make a request to download page metadata
+         Then Page metadata is downloaded


### PR DESCRIPTION
## Description

In the Classic NBS, the Excel File gets downloaded when the user taps on the “Page Metadata” button. Modernization must follow the same interaction, and the same data and column should be generated. 

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1127

## Steps to verify

1. From Classic, click on button "Page Metadata" in page "PreviewPage" to get the CSV.
2. From Modern API, use this endpoint to generate the same CSV: http://localhost:9095/nbs/page-builder/swagger-ui/#/page-controller/downloadPageMetadataUsingGET
3. The two CSV's should match.
