### PR TITLE
[CVE] addresses apache commons related vulnerabilities

### DIFF
--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -39,9 +39,9 @@ testing {
 dependencies {
 
     implementation platform(SpringBootPlugin.BOM_COORDINATES)
-    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2022.0.4")
+
     implementation libs.snake.yaml
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway:4.0.8'
 }
 
 tasks.withType(JavaExec).configureEach {

--- a/apps/nbs-gateway/src/main/resources/application-development.yml
+++ b/apps/nbs-gateway/src/main/resources/application-development.yml
@@ -1,3 +1,4 @@
-logging:
-  level:
-    org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping: DEBUG
+nbs:
+  gateway:
+    log:
+      level: DEBUG

--- a/apps/nbs-gateway/src/main/resources/application.yml
+++ b/apps/nbs-gateway/src/main/resources/application.yml
@@ -23,6 +23,8 @@ spring:
             - Path=/favicon.ico
 nbs:
   gateway:
+    log:
+      level: INFO
     defaults:
       protocol: 'http'
     classic: '${nbs.gateway.defaults.protocol}://localhost:7001'
@@ -36,3 +38,7 @@ nbs:
     pagebuilder:
       enabled: false
       service: 'localhost:8080'
+
+logging:
+  level:
+    org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping: ${nbs.gateway.log.level}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       dockerfile: ./apps/nbs-gateway/Dockerfile
     container_name: nbs-gateway
     environment:
+      - NBS_GATEWAY_LOG_LEVEL=${NBS_GATEWAY_LOG_LEVEL:-INFO}
       - NBS_GATEWAY_CLASSIC=http://wildfly:7001
       - NBS_GATEWAY_PATIENT_SEARCH_SERVICE=${NBS_GATEWAY_PATIENT_SEARCH_SERVICE:-reverse-proxy:8080}
       - NBS_GATEWAY_PATIENT_PROFILE_SERVICE=${NBS_GATEWAY_PATIENT_PROFILE_SERVICE:-reverse-proxy:8080}


### PR DESCRIPTION
## Description

Addresses recent CVE findings on the `nbs-gateway` related to Apache Commons Compress.  This library is not used by the gateway.  The `spring-cloud-dependencies` dependency was removed in favor of specifying the `spring-cloud-starter-gateway` version directly.

https://github.com/CDCgov/NEDSS-Modernization/security/code-scanning/413
https://github.com/CDCgov/NEDSS-Modernization/security/code-scanning/414
https://github.com/CDCgov/NEDSS-Modernization/security/code-scanning/415

### Steps to verify

1. Ensure that the `nbs-gateway` container runs by executing `docker compose up -d --build nbs-gateway`