### PR TITLE
CNFT2-1223 legacy custom fields admin

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.scss
@@ -2,11 +2,11 @@
 
 .alert-banner {
     width: 100%;
-    padding: 0.6rem 1.0rem;
+    padding: 0.6rem 1rem;
     display: flex;
     flex-direction: row;
     gap: 0.5rem;
-    margin-bottom: 1.0rem;
+    margin-bottom: 1rem;
     align-items: center;
     &.success {
         background-color: $color-bg-alert-success;
@@ -20,11 +20,16 @@
         background-color: $color-bg-alert-prompt;
         border-left: 8px solid $color-alert-prompt;
     }
+    &.info {
+        background-color: $color-bg-info-prompt;
+        border-left: 8px solid $color-alert-info;
+    }
     &.error {
         background-color: $color-bg-alert-error;
         border-left: 8px solid $color-alert-error;
     }
-    &__left, &__right{
+    &__left,
+    &__right {
         display: flex;
         align-items: center;
     }

--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
@@ -13,6 +13,7 @@ export const AlertBanner = ({ type, children }: AlertBannerProps) => {
                 {type === 'success' && <Icon.CheckCircle size={3} />}
                 {type === 'warning' && <Icon.Warning size={3} />}
                 {type === 'prompt' && <Icon.Info size={3} />}
+                {type === 'info' && <Icon.Info size={3} />}
                 {type === 'error' && <Icon.Error size={5} />}
             </div>
             <div className="alert-banner__right">{children}</div>

--- a/apps/modernization-ui/src/apps/page-builder/pages/ConditionLibrary/ConditionLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ConditionLibrary/ConditionLibrary.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 import { PageBuilder } from '../PageBuilder/PageBuilder';
 import { UserContext } from 'user';
-// import { ConditionsContext } from 'apps/page-builder/context/ConditionsContext';
 import { searchConditions } from 'apps/page-builder/services/conditionAPI';
 import ConditionLibraryTable from './ConditionLibraryTable';
 import './ConditionLibrary.scss';
@@ -32,7 +31,7 @@ const ConditionLibrary = () => {
     }, [searchQuery, currentPage, pageSize, sortBy, sortDirection]);
 
     return (
-        <PageBuilder page="condition-library" menu={true}>
+        <PageBuilder nav>
             <div className="condition-local-library">
                 <div className="condition-local-library__container">
                     <div className="condition-local-library__table">

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPage.tsx
@@ -56,7 +56,7 @@ export const EditPage = () => {
     };
 
     return (
-        <PageBuilder page="edit-page">
+        <PageBuilder>
             {page ? (
                 <DragDropProvider data={page.tabs?.[active]}>
                     <div className="edit-page">

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageBuilder/PageBuilder.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageBuilder/PageBuilder.scss
@@ -2,11 +2,10 @@
 
 .page-builder {
     position: relative;
-    background-color: $color-bg-base-lightest;
+    background-color: #f1f6f9;
     height: 100%;
-    min-height: calc( 100vh - 5rem );
+    min-height: calc(100vh - 5rem);
     width: 100%;
-    position: relative;
     padding: 1rem;
     display: flex;
     gap: 1rem;

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageBuilder/PageBuilder.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageBuilder/PageBuilder.spec.tsx
@@ -1,0 +1,27 @@
+import { BrowserRouter } from 'react-router-dom';
+import { PageBuilder } from './PageBuilder';
+import { render } from '@testing-library/react';
+
+describe('when rendered', () => {
+    it('should display side nav', async () => {
+        const { container } = render(
+            <BrowserRouter>
+                <PageBuilder nav>Child</PageBuilder>
+            </BrowserRouter>
+        );
+
+        const sideNav = container.getElementsByClassName('page-builder-side-nav')[0];
+        expect(sideNav).toBeInTheDocument();
+    });
+
+    it('should not side nav', async () => {
+        const { container } = render(
+            <BrowserRouter>
+                <PageBuilder>Child</PageBuilder>
+            </BrowserRouter>
+        );
+
+        const sideNav = container.getElementsByClassName('page-builder-side-nav')[0];
+        expect(sideNav).toBeUndefined();
+    });
+});

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageBuilder/PageBuilder.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageBuilder/PageBuilder.tsx
@@ -2,15 +2,14 @@ import { PageBuilderSideNav } from '../../components/Navigation/PageBuilderSideN
 import './PageBuilder.scss';
 
 type Props = {
-    page: string;
     children: any;
-    menu?: boolean;
+    nav?: boolean;
 };
 
-export const PageBuilder = ({ children }: Props) => {
+export const PageBuilder = ({ nav = false, children }: Props) => {
     return (
         <div className="page-builder">
-            <PageBuilderSideNav />
+            {nav ? <PageBuilderSideNav /> : null}
             <div className="page-builder__content">{children}</div>
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/CustomFieldAdminBanner.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/CustomFieldAdminBanner.scss
@@ -1,7 +1,6 @@
-@use 'settings.scss';
 .custom-field-admin {
     padding: 1rem 1rem 0 1rem;
-    background-color: settings.$color-gray-5;
+    background-color: #f1f6f9;
 
     .alert-banner {
         margin-bottom: 0;

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/CustomFieldAdminBanner.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/CustomFieldAdminBanner.scss
@@ -1,0 +1,9 @@
+@use 'settings.scss';
+.custom-field-admin {
+    padding: 1rem 1rem 0 1rem;
+    background-color: settings.$color-gray-5;
+
+    .alert-banner {
+        margin-bottom: 0;
+    }
+}

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/CustomFieldAdminBanner.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/CustomFieldAdminBanner.tsx
@@ -1,0 +1,12 @@
+import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
+import './CustomFieldAdminBanner.scss';
+export const CustomFieldAdminBanner = () => {
+    return (
+        <div className="custom-field-admin">
+            <AlertBanner type="info">
+                <span style={{ marginRight: '4px' }}>To access the legacy Custom Fields Admin menu,</span>{' '}
+                <a href="/nbs/LDFAdminLoad.do">click here</a>.
+            </AlertBanner>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/PageLibrary.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/PageLibrary.scss
@@ -1,6 +1,6 @@
 @import 'settings.scss';
-
 .manage-pages {
+    display: flex;
     position: relative;
     border-radius: 5px;
     border: $border-medium;

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/PageLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/PageLibrary.tsx
@@ -7,6 +7,7 @@ import { PageBuilder } from '../PageBuilder/PageBuilder';
 import './PageLibrary.scss';
 import { ManagePagesTable } from './ManagePagesTable';
 import { PageSummary } from 'apps/page-builder/generated';
+import { CustomFieldAdminBanner } from './CustomFieldAdminBanner';
 
 export const PageLibrary = () => {
     const [pages, setPages] = useState<PageSummary[]>([]);
@@ -23,7 +24,7 @@ export const PageLibrary = () => {
         // set current page from query param
         if (searchParams.get('page') && parseInt(searchParams.get('page') || '') > 0) {
             const pageFromQuery = searchParams.get('page');
-            setCurrentPage(parseInt(pageFromQuery || '') || 1);
+            setCurrentPage(parseInt(pageFromQuery ?? '') || 1);
         }
 
         // get Pages
@@ -39,19 +40,22 @@ export const PageLibrary = () => {
     }, [searchQuery, currentPage, pageSize, sortBy, sortDirection]);
 
     return (
-        <PageBuilder page="manage-pages" menu={true}>
-            <div className="manage-pages">
-                <div className="manage-pages__container">
-                    <div className="manage-pages__table">
-                        <ManagePagesTable
-                            summaries={pages}
-                            currentPage={currentPage}
-                            pageSize={pageSize}
-                            totalElements={totalElements}
-                        />
+        <>
+            <CustomFieldAdminBanner />
+            <PageBuilder nav>
+                <div className="manage-pages">
+                    <div className="manage-pages__container">
+                        <div className="manage-pages__table">
+                            <ManagePagesTable
+                                summaries={pages}
+                                currentPage={currentPage}
+                                pageSize={pageSize}
+                                totalElements={totalElements}
+                            />
+                        </div>
                     </div>
                 </div>
-            </div>
-        </PageBuilder>
+            </PageBuilder>
+        </>
     );
 };

--- a/apps/modernization-ui/src/apps/page-builder/pages/QuestionLibrary/QuestionLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/QuestionLibrary/QuestionLibrary.tsx
@@ -45,7 +45,7 @@ export const QuestionLibrary = ({ hideTabs, modalRef }: any) => {
 
     if (hideTabs) return <div className="question-local-library">{renderQuestionList}</div>;
     return (
-        <PageBuilder page="question-library" menu={true}>
+        <PageBuilder nav={true}>
             <div className="question-local-library">
                 {!hideTabs && (
                     <div className="margin-left-2em">

--- a/apps/modernization-ui/src/apps/page-builder/pages/ValuesetLibrary/ValuesetLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/ValuesetLibrary/ValuesetLibrary.tsx
@@ -36,7 +36,7 @@ export const ValuesetLibrary = ({ hideTabs, types, modalRef }: any) => {
     }, [searchQuery, currentPage, pageSize, sortBy, filter]);
 
     return (
-        <PageBuilder page="valueset-library" menu={true}>
+        <PageBuilder nav>
             <div className="valueset-local-library">
                 {!hideTabs && (
                     <div className="margin-left-2em">

--- a/apps/modernization-ui/src/styles/_colors.scss
+++ b/apps/modernization-ui/src/styles/_colors.scss
@@ -30,7 +30,7 @@ $color-orange-30: #fa9441;
 $color-orange-40: #c05600;
 $color-gold: #ffbe2e;
 $color-yellow: #fee685;
-$color-yellow-10: #faf3d1; 
+$color-yellow-10: #faf3d1;
 $color-green: #538200;
 $color-green-10: #ecf3ec;
 $color-mint: #04c585;
@@ -85,6 +85,7 @@ $color-emergency-dark: $color-gray-80;
 $color-alert-success: $color-green;
 $color-alert-warning: $color-gold;
 $color-alert-prompt: $color-primary;
+$color-alert-info: #00bde3;
 $color-alert-error: $color-red-25;
 
 //Background colours
@@ -124,3 +125,4 @@ $color-bg-alert-success: $color-green-10;
 $color-bg-alert-warning: $color-yellow-10;
 $color-bg-alert-prompt: $color-blue-5;
 $color-bg-alert-error: $color-red-5;
+$color-bg-info-prompt: $color-blue-5;


### PR DESCRIPTION
## Description

A link to the `Legacy Custom Fields Admin` page needs to be added to the Page Library
Hides the side nav in the `Edit` page

## Tickets

* [CNFT2-1223](https://cdc-nbs.atlassian.net/browse/CNFT2-1223)

## Steps to verify

1. Navigate to http://localhost:8080/nbs/login
2. Log in as `superuser`
3. Click System Management -> Page Management -> Manage Pages
4. Verify `Custom Fields Admin` banner is displayed
5. Click the link within the banner
6. Verify Classic™ custom fields admin screen is loaded


![legacyCustomAdmin](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/50c8220e-f46c-4b97-af1b-5fd07716e219)


[CNFT2-1223]: https://cdc-nbs.atlassian.net/browse/CNFT2-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ