### PR TITLE
CNFT-1406-puntuation-missing

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
@@ -140,7 +140,7 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
                 </div>
             </ModalHeading>
             <div className="condition-lookup-modal-body">
-                <p className="description">You can search for existing condition(s) or create a new one</p>
+                <p className="description">You can search for existing condition(s) or create a new one.</p>
                 <div className="search-container">
                     <div style={{ display: 'flex' }}>
                         <TextInput


### PR DESCRIPTION
## Description

When accessing Search and add condition(s) modal and viewing the single sentence under the title heading, the period punctuation is missing.

You can search for existing condition(s) or create a new one

## Tickets

* [CNFT2-1406](https://cdc-nbs.atlassian.net/browse/CNFT2-1406)

## Steps to verify

1. Navigate to /page-builder/manage/pages and click on create a new page
2. Then navigation to the Search and add conditions link and check the punctuation on the title


[CNFT2-1406]: https://cdc-nbs.atlassian.net/browse/CNFT2-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ