### PR TITLE
[CNFT2-1487] clone api

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageHeader/EditPageHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/EditPage/EditPageHeader/EditPageHeader.tsx
@@ -47,6 +47,9 @@ export const EditPageHeader = ({ page, handleSaveDraft }: PageProps) => {
                 <Button type="button" outline>
                     {isSaveTemplate ? 'Edit' : 'Cancel'}
                 </Button>
+                <LinkButton href={`/nbs/page-builder/api/v1/pages/${page.id}/clone`} label="clone the current page">
+                    <Icon.ContentCopy size={3} />
+                </LinkButton>
                 <LinkButton
                     href={`/nbs/page-builder/api/v1/pages/${page.id}/print`}
                     label="open simplified page view for printing">

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/PageBuilderProvider.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/PageBuilderProvider.java
@@ -10,11 +10,14 @@ import org.springframework.context.annotation.Configuration;
 public class PageBuilderProvider {
 
   @Bean
-  PageBuilderService pagebuilderManagePagesRoute(
+  PageBuilderService pageBuilderManagePagesRoute(
       @Value("${nbs.gateway.pagebuilder.protocol:${nbs.gateway.defaults.protocol}}") final String protocol,
-      @Value("${nbs.gateway.pagebuilder.service}") final String service) throws URISyntaxException {
+      @Value("${nbs.gateway.pagebuilder.service}") final String service,
+      @Value("${nbs.gateway.pagebuilder.base:/nbs/page-builder/api/v1/}")
+      final String base
+  ) throws URISyntaxException {
     URI uri = new URI(protocol + "://" + service);
 
-    return new PageBuilderService(uri);
+    return new PageBuilderService(uri, base);
   }
 }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/PageBuilderService.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/PageBuilderService.java
@@ -1,7 +1,14 @@
 package gov.cdc.nbs.gateway.pagebuilder;
 
+import org.springframework.web.util.UriComponentsBuilder;
+
 import java.net.URI;
 
-public record PageBuilderService(URI uri) {
+public record PageBuilderService(URI uri, String base) {
 
+  public String path(final String path) {
+    return UriComponentsBuilder.fromPath(base)
+        .path(path)
+        .toUriString();
+  }
 }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/page/ManagePageViewPageDetailsRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/page/ManagePageViewPageDetailsRouteLocatorConfiguration.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.gateway.pagebuilder.page;
+
+import gov.cdc.nbs.gateway.pagebuilder.PageBuilderService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+@ConditionalOnProperty(prefix = "nbs.gateway.pagebuilder", name = "enabled", havingValue = "true")
+public class ManagePageViewPageDetailsRouteLocatorConfiguration {
+
+  @Bean
+  RouteLocator pageBuilderManagePageViewPageDetailsRouteLocator(
+      final RouteLocatorBuilder builder,
+      @Qualifier("default") final GatewayFilter globalFilter,
+      final PageBuilderService service
+  ) {
+    return builder.routes()
+        .route(
+            "page-builder-manage-page-view-page-details-return",
+            route -> route
+                .order(Ordered.HIGHEST_PRECEDENCE)
+                .path("/nbs/ManagePage.do")
+                .and()
+                .query("method", "viewPageDetailsLoad")
+                .and()
+                .cookie("Return-Page", "\\d+")
+                .filters(
+                    filter -> filter.setPath(service.path("pages/return"))
+                        .filter(globalFilter)
+                )
+                .uri(service.uri()))
+        .build();
+  }
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/page/PreviewPageViewPageLoadRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/pagebuilder/page/PreviewPageViewPageLoadRouteLocatorConfiguration.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.gateway.pagebuilder.page;
+
+import gov.cdc.nbs.gateway.pagebuilder.PageBuilderService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+@ConditionalOnProperty(prefix = "nbs.gateway.pagebuilder", name = "enabled", havingValue = "true")
+public class PreviewPageViewPageLoadRouteLocatorConfiguration {
+
+  @Bean
+  RouteLocator pageBuilderPreviewPageViewPageLoadRouteLocator(
+      final RouteLocatorBuilder builder,
+      @Qualifier("default") final GatewayFilter globalFilter,
+      final PageBuilderService service
+  ) {
+    return builder.routes()
+        .route(
+            "page-builder-preview-page-return",
+            route -> route
+                .order(Ordered.HIGHEST_PRECEDENCE)
+                .path("/nbs/PreviewPage.do")
+                .and()
+                .query("method", "viewPageLoad")
+                .and()
+                .cookie("Return-Page", "\\d+")
+                .filters(
+                    filter -> filter.setPath("/nbs/page-builder/api/v1/pages/return")
+                        .filter(globalFilter)
+                )
+                .uri(service.uri()))
+        .build();
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/PageBuilderProviderTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/PageBuilderProviderTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.gateway.pagebuilder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,14 @@ class PageBuilderProviderTest {
   @Test
   void should_return_valid_uri() throws URISyntaxException {
     PageBuilderProvider provider = new PageBuilderProvider();
-    PageBuilderService service = provider.pagebuilderManagePagesRoute("http", "google.com");
+    PageBuilderService service = provider.pageBuilderManagePagesRoute(
+        "http",
+        "google.com",
+        "base/path"
+    );
+
+    assertThat(service.base()).isEqualTo("base/path");
+
     assertEquals("http://google.com", service.uri().toString());
   }
 }

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/ManagePageViewPageDetailsRouteLocatorConfigurationDisabledTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/ManagePageViewPageDetailsRouteLocatorConfigurationDisabledTest.java
@@ -1,0 +1,53 @@
+package gov.cdc.nbs.gateway.pagebuilder.page;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000",
+        "nbs.gateway.pagebuilder.service=localhost:10002",
+        "nbs.gateway.pagebuilder.enabled=false"
+    })
+class ManagePageViewPageDetailsRouteLocatorConfigurationDisabledTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @RegisterExtension
+  static WireMockExtension pageBuilderApi = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10002))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Test
+  void should_route_to_classic_when_manage_page_route_is_disabled() {
+
+    classic.stubFor(get(urlPathMatching("/nbs/ManagePage.do\\\\?.*")).willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(
+            builder -> builder
+                .path("/nbs/ManagePage.do")
+                .queryParam("method", "viewPageDetailsLoad")
+                .build()
+        )
+        .cookie("Return-Page", "3119")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/ManagePageViewPageDetailsRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/ManagePageViewPageDetailsRouteLocatorConfigurationTest.java
@@ -1,0 +1,73 @@
+package gov.cdc.nbs.gateway.pagebuilder.page;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000",
+        "nbs.gateway.pagebuilder.service=localhost:10002",
+        "nbs.gateway.pagebuilder.enabled=true"
+    })
+class ManagePageViewPageDetailsRouteLocatorConfigurationTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @RegisterExtension
+  static WireMockExtension pageBuilderApi = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10002))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Test
+  void should_route_to_page_builder_redirect() {
+
+    pageBuilderApi.stubFor(get(urlPathMatching("/nbs/page-builder/api/v1/pages/return"))
+        .willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(
+            builder -> builder
+                .path("/nbs/ManagePage.do")
+                .queryParam("method", "viewPageDetailsLoad")
+                .build()
+        )
+        .cookie("Return-Page", "3119")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void should_not_route_to_page_builder_redirect_when_return_cookie_is_not_present() {
+
+    classic.stubFor(get(urlPathMatching("/nbs/ManagePage.do\\\\?.*")).willReturn(ok()));
+
+
+    webClient
+        .get()
+        .uri(
+            builder -> builder
+                .path("/nbs/ManagePage.do")
+                .queryParam("method", "viewPageDetailsLoad")
+                .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/PreviewPageViewPageLoadRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/PreviewPageViewPageLoadRouteLocatorConfigurationTest.java
@@ -1,0 +1,73 @@
+package gov.cdc.nbs.gateway.pagebuilder.page;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000",
+        "nbs.gateway.pagebuilder.service=localhost:10002",
+        "nbs.gateway.pagebuilder.enabled=true"
+    })
+class PreviewPageViewPageLoadRouteLocatorConfigurationTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @RegisterExtension
+  static WireMockExtension pageBuilderApi = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10002))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Test
+  void should_route_to_page_builder_redirect() {
+
+    pageBuilderApi.stubFor(get(urlPathMatching("/nbs/page-builder/api/v1/pages/return"))
+        .willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(
+            builder -> builder
+                .path("/nbs/PreviewPage.do")
+                .queryParam("method", "viewPageLoad")
+                .build()
+        )
+        .cookie("Return-Page", "3119")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void should_not_route_to_page_builder_redirect_when_return_cookie_is_not_present() {
+
+    classic.stubFor(get(urlPathMatching("/nbs/PreviewPage.do\\\\?.*")).willReturn(ok()));
+
+
+    webClient
+        .get()
+        .uri(
+            builder -> builder
+                .path("/nbs/PreviewPage.do")
+                .queryParam("method", "viewPageLoad")
+                .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/PreviewPageViewPageLoadRouteLocatorDisabledTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/pagebuilder/page/PreviewPageViewPageLoadRouteLocatorDisabledTest.java
@@ -1,0 +1,54 @@
+package gov.cdc.nbs.gateway.pagebuilder.page;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000",
+        "nbs.gateway.pagebuilder.service=localhost:10002",
+        "nbs.gateway.pagebuilder.enabled=false"
+    })
+class PreviewPageViewPageLoadRouteLocatorDisabledTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @RegisterExtension
+  static WireMockExtension pageBuilderApi = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10002))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Test
+  void should_route_to_classic_when_preview_page_route_is_disabled() {
+
+    classic.stubFor(get(urlPathMatching("/nbs/PreviewPage.do\\\\?.*")).willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(
+            builder -> builder
+                .path("/nbs/PreviewPage.do")
+                .queryParam("method", "viewPageLoad")
+                .build()
+        )
+        .cookie("Return-Page", "3119")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/classic/ReturningPageCookie.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/classic/ReturningPageCookie.java
@@ -1,14 +1,20 @@
 package gov.cdc.nbs.questionbank.page.classic;
 
-import java.util.Optional;
-import java.util.function.Consumer;
-import javax.servlet.http.Cookie;
-import org.springframework.http.HttpHeaders;
 import gov.cdc.nbs.web.AddCookie;
 import gov.cdc.nbs.web.FindCookie;
 import gov.cdc.nbs.web.RemoveCookie;
+import org.springframework.http.HttpHeaders;
+
+import javax.servlet.http.Cookie;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 public record ReturningPageCookie(String page) {
+
+  public ReturningPageCookie(long page) {
+    this(String.valueOf(page));
+  }
+
   private static final String COOKIE_NAME = "Return-Page";
 
   private static final ReturningPageCookie EMPTY = new ReturningPageCookie(null);

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/classic/redirect/outgoing/ClassicPageDetailsRequester.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/classic/redirect/outgoing/ClassicPageDetailsRequester.java
@@ -1,0 +1,37 @@
+package gov.cdc.nbs.questionbank.page.classic.redirect.outgoing;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class ClassicPageDetailsRequester {
+
+  private static final String LOCATION = "/ManagePage.do";
+
+  private final RestTemplate template;
+
+
+  public ClassicPageDetailsRequester(
+      @Qualifier("classic") final RestTemplate template) {
+    this.template = template;
+  }
+
+  public void request() {
+
+    String pageLocation = UriComponentsBuilder.fromPath(LOCATION)
+        .queryParam("method", "viewPageDetailsLoad")
+        .queryParam("initLoad", "true")
+        .build()
+        .toUriString();
+
+    RequestEntity<Void> viewPageRequest = RequestEntity
+        .get(pageLocation)
+        .build();
+
+    this.template.exchange(viewPageRequest, Void.class);
+
+  }
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/classic/redirect/outgoing/ClassicPageRedirector.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/classic/redirect/outgoing/ClassicPageRedirector.java
@@ -1,0 +1,20 @@
+package gov.cdc.nbs.questionbank.page.classic.redirect.outgoing;
+
+import gov.cdc.nbs.questionbank.page.classic.ReturningPageCookie;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+public class ClassicPageRedirector {
+
+  public ResponseEntity<Void> redirect(final long page, final URI location) {
+    return ResponseEntity
+        .status(HttpStatus.TEMPORARY_REDIRECT)
+        .location(location)
+        .headers(new ReturningPageCookie(page).apply())
+        .build();
+  }
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/clone/ClassicClonePagePreparer.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/clone/ClassicClonePagePreparer.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.questionbank.page.clone;
+
+import gov.cdc.nbs.questionbank.page.classic.redirect.outgoing.ClassicManagePageRequester;
+import gov.cdc.nbs.questionbank.page.classic.redirect.outgoing.ClassicPageDetailsRequester;
+import gov.cdc.nbs.questionbank.page.classic.redirect.outgoing.ClassicPreviewPageRequester;
+import org.springframework.stereotype.Component;
+
+@Component
+class ClassicClonePagePreparer {
+
+  private final ClassicManagePageRequester managePageRequester;
+  private final ClassicPreviewPageRequester previewPageRequester;
+  private final ClassicPageDetailsRequester pageDetailsRequester;
+
+  ClassicClonePagePreparer(
+      final ClassicManagePageRequester managePageRequester,
+      final ClassicPreviewPageRequester previewPageRequester,
+      final ClassicPageDetailsRequester pageDetailsRequester
+  ) {
+    this.managePageRequester = managePageRequester;
+    this.previewPageRequester = previewPageRequester;
+    this.pageDetailsRequester = pageDetailsRequester;
+  }
+
+  void prepare(final long page) {
+    //  simulates navigating to Manage Pages
+    this.managePageRequester.request();
+    //  simulates previewing a page
+    this.previewPageRequester.request(page);
+    //  simulates navigating to Page Details
+    this.pageDetailsRequester.request();
+
+  }
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/clone/PageCloneController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/clone/PageCloneController.java
@@ -1,0 +1,29 @@
+package gov.cdc.nbs.questionbank.page.clone;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@ApiIgnore(
+    "The intended client of this endpoint is a Classic redirection component so it will not be exposed through API documentation."
+)
+@RestController
+@RequestMapping("/api/v1/pages/{page}/clone")
+@PreAuthorize("hasAuthority('LDFADMINISTRATION-SYSTEM')")
+class PageCloneController {
+
+  private final PageCloneRedirector redirector;
+
+  PageCloneController(final PageCloneRedirector redirector) {
+    this.redirector = redirector;
+  }
+
+  @GetMapping
+  ResponseEntity<Void> print(@PathVariable("page") final long page) {
+    return this.redirector.redirect(page);
+  }
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/clone/PageCloneRedirector.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/clone/PageCloneRedirector.java
@@ -1,0 +1,36 @@
+package gov.cdc.nbs.questionbank.page.clone;
+
+import gov.cdc.nbs.questionbank.page.classic.redirect.outgoing.ClassicPageRedirector;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Component
+class PageCloneRedirector {
+
+  private static final String LOCATION = "/nbs/ManagePage.do";
+
+  private final ClassicClonePagePreparer preparer;
+  private final ClassicPageRedirector redirector;
+
+  PageCloneRedirector(
+      final ClassicClonePagePreparer preparer,
+      final ClassicPageRedirector redirector
+  ) {
+    this.preparer = preparer;
+    this.redirector = redirector;
+  }
+
+  ResponseEntity<Void> redirect(final long page) {
+    this.preparer.prepare(page);
+
+    URI location = UriComponentsBuilder.fromPath(LOCATION)
+        .queryParam("method", "clonePageLoad")
+        .build()
+        .toUri();
+
+    return this.redirector.redirect(page, location);
+  }
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/clone/PageCloneRequester.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/clone/PageCloneRequester.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.questionbank.page.clone;
+
+import gov.cdc.nbs.testing.interaction.http.Authenticated;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@Component
+class PageCloneRequester {
+
+  private final Authenticated authenticated;
+  private final MockMvc mvc;
+
+  PageCloneRequester(
+      final Authenticated authenticated,
+      final MockMvc mvc
+  ) {
+    this.authenticated = authenticated;
+    this.mvc = mvc;
+  }
+
+  ResultActions request(final long page) {
+    try {
+      return mvc.perform(
+          this.authenticated.withSession(get("/api/v1/pages/{page}/clone", page))
+      );
+    } catch (Exception exception) {
+      throw new IllegalStateException("Unable to execute Page Print Request", exception);
+    }
+  }
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/clone/PageCloneSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/clone/PageCloneSteps.java
@@ -1,0 +1,91 @@
+package gov.cdc.nbs.questionbank.page.clone;
+
+import gov.cdc.nbs.questionbank.support.PageIdentifier;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class PageCloneSteps {
+
+  private final String classicUrl;
+  private final MockRestServiceServer server;
+  private final Active<PageIdentifier> page;
+
+  private final PageCloneRequester requester;
+  private final Active<ResultActions> response;
+
+  PageCloneSteps(
+      @Value("${nbs.wildfly.url:http://wildfly:7001}") final String classicUrl,
+      @Qualifier("classic") final MockRestServiceServer server,
+      final Active<PageIdentifier> page,
+      final PageCloneRequester requester
+  ) {
+    this.classicUrl = classicUrl;
+    this.page = page;
+    this.server = server;
+    this.requester = requester;
+    this.response = new Active<>();
+  }
+
+  @Before("@page-clone")
+  public void clean() {
+    server.reset();
+    response.reset();
+  }
+
+  @When("the page is cloned from Page Preview")
+  public void the_page_is_cloned_from_Page_Preview() {
+    this.page.maybeActive()
+        .map(found -> clone(found.id()))
+        .ifPresent(this.response::active);
+
+  }
+
+  private ResultActions clone(final long page) {
+    server.expect(requestTo(classicUrl + "/nbs/ManagePage.do?method=list&initLoad=true"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+    server.expect(requestTo(classicUrl + "/nbs/PreviewPage.do?method=viewPageLoad&waTemplateUid=" + page))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+    server.expect(requestTo(classicUrl + "/nbs/ManagePage.do?method=viewPageDetailsLoad&initLoad=true"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+    return requester.request(page);
+  }
+
+  @Then("I am redirected to Classic NBS to clone the page")
+  public void i_am_redirected_to_classic_nbs_to_view_the_simplified_page() throws Exception {
+    server.verify();
+
+    String returning = this.page.maybeActive()
+        .map(PageIdentifier::id)
+        .map(String::valueOf)
+        .orElse("NOPE");
+
+    response.active()
+        .andExpect(status().isTemporaryRedirect())
+        .andExpect(
+            header().string(
+                HttpHeaders.LOCATION,
+                "/nbs/ManagePage.do?method=clonePageLoad"
+            )
+        ).andExpect(cookie().value("Return-Page", returning))
+    ;
+  }
+}

--- a/apps/question-bank/src/test/resources/features/page/clone/PageClone.feature
+++ b/apps/question-bank/src/test/resources/features/page/clone/PageClone.feature
@@ -1,0 +1,12 @@
+@page-clone
+Feature: Cloning an existing page
+
+  Background:
+    Given I am logged in
+    And I can "LDFAdministration" any "System"
+    And I have a page
+
+  @web-interaction
+  Scenario: A page is cloned from Page Preview
+    When the page is cloned from Page Preview
+    Then I am redirected to Classic NBS to clone the page


### PR DESCRIPTION
## Description

Adds routing to the NBS Gateway to support navigating to the NBS 6.0.X Page Clone from modernized Page Builder.  The clone button was added to Page Edit.

## Tickets

* [CNFT2-1487](https://cdc-nbs.atlassian.net/browse/CNFT2-1487)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1487]: https://cdc-nbs.atlassian.net/browse/CNFT2-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ