### PR TITLE
[CNFT2-1511] Filter page library by event names

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/options/page/usePageNameOptionsAutocomplete.ts
+++ b/apps/modernization-ui/src/apps/page-builder/options/page/usePageNameOptionsAutocomplete.ts
@@ -1,19 +1,14 @@
 import { PageBuilderOptionsService } from 'apps/page-builder/generated';
 import { authorization } from 'authorization';
-import {
-    AutocompleteOptionsResolver,
-    PageBuilderOptionsAutocompletion,
-    usePageBuilderOptionsAutocomplete
-} from 'apps/page-builder/options/usePageBuilderOptionsAutocomplete';
+
+import { AutocompleteOptionsResolver, SelectableAutocompletion, useSelectableAutocomplete } from 'options/autocompete';
 
 type Settings = {
     initialCriteria?: string;
     limit?: number;
 };
 
-const usePageNameOptionsAutocomplete = (
-    settings: Settings = { initialCriteria: '' }
-): PageBuilderOptionsAutocompletion => {
+const usePageNameOptionsAutocomplete = (settings: Settings = { initialCriteria: '' }): SelectableAutocompletion => {
     const resolver: AutocompleteOptionsResolver = (criteria: string, limit?: number) =>
         PageBuilderOptionsService.pageNamesAutocomplete({
             authorization: authorization(),
@@ -21,7 +16,7 @@ const usePageNameOptionsAutocomplete = (
             limit
         });
 
-    const { criteria, options, suggest, complete, reset } = usePageBuilderOptionsAutocomplete({
+    const { criteria, options, suggest, complete, reset } = useSelectableAutocomplete({
         resolver,
         criteria: settings.initialCriteria,
         limit: settings.limit

--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
@@ -1,21 +1,12 @@
 import { usePageNameOptionsAutocomplete } from 'apps/page-builder/options/page';
 import { DateProperty, Property, ValueProperty } from 'filters/properties';
 import { Selectable } from 'options';
+import { useConceptOptions } from 'options/concepts';
 
 const statusOptions: Selectable[] = [
     { label: 'Draft', value: 'Draft', name: 'Draft' },
     { label: 'Published', value: 'Published', name: 'Published' },
     { label: 'Published with draft', value: 'Published with draft', name: 'Published with draft' }
-];
-
-const eventTypeOptions = [
-    { label: 'Investigation', name: 'Investigation', value: 'INV' },
-    { label: 'Contact Record', name: 'Contact Record', value: 'CON' },
-    { label: 'Interview', name: 'Interview', value: 'IXS' },
-    { label: 'Lab Isolate tracking', name: 'Lab Isolate Tracking', value: 'ISO' },
-    { label: 'Lab Report', name: 'Lab Report', value: 'LAB' },
-    { label: 'Lab Susceptibility', name: 'Lab Susceptibility', value: 'SUS' },
-    { label: 'Vaccination', name: 'Vaccination', value: 'VAC' }
 ];
 
 const startsWith = (criteria: string) => (option: Selectable) =>
@@ -25,14 +16,16 @@ const completeByName = (options: Selectable[]) => (criteria: string) =>
     new Promise<Selectable[]>((resolve) => resolve(options.filter(startsWith(criteria.toLocaleLowerCase()))));
 
 const usePageLibraryProperties = () => {
-    const { complete } = usePageNameOptionsAutocomplete();
+    const { complete: completePageName } = usePageNameOptionsAutocomplete();
 
     const name: ValueProperty = {
         value: 'name',
         name: 'Page name',
         type: 'value',
-        complete: (criteria: string) => complete(criteria)
+        complete: (criteria: string) => completePageName(criteria)
     };
+
+    const { options: eventTypeOptions } = useConceptOptions('BUS_OBJ_TYPE', { lazy: false });
 
     const eventType: ValueProperty = {
         value: 'event-type',

--- a/apps/modernization-ui/src/generated/models/ConceptOptionsResponse.ts
+++ b/apps/modernization-ui/src/generated/models/ConceptOptionsResponse.ts
@@ -5,7 +5,7 @@
 import type { Option } from './Option';
 
 export type ConceptOptionsResponse = {
-    options?: Array<Option>;
-    valueSet?: string;
+    options: Array<Option>;
+    valueSet: string;
 };
 

--- a/apps/modernization-ui/src/generated/models/Option.ts
+++ b/apps/modernization-ui/src/generated/models/Option.ts
@@ -3,9 +3,9 @@
 /* eslint-disable */
 
 export type Option = {
-    label?: string;
-    name?: string;
+    label: string;
+    name: string;
     order?: number;
-    value?: string;
+    value: string;
 };
 

--- a/apps/modernization-ui/src/options/autocompete/ConceptAutocomplete.tsx
+++ b/apps/modernization-ui/src/options/autocompete/ConceptAutocomplete.tsx
@@ -1,9 +1,9 @@
-import { KeyboardEvent, useRef, useState, useEffect } from 'react';
-import { Option } from 'generated';
+import { KeyboardEvent as ReactKeyboardEvent, useRef, useState, useEffect } from 'react';
 import { useConceptOptionsAutocomplete } from './useConceptOptionsAutocomplete';
 import { Suggestions } from 'suggestion/Suggestions';
+import { Selectable } from 'options/selectable';
 
-const renderSuggestion = (suggestion: Option) => <>{suggestion.name}</>;
+const renderSuggestion = (suggestion: Selectable) => <>{suggestion.name}</>;
 
 type Props = {
     id: string;
@@ -11,7 +11,7 @@ type Props = {
     valueSet: string;
     className?: string;
     placeholder?: string;
-    value?: Option;
+    value?: Selectable;
     onChange?: (value?: string) => void;
 };
 
@@ -19,7 +19,7 @@ const ConceptAutocomplete = ({ id, label, valueSet, placeholder, value, onChange
     const suggestionRef = useRef<HTMLUListElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const { options, autocomplete, reset } = useConceptOptionsAutocomplete({ valueSet });
+    const { options, suggest, reset } = useConceptOptionsAutocomplete(valueSet);
 
     const [entered, setEntered] = useState(value?.name || '');
 
@@ -29,13 +29,13 @@ const ConceptAutocomplete = ({ id, label, valueSet, placeholder, value, onChange
 
     useEffect(() => {
         if (entered) {
-            autocomplete(entered);
+            suggest(entered);
         } else {
             reset();
         }
     }, [entered]);
 
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleKeyDown = (event: ReactKeyboardEvent) => {
         if (event.key === 'ArrowDown') {
             event.preventDefault();
             suggestionRef.current?.focus();
@@ -45,7 +45,7 @@ const ConceptAutocomplete = ({ id, label, valueSet, placeholder, value, onChange
         }
     };
 
-    const handleSelection = (option: Option) => {
+    const handleSelection = (option: Selectable) => {
         reset(option.name);
         setEntered(option.name ?? '');
         if (onChange) {

--- a/apps/modernization-ui/src/options/autocompete/index.ts
+++ b/apps/modernization-ui/src/options/autocompete/index.ts
@@ -1,0 +1,1 @@
+export * from './useSelectableAutocomplete';

--- a/apps/modernization-ui/src/options/autocompete/useConceptOptionsAutocomplete.ts
+++ b/apps/modernization-ui/src/options/autocompete/useConceptOptionsAutocomplete.ts
@@ -1,81 +1,39 @@
-import { ConceptOptionsService, Option } from 'generated';
-import debounce from 'lodash.debounce';
-import { useCallback, useEffect, useReducer } from 'react';
-import { useUser } from 'user';
+import { authorization } from 'authorization';
+import {
+    AutocompleteOptionsResolver,
+    SelectableAutocompletion,
+    useSelectableAutocomplete
+} from './useSelectableAutocomplete';
+import { ConceptOptionsService } from 'generated';
 
-type State =
-    | { status: 'idle'; criteria?: string }
-    | { status: 'suggested'; criteria?: string; options: Option[] }
-    | { status: 'suggesting'; criteria: string; limit: number };
-
-type Action =
-    | { type: 'reset'; criteria?: string }
-    | { type: 'suggest'; criteria: string; limit: number }
-    | { type: 'suggested'; suggestions: Option[] };
-
-const reducer = (state: State, action: Action): State => {
-    switch (action.type) {
-        case 'suggest':
-            //  only suggest if the criteria has changed
-            return state.criteria === action.criteria
-                ? state
-                : { ...initial, status: 'suggesting', criteria: action.criteria, limit: action.limit };
-        case 'suggested':
-            return { ...state, status: 'suggested', options: action.suggestions };
-        case 'reset':
-            return { status: 'idle', criteria: action.criteria };
-        default:
-            return initial();
-    }
+type Settings = {
+    initialCriteria?: string;
+    limit?: number;
 };
 
-const initial = (criteria?: string): State => ({
-    status: 'idle',
-    criteria
-});
+const useConceptOptionsAutocomplete = (
+    valueSet: string,
+    settings: Settings = { initialCriteria: '' }
+): SelectableAutocompletion => {
+    const resolver: AutocompleteOptionsResolver = (criteria: string, limit?: number) =>
+        ConceptOptionsService.specificUsingGet({
+            authorization: authorization(),
+            name: valueSet,
+            criteria: criteria,
+            limit: limit
+        }).then((response) => response.options);
 
-type AutocompleteResolver = (criteria?: string, limit?: number) => void;
-
-type ConceptOptions = {
-    criteria?: string;
-    options: Option[];
-    autocomplete: AutocompleteResolver;
-    reset: (criteria?: string) => void;
-};
-
-type Options = {
-    valueSet: string;
-    criteria?: string;
-};
-
-const useConceptOptionsAutocomplete = ({ valueSet, criteria = '' }: Options): ConceptOptions => {
-    const {
-        state: { getToken }
-    } = useUser();
-
-    const [state, dispatch] = useReducer(reducer, criteria, initial);
-
-    useEffect(() => {
-        if (state.status === 'suggesting') {
-            ConceptOptionsService.specificUsingGet({
-                authorization: `Bearer ${getToken()}`,
-                name: valueSet,
-                criteria: state.criteria,
-                limit: state.limit
-            })
-                .then((response) => response.options ?? [])
-                .then((options) => dispatch({ type: 'suggested', suggestions: options }));
-        }
-    }, [state.status]);
-
-    const options = state.status === 'suggested' ? state.options : [];
-    const autocomplete = (criteria = '', limit = 15) => dispatch({ type: 'suggest', criteria, limit });
-    const reset = (criteria?: string) => dispatch({ type: 'reset', criteria });
+    const { criteria, options, suggest, complete, reset } = useSelectableAutocomplete({
+        resolver,
+        criteria: settings.initialCriteria,
+        limit: settings.limit
+    });
 
     return {
-        criteria: state.criteria,
+        criteria,
         options,
-        autocomplete: useCallback(debounce(autocomplete, 600), []),
+        suggest,
+        complete,
         reset
     };
 };

--- a/apps/modernization-ui/src/options/autocompete/useSelectableAutocomplete.ts
+++ b/apps/modernization-ui/src/options/autocompete/useSelectableAutocomplete.ts
@@ -37,7 +37,7 @@ type SuggestRequester = (criteria: string, limit?: number) => void;
 
 type AutocompleteOptionsResolver = (criteria: string, limit?: number) => Promise<Selectable[]>;
 
-type PageBuilderOptionsAutocompletion = {
+type SelectableAutocompletion = {
     criteria?: string;
     options: Selectable[];
     suggest: SuggestRequester;
@@ -45,17 +45,17 @@ type PageBuilderOptionsAutocompletion = {
     complete: AutocompleteOptionsResolver;
 };
 
-type PageBuilderOptionsAutocompleteParameters = {
+type SelectableAutocompleteParameters = {
     resolver: AutocompleteOptionsResolver;
     criteria?: string;
     limit?: number;
 };
 
-const usePageBuilderOptionsAutocomplete = ({
+const useSelectableAutocomplete = ({
     resolver,
     criteria = '',
     limit
-}: PageBuilderOptionsAutocompleteParameters): PageBuilderOptionsAutocompletion => {
+}: SelectableAutocompleteParameters): SelectableAutocompletion => {
     const [state, dispatch] = useReducer(reducer, criteria, initial);
 
     useEffect(() => {
@@ -79,5 +79,5 @@ const usePageBuilderOptionsAutocomplete = ({
     };
 };
 
-export { usePageBuilderOptionsAutocomplete };
-export type { PageBuilderOptionsAutocompletion, AutocompleteOptionsResolver };
+export { useSelectableAutocomplete };
+export type { SelectableAutocompletion, AutocompleteOptionsResolver };

--- a/apps/modernization-ui/src/options/concepts/useConceptOptions.ts
+++ b/apps/modernization-ui/src/options/concepts/useConceptOptions.ts
@@ -1,12 +1,13 @@
-import { ConceptOptionsService, Option } from 'generated';
 import { useEffect, useReducer } from 'react';
-import { useUser } from 'user';
+import { ConceptOptionsService } from 'generated';
+import { Selectable } from 'options/selectable';
+import { authorization } from 'authorization';
 
-type State = { status: 'idle' | 'loading' } | { status: 'loaded'; options: Option[] };
+type State = { status: 'idle' | 'loading' } | { status: 'loaded'; options: Selectable[] };
 
-type Action = { type: 'reset' } | { type: 'load' } | { type: 'loaded'; options: Option[] };
+type Action = { type: 'reset' } | { type: 'load' } | { type: 'loaded'; options: Selectable[] };
 
-const reducer = (state: State, action: Action): State => {
+const reducer = (_state: State, action: Action): State => {
     switch (action.type) {
         case 'load':
             return { ...initial, status: 'loading' };
@@ -22,20 +23,15 @@ const initial: State = {
 };
 
 type ConceptOptions = {
-    options: Option[];
+    options: Selectable[];
     load: () => void;
 };
 
-type Options = {
-    valueSet: string;
+type Settings = {
     lazy?: boolean;
 };
 
-const useConceptOptions = ({ valueSet, lazy = true }: Options): ConceptOptions => {
-    const {
-        state: { getToken }
-    } = useUser();
-
+const useConceptOptions = (valueSet: string, { lazy = true }: Settings): ConceptOptions => {
     const [state, dispatch] = useReducer(reducer, initial);
 
     useEffect(() => {
@@ -47,11 +43,9 @@ const useConceptOptions = ({ valueSet, lazy = true }: Options): ConceptOptions =
     useEffect(() => {
         if (state.status === 'loading') {
             ConceptOptionsService.allUsingGet({
-                authorization: `Bearer ${getToken()}`,
+                authorization: authorization(),
                 name: valueSet
-            })
-                .then((response) => response.options ?? [])
-                .then((options) => dispatch({ type: 'loaded', options }));
+            }).then((response) => dispatch({ type: 'loaded', options: response.options }));
         }
     }, [state.status]);
 

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/Option.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/Option.java
@@ -1,9 +1,15 @@
 package gov.cdc.nbs.option;
 
-public record Option(String value, String name, String label, int order) {
+import io.swagger.v3.oas.annotations.media.Schema;
 
-  public Option(String value, String name, int order) {
-    this(value, name, name, order);
-  }
+public record Option(
+    @Schema(required = true)
+    String value,
+    @Schema(required = true)
+    String name,
+    @Schema(required = true)
+    String label,
+    int order
+) {
 
 }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionsResponse.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionsResponse.java
@@ -1,9 +1,16 @@
 package gov.cdc.nbs.option.concept;
 
 import gov.cdc.nbs.option.Option;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Collection;
 
-public record ConceptOptionsResponse(String valueSet, Collection<Option> options) {
+public record ConceptOptionsResponse(
+    @Schema(required = true)
+    String valueSet,
+    @Schema(required = true)
+    Collection<Option> options
+) {
 
 }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionsResponse.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionsResponse.java
@@ -1,7 +1,6 @@
 package gov.cdc.nbs.option.concept;
 
 import gov.cdc.nbs.option.Option;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Collection;


### PR DESCRIPTION
## Description

Connects the Page library filter for event names to the options API that obtains concepts from the database.  

- Refined the documentation for the `options/concepts` API so that the generated types have the correct required types.
- Standardizes how `Selectable` autocomplete is handled

## Tickets

* [CNFT2-1511](https://cdc-nbs.atlassian.net/browse/CNFT2-1511)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1511]: https://cdc-nbs.atlassian.net/browse/CNFT2-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ