### PR TITLE
CNFT2-1468 Manage Tabs - Delete tab in modal

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.scss
@@ -14,6 +14,9 @@
     margin-bottom: 1rem;
     align-items: center;
     position: relative;
+    &.hidden {
+        display: none;
+    }
     &.success {
         @include indicator(colors.$success-lighter, colors.$success);
     }
@@ -42,6 +45,7 @@
     }
     p {
         margin: 0;
+        font-size: 0.8rem;
         span {
             font-weight: 700;
         }

--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import './AlertBanner.scss';
 import { Icon } from '@trussworks/react-uswds';
 
@@ -5,11 +6,22 @@ export type AlertBannerProps = {
     type?: string;
     children?: any;
     onClose?: () => void;
+    expiration?: number;
 };
 
-export const AlertBanner = ({ type, children, onClose }: AlertBannerProps) => {
+export const AlertBanner = ({ type, children, onClose, expiration }: AlertBannerProps) => {
+    const [hidden, setHidden] = useState(false);
+
+    useEffect(() => {
+        if (expiration) {
+            setTimeout(() => {
+                setHidden(true);
+            }, expiration);
+        }
+    }, []);
+
     return (
-        <div className={`alert-banner ${type}`}>
+        <div className={`alert-banner ${type} ${hidden ? 'hidden' : ''}`}>
             <div className="alert-banner__left">
                 {type === 'success' && <Icon.CheckCircle size={3} />}
                 {type === 'warning' && <Icon.Warning size={3} />}
@@ -17,7 +29,9 @@ export const AlertBanner = ({ type, children, onClose }: AlertBannerProps) => {
                 {type === 'info' && <Icon.Info size={3} />}
                 {type === 'error' && <Icon.Error size={5} />}
             </div>
-            <div className="alert-banner__right">{children}</div>
+            <div className="alert-banner__right">
+                <p>{children}</p>
+            </div>
             {onClose ? (
                 <div className="alert-banner__close" onClick={() => onClose()}>
                     <Icon.Close />

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageTabs/EditPageTabs.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageTabs/EditPageTabs.tsx
@@ -1,4 +1,4 @@
-import { SetStateAction, useRef, useState, useContext, useEffect } from 'react';
+import { SetStateAction, useRef, useState, useContext } from 'react';
 import './EditPageTabs.scss';
 import { Button, Icon, ModalRef, ModalToggleButton } from '@trussworks/react-uswds';
 import { ModalComponent } from '../../../../../components/ModalComponent/ModalComponent';
@@ -7,7 +7,7 @@ import ManageTabs from '../ManageTabs/ManageTabs';
 import { PagesTab, Tab } from 'apps/page-builder/generated';
 import { useParams } from 'react-router-dom';
 import { UserContext } from 'user';
-import { addTab, updateTab } from 'apps/page-builder/services/tabsAPI';
+import { addTab, deleteTab, updateTab } from 'apps/page-builder/services/tabsAPI';
 import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
 
 type Props = {
@@ -22,21 +22,15 @@ export const EditPageTabs = ({ tabs, active, setActive, onAddSuccess }: Props) =
     const [isEditing, setIsEditing] = useState(false);
     const [addSuccess, setAddSuccess] = useState(false);
     const [editSuccess, setEditSuccess] = useState(false);
+    const [deleteSuccess, setDeleteSuccess] = useState(false);
     const [selectedEditTab, setSelectedEditTab] = useState<PagesTab | undefined>(undefined);
     const [selectedTabIndex, setSelectedIndex] = useState<number | undefined>(undefined);
+    const [selectedForDelete, setSelectedForDelete] = useState<PagesTab | undefined>(undefined);
     const modalRef = useRef<ModalRef>(null);
     const { state } = useContext(UserContext);
     const { pageId } = useParams();
     const token = `Bearer ${state.getToken()}`;
     const [tabDetails, setTabDetails] = useState({ name: '', visible: true });
-
-    useEffect(() => {
-        if (addSuccess || editSuccess) {
-            setTimeout(() => {
-                resetEditPageTabs();
-            }, 5000);
-        }
-    }, [addSuccess, editSuccess]);
 
     const handleEditTab = (tab: PagesTab, index: number) => {
         setSelectedEditTab(tab);
@@ -45,6 +39,7 @@ export const EditPageTabs = ({ tabs, active, setActive, onAddSuccess }: Props) =
     };
 
     const handleAddTab = async () => {
+        setSelectedEditTab(tabDetails);
         if (pageId) {
             addTab(token, parseInt(pageId), {
                 name: tabDetails.name,
@@ -83,10 +78,26 @@ export const EditPageTabs = ({ tabs, active, setActive, onAddSuccess }: Props) =
         }
     };
 
+    const handleDeleteTab = async (tab: PagesTab) => {
+        setSelectedForDelete(undefined);
+        setSelectedEditTab(tab);
+        if (pageId) {
+            deleteTab(token, parseInt(pageId), tab.id!)
+                .then(() => {
+                    setDeleteSuccess(true);
+                    setIsEditing(false);
+                    onAddSuccess();
+                })
+                .then(() => setTimeout(() => resetEditPageTabs(), 3000));
+        }
+    };
+
     const resetEditPageTabs = () => {
         setSelectedEditTab(undefined);
+        setSelectedForDelete(undefined);
         setAddSuccess(false);
         setEditSuccess(false);
+        setDeleteSuccess(false);
     };
 
     return (
@@ -131,12 +142,30 @@ export const EditPageTabs = ({ tabs, active, setActive, onAddSuccess }: Props) =
                 modalBody={
                     <div className="edit-page-tabs__modal--body">
                         {addSuccess ? (
-                            <AlertBanner type="success">You've successfully added a new tab!</AlertBanner>
-                        ) : editSuccess ? (
-                            <AlertBanner type="success" onClose={() => resetEditPageTabs()}>
+                            <AlertBanner type="success" expiration={3000}>
                                 <p>
-                                    You've successfully saved your changes to <span>&nbsp;{tabDetails?.name}!</span>
+                                    You've successfully added <span>{tabDetails.name}</span>
                                 </p>
+                            </AlertBanner>
+                        ) : null}
+                        {editSuccess ? (
+                            <AlertBanner type="success" onClose={() => resetEditPageTabs()} expiration={3000}>
+                                <p>
+                                    Successfully edited <span>{selectedEditTab?.name}</span>
+                                </p>
+                            </AlertBanner>
+                        ) : null}
+                        {deleteSuccess ? (
+                            <AlertBanner type="success" onClose={() => resetEditPageTabs()} expiration={3000}>
+                                <p>
+                                    Successfuly deleted <span>{selectedEditTab?.name}</span>
+                                </p>
+                            </AlertBanner>
+                        ) : null}
+                        {selectedForDelete ? (
+                            <AlertBanner type="warning">
+                                Are you sure you want to delete this tab? All sections, subsections, and questions
+                                within this tab will also be deleted and cannot be undone.
                             </AlertBanner>
                         ) : null}
                         {isAdding ? (
@@ -144,7 +173,14 @@ export const EditPageTabs = ({ tabs, active, setActive, onAddSuccess }: Props) =
                         ) : isEditing ? (
                             <AddEditTab tabData={tabs[selectedTabIndex!]} setTabDetails={setTabDetails} />
                         ) : (
-                            <ManageTabs tabs={tabs} setSelectedEditTab={handleEditTab} />
+                            <ManageTabs
+                                tabs={tabs}
+                                setSelectedEditTab={handleEditTab}
+                                selectedForDelete={selectedForDelete}
+                                setSelectedForDelete={setSelectedForDelete}
+                                setDeleteTab={handleDeleteTab}
+                                reset={resetEditPageTabs}
+                            />
                         )}
                     </div>
                 }
@@ -168,7 +204,7 @@ export const EditPageTabs = ({ tabs, active, setActive, onAddSuccess }: Props) =
                             </ModalToggleButton>
                         </>
                     ) : (
-                        <ModalToggleButton modalRef={modalRef} closer outline>
+                        <ModalToggleButton modalRef={modalRef} onClick={() => resetEditPageTabs()} closer>
                             Close
                         </ModalToggleButton>
                     )

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/ManageTabs/ManageTabs.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/ManageTabs/ManageTabs.scss
@@ -8,9 +8,22 @@
         color: colors.$base-black;
         padding: 1rem 1.5rem;
     }
+    .manage-tabs__handle {
+        svg {
+            cursor: pointer;
+        }
+        p {
+            display: none;
+        }
+    }
     .manage-tabs__label {
         display: flex;
+        align-items: center;
+        width: 70%;
         gap: 1rem;
+        svg {
+            height: 0.6rem;
+        }
     }
     .manage-tabs__buttons {
         color: colors.$primary;
@@ -26,6 +39,58 @@
             &:nth-of-type(2) {
                 &:hover {
                     color: colors.$error;
+                }
+            }
+        }
+        .delete {
+            display: none;
+        }
+        &.locked {
+            svg:nth-of-type(2) {
+                color: colors.$clear;
+                cursor: none;
+            }
+        }
+    }
+    .manage-tabs__tile {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        color: colors.$base-darkest;
+        padding: 1rem 1.5rem;
+        &.delete {
+            background-color: colors.$warning-lighter;
+            border: 3px solid colors.$warning;
+            flex-direction: column;
+            .manage-tabs__handle {
+                padding-bottom: 0.8rem;
+                img {
+                    display: none;
+                }
+                p {
+                    display: inline;
+                    font-weight: 700;
+                    font-size: 0.8rem;
+                }
+            }
+            .manage-tabs__buttons {
+                display: flex;
+                svg {
+                    display: none;
+                }
+                p {
+                    cursor: pointer;
+                }
+            }.delete {
+                display: flex;
+                gap: 1.5rem;
+                width: 100%;
+                justify-content: flex-end;
+                p {
+                    font-size: 0.8rem;
+                    font-weight: 700;
+                    margin: 0;
+                    cursor: pointer;
                 }
             }
         }

--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/ManageTabs/ManageTabs.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/ManageTabs/ManageTabs.tsx
@@ -1,28 +1,60 @@
-import React from 'react';
-import { PagesTab, Tab } from 'apps/page-builder/generated';
+// import { useState } from 'react';
+import { PagesTab } from 'apps/page-builder/generated';
 import './ManageTabs.scss';
 import { Icon } from '@trussworks/react-uswds';
 import { Icon as IconComponent } from 'components/Icon/Icon';
 
 type Props = {
-    tabs: Tab[];
+    tabs: PagesTab[];
     setSelectedEditTab: (tab: PagesTab, index: number) => void;
+    setDeleteTab: (tab: PagesTab) => void;
+    selectedForDelete: PagesTab | undefined;
+    setSelectedForDelete: (tab: PagesTab | undefined) => void;
+    reset: () => void;
 };
 
-const ManageTabs = ({ tabs, setSelectedEditTab }: Props) => {
+const ManageTabs = ({
+    tabs,
+    setSelectedEditTab,
+    setDeleteTab,
+    selectedForDelete,
+    setSelectedForDelete,
+    reset
+}: Props) => {
     return (
         <div className="manage-tabs">
             {tabs.map((tab, i) => {
                 return (
-                    <div key={i} className="manage-tabs__tile" style={{ listStyle: 'none' }}>
-                        <div className="manage-tabs__label">
+                    <div
+                        key={i}
+                        className={`manage-tabs__tile ${tab.id === selectedForDelete?.id ? 'delete' : ''}`}
+                        style={{ listStyle: 'none' }}>
+                        <div className="manage-tabs__handle">
                             <IconComponent name="drag" />
+                            <p>Delete this tab?</p>
+                        </div>
+                        <div className="manage-tabs__label">
                             <IconComponent name="folder" />
                             {tab.name}
                         </div>
-                        <div className="manage-tabs__buttons">
-                            <Icon.Edit onClick={() => setSelectedEditTab(tab, i)} size={3} />
-                            <Icon.Delete size={3} />
+                        <div className={`manage-tabs__buttons ${tab.sections?.length !== 0 ? 'locked' : ''}`}>
+                            <Icon.Edit
+                                onClick={() => {
+                                    reset();
+                                    setSelectedEditTab(tab, i);
+                                }}
+                                size={3}
+                            />
+                            <Icon.Delete
+                                onClick={() => {
+                                    tab.sections?.length === 0 ? (reset(), setSelectedForDelete(tab)) : null;
+                                }}
+                                size={3}
+                            />
+                            <div className="delete">
+                                <p onClick={() => setSelectedForDelete(undefined)}>Cancel</p>
+                                <p onClick={() => setDeleteTab(selectedForDelete!)}>Delete</p>
+                            </div>
                         </div>
                     </div>
                 );

--- a/apps/modernization-ui/src/apps/page-builder/services/tabsAPI.ts
+++ b/apps/modernization-ui/src/apps/page-builder/services/tabsAPI.ts
@@ -21,3 +21,11 @@ export const updateTab = async (
         tabId: tabId
     });
 };
+
+export const deleteTab = async (token: string, page: number, tabId: number) => {
+    return await TabControllerService.deleteTabUsingDelete({
+        authorization: token,
+        page: page,
+        tabId: tabId
+    });
+};

--- a/apps/modernization-ui/src/styles/_animation.scss
+++ b/apps/modernization-ui/src/styles/_animation.scss
@@ -1,1 +1,1 @@
-$transition-1: max-height 100ms ease-out, opacity 100ms ease;
+$transition-1: height 100ms ease-out, max-height 100ms ease-out, opacity 100ms ease, display 200ms ease;

--- a/apps/modernization-ui/src/styles/_colors.scss
+++ b/apps/modernization-ui/src/styles/_colors.scss
@@ -69,3 +69,5 @@ $requried: $mandatory;
 
 $visited-link: #562b97;
 $background: #f1f6f9;
+
+$clear: rgba(0, 0, 0, 0);


### PR DESCRIPTION
Description
Here we add the tab delete functionality to the Manage Tabs modal.
Alert banners now can accept functions that can be attached to the optional close button.
Expiration can also be passed to AlertBanners as a prop in millisecons.
https://www.figma.com/file/Uz9YzHbHQAubHpQTcsibA2/NBS-PageBuilder-2.0?node-id=3526%3A108877&mode=dev

Tickets
https://cdc-nbs.atlassian.net/browse/CNFT2-1468

Steps to verify
From Page Builder Pages Library:

1. Select a Page by clicking the Page name
2. In the Tabs menu bar, select Manage Tabs
3. Tabs with content cannot be deleted, their Delete icons are hidden.
4. Click on the Delete (pencil icon) button
5. A confirmation toggle will be shown to confirm or cancel delete.
6. Confirming Delete will show an alert of what was deleted.