### PR TITLE
uses ubi9 as runtime base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,10 @@
 cdc-sandbox
 docs
 documentation
-node_modules
+**/node_modules
 .vscode
 .gradle
-bin
-build
-log
+**/bin
+**/build
+**/log
 **/.DS_Store

--- a/apps/modernization-api/Dockerfile
+++ b/apps/modernization-api/Dockerfile
@@ -50,7 +50,7 @@ RUN jlink \
     --no-man-pages \
     --output modernization-api/runtime
 
-FROM debian:12-slim
+FROM redhat/ubi9-micro:latest
 
 ENV NBS_DATASOURCE_SERVER=nbs-mssql
 ENV NBS_ELASTICSEARCH_SERVER=elasticsearch

--- a/apps/nbs-gateway/Dockerfile
+++ b/apps/nbs-gateway/Dockerfile
@@ -28,7 +28,7 @@ RUN jlink \
     --no-man-pages \
     --output gateway/runtime
 
-FROM debian:12-slim
+FROM redhat/ubi9-micro:latest
 
 COPY --from=builder /usr/src/nbs/gateway/runtime /deployment/runtime
 

--- a/apps/question-bank/Dockerfile
+++ b/apps/question-bank/Dockerfile
@@ -33,7 +33,7 @@ RUN jlink \
     --no-man-pages \
     --output page-builder/runtime
 
-FROM debian:12-slim
+FROM redhat/ubi9-micro:latest
 
 ENV NBS_DATASOURCE_SERVER=nbs-mssql
 


### PR DESCRIPTION
## Description

Changes the base image of the Java application from `debian:12-slim` to Red Hat's `ubi9-micro`.  This will reduce the size and attack surface of the containers.  The base `.dockerignore` file was also updated to ensure that files not required for the build are not added to the build context.

## Steps to verify

1. Rebuild and run all containers with `docker compose up -d --build`
2. Ensure they work 😉 
