### PR TITLE
Changes that are related to group/ungroup subsection

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaUiMetadata.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaUiMetadata.java
@@ -18,6 +18,7 @@ import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand.UpdateSection;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand.UpdateSubsection;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand.UpdateTab;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.GroupSubSectionRequest;
 import gov.cdc.nbs.questionbank.page.exception.AddQuestionException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -522,6 +523,33 @@ public class WaUiMetadata {
 
   private void setVisible(boolean visible) {
     this.displayInd = visible ? "T" : "F";
+  }
+
+  public void update(PageContentCommand.GroupSubsection command) {
+    setBlockNm(command.blockName());
+    updated(command);
+  }
+
+  public void updateQuestionBatch(PageContentCommand.GroupSubsection command) {
+    setBlockNm(command.blockName());
+    GroupSubSectionRequest.Batch batch = command.batches().stream().filter(b -> b.id() == this.id).findFirst().get();
+    setBatchTableAppearIndCd(batch.batchTableAppearIndCd());
+    setBatchTableHeader(batch.batchTableHeader());
+    setBatchTableColumnWidth(batch.batchTableColumnWidth());
+    updated(command);
+  }
+
+  public void update(PageContentCommand.UnGroupSubsection command) {
+    setBlockNm(null);
+    updated(command);
+  }
+
+  public void updateQuestionBatch(PageContentCommand.UnGroupSubsection command) {
+    setBlockNm(null);
+    setBatchTableAppearIndCd(null);
+    setBatchTableHeader(null);
+    setBatchTableColumnWidth(null);
+    updated(command);
   }
 
   @Override

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/command/PageContentCommand.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/command/PageContentCommand.java
@@ -1,10 +1,12 @@
 package gov.cdc.nbs.questionbank.page.command;
 
 import java.time.Instant;
+import java.util.List;
 
 
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.entity.question.WaQuestion;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.GroupSubSectionRequest;
 
 public sealed interface PageContentCommand {
         long userId();
@@ -129,4 +131,21 @@ public sealed interface PageContentCommand {
                         Instant requestedOn) implements PageContentCommand {
 
         }
+
+        public record GroupSubsection(
+                long subsection,
+                String blockName,
+                List<GroupSubSectionRequest.Batch> batches,
+                long userId,
+                Instant requestedOn) implements PageContentCommand {
+        }
+
+        public record UnGroupSubsection(
+                long subsection,
+                List<Long> batches,
+                long userId,
+                Instant requestedOn) implements PageContentCommand {
+        }
+
+
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionController.java
@@ -1,6 +1,9 @@
 package gov.cdc.nbs.questionbank.page.content.subsection;
 
 
+import gov.cdc.nbs.questionbank.page.content.subsection.request.GroupSubSectionRequest;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.UnGroupSubSectionRequest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,14 +28,18 @@ public class SubSectionController {
     private final SubSectionCreator creator;
     private final SubSectionUpdater updater;
     private final SubSectionDeleter deleter;
+    private final SubSectionGrouper grouper;
 
     public SubSectionController(
             final SubSectionCreator createSubSectionService,
             final SubSectionDeleter deleter,
-            final SubSectionUpdater updater) {
+            final SubSectionUpdater updater,
+            final SubSectionGrouper grouper) {
+
         this.deleter = deleter;
         this.updater = updater;
         this.creator = createSubSectionService;
+        this.grouper = grouper;
     }
 
     @PostMapping
@@ -60,5 +67,22 @@ public class SubSectionController {
             @ApiIgnore @AuthenticationPrincipal final NbsUserDetails details) {
         return updater.update(page, subSectionId, request, details.getId());
     }
+
+    @PostMapping("/group")
+    public ResponseEntity<String> groupSubSection(
+            @PathVariable("page") Long page,
+            @RequestBody GroupSubSectionRequest request,
+            @ApiIgnore @AuthenticationPrincipal final NbsUserDetails details) {
+        return grouper.group(page, request, details.getId());
+    }
+
+    @PostMapping("/un-group")
+    public ResponseEntity<String> unGroupSubSection(
+            @PathVariable("page") Long page,
+            @RequestBody UnGroupSubSectionRequest request,
+            @ApiIgnore @AuthenticationPrincipal final NbsUserDetails details) {
+        return grouper.unGroup(page, request, details.getId());
+    }
+
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionGrouper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionGrouper.java
@@ -1,0 +1,81 @@
+package gov.cdc.nbs.questionbank.page.content.subsection;
+
+import gov.cdc.nbs.questionbank.entity.WaTemplate;
+import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
+import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.subsection.exception.UpdateSubSectionException;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.GroupSubSectionRequest;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.UnGroupSubSectionRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.time.Instant;
+
+@Component
+@Transactional
+public class SubSectionGrouper {
+
+    private final EntityManager entityManager;
+
+    public SubSectionGrouper(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+
+    public ResponseEntity<String> group(Long pageId, GroupSubSectionRequest request, Long userId) {
+        if (request.blockName() == null) {
+            throw new UpdateSubSectionException("SubSection Block Name is required");
+        }
+        int totalPercentage = 0;
+        for (GroupSubSectionRequest.Batch b : request.batches()) {
+            if (b.batchTableColumnWidth() == 0) {
+                throw new UpdateSubSectionException("batchTableColumnWidth is required");
+            }
+            totalPercentage += b.batchTableColumnWidth();
+        }
+        if (totalPercentage != 100) {
+            throw new UpdateSubSectionException("the total of batchTableColumnWidth must calculate to 100");
+        }
+        WaTemplate page = entityManager.find(WaTemplate.class, pageId);
+        if (page == null) {
+            throw new UpdateSubSectionException("Unable to find page with id: " + pageId);
+        }
+        WaUiMetadata section = page.groupSubSection(asCommand(userId, request));
+        entityManager.flush();
+        return ResponseEntity.ok("Subsection " + section.getId() + " is  Grouped Successfully , Block Name is " + section.getBlockNm());
+    }
+
+    public ResponseEntity<String> unGroup(Long pageId, UnGroupSubSectionRequest request, Long userId) {
+        WaTemplate page = entityManager.find(WaTemplate.class, pageId);
+        if (page == null) {
+            throw new UpdateSubSectionException("Unable to find page with id: " + pageId);
+        }
+        WaUiMetadata section = page.unGroupSubSection(asCommand(userId, request));
+        entityManager.flush();
+        return ResponseEntity.ok("Subsection " + section.getId() + " is UnGrouped Successfully ");
+    }
+
+    private PageContentCommand.GroupSubsection asCommand(
+            Long userId,
+            GroupSubSectionRequest request) {
+        return new PageContentCommand.GroupSubsection(
+                request.id(),
+                request.blockName(),
+                request.batches(),
+                userId,
+                Instant.now());
+    }
+
+    private PageContentCommand.UnGroupSubsection asCommand(
+            Long userId,
+            UnGroupSubSectionRequest request) {
+        return new PageContentCommand.UnGroupSubsection(
+                request.id(),
+                request.batches(),
+                userId,
+                Instant.now());
+    }
+
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/request/GroupSubSectionRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/request/GroupSubSectionRequest.java
@@ -1,0 +1,9 @@
+package gov.cdc.nbs.questionbank.page.content.subsection.request;
+
+import java.util.List;
+
+public record GroupSubSectionRequest(long id, String blockName, List<Batch> batches) {
+    public record Batch(long id, char batchTableAppearIndCd, String batchTableHeader, int batchTableColumnWidth) {
+    }
+
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/request/UnGroupSubSectionRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/request/UnGroupSubSectionRequest.java
@@ -1,0 +1,6 @@
+package gov.cdc.nbs.questionbank.page.content.subsection.request;
+
+import java.util.List;
+
+public record UnGroupSubSectionRequest(long id,  List<Long> batches) {
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionControllerTest.java
@@ -1,0 +1,69 @@
+package gov.cdc.nbs.questionbank.page.content.subsection;
+
+import gov.cdc.nbs.authentication.NbsUserDetails;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.GroupSubSectionRequest;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.UnGroupSubSectionRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubSectionControllerTest {
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private SubSectionGrouper grouper;
+
+    @Mock
+    private NbsUserDetails details;
+
+    @InjectMocks
+    private SubSectionController controller;
+
+    @Test
+    void testGroupSubSection() {
+        List<GroupSubSectionRequest.Batch> batches = getValidBatchList();
+        long subSectionId = 100l;
+        String blockName = "BlockName";
+        GroupSubSectionRequest request = new GroupSubSectionRequest(subSectionId, blockName, batches);
+        when(grouper.group(any(), any(), any())).thenReturn(ResponseEntity.
+                ok("Subsection " + subSectionId + " is  Grouped Successfully , Block Name is " + blockName));
+        ResponseEntity<String> response = controller.groupSubSection(1L, request, details);
+        assertEquals("Subsection " + subSectionId + " is  Grouped Successfully , Block Name is " + blockName, response.getBody());
+        assertEquals(200, response.getStatusCodeValue());
+    }
+    List<GroupSubSectionRequest.Batch> getValidBatchList() {
+        List<GroupSubSectionRequest.Batch> batchList = new ArrayList<>();
+        batchList.add(new GroupSubSectionRequest.Batch(101l, 'Y', "header1", 25));
+        batchList.add(new GroupSubSectionRequest.Batch(102l, 'Y', "header2", 75));
+        return batchList;
+    }
+
+    @Test
+    void testUnGroupSubSection() {
+        List<Long> batches = Arrays.asList(101l,102l);
+        long subSectionId = 100l;
+        UnGroupSubSectionRequest request = new UnGroupSubSectionRequest(subSectionId, batches);
+        when(grouper.unGroup(any(), any(), any())).thenReturn(ResponseEntity.
+                ok("Subsection " + subSectionId + " is UnGrouped Successfully "));
+        ResponseEntity<String> response = controller.unGroupSubSection(1L, request, details);
+        assertEquals("Subsection " + subSectionId + " is UnGrouped Successfully ", response.getBody());
+        assertEquals(200, response.getStatusCodeValue());
+    }
+
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/subsection/SubsectionGrouperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/subsection/SubsectionGrouperTest.java
@@ -1,0 +1,250 @@
+package gov.cdc.nbs.questionbank.page.content.subsection;
+
+import gov.cdc.nbs.questionbank.entity.WaTemplate;
+import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
+import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.subsection.exception.UpdateSubSectionException;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.GroupSubSectionRequest;
+import gov.cdc.nbs.questionbank.page.content.subsection.request.UnGroupSubSectionRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubsectionGrouperTest {
+
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private SubSectionGrouper grouper;
+
+
+    @Test
+    void should_group_subsection() {
+        WaTemplate page = mock(WaTemplate.class);
+        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
+        doNothing().when(entityManager).flush();
+        WaUiMetadata waUiMetadata = new WaUiMetadata();
+        GroupSubSectionRequest request = new GroupSubSectionRequest(100l, "BLOCK_X", getValidBatchList());
+        waUiMetadata.setId(request.id());
+        waUiMetadata.setBlockNm(request.blockName());
+        when(page.groupSubSection(any())).thenReturn(waUiMetadata);
+        Long userId = 456L;
+        ResponseEntity<String> result = grouper.group(1l, request, userId);
+        assertEquals("Subsection " + request.id() + " is  Grouped Successfully , Block Name is " + request.blockName(), result.getBody());
+    }
+
+    @Test
+    void should_not_update_null_blockName() {
+        GroupSubSectionRequest request = new GroupSubSectionRequest(100l, null, getValidBatchList());
+        Long userId = 456L;
+        UpdateSubSectionException exception = assertThrows(UpdateSubSectionException.class, () -> grouper.group(1l, request, userId));
+        assertEquals("SubSection Block Name is required", exception.getMessage());
+    }
+
+    @Test
+    void should_not_update_null_columWith() {
+        GroupSubSectionRequest request = new GroupSubSectionRequest(100l, "BLOCK_X", getUnValidBatchColumnWidth());
+        Long userId = 456L;
+        UpdateSubSectionException exception = assertThrows(UpdateSubSectionException.class, () -> grouper.group(1l, request, userId));
+        assertEquals("batchTableColumnWidth is required", exception.getMessage());
+    }
+
+    @Test
+    void should_not_update_columnWith_lessThan_100() {
+        GroupSubSectionRequest request = new GroupSubSectionRequest(100l, "BLOCK_X", getUnValidBatchColumnWidthTotal());
+        Long userId = 456L;
+        UpdateSubSectionException exception = assertThrows(UpdateSubSectionException.class, () -> grouper.group(1l, request, userId));
+        assertEquals("the total of batchTableColumnWidth must calculate to 100", exception.getMessage());
+    }
+
+    List<GroupSubSectionRequest.Batch> getValidBatchList() {
+        List<GroupSubSectionRequest.Batch> batchList = new ArrayList<>();
+        batchList.add(new GroupSubSectionRequest.Batch(101l, 'Y', "header1", 25));
+        batchList.add(new GroupSubSectionRequest.Batch(102l, 'Y', "header2", 75));
+        return batchList;
+    }
+
+    List<GroupSubSectionRequest.Batch> getUnValidBatchColumnWidth() {
+        List<GroupSubSectionRequest.Batch> batchList = new ArrayList<>();
+        batchList.add(new GroupSubSectionRequest.Batch(101l, 'Y', "header1", 0));
+        batchList.add(new GroupSubSectionRequest.Batch(102l, 'Y', "header2", 75));
+        return batchList;
+    }
+
+    List<GroupSubSectionRequest.Batch> getUnValidBatchColumnWidthTotal() {
+        List<GroupSubSectionRequest.Batch> batchList = new ArrayList<>();
+        batchList.add(new GroupSubSectionRequest.Batch(101l, 'Y', "header1", 30));
+        batchList.add(new GroupSubSectionRequest.Batch(102l, 'Y', "header2", 40));
+        return batchList;
+    }
+
+
+    @Test
+    void should_unGroup_subsection() {
+        WaTemplate page = mock(WaTemplate.class);
+        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
+        doNothing().when(entityManager).flush();
+        WaUiMetadata waUiMetadata = new WaUiMetadata();
+        waUiMetadata.setId(100l);
+        List<Long> batches = new ArrayList<>(Arrays.asList(101L, 102L));
+        UnGroupSubSectionRequest request = new UnGroupSubSectionRequest(100l, batches);
+        when(page.unGroupSubSection(any())).thenReturn(waUiMetadata);
+        Long userId = 456L;
+        ResponseEntity<String> result = grouper.unGroup(1l, request, userId);
+        assertEquals("Subsection " + waUiMetadata.getId() + " is UnGrouped Successfully ", result.getBody());
+    }
+
+    @Test
+    void testGroupSubSection() {
+        // Create a mock for WaUiMetadata
+        Long subSectionId = 1L;
+        WaUiMetadata subsection = mock(WaUiMetadata.class);
+        when(subsection.getId()).thenReturn(subSectionId);
+        when(subsection.getNbsUiComponentUid()).thenReturn(1016l);
+
+        PageContentCommand.GroupSubsection command = mock(PageContentCommand.GroupSubsection.class);
+
+        // Create a mock for the list of batches
+        GroupSubSectionRequest.Batch batch1 = mock(GroupSubSectionRequest.Batch.class);
+        when(batch1.id()).thenReturn(2L);
+        GroupSubSectionRequest.Batch batch2 = mock(GroupSubSectionRequest.Batch.class);
+        when(batch2.id()).thenReturn(3L);
+        List<GroupSubSectionRequest.Batch> batches = Arrays.asList(batch1, batch2);
+
+        when(command.batches()).thenReturn(batches);
+        when(command.subsection()).thenReturn(subSectionId);
+
+        // Create a mock for WaUiMetadata for question batches
+        WaUiMetadata questionBatch1 = mock(WaUiMetadata.class);
+        when(questionBatch1.getId()).thenReturn(2L);
+        when(questionBatch1.getNbsUiComponentUid()).thenReturn(1007l);
+        WaUiMetadata questionBatch2 = mock(WaUiMetadata.class);
+        when(questionBatch2.getId()).thenReturn(3L);
+        when(questionBatch2.getNbsUiComponentUid()).thenReturn(1007l);
+
+        List<WaUiMetadata> uiMetadata = Arrays.asList(subsection, questionBatch1, questionBatch2);
+
+        WaTemplate waTemplate = new WaTemplate();
+        waTemplate.setUiMetadata(uiMetadata);
+        WaUiMetadata result = waTemplate.groupSubSection(command);
+        assertEquals(subsection, result);
+        verify(subsection).update(command);
+        verify(questionBatch1).updateQuestionBatch(command);
+        verify(questionBatch2).updateQuestionBatch(command);
+    }
+
+    @Test
+    void testUnGroupSubSection() {
+        // Create a mock for WaUiMetadata
+        WaUiMetadata subsection = mock(WaUiMetadata.class);
+        when(subsection.getId()).thenReturn(1L);
+        when(subsection.getNbsUiComponentUid()).thenReturn(1016l);
+        PageContentCommand.UnGroupSubsection command = mock(PageContentCommand.UnGroupSubsection.class);
+
+        when(command.subsection()).thenReturn(1L);
+        List<Long> batchIds = Arrays.asList(1L, 2L);
+        when(command.batches()).thenReturn(batchIds);
+
+        WaUiMetadata questionBatch1 = mock(WaUiMetadata.class);
+        when(questionBatch1.getId()).thenReturn(1L);
+        when(questionBatch1.getNbsUiComponentUid()).thenReturn(1007l);
+        WaUiMetadata questionBatch2 = mock(WaUiMetadata.class);
+        when(questionBatch2.getId()).thenReturn(2L);
+        when(questionBatch2.getNbsUiComponentUid()).thenReturn(1007l);
+
+        List<WaUiMetadata> uiMetadata = Arrays.asList(subsection, questionBatch1, questionBatch2);
+
+        WaTemplate waTemplate = new WaTemplate();
+        waTemplate.setUiMetadata(uiMetadata);
+        WaUiMetadata result = waTemplate.unGroupSubSection(command);
+
+        assertEquals(subsection, result);
+        verify(subsection).update(command);
+        verify(questionBatch1).updateQuestionBatch(command);
+        verify(questionBatch2).updateQuestionBatch(command);
+    }
+
+    @Test
+    void testUpdateGroupQuestionBatch() {
+        PageContentCommand.GroupSubsection command = mock(PageContentCommand.GroupSubsection.class);
+
+        GroupSubSectionRequest.Batch batch = mock(GroupSubSectionRequest.Batch.class);
+        when(batch.id()).thenReturn(123l);
+        when(batch.batchTableAppearIndCd()).thenReturn('Y');
+        when(batch.batchTableHeader()).thenReturn("TableHeader");
+        when(batch.batchTableColumnWidth()).thenReturn(50);
+
+        List<GroupSubSectionRequest.Batch> batches = Arrays.asList(batch);
+        when(command.batches()).thenReturn(batches);
+        when(command.blockName()).thenReturn("BlockName");
+
+        WaUiMetadata waUiMetadata = getInitialWaUiMetadata();
+        waUiMetadata.setId(123l);
+
+        waUiMetadata.updateQuestionBatch(command);
+
+        assertEquals("BlockName", waUiMetadata.getBlockNm());
+        assertEquals('Y', waUiMetadata.getBatchTableAppearIndCd());
+        assertEquals("TableHeader", waUiMetadata.getBatchTableHeader());
+        assertEquals(50, waUiMetadata.getBatchTableColumnWidth());
+    }
+
+
+    @Test
+    void testUpdateGroup() {
+        PageContentCommand.GroupSubsection command = mock(PageContentCommand.GroupSubsection.class);
+        when(command.blockName()).thenReturn("BlockName");
+        WaUiMetadata waUiMetadata = getInitialWaUiMetadata();
+        waUiMetadata.update(command);
+        assertEquals("BlockName", waUiMetadata.getBlockNm());
+
+    }
+
+    @Test
+    void testUpdateUnGroup() {
+        PageContentCommand.UnGroupSubsection command = mock(PageContentCommand.UnGroupSubsection.class);
+        WaUiMetadata waUiMetadata = getInitialWaUiMetadata();
+        waUiMetadata.update(command);
+        assertEquals(null, waUiMetadata.getBlockNm());
+
+    }
+
+    @Test
+    void testUpdateUnGroupQuestionBatch() {
+        PageContentCommand.UnGroupSubsection command = mock(PageContentCommand.UnGroupSubsection.class);
+        WaUiMetadata waUiMetadata = getInitialWaUiMetadata();
+        waUiMetadata.updateQuestionBatch(command);
+        assertEquals(null, waUiMetadata.getBlockNm());
+        assertEquals(null, waUiMetadata.getBatchTableAppearIndCd());
+        assertEquals(null, waUiMetadata.getBatchTableHeader());
+        assertEquals(null, waUiMetadata.getBatchTableColumnWidth());
+
+    }
+
+
+    WaUiMetadata getInitialWaUiMetadata() {
+        WaUiMetadata waUiMetadata = new WaUiMetadata();
+        waUiMetadata.setId(1L);
+        waUiMetadata.setBlockNm("InitialBlockName");
+        waUiMetadata.setBatchTableAppearIndCd('N');
+        waUiMetadata.setBatchTableHeader("InitialTableHeader");
+        waUiMetadata.setBatchTableColumnWidth(0);
+        return waUiMetadata;
+    }
+
+}


### PR DESCRIPTION
## Description

In NBS Classic Page Builder, a user is able to mark a subsection as grouped or ungrouped. Modernized APIs needs to be created to perform these actions.

The modernized APIs should leave the database in a state that is exactly the same as if the group or ungroup was handled by NBS Classic. 

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1527

