### PR TITLE
adding a condition to display the arrow in add new button

### DIFF
--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
@@ -421,7 +421,9 @@ export const AdvancedSearch = () => {
                                 onClick={() => setShowAddNewDropDown(!showAddNewDropDown)}
                                 outline>
                                 Add new
-                                <img src={'/icons/down-arrow-white.svg'} />
+                                <img
+                                    src={lastSearchType ? '/icons/down-arrow-blue.svg' : '/icons/down-arrow-white.svg'}
+                                />
                             </Button>
                             {showAddNewDropDown && (
                                 <ul ref={addPatiendRef} id="basic-nav-section-one" className="usa-nav__submenu">


### PR DESCRIPTION
## Description

Fixing the add new button arrow color and ensuring it displays a white arrow if disabled otherwise it will display blue

## Tickets

NO tickets associated with this fix

## Steps to verify

1. Provide steps here
1.Navigate to advanced search
2. Make a search for anything 
3. Observe the blue arrow in the add new button in advanced search page

