### PR TITLE
[Workflow] Release canidate containers build and deploymeny preparation

### DIFF
--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -3,15 +3,30 @@ on:
   workflow_dispatch:
     inputs: 
         environment:
+          description: 'The environment to tag the resulting images to.  The resulting container would be tagged as <application-name>:<application-version>-<environment>.<githubsha>'
           type: choice
           required: true
+          default: 'TEST'
           options:
           - TEST
         values:
+          description: 'The name of the Helm chart values file to update with the resulting tag name.'
           type: choice
           required: true
+          default: 'test2'
           options:
-          - test2          
+          - test2
+        build-elasticsearch:
+          description: 'Release a new ElasticSearch Container?'
+          required: true
+          type: boolean
+          default: false    
+        build-nifi:
+          description: 'Release a new NiFi Container?'
+          required: true
+          type: boolean
+          default: false            
+
 jobs:
   build-nbs-gateway-release-candidate:
     name: Build NBS Gateway Release Candidate
@@ -66,6 +81,7 @@ jobs:
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
   build-elasticsearch-release-candidate:
+    if: ${{ inputs.build-elasticsearch == 'true' }}
     name: Build Elasticsearch Release Candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
     with:
@@ -92,6 +108,7 @@ jobs:
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
   build-nifi-release-candidate:
+    if: ${{ inputs.build-nifi == 'true' }}
     name: Build NiFi Release Candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
     with:

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -87,7 +87,7 @@ jobs:
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: elasticsearch
-      values_file_with_path: charts/elasticsearch/values_${{inputs.environment}}.yaml
+      values_file_with_path: charts/elasticsearch-efs/values_${{inputs.environment}}.yaml
       new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
     secrets:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
@@ -113,7 +113,7 @@ jobs:
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: nifi
-      values_file_with_path: charts/nifi/values_${{inputs.environment}}.yaml
+      values_file_with_path: charts/nifi-efs/values_${{inputs.environment}}.yaml
       new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
     secrets:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -15,7 +15,7 @@ on:
 
 
 jobs:
-  call-build-microservice-container-workflow:
+  build-nbs-gateway-release-candidate:
     name: Build NBS Gateway Release Candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
     with:
@@ -29,7 +29,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  call-update-helm:
+  prepare-nbs-gateway-release-candidate:
     name: Prepare NBS Gateway Release Candidate Deployment
     needs: call-build-microservice-container-workflow
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
@@ -41,7 +41,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  call-build-microservice-container-workflow:
+  build-modernization-api-release-candidate:
     name: Build Modernization API Release Candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
     with:
@@ -55,7 +55,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  call-update-helm:
+  prepare-modernization-api-release-candidate:
     name: Prepare Modernization API Candidate Deployment
     needs: call-build-microservice-container-workflow
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
@@ -67,7 +67,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
-  call-build-microservice-container-workflow:
+  build-elasticsearch-release-candidate:
     name: Build Elasticsearch Release Candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
     with:
@@ -81,7 +81,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  call-update-helm:
+  prepare-elasticsearch-release-candidate:
     name: Prepare Elasticsearch Release Candidate Deployment
     needs: call-build-microservice-container-workflow
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
@@ -93,7 +93,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
-  call-build-microservice-container-workflow:
+  build-nifi-release-candidate:
     name: Build NiFi Release Candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
     with:
@@ -107,7 +107,7 @@ jobs:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
       GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  call-update-helm:
+  prepare-nifi-release-candidate:
     name: Prepare NiFi Release Candidate Deployment
     needs: call-build-microservice-container-workflow
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -13,114 +13,107 @@ on:
           options:
           - test2          
 jobs:
-  nbs-gateway-release-candidate:
-    runs-on: ubuntu-latest
-    name: NBS Gateway Release Candidate
-    steps:
-      - name: Build NBS Gateway Release Candidate
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-        with:
-          microservice_name: nbs-gateway
-          build-new-container: true
-          dockerfile_relative_path: -f ./apps/nbs-gateway/Dockerfile .
-          environment_classifier: ${{inputs.environment}}
-        secrets:
-          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-      - name: Prepare NBS Gateway Release Candidate Deployment
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-        with:
-          microservice_name: nbs-gateway
-          values_file_with_path: charts/nbs-gateway/values_${{input.values}}.yaml
-          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-        secrets:
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-
-  modernization-api-release-candidate:
-    runs-on: ubuntu-latest
-    name: Modernization API Release Candidate
-    steps:
-      - name: Build Modernization API Release Candidate
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-        with:
-          microservice_name: modernization-api
-          build-new-container: true
-          dockerfile_relative_path: -f ./apps/modernization-api/Dockerfile .
-          environment_classifier: ${{inputs.environment}}
-        secrets:
-          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-      - name: Prepare Modernization API Candidate Deployment
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-        with:
-          microservice_name: modernization-api
-          values_file_with_path: charts/modernization-api/values_${{input.values}}.yaml
-          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-        secrets:
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-
-  elasticsearch-release-candidate:
-    runs-on: ubuntu-latest
-    name: Elasticsearch Release Candidate
-    steps:
-      - name: Build Elasticsearch Release Candidate
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-        with:
-          microservice_name: elasticsearch
-          build-new-container: true
-          dockerfile_relative_path: -f ./cdc-sandbox/elasticsearch/Dockerfile .
-          environment_classifier: ${{inputs.environment}}
-        secrets:
-          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-      - name: Prepare Elasticsearch Release Candidate Deployment
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-        with:
-          microservice_name: elasticsearch
-          values_file_with_path: charts/elasticsearch-efs/values_${{input.values}}.yaml
-          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-        secrets:
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-
-  nifi-release-candidate:
-    runs-on: ubuntu-latest
-    name: NiFi Release Candidate
-    steps:
-      - name: Build NiFi Release Candidate
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-        with:
-          microservice_name: nifi
-          build-new-container: true
-          dockerfile_relative_path: -f ./cdc-sandbox/nifi/Dockerfile .
-          environment_classifier: ${{inputs.environment}}
-        secrets:
-          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-      - name: Prepare NiFi Release Candidate Deployment
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-        with:
-          microservice_name: nifi
-          values_file_with_path: charts/nifi/values_${{input.values}}.yaml
-          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-        secrets:
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}       
+  build-nbs-gateway-release-candidate:
+    name: Build NBS Gateway Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: nbs-gateway    
+      build-new-container: true
+      dockerfile_relative_path: -f ./apps/nbs-gateway/Dockerfile .
+      environment_classifier: ${{inputs.environment}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  prepare-nbs-gateway-release-candidate:
+    name: Prepare NBS Gateway Release Candidate Deployment
+    needs: build-nbs-gateway-release-candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: nbs-gateway
+      values_file_with_path: charts/nbs-gateway/values_${{inputs.values}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  build-modernization-api-release-candidate:
+    name: Build Modernization API Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: modernization-api    
+      build-new-container: true
+      dockerfile_relative_path: -f ./apps/modernization-api/Dockerfile .
+      environment_classifier: ${{inputs.environment}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  prepare-modernization-api-release-candidate:
+    name: Prepare Modernization API Candidate Deployment
+    needs: build-modernization-api-release-candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: modernization-api
+      values_file_with_path: charts/modernization-api/values_${{inputs.values}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
+  build-elasticsearch-release-candidate:
+    name: Build Elasticsearch Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: elasticsearch    
+      build-new-container: true
+      dockerfile_relative_path: -f ./cdc-sandbox/elasticsearch/Dockerfile .
+      environment_classifier: ${{inputs.environment}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  prepare-elasticsearch-release-candidate:
+    name: Prepare Elasticsearch Release Candidate Deployment
+    needs: build-elasticsearch-release-candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: elasticsearch
+      values_file_with_path: charts/elasticsearch-efs/values_${{inputs.values}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
+  build-nifi-release-candidate:
+    name: Build NiFi Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: nifi    
+      build-new-container: true
+      dockerfile_relative_path: -f ./cdc-sandbox/nifi/Dockerfile .
+      environment_classifier: ${{inputs.environment}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  prepare-nifi-release-candidate:
+    name: Prepare NiFi Release Candidate Deployment
+    needs: build-nifi-release-candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: nifi
+      values_file_with_path: charts/nifi-efs/values_${{inputs.values}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}       

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -1,123 +1,124 @@
 name: Release Candidate Container Build and Deployment Preparation
 on:
   workflow_dispatch:
-
-env:
-  environment: TEST
-  values: test2
-
+    inputs: 
+        environment:
+          type: choice
+          required: true
+          options:
+          - TEST
+        values:
+          type: choice
+          required: true
+          options:
+          - test2          
 jobs:
   nbs-gateway-release-candidate:
+    runs-on: ubuntu-latest
     name: NBS Gateway Release Candidate
-    env:
-      name: nbs-gateway
-      chart: nbs-gateway
-    steps:    
+    steps:
       - name: Build NBS Gateway Release Candidate
         uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
         with:
-          microservice_name: ${{env.name}}   
+          microservice_name: nbs-gateway
           build-new-container: true
-          dockerfile_relative_path: -f ./apps/${{env.name}}/Dockerfile .
-          environment_classifier: ${{env.environment}}
+          dockerfile_relative_path: -f ./apps/nbs-gateway/Dockerfile .
+          environment_classifier: ${{inputs.environment}}
         secrets:
           CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
           ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
           GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
           GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}    
-      - name: Prepare NBS Gateway Release Candidate Deployment      
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+      - name: Prepare NBS Gateway Release Candidate Deployment
         uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
         with:
-          microservice_name: ${{env.name}}
-          values_file_with_path: charts/${{env.chart}}/values_${{env.values}}.yaml
+          microservice_name: nbs-gateway
+          values_file_with_path: charts/nbs-gateway/values_${{input.values}}.yaml
           new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
         secrets:
           GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
           GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
           HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+
   modernization-api-release-candidate:
+    runs-on: ubuntu-latest
     name: Modernization API Release Candidate
-    env:
-      name: modernization-api
-      chart: modernization-api
     steps:
       - name: Build Modernization API Release Candidate
         uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
         with:
-          microservice_name: ${{env.name}} 
+          microservice_name: modernization-api
           build-new-container: true
-          dockerfile_relative_path: -f ./apps/${{env.name}}/Dockerfile .
-          environment_classifier: ${{env.environment}}
+          dockerfile_relative_path: -f ./apps/modernization-api/Dockerfile .
+          environment_classifier: ${{inputs.environment}}
         secrets:
           CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
           ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
           GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
           GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
           HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-    - name: Prepare Modernization API Candidate Deployment      
-      uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-      with:
-        microservice_name: ${{env.name}}
-        values_file_with_path: charts/${{env.chart}}/values_${{env.values}}.yaml
-        new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-      secrets:
-        GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-        GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-        HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
-  elasticsearch-release-candidate:
-    name: Elasticsearch Release Candidate
-    env:
-      name: elasticsearch
-      chart: elasticsearch-efs
-    steps:
-      - name: Build Elasticsearch Release Candidate
-        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-        with:
-          microservice_name: ${{env.name}}    
-          build-new-container: true
-          dockerfile_relative_path: -f ./cdc-sandbox/${{env.name}}/Dockerfile .
-          environment_classifier: ${{env.environment}}
-        secrets:
-          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-      - name: Prepare Elasticsearch Release Candidate Deployment        
+      - name: Prepare Modernization API Candidate Deployment
         uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
         with:
-          microservice_name: ${{env.name}}
-          values_file_with_path: charts/${{env.chart}}/values_${{env.values}}.yaml
+          microservice_name: modernization-api
+          values_file_with_path: charts/modernization-api/values_${{input.values}}.yaml
           new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
         secrets:
           GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
           GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-          HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
-  nifi-release-candidate:
-    name: NiFi Release Candidate
-    env:
-      name: nifi
-      chart: nifi-efs    
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+
+  elasticsearch-release-candidate:
+    runs-on: ubuntu-latest
+    name: Elasticsearch Release Candidate
     steps:
-      - name: Build NiFi Release Candidate
+      - name: Build Elasticsearch Release Candidate
         uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
         with:
-          microservice_name: ${{env.name}}
+          microservice_name: elasticsearch
           build-new-container: true
-          dockerfile_relative_path: -f ./cdc-sandbox/${{env.name}}/Dockerfile .
-          environment_classifier: ${{env.environment}}
+          dockerfile_relative_path: -f ./cdc-sandbox/elasticsearch/Dockerfile .
+          environment_classifier: ${{inputs.environment}}
         secrets:
           CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
           ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
           GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
           GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
           HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-      - name: Prepare NiFi Release Candidate Deployment        
+      - name: Prepare Elasticsearch Release Candidate Deployment
         uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
         with:
-          microservice_name: ${{env.name}}
-          values_file_with_path: charts/${{env.chart}}}/values_${{env.values}}.yaml
+          microservice_name: elasticsearch
+          values_file_with_path: charts/elasticsearch-efs/values_${{input.values}}.yaml
+          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+        secrets:
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+
+  nifi-release-candidate:
+    runs-on: ubuntu-latest
+    name: NiFi Release Candidate
+    steps:
+      - name: Build NiFi Release Candidate
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+        with:
+          microservice_name: nifi
+          build-new-container: true
+          dockerfile_relative_path: -f ./cdc-sandbox/nifi/Dockerfile .
+          environment_classifier: ${{inputs.environment}}
+        secrets:
+          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+      - name: Prepare NiFi Release Candidate Deployment
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+        with:
+          microservice_name: nifi
+          values_file_with_path: charts/nifi/values_${{input.values}}.yaml
           new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
         secrets:
           GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -6,7 +6,7 @@ on:
           description: Metadata to append to application version (A setting of NONE, indicates all metadata to be stripped). Ex. if version=1.0.0, and classifier=SNAPSHOT result will be 1.0.0-SNAPSHOT.<githubsha>. If version=1.0.0, and classifier=NONE result will be 1.0.0.
           required: true
           type: string
-          default: NONE
+          default: release-7.<minor>.<patch>
         environment:
           type: choice
           required: true
@@ -31,7 +31,7 @@ jobs:
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
   prepare-nbs-gateway-release-candidate:
     name: Prepare NBS Gateway Release Candidate Deployment
-    needs: call-build-microservice-container-workflow
+    needs: build-nbs-gateway-release-candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: nbs-gateway
@@ -57,7 +57,7 @@ jobs:
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
   prepare-modernization-api-release-candidate:
     name: Prepare Modernization API Candidate Deployment
-    needs: call-build-microservice-container-workflow
+    needs: build-modernization-api-release-candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: modernization-api
@@ -83,7 +83,7 @@ jobs:
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
   prepare-elasticsearch-release-candidate:
     name: Prepare Elasticsearch Release Candidate Deployment
-    needs: call-build-microservice-container-workflow
+    needs: build-elasticsearch-release-candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: elasticsearch
@@ -109,7 +109,7 @@ jobs:
       HELM_TOKEN: ${{secrets.HELM_TOKEN}}
   prepare-nifi-release-candidate:
     name: Prepare NiFi Release Candidate Deployment
-    needs: call-build-microservice-container-workflow
+    needs: build-nifi-release-candidate
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: nifi

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -1,121 +1,125 @@
 name: Release Candidate Container Build and Deployment Preparation
 on:
   workflow_dispatch:
-    inputs: 
-        classifier:
-          description: Metadata to append to application version (A setting of NONE, indicates all metadata to be stripped). Ex. if version=1.0.0, and classifier=SNAPSHOT result will be 1.0.0-SNAPSHOT.<githubsha>. If version=1.0.0, and classifier=NONE result will be 1.0.0.
-          required: true
-          type: string
-          default: release-7.<minor>.<patch>
-        environment:
-          type: choice
-          required: true
-          options:
-          - test2
 
+env:
+  environment: TEST
+  values: test2
 
 jobs:
-  build-nbs-gateway-release-candidate:
-    name: Build NBS Gateway Release Candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nbs-gateway    
-      build-new-container: true
-      dockerfile_relative_path: -f ./apps/nbs-gateway/Dockerfile .
-      environment_classifier: ${{inputs.classifier}}
-    secrets:
-      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  prepare-nbs-gateway-release-candidate:
-    name: Prepare NBS Gateway Release Candidate Deployment
-    needs: build-nbs-gateway-release-candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-    with:
-      microservice_name: nbs-gateway
-      values_file_with_path: charts/nbs-gateway/values_${{inputs.environment}}.yaml
-      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-    secrets:
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  build-modernization-api-release-candidate:
-    name: Build Modernization API Release Candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: modernization-api    
-      build-new-container: true
-      dockerfile_relative_path: -f ./apps/modernization-api/Dockerfile .
-      environment_classifier: ${{inputs.classifier}}
-    secrets:
-      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  prepare-modernization-api-release-candidate:
-    name: Prepare Modernization API Candidate Deployment
-    needs: build-modernization-api-release-candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-    with:
-      microservice_name: modernization-api
-      values_file_with_path: charts/modernization-api/values_${{inputs.environment}}.yaml
-      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-    secrets:
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
-  build-elasticsearch-release-candidate:
-    name: Build Elasticsearch Release Candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: elasticsearch    
-      build-new-container: true
-      dockerfile_relative_path: -f ./cdc-sandbox/elasticsearch/Dockerfile .
-      environment_classifier: ${{inputs.classifier}}
-    secrets:
-      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  prepare-elasticsearch-release-candidate:
-    name: Prepare Elasticsearch Release Candidate Deployment
-    needs: build-elasticsearch-release-candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-    with:
-      microservice_name: elasticsearch
-      values_file_with_path: charts/elasticsearch-efs/values_${{inputs.environment}}.yaml
-      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-    secrets:
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
-  build-nifi-release-candidate:
-    name: Build NiFi Release Candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nifi    
-      build-new-container: true
-      dockerfile_relative_path: -f ./cdc-sandbox/nifi/Dockerfile .
-      environment_classifier: ${{inputs.classifier}}
-    secrets:
-      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
-      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
-  prepare-nifi-release-candidate:
-    name: Prepare NiFi Release Candidate Deployment
-    needs: build-nifi-release-candidate
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
-    with:
-      microservice_name: nifi
-      values_file_with_path: charts/nifi-efs/values_${{inputs.environment}}.yaml
-      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
-    secrets:
-      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
-      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
-      HELM_TOKEN: ${{secrets.HELM_TOKEN}}       
+  nbs-gateway-release-candidate:
+    name: NBS Gateway Release Candidate
+    env:
+      name: nbs-gateway
+      chart: nbs-gateway
+    steps:    
+      - name: Build NBS Gateway Release Candidate
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+        with:
+          microservice_name: ${{env.name}}   
+          build-new-container: true
+          dockerfile_relative_path: -f ./apps/${{env.name}}/Dockerfile .
+          environment_classifier: ${{env.environment}}
+        secrets:
+          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}    
+      - name: Prepare NBS Gateway Release Candidate Deployment      
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+        with:
+          microservice_name: ${{env.name}}
+          values_file_with_path: charts/${{env.chart}}/values_${{env.values}}.yaml
+          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+        secrets:
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  modernization-api-release-candidate:
+    name: Modernization API Release Candidate
+    env:
+      name: modernization-api
+      chart: modernization-api
+    steps:
+      - name: Build Modernization API Release Candidate
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+        with:
+          microservice_name: ${{env.name}} 
+          build-new-container: true
+          dockerfile_relative_path: -f ./apps/${{env.name}}/Dockerfile .
+          environment_classifier: ${{env.environment}}
+        secrets:
+          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+    - name: Prepare Modernization API Candidate Deployment      
+      uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+      with:
+        microservice_name: ${{env.name}}
+        values_file_with_path: charts/${{env.chart}}/values_${{env.values}}.yaml
+        new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+      secrets:
+        GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+        GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+        HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
+  elasticsearch-release-candidate:
+    name: Elasticsearch Release Candidate
+    env:
+      name: elasticsearch
+      chart: elasticsearch-efs
+    steps:
+      - name: Build Elasticsearch Release Candidate
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+        with:
+          microservice_name: ${{env.name}}    
+          build-new-container: true
+          dockerfile_relative_path: -f ./cdc-sandbox/${{env.name}}/Dockerfile .
+          environment_classifier: ${{env.environment}}
+        secrets:
+          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+      - name: Prepare Elasticsearch Release Candidate Deployment        
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+        with:
+          microservice_name: ${{env.name}}
+          values_file_with_path: charts/${{env.chart}}/values_${{env.values}}.yaml
+          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+        secrets:
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
+  nifi-release-candidate:
+    name: NiFi Release Candidate
+    env:
+      name: nifi
+      chart: nifi-efs    
+    steps:
+      - name: Build NiFi Release Candidate
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+        with:
+          microservice_name: ${{env.name}}
+          build-new-container: true
+          dockerfile_relative_path: -f ./cdc-sandbox/${{env.name}}/Dockerfile .
+          environment_classifier: ${{env.environment}}
+        secrets:
+          CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+          ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+      - name: Prepare NiFi Release Candidate Deployment        
+        uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+        with:
+          microservice_name: ${{env.name}}
+          values_file_with_path: charts/${{env.chart}}}/values_${{env.values}}.yaml
+          new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+        secrets:
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+          HELM_TOKEN: ${{secrets.HELM_TOKEN}}       

--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -1,0 +1,121 @@
+name: Release Candidate Container Build and Deployment Preparation
+on:
+  workflow_dispatch:
+    inputs: 
+        classifier:
+          description: Metadata to append to application version (A setting of NONE, indicates all metadata to be stripped). Ex. if version=1.0.0, and classifier=SNAPSHOT result will be 1.0.0-SNAPSHOT.<githubsha>. If version=1.0.0, and classifier=NONE result will be 1.0.0.
+          required: true
+          type: string
+          default: NONE
+        environment:
+          type: choice
+          required: true
+          options:
+          - test2
+
+
+jobs:
+  call-build-microservice-container-workflow:
+    name: Build NBS Gateway Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: nbs-gateway    
+      build-new-container: true
+      dockerfile_relative_path: -f ./apps/nbs-gateway/Dockerfile .
+      environment_classifier: ${{inputs.classifier}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  call-update-helm:
+    name: Prepare NBS Gateway Release Candidate Deployment
+    needs: call-build-microservice-container-workflow
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: nbs-gateway
+      values_file_with_path: charts/nbs-gateway/values_${{inputs.environment}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  call-build-microservice-container-workflow:
+    name: Build Modernization API Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: modernization-api    
+      build-new-container: true
+      dockerfile_relative_path: -f ./apps/modernization-api/Dockerfile .
+      environment_classifier: ${{inputs.classifier}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  call-update-helm:
+    name: Prepare Modernization API Candidate Deployment
+    needs: call-build-microservice-container-workflow
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: modernization-api
+      values_file_with_path: charts/modernization-api/values_${{inputs.environment}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}      
+  call-build-microservice-container-workflow:
+    name: Build Elasticsearch Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: elasticsearch    
+      build-new-container: true
+      dockerfile_relative_path: -f ./cdc-sandbox/elasticsearch/Dockerfile .
+      environment_classifier: ${{inputs.classifier}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  call-update-helm:
+    name: Prepare Elasticsearch Release Candidate Deployment
+    needs: call-build-microservice-container-workflow
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: elasticsearch
+      values_file_with_path: charts/elasticsearch/values_${{inputs.environment}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}        
+  call-build-microservice-container-workflow:
+    name: Build NiFi Release Candidate
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Release-gradle-microservice-container.yaml@main
+    with:
+      microservice_name: nifi    
+      build-new-container: true
+      dockerfile_relative_path: -f ./cdc-sandbox/nifi/Dockerfile .
+      environment_classifier: ${{inputs.classifier}}
+    secrets:
+      CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
+      ECR_REPO_BASE_NAME: ${{secrets.ECR_REPO_BASE_NAME}}
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}
+  call-update-helm:
+    name: Prepare NiFi Release Candidate Deployment
+    needs: call-build-microservice-container-workflow
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
+    with:
+      microservice_name: nifi
+      values_file_with_path: charts/nifi/values_${{inputs.environment}}.yaml
+      new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
+    secrets:
+      GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+      GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
+      HELM_TOKEN: ${{secrets.HELM_TOKEN}}       

--- a/.github/workflows/Release-container.yaml
+++ b/.github/workflows/Release-container.yaml
@@ -1,4 +1,4 @@
-name: Release container
+name: Container Build and Deployment Preparation
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Release-container.yaml
+++ b/.github/workflows/Release-container.yaml
@@ -1,4 +1,4 @@
-name: Release modernization-api image
+name: Release container
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
An attempt at automating the creation of the individual containers that make up a release candidate for the NBS Modernization.  This workflow is meant to automate the tedious steps of building/tagging each release candidate container.

Includes the container build and helm chart update for each application that is part of the release candidate.

- NBS Gateway
- Modernization API
- Elasticsearch
- Nifi

Limits the environment selection to just TEST (test2) for now.
