### PR TITLE
Release Workflow typo fix

### DIFF
--- a/.github/workflows/Release-candidate-containers.yml
+++ b/.github/workflows/Release-candidate-containers.yml
@@ -48,7 +48,7 @@ jobs:
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: nbs-gateway
-      values_file_with_path: charts/nbs-gateway/values_${{inputs.values}}.yaml
+      values_file_with_path: charts/nbs-gateway/values-${{inputs.values}}.yaml
       new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
     secrets:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
@@ -74,7 +74,7 @@ jobs:
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: modernization-api
-      values_file_with_path: charts/modernization-api/values_${{inputs.values}}.yaml
+      values_file_with_path: charts/modernization-api/values-${{inputs.values}}.yaml
       new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
     secrets:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
@@ -101,7 +101,7 @@ jobs:
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: elasticsearch
-      values_file_with_path: charts/elasticsearch-efs/values_${{inputs.values}}.yaml
+      values_file_with_path: charts/elasticsearch-efs/values-${{inputs.values}}.yaml
       new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
     secrets:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
@@ -128,7 +128,7 @@ jobs:
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Update-helm-charts.yaml@main
     with:
       microservice_name: nifi
-      values_file_with_path: charts/nifi-efs/values_${{inputs.values}}.yaml
+      values_file_with_path: charts/nifi-efs/values-${{inputs.values}}.yaml
       new_image_tag: ${{ needs.call-build-microservice-container-workflow.outputs.output_image_tag }}
     secrets:
       GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}


### PR DESCRIPTION
Fixes a typo in the name of the `values` to use a `-` over an `_`
