### PR TITLE
init

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.spec.tsx
@@ -56,11 +56,16 @@ afterEach(() => {
 describe('QuickConditionLookup', () => {
     it('should render successfully', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
 
         const { baseElement } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -72,10 +77,16 @@ describe('QuickConditionLookup', () => {
 
     it('should fetch  the conditions when mounted', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { container } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -87,10 +98,16 @@ describe('QuickConditionLookup', () => {
 
     it('has the correct title', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { getByText } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -104,10 +121,16 @@ describe('QuickConditionLookup', () => {
 
     it('has a search bar', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { container } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -121,10 +144,16 @@ describe('QuickConditionLookup', () => {
 
     it('has a search button', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { container } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -138,10 +167,16 @@ describe('QuickConditionLookup', () => {
 
     it('should display the correct table headers', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { container } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -165,10 +200,16 @@ describe('QuickConditionLookup', () => {
 
     it('should display the correct table data', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const {} = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -190,10 +231,16 @@ describe('QuickConditionLookup', () => {
 
     it('should have a cancel button', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { getByTestId } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -207,10 +254,16 @@ describe('QuickConditionLookup', () => {
 
     it('should have an add condition button', async () => {
         const modal = { current: null };
+        const createConditionModal = { current: null };
+
         const { getByTestId } = render(
             <BrowserRouter>
                 <PagesContext.Provider value={pageContext}>
-                    <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                    <QuickConditionLookup
+                        modal={modal}
+                        addConditions={addConditions}
+                        createConditionModal={createConditionModal}
+                    />
                 </PagesContext.Provider>
             </BrowserRouter>
         );
@@ -225,10 +278,16 @@ describe('QuickConditionLookup', () => {
     describe('when the cancel button is clicked', () => {
         it('should close the modal', async () => {
             const modal: React.RefObject<ModalRef> = { current: null };
+            const createConditionModal = { current: null };
+
             const { getByTestId } = render(
                 <BrowserRouter>
                     <PagesContext.Provider value={pageContext}>
-                        <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                        <QuickConditionLookup
+                            modal={modal}
+                            addConditions={addConditions}
+                            createConditionModal={createConditionModal}
+                        />
                     </PagesContext.Provider>
                 </BrowserRouter>
             );
@@ -247,10 +306,16 @@ describe('QuickConditionLookup', () => {
     describe('when the search button is clicked', () => {
         it('should search for the condition', async () => {
             const modal = { current: null };
+            const createConditionModal = { current: null };
+
             const { getByTestId } = render(
                 <BrowserRouter>
                     <PagesContext.Provider value={pageContext}>
-                        <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                        <QuickConditionLookup
+                            modal={modal}
+                            addConditions={addConditions}
+                            createConditionModal={createConditionModal}
+                        />
                     </PagesContext.Provider>
                 </BrowserRouter>
             );
@@ -267,10 +332,16 @@ describe('QuickConditionLookup', () => {
 
         it('should call the searchConditionUsingPost with the correct parameters', async () => {
             const modal = { current: null };
+            const createConditionModal = { current: null };
+
             const { container, getByTestId } = render(
                 <BrowserRouter>
                     <PagesContext.Provider value={pageContext}>
-                        <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                        <QuickConditionLookup
+                            modal={modal}
+                            addConditions={addConditions}
+                            createConditionModal={createConditionModal}
+                        />
                     </PagesContext.Provider>
                 </BrowserRouter>
             );
@@ -304,10 +375,16 @@ describe('QuickConditionLookup', () => {
     describe('when the add button is clicked', () => {
         it('should add the selected conditions', async () => {
             const modal = { current: null };
+            const createConditionModal = { current: null };
+
             const { getByTestId } = render(
                 <BrowserRouter>
                     <PagesContext.Provider value={pageContext}>
-                        <QuickConditionLookup modal={modal} addConditions={addConditions} />
+                        <QuickConditionLookup
+                            modal={modal}
+                            addConditions={addConditions}
+                            createConditionModal={createConditionModal}
+                        />
                     </PagesContext.Provider>
                 </BrowserRouter>
             );

--- a/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/QuickConditionLookup/QuickConditionLookup.tsx
@@ -19,6 +19,7 @@ import { ConditionsContext } from 'apps/page-builder/context/ConditionsContext';
 
 type Props = {
     modal: RefObject<ModalRef>;
+    createConditionModal: RefObject<ModalRef>;
     addConditions: (conditions: string[]) => void;
 };
 
@@ -31,7 +32,7 @@ const tableHeaders = [
     { name: 'Status', sortable: true }
 ];
 
-export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
+export const QuickConditionLookup = ({ modal, addConditions, createConditionModal }: Props) => {
     const [conditions, setConditions] = useState<Condition[]>([]);
     const [selectedConditions, setSelectedConditions] = useState<string[]>([]);
     const [searchText, setSearchTerm] = useState('');
@@ -166,9 +167,8 @@ export const QuickConditionLookup = ({ modal, addConditions }: Props) => {
                         </Button>
                     </div>
                     <ModalToggleButton
-                        modalRef={modal}
-                        closer
-                        onClick={handleAddConditions}
+                        modalRef={createConditionModal}
+                        onClick={() => modal.current?.toggleModal(undefined, false)}
                         data-testid="condition-add-btn">
                         Create new condition
                     </ModalToggleButton>

--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.tsx
@@ -194,7 +194,11 @@ export const AddNewPage = () => {
             <Modal id="import-template-modal" isLarge ref={importTemplateModal}>
                 <ImportTemplate modal={importTemplateModal} onTemplateCreated={handleTemplateImported} />
             </Modal>
-            <QuickConditionLookup modal={conditionLookupModal} addConditions={handleAddConditions} />
+            <QuickConditionLookup
+                modal={conditionLookupModal}
+                addConditions={handleAddConditions}
+                createConditionModal={createConditionModal}
+            />
         </div>
     );
 };


### PR DESCRIPTION
## Description

On the quick condition lookup modal, when a user clicks the "Create new condition" button, the quick condition modal closes and the create condition modal opens.  

Only had to pass a callback prop that opens the new modal, and sets the current modal to undefined which closes the current modal
"

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1519)

## Steps to verify

1. Navigate to /page-builder/manage/pages
2. Click the "Create new page" button.
3. Select "investigation" from the dropdown.
4. Click "Search for condition(s)".
5. In the conditions search modal, click "Create new condition".
6. Verify the conditions search modal is closed.
7. Verify the "Create Condition" modal has opened.
