### PR TITLE
CNFT2-1334-revise-row-selection

### DIFF
--- a/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.scss
+++ b/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.scss
@@ -3,6 +3,6 @@
 .range-toggle {
     display: inline-block;
     select {
-        width: 4rem;
+        width: 4.5rem;
     }
 }

--- a/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.tsx
+++ b/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.tsx
@@ -38,8 +38,10 @@ export const RangeToggle = ({ contextName }: RangeToggleProps) => {
     const [range, setRange] = useState(10);
     const options = [
         { name: '10', value: '10' },
-        { name: '25', value: '25' },
-        { name: '50', value: '50' }
+        { name: '20', value: '20' },
+        { name: '30', value: '30' },
+        { name: '50', value: '50' },
+        { name: '100', value: '100' }
     ];
 
     useEffect(() => {

--- a/apps/question-bank/src/main/resources/application.yml
+++ b/apps/question-bank/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
   data:
     web:
       pageable:
-        max-page-size: 50 # max pageable size
+        max-page-size: 100 # max pageable size
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## Description

Currently, the values available for selection in the drop-down (bottom left footer) are 10, 25, 50.

The list should be revised to provide the standard values: 10, 20, 30, 50, 100.

## Tickets

* [CNFT2-1334](https://cdc-nbs.atlassian.net/browse/CNFT2-1334)

## Steps to verify

1. Navigate to page: /page-builder/manage/pages
2. Scroll to the bottom of the page and check the dropdown values for the 'Showing' option
3. Verify that they are in fact: 10, 20, 30, 50, 100


[CNFT2-1334]: https://cdc-nbs.atlassian.net/browse/CNFT2-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ