### PR TITLE
[CNFT2-1129] - Save Page as Template API Interaction

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/SaveTemplate/SaveTemplate.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/SaveTemplate/SaveTemplate.spec.tsx
@@ -1,13 +1,16 @@
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { SaveTemplates } from './SaveTemplate';
+import { AlertProvider } from 'alert';
 
 describe('When SaveTemplates component loads', () => {
     it('Save button should be disabled', () => {
         const { container } = render(
-            <BrowserRouter>
-                <SaveTemplates />
-            </BrowserRouter>
+            <AlertProvider>
+                <BrowserRouter>
+                    <SaveTemplates />
+                </BrowserRouter>
+            </AlertProvider>
         );
         const btn = container.getElementsByClassName('usa-button')[0];
         expect(btn.hasAttribute('disabled'));

--- a/apps/modernization-ui/src/apps/page-builder/components/SaveTemplate/SaveTemplate.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/SaveTemplate/SaveTemplate.tsx
@@ -1,12 +1,15 @@
 import React, { useContext, useState } from 'react';
-import { ModalToggleButton, TextInput } from '@trussworks/react-uswds';
+import { ModalToggleButton, TextInput, Textarea } from '@trussworks/react-uswds';
 import { UserContext } from '../../../../providers/UserContext';
 import './SavetTemplate.scss';
+import { TemplateControllerService } from '../../generated';
+import { useAlert } from '../../../../alert';
 
-export const SaveTemplates = ({ modalRef }: any) => {
+export const SaveTemplates = ({ modalRef, page }: any) => {
     const init = { name: '', desc: '' };
     const [details, setDetails] = useState(init);
     const { state } = useContext(UserContext);
+    const { showAlert } = useAlert();
     const [validateName, setValidateName] = useState(false);
     const handleTabInput = ({ target }: any) => {
         setDetails({
@@ -21,17 +24,24 @@ export const SaveTemplates = ({ modalRef }: any) => {
     const authorization = `Bearer ${state.getToken()}`;
     const handleSubmit = () => {
         const { name, desc } = details;
-        const request = { name, desc };
-        console.log('authorization..', request, authorization);
+        const request = {
+            templateDescription: desc,
+            name: name,
+            waTemplateUid: page.id
+        };
+        TemplateControllerService.saveTemplateUsingPost({ request, authorization }).then((resp) => {
+            console.log(resp);
+            showAlert({ type: 'success', header: 'Add', message: 'Question Added successfully' });
+        });
     };
     const validateBtn = !details.name || validateName || !details.desc;
     const renderTemplateForm = (
         <div className="form-container save-template margin-top-1em">
             <div className={validateName ? 'error-border' : ''}>
                 <label>
-                    Template Name <span className="mandatory-indicator">*</span>
+                    Template name <span className="mandatory-indicator">*</span>
                 </label>
-                {validateName && <label className="error-text">Template Name Not Valid</label>}
+                {validateName && <label className="error-text">Template name Not Valid</label>}
                 <TextInput
                     className="field-space"
                     type="text"
@@ -46,14 +56,15 @@ export const SaveTemplates = ({ modalRef }: any) => {
             </div>
             <div>
                 <label>
-                    Template Description <span className="mandatory-indicator">*</span>
+                    Template description <span className="mandatory-indicator">*</span>
                 </label>
-                <TextInput
+                <Textarea
                     className="field-space"
-                    type="text"
+                    maxLength={2000}
                     id="tab-description"
                     data-testid="tab-description"
                     name="desc"
+                    rows={2}
                     value={details.desc}
                     onChange={handleTabInput}
                 />

--- a/apps/modernization-ui/src/apps/page-builder/generated/index.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/index.ts
@@ -76,6 +76,7 @@ export type { QuestionStatusRequest } from './models/QuestionStatusRequest';
 export type { ReadConditionRequest } from './models/ReadConditionRequest';
 export type { ReportingInfo } from './models/ReportingInfo';
 export type { Resource } from './models/Resource';
+export type { SaveTemplateRequest } from './models/SaveTemplateRequest';
 export type { SearchPageRuleRequest } from './models/SearchPageRuleRequest';
 export type { Section } from './models/Section';
 export type { SelectableCondition } from './models/SelectableCondition';

--- a/apps/modernization-ui/src/apps/page-builder/generated/models/SaveTemplateRequest.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/models/SaveTemplateRequest.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type SaveTemplateRequest = {
+    templateDescription?: string;
+    templateName?: string;
+    waTemplateUid?: number;
+};
+

--- a/apps/modernization-ui/src/apps/page-builder/generated/services/TemplateControllerService.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/services/TemplateControllerService.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { SaveTemplateRequest } from '../models/SaveTemplateRequest';
 import type { Template } from '../models/Template';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -25,6 +26,37 @@ export class TemplateControllerService {
             headers: {
                 'Authorization': authorization,
             },
+            errors: {
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * saveTemplate
+     * @returns Template OK
+     * @returns any Created
+     * @throws ApiError
+     */
+    public static saveTemplateUsingPost({
+        authorization,
+        request,
+    }: {
+        authorization: string,
+        /**
+         * request
+         */
+        request: SaveTemplateRequest,
+    }): CancelablePromise<Template | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/nbs/page-builder/api/v1/template/save',
+            headers: {
+                'Authorization': authorization,
+            },
+            body: request,
             errors: {
                 401: `Unauthorized`,
                 403: `Forbidden`,

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageHeader/EditPageHeader.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageHeader/EditPageHeader.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { PagesResponse } from 'apps/page-builder/generated';
 import { EditPageHeader } from './EditPageHeader';
+import { AlertProvider } from 'alert';
 
 describe('when EditPageHeader renders', () => {
     const page: PagesResponse = {
@@ -26,14 +27,21 @@ describe('when EditPageHeader renders', () => {
     const mockFunction = jest.fn();
 
     it('should display Page name', () => {
-        const { getByText } = render(<EditPageHeader page={page} handleSaveDraft={mockFunction} />);
+        const { getByText } = render(
+            <AlertProvider>
+                <EditPageHeader page={page} handleSaveDraft={mockFunction} />
+            </AlertProvider>
+        );
 
         expect(getByText('Test Page')).toBeInTheDocument();
     });
 
     it('should display Page description', () => {
-        const { getByText } = render(<EditPageHeader page={page} handleSaveDraft={mockFunction} />);
-
+        const { getByText } = render(
+            <AlertProvider>
+                <EditPageHeader page={page} handleSaveDraft={mockFunction} />
+            </AlertProvider>
+        );
         expect(getByText('Test Page description')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageHeader/EditPageHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageHeader/EditPageHeader.tsx
@@ -56,7 +56,7 @@ export const EditPageHeader = ({ page, handleSaveDraft }: PageProps) => {
             <ModalComponent
                 modalRef={modalRef}
                 modalHeading={'Save as Template'}
-                modalBody={<SaveTemplates modalRef={modalRef} />}
+                modalBody={<SaveTemplates modalRef={modalRef} page={page} />}
             />
         </div>
     );


### PR DESCRIPTION
## Description

Save Page as Template API wire up

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNFT2-1129

## Steps to verify

Backend API dependency PR - Will come up on Monday

1.  Navigate to manage/pages
2. Select any page name that navigate to edit the particular page
3. At top of the page, click the Save as Template button 
4. verify the UI in inspect mode for successful response ( Screenshot 2 )
5. That make entry in database dbo.WA_template with new template id and xml payload ( Screenshot 4 )

<img width="1453" alt="Screenshot 2023-11-10 at 12 32 00 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/1281870c-fff4-49a2-856e-fa915a150a7e">

<img width="1443" alt="Screenshot 2023-11-10 at 12 30 55 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/b039a603-8d1d-4ed8-9904-5e4aafa560e9">

<img width="1499" alt="Screenshot 2023-11-10 at 12 39 51 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/fe5b9b60-b5c4-44d7-aaf0-f8f4c57d138d">

<img width="1493" alt="Screenshot 2023-11-10 at 12 33 09 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/b77b0658-979d-491c-960d-aa80528ceba8">