### PR TITLE
[CNFT1-1667] Adds Patient-Action cookie for observations

### DIFF
--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfiguration.java
@@ -1,0 +1,61 @@
+package gov.cdc.nbs.gateway.patient.profile.events.observation;
+
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory;
+import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory.Config;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Adds the {@code Patient-Action} cookie to the response when the {@code routes.patient.profile.enabled} property is {@code true}
+ * and any of the following criteria is satisfied;
+ *
+ * <ul>
+ *     <li>Path equal to {@code /nbs/NewLabReview1.do.do}</li>*
+ *     <li>Query Parameter {@code observationUID} exists</li>
+ * </ul>
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "nbs.gateway.patient.profile", name = "enabled", havingValue = "true")
+class ViewObservationRouteLocatorConfiguration {
+
+    private static final String IDENTIFIER_PARAMETER = "observationUID";
+
+    @Bean
+    RouteLocator viewObservationActionCookie(
+            final RouteLocatorBuilder builder,
+            @Qualifier("default") final GatewayFilter defaultFilter,
+            @Qualifier("classic") final GatewayFilter classicFilter,
+            final NBSClassicService service
+    ) {
+        return builder
+                .routes()
+                .route(
+                        "view-observation-apply-patient-action-cookie",
+                        route -> route.path("/nbs/NewLabReview1.do")
+                                .and()
+                                .query(IDENTIFIER_PARAMETER)
+                                .filters(
+                                        filter -> filter.filter(
+                                                        new RequestParameterToCookieGatewayFilterFactory()
+                                                                .apply(
+                                                                        new Config(
+                                                                            IDENTIFIER_PARAMETER,
+                                                                                "Patient-Action"
+                                                                        )
+                                                                )
+                                                )
+                                                .filter(defaultFilter)
+                                                .filter(classicFilter)
+                                )
+                                .uri(service.uri())
+                )
+                .build();
+    }
+
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfigurationTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.nbs.gateway.patient.profile.events.observation;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.containsString;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "nbs.gateway.classic=http://localhost:10000",
+                "nbs.gateway.patient.profile.enabled=true"
+        }
+)
+class ViewObservationRouteLocatorConfigurationTest {
+
+    @RegisterExtension
+    static WireMockExtension classic = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(10000))
+            .build();
+
+    @Autowired
+    WebTestClient webClient;
+
+    @Test
+    void should_add_Patient_Action_cookie_when_viewing_a_morbidity_observation() {
+
+        classic.stubFor(get(urlPathMatching("/nbs/NewLabReview1.do\\\\?.*")).willReturn(ok()));
+
+        webClient
+                .get().uri(
+                        builder -> builder
+                                .path("/nbs/NewLabReview1.do")
+                                .queryParam("ContextAction", "ViewMorb")
+                                .queryParam("observationUID", "7841")
+                                .build()
+                )
+                .exchange()
+                .expectHeader()
+                .value("Set-Cookie", containsString("Patient-Action=7841"));
+
+    }
+
+    @Test
+    void should_add_Patient_Action_cookie_when_viewing_a_lab_report_observation() {
+
+        classic.stubFor(get(urlPathMatching("/nbs/NewLabReview1.do\\\\?.*")).willReturn(ok()));
+
+        webClient
+            .get().uri(
+                builder -> builder
+                    .path("/nbs/NewLabReview1.do")
+                    .queryParam("ContextAction", "ViewLab")
+                    .queryParam("observationUID", "7841")
+                    .build()
+            )
+            .exchange()
+            .expectHeader()
+            .value("Set-Cookie", containsString("Patient-Action=7841"));
+
+    }
+}


### PR DESCRIPTION
## Description

Adds Patient-Action cookie when observations are navigated to from documents requiring review

## Tickets

* [CNFT1-1667](https://cdc-nbs.atlassian.net/browse/CNFT1-1667)

## Steps to verify

1. Build the `nbs-gateway` container using `docker compose up -d --build nbs-gateway`
2. Create a new Patient or Search for an existing Patient
3. On the Events tab of the Patient Profile click Add morbidity report
4. Fill out the required fields and click submit
5. Once you have been routed back to the Patient Profile click the Home link
6. From My Queues click Documents Requiring Review
7. Search for the Morbidity Report created for the Patient, click the Morbidity Report link
8. On the View Morbidity Report page click View File
9. Ensure that the correct Patient Profile is displayed

[CNFT1-1667]: https://cdc-nbs.atlassian.net/browse/CNFT1-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ