### PR TITLE
CNFT2-1402-updating-date-format

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/generated/services/PageControllerService.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/services/PageControllerService.ts
@@ -156,4 +156,36 @@ export class PageControllerService {
         });
     }
 
+    /**
+     * downloadPageMetadata
+     * @returns Resource OK
+     * @throws ApiError
+     */
+    public static downloadPageMetadataUsingGet({
+        authorization,
+        waTemplateUid,
+    }: {
+        authorization: string,
+        /**
+         * waTemplateUid
+         */
+        waTemplateUid: number,
+    }): CancelablePromise<Resource> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/page-builder/api/v1/pages/{waTemplateUid}/download-metadata',
+            path: {
+                'waTemplateUid': waTemplateUid,
+            },
+            headers: {
+                'Authorization': authorization,
+            },
+            errors: {
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
+            },
+        });
+    }
+
 }

--- a/apps/modernization-ui/src/apps/page-builder/generated/services/PageRuleControllerService.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/services/PageRuleControllerService.ts
@@ -35,11 +35,13 @@ export class PageRuleControllerService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/nbs/page-builder/api/v1/pages/{page}/rules',
+            path: {
+                'page': page,
+            },
             headers: {
                 'Authorization': authorization,
             },
             query: {
-                'page': page,
                 'size': size,
                 'sort': sort,
             },

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.spec.tsx
@@ -54,7 +54,7 @@ describe('when at least one summary is available', () => {
         expect(tableData[1]).toHaveTextContent('Investigation');
         expect(tableData[2]).toHaveTextContent('condition display');
         expect(tableData[3]).toHaveTextContent('Draft');
-        expect(tableData[4]).toHaveTextContent('9/25/2019, 1:27:16 PM');
+        expect(tableData[4]).toHaveTextContent('09/25/2019');
         expect(tableData[5]).toHaveTextContent('last updateBy');
     });
 

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.tsx
@@ -45,6 +45,15 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
     const setSearchParams = searchParams[1];
     const token = `Bearer ${state.getToken()}`;
 
+    const dateOptions: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+    };
+
     const asTableRow = (page: PageSummary): TableBody => ({
         id: page.name,
         expanded: false,
@@ -71,7 +80,10 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
                     ) || null
             },
             { id: 4, title: page?.status || null },
-            { id: 5, title: page?.lastUpdate ? asLocalDate(page.lastUpdate).toLocaleString() : null },
+            {
+                id: 5,
+                title: page?.lastUpdate ? asLocalDate(page.lastUpdate).toLocaleString('en-US', dateOptions) : null
+            },
             { id: 6, title: page?.lastUpdateBy || null }
         ]
     });

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { PageControllerService, PageSummary } from 'apps/page-builder/generated';
 import { TableBody, TableComponent } from 'components/Table/Table';
-import { asLocalDate } from 'date';
+import { internalizeDate } from 'date';
 import { useContext, useEffect, useState } from 'react';
 import { Direction } from 'sorting';
 import './ManagePagesTable.scss';
@@ -45,12 +45,6 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
     const setSearchParams = searchParams[1];
     const token = `Bearer ${state.getToken()}`;
 
-    const dateOptions: Intl.DateTimeFormatOptions = {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-    };
-
     const asTableRow = (page: PageSummary): TableBody => ({
         id: page.name,
         expanded: false,
@@ -79,7 +73,7 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
             { id: 4, title: page?.status || null },
             {
                 id: 5,
-                title: page?.lastUpdate ? asLocalDate(page.lastUpdate).toLocaleDateString('en-US', dateOptions) : null
+                title: page?.lastUpdate ? internalizeDate(page.lastUpdate) : null
             },
             { id: 6, title: page?.lastUpdateBy || null }
         ]

--- a/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/PageLibrary/ManagePagesTable.tsx
@@ -48,10 +48,7 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
     const dateOptions: Intl.DateTimeFormatOptions = {
         year: 'numeric',
         month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit'
+        day: '2-digit'
     };
 
     const asTableRow = (page: PageSummary): TableBody => ({
@@ -82,7 +79,7 @@ export const ManagePagesTable = ({ summaries, currentPage, pageSize, totalElemen
             { id: 4, title: page?.status || null },
             {
                 id: 5,
-                title: page?.lastUpdate ? asLocalDate(page.lastUpdate).toLocaleString('en-US', dateOptions) : null
+                title: page?.lastUpdate ? asLocalDate(page.lastUpdate).toLocaleDateString('en-US', dateOptions) : null
             },
             { id: 6, title: page?.lastUpdateBy || null }
         ]

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummary.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummary.java
@@ -2,7 +2,7 @@ package gov.cdc.nbs.questionbank.page.summary.search;
 
 import gov.cdc.nbs.questionbank.question.model.ConditionSummary;
 
-import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collection;
 
 public record PageSummary(
@@ -11,7 +11,7 @@ public record PageSummary(
     String name,
     String status,
     Collection<ConditionSummary> conditions,
-    Instant lastUpdate,
+    LocalDate lastUpdate,
     String lastUpdateBy
 ) {
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryMapper.java
@@ -4,6 +4,8 @@ import com.querydsl.core.Tuple;
 import gov.cdc.nbs.questionbank.question.model.ConditionSummary;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,7 +31,7 @@ class PageSummaryMapper {
         name,
         getStatus(tuple),
         conditions,
-        lastUpdate,
+        LocalDate.ofInstant(lastUpdate, ZoneId.systemDefault()),
         lastUpdateBy
     );
   }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryMapper.java
@@ -24,6 +24,7 @@ class PageSummaryMapper {
 
     String lastUpdateBy = tuple.get(this.tables.lastUpdatedBy());
     Instant lastUpdate = tuple.get(this.tables.page().lastChgTime);
+    LocalDate lastUpdateDate = (lastUpdate != null) ? LocalDate.ofInstant(lastUpdate, ZoneId.systemDefault()) : null;
     String name = tuple.get(this.tables.page().templateNm);
     return new PageSummary(
         identifier,
@@ -31,7 +32,7 @@ class PageSummaryMapper {
         name,
         getStatus(tuple),
         conditions,
-        LocalDate.ofInstant(lastUpdate, ZoneId.systemDefault()),
+        lastUpdateDate,
         lastUpdateBy
     );
   }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryMapperTest.java
@@ -31,6 +31,8 @@ class PageSummaryMapperTest {
     Integer version = "null".equals(versionNbr) ? null : Integer.parseInt(versionNbr);
     when(tuple.get(this.tables.page().publishVersionNbr)).thenReturn(version);
 
+    // when(tuple.get(this.tables.page().lastChgTime)).thenReturn(Instant.parse("9999-99-99T00:00:00Z"));
+
     PageSummary summary = mapper.map(tuple);
 
     assertThat(summary.status()).isEqualTo(expected);
@@ -61,7 +63,7 @@ class PageSummaryMapperTest {
     assertThat(actual.eventType().name()).isEqualTo("Investigation");
 
     assertThat(actual.lastUpdateBy()).isEqualTo("first last");
-    assertThat(actual.lastUpdate()).isEqualTo("2023-10-17T15:27:13Z");
+    assertThat(actual.lastUpdate()).isEqualTo("2023-10-17");
 
   }
 


### PR DESCRIPTION
## Description

On the Page Library in the Last Updated column, the timestamp is included with the date.

*Figma design 2.0 presents the date as mm/dd/yyyy or 10/2/2023. Time should not be included

## Tickets

* [CNFT2-1402](https://cdc-nbs.atlassian.net/browse/CNFT2-1402)

## Steps to verify

1. Navigate to page library and check the last updated column, and it should only show the date in the format MM/DD/YYYY


[CNFT2-1402]: https://cdc-nbs.atlassian.net/browse/CNFT2-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ