### PR TITLE
Add page range selector to Quick Condition table

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
@@ -60,7 +60,6 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
 
     const handleSubmitSearch = useCallback(
         (page: number) => {
-            console.log('called', pageSize);
             setLoading(true);
             const authorization = `Bearer ${state.getToken()}`;
             const search: ReadConditionRequest = { searchText };
@@ -85,7 +84,6 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
     );
 
     useEffect(() => {
-        console.log('pageSize', pageSize);
         handleSubmitSearch(currentPage);
     }, [currentPage, pageSize]);
 

--- a/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
@@ -9,13 +9,13 @@ import {
     ModalToggleButton,
     TextInput
 } from '@trussworks/react-uswds';
-import { ChangeEvent, RefObject, useContext, useEffect, useState } from 'react';
+import { ChangeEvent, RefObject, useCallback, useContext, useEffect, useState } from 'react';
 import './QuickConditionLookup.scss';
 import { TableComponent, TableBody } from 'components/Table/Table';
-import { ConditionControllerService, ReadConditionRequest } from 'apps/page-builder/generated';
+import { Condition, ConditionControllerService, ReadConditionRequest } from 'apps/page-builder/generated';
 import { UserContext } from 'user';
-import { PagesContext } from 'apps/page-builder/context/PagesContext';
 import { NoData } from 'components/NoData';
+import { ConditionsContext } from 'apps/page-builder/context/ConditionsContext';
 
 type Props = {
     modal: RefObject<ModalRef>;
@@ -32,14 +32,14 @@ const tableHeaders = [
 ];
 
 export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
-    const [conditions, setConditions] = useState<any[]>([]);
+    const [conditions, setConditions] = useState<Condition[]>([]);
     const [selectedConditions, setSelectedConditions] = useState<string[]>([]);
     const [searchText, setSearchTerm] = useState('');
     const [loading, setLoading] = useState(false);
     const [totalConditions, setTotalConditions] = useState(0);
     const [tableRows, setTableRows] = useState<TableBody[]>([]);
     const { state } = useContext(UserContext);
-    const { currentPage, setCurrentPage } = useContext(PagesContext);
+    const { currentPage, setCurrentPage, pageSize, setPageSize } = useContext(ConditionsContext);
 
     const handleSelectConditions = (event: ChangeEvent<HTMLInputElement>, condition: any) => {
         if (selectedConditions.includes(condition.id)) {
@@ -58,30 +58,36 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
         addConditions(selectedConditions);
     };
 
-    const handleSubmitSearch = (page: number) => {
-        setLoading(true);
-        const authorization = `Bearer ${state.getToken()}`;
-        const search: ReadConditionRequest = { searchText };
+    const handleSubmitSearch = useCallback(
+        (page: number) => {
+            console.log('called', pageSize);
+            setLoading(true);
+            const authorization = `Bearer ${state.getToken()}`;
+            const search: ReadConditionRequest = { searchText };
 
-        ConditionControllerService.searchConditionsUsingPost({
-            authorization,
-            search,
-            page,
-            size: 10
-        })
-            .then((response: any) => {
-                setLoading(false);
-                setConditions(response.content);
-                setTotalConditions(response.totalElements);
+            ConditionControllerService.searchConditionsUsingPost({
+                authorization,
+                search,
+                page,
+                size: pageSize
             })
-            .catch((error: any) => {
-                console.error('Error', error);
-            });
-    };
+                .then((response: any) => {
+                    setLoading(false);
+                    setConditions(response.content);
+                    setTotalConditions(response.totalElements);
+                    setPageSize(pageSize);
+                })
+                .catch((error: any) => {
+                    console.error('Error', error);
+                });
+        },
+        [currentPage, pageSize, searchText]
+    );
 
     useEffect(() => {
+        console.log('pageSize', pageSize);
         handleSubmitSearch(currentPage);
-    }, [currentPage]);
+    }, [currentPage, pageSize]);
 
     useEffect(() => {
         addConditions(selectedConditions);
@@ -173,7 +179,7 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
                     <ModalToggleButton
                         modalRef={modal}
                         closer
-                        onClick={() => handleAddConditions()}
+                        onClick={handleAddConditions}
                         data-testid="condition-add-btn">
                         Add Condition
                     </ModalToggleButton>
@@ -185,11 +191,13 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
                         tableHead={tableHeaders}
                         tableBody={tableRows}
                         isPagination={true}
-                        pageSize={10}
+                        pageSize={pageSize}
                         totalResults={totalConditions}
                         currentPage={currentPage}
                         handleNext={setCurrentPage}
                         selectable={true}
+                        contextName="conditions"
+                        rangeSelector={true}
                         handleSelected={handleSelectConditions}
                     />
                 ) : (


### PR DESCRIPTION
## Description

Quick conditions lookup modal was missing the range selector for the table page size.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1422)

## Steps to verify

1. Navigate to /page-builder/add/page
2. Click "search or add condition(s)"
3. use the page size selector at the bottom of the table and verify it functions correctly.
