### PR TITLE
Remove filter from quick condition search

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
@@ -165,15 +165,6 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
                             <Icon.Search />
                         </Button>
                     </div>
-                    <Button type="button" outline style={{ height: '41px' }}>
-                        <Icon.FilterAlt />
-                        Filter
-                    </Button>
-                    {/* <NavLink to={'page-builder/add/condition'}>
-                        <Button type="button" style={{ height: '41px' }}>
-                            Add new condition
-                        </Button>
-                    </NavLink> */}
                     <ModalToggleButton
                         modalRef={modal}
                         closer


### PR DESCRIPTION
## Description

Remove the filter button from the quick condition lookup modal

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1474)

## Steps to verify

1. Verify there is no filter button on the quick condition lookup modal