### PR TITLE
[CNFT1-1665] Update graphql dependency to exclude guava

### DIFF
--- a/apps/modernization-api/build.gradle
+++ b/apps/modernization-api/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation libs.springBoot.web
 
     // graphql
-    implementation libs.springBoot.graphql
+    implementation libs.bundles.graphql
 
     // elasticsearch
     implementation libs.bundles.elasticsearch

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ springBoot = "2.7.17"
 assertj = "3.24.2"
 queryDSL = "5.0.0"
 blaze-persistence = "1.6.8"
+graphql = "21.3"
 testcontainers = "1.17.6"
 cucumber = "7.14.0"
 
@@ -13,6 +14,7 @@ springBoot = { module = "org.springframework.boot:spring-boot-starter", version.
 springBoot-jdbc = { module = "org.springframework.boot:spring-boot-starter-data-jdbc", version.ref = "springBoot" }
 springBoot-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBoot" }
 springBoot-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springBoot" }
+graphql = {module = 'com.graphql-java:graphql-java', version.ref = "graphql"}
 springBoot-graphql = { module = "org.springframework.boot:spring-boot-starter-graphql", version.ref = "springBoot" }
 spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
 spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test" }
@@ -48,6 +50,7 @@ awaitility = { module = "org.awaitility:awaitility" }
 
 [bundles]
 security = ["java-jwt", "spring-security"]
+graphql = ['graphql', 'springBoot-graphql']
 jackson = ["jackson-core", "jackson-datatype-jsr310"]
 jpa = ["springBoot", "springBoot-jpa"]
 elasticsearch = ["spring-elasticsearch"]


### PR DESCRIPTION
## Description

Updates the Graphql dependency to use version `21.3` which does not include a shaded version of Guava that is susceptible to [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976)

## Tickets

* [CNFT1-1665](https://cdc-nbs.atlassian.net/browse/CNFT1-1665)

## Steps to verify

1.  Ensure that the `modernization-api` container builds by running `docker compose build modernization-api`


[CNFT1-1665]: https://cdc-nbs.atlassian.net/browse/CNFT1-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ