### PR TITLE
CNFT2-1453/Set default value for contact tracing on add new page form

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
@@ -241,7 +241,7 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
                     <Controller
                         control={control}
                         name="contactTracingEnableInd"
-                        defaultValue="N"
+                        defaultValue="Y"
                         render={({ field: { onChange, value } }) => (
                             <div className="radio-group">
                                 <Radio


### PR DESCRIPTION
## Description

Resets the default value from NO to YES for the contact tracing field on the add new page form.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1453)

## Steps to verify

1. Navigate to page builder
2. Click create new page.
3. select investigation from the dropdown
4. on the contact tracing field, verify that YES is selected by default
