### PR TITLE
Resolve sorting issues on status column for pages library

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/generated/models/Page_PageSummary_.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/models/Page_PageSummary_.ts
@@ -7,16 +7,15 @@ import type { PageSummary } from './PageSummary';
 import type { Sort } from './Sort';
 
 export type Page_PageSummary_ = {
-    content?: Array<PageSummary>;
-    empty?: boolean;
-    first?: boolean;
-    last?: boolean;
-    number?: number;
-    numberOfElements?: number;
-    pageable?: Pageable;
-    size?: number;
-    sort?: Sort;
-    totalElements?: number;
-    totalPages?: number;
+    content: Array<PageSummary>;
+    empty: boolean;
+    first: boolean;
+    last: boolean;
+    number: number;
+    numberOfElements: number;
+    pageable: Pageable;
+    size: number;
+    sort: Sort;
+    totalElements: number;
+    totalPages: number;
 };
-

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePages.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePages.tsx
@@ -6,9 +6,10 @@ import { fetchPageSummaries } from '../../services/pagesAPI';
 import { ManagePagesTable } from './ManagePagesTable';
 import { UserContext } from 'user';
 import { useSearchParams } from 'react-router-dom';
+import { PageSummary, Page_PageSummary_ } from 'apps/page-builder/generated';
 
 export const ManagePages = () => {
-    const [pages, setPages] = useState([]);
+    const [pages, setPages] = useState<PageSummary[]>([]);
     const { searchQuery, sortBy, sortDirection, setCurrentPage, currentPage, pageSize, setIsLoading } =
         useContext(PagesContext);
     const { state } = useContext(UserContext);
@@ -27,19 +28,16 @@ export const ManagePages = () => {
 
         // get Pages
         try {
-            fetchPageSummaries(
-                token,
-                searchQuery,
-                sortBy.toLowerCase() + ',' + sortDirection,
-                currentPage,
-                pageSize
-            ).then((data: any) => {
-                setPages(data.content);
-                setTotalElements(data.totalElements);
-                setIsLoading(false);
-            });
+            fetchPageSummaries(token, searchQuery, sortBy + ',' + sortDirection, currentPage, pageSize).then(
+                (data: Page_PageSummary_) => {
+                    setPages(data.content);
+                    setTotalElements(data.totalElements);
+                    setIsLoading(false);
+                }
+            );
         } catch (error) {
             console.log(error);
+            setIsLoading(false);
         }
     }, [searchQuery, currentPage, pageSize, sortBy, sortDirection]);
 

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePages.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePages.tsx
@@ -6,7 +6,7 @@ import { fetchPageSummaries } from '../../services/pagesAPI';
 import { ManagePagesTable } from './ManagePagesTable';
 import { UserContext } from 'user';
 import { useSearchParams } from 'react-router-dom';
-import { PageSummary, Page_PageSummary_ } from 'apps/page-builder/generated';
+import { PageSummary, Page_PageSummary_ as PageSummaryResponse } from 'apps/page-builder/generated';
 
 export const ManagePages = () => {
     const [pages, setPages] = useState<PageSummary[]>([]);
@@ -29,7 +29,7 @@ export const ManagePages = () => {
         // get Pages
         try {
             fetchPageSummaries(token, searchQuery, sortBy + ',' + sortDirection, currentPage, pageSize).then(
-                (data: Page_PageSummary_) => {
+                (data: PageSummaryResponse) => {
                     setPages(data.content);
                     setTotalElements(data.totalElements);
                     setIsLoading(false);

--- a/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePagesTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ManagePages/ManagePagesTable.tsx
@@ -117,8 +117,16 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
         if (currentPage > 1 && setCurrentPage) {
             setCurrentPage(1);
         }
-        toSortString(name);
-        setSortDirection(direction);
+
+        if (direction === Direction.None) {
+            console.log('ascend...');
+            toSortString(Column.PageName);
+            setSortDirection(Direction.Ascending);
+        } else {
+            console.log('direction', direction);
+            toSortString(name);
+            setSortDirection(direction);
+        }
     };
 
     const handleDownloadCSV = async () => {


### PR DESCRIPTION
## Description

The sort direction was not being set properly when clicking the Status column header.  Also adds a bit of type safety for retrieving pages.
## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1397)

## Steps to verify

1. Navigate to page-builder/manage/pages
2. Sort by the status column.
3. Verify the fetch goes from desc, to asc, and back to none.
4. Switch pagination to higher pages and verify still functions properly
