### PR TITLE
[CNFT2-1529] Adds status to page details API

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PageDescription.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PageDescription.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.questionbank.page.detail;
 public record PageDescription(
     long identifier,
     String name,
+    String status,
     String description
 ) {
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PageDescriptionFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PageDescriptionFinder.java
@@ -13,6 +13,7 @@ class PageDescriptionFinder {
       select
           [template].wa_template_uid  as [identifier],
           [template].template_nm      as [name],
+          [template].template_type    as [status],
           [template].desc_txt         as [description]
       from WA_template [template]
       where [template].wa_template_uid = ?

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PageDescriptionRowMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PageDescriptionRowMapper.java
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 
 class PageDescriptionRowMapper implements RowMapper<PageDescription> {
 
-  record Column(int identifier, int name, int description) {
+  record Column(int identifier, int name, int status, int description) {
     Column() {
-      this(1, 2, 3);
+      this(1, 2, 3,4);
     }
   }
 
@@ -31,10 +31,12 @@ class PageDescriptionRowMapper implements RowMapper<PageDescription> {
   public PageDescription mapRow(final ResultSet rs, final int rowNum) throws SQLException {
     long identifier = rs.getLong(columns.identifier());
     String name = rs.getString(columns.name());
+    String status = rs.getString(columns.status());
     String description = rs.getString(columns.description());
     return new PageDescription(
         identifier,
         name,
+        status,
         description
     );
   }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponse.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponse.java
@@ -10,6 +10,8 @@ public record PagesResponse(
     long id,
     @ApiModelProperty(required = true)
     String name,
+    @ApiModelProperty(required = true)
+    String status,
     String description,
     long root,
     Collection<PagesTab> tabs,
@@ -19,6 +21,7 @@ public record PagesResponse(
   PagesResponse(
       long id,
       String name,
+      String status,
       String description,
       long root,
       Collection<PageRule> rules
@@ -26,6 +29,7 @@ public record PagesResponse(
     this(
         id,
         name,
+        status,
         description,
         root,
         List.of(),
@@ -34,40 +38,58 @@ public record PagesResponse(
   }
 
   public record PagesTab(
+      @ApiModelProperty(required = true)
       long id,
+      @ApiModelProperty(required = true)
       String name,
+      @ApiModelProperty(required = true)
       int order,
+      @ApiModelProperty(required = true)
       boolean visible,
+      @ApiModelProperty(required = true)
       Collection<PagesSection> sections
   ) {
   }
 
 
   public record PagesSection(
+      @ApiModelProperty(required = true)
       long id,
+      @ApiModelProperty(required = true)
       String name,
+      @ApiModelProperty(required = true)
       int order,
+      @ApiModelProperty(required = true)
       boolean visible,
+      @ApiModelProperty(required = true)
       Collection<PagesSubSection> subSections
   ) {
   }
 
 
   public record PagesSubSection(
+      @ApiModelProperty(required = true)
       long id,
+      @ApiModelProperty(required = true)
       String name,
+      @ApiModelProperty(required = true)
       int order,
+      @ApiModelProperty(required = true)
       boolean visible,
+      @ApiModelProperty(required = true)
       Collection<PagesQuestion> questions
   ) {
   }
 
   public record PagesQuestion(
+      @ApiModelProperty(required = true)
       long id,
       boolean isStandard,
       String standard,
       String question,
+      @ApiModelProperty(required = true)
       String name,
+      @ApiModelProperty(required = true)
       int order,
       String subGroup,
       String description,

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapper.java
@@ -21,6 +21,7 @@ class PagesResponseMapper {
     return new PagesResponse(
         detailed.identifier(),
         detailed.name(),
+        detailed.status(),
         detailed.description(),
         0,
         mapAll(this::asRule, rules)
@@ -40,6 +41,7 @@ class PagesResponseMapper {
     return new PagesResponse(
         detailed.identifier(),
         detailed.name(),
+        detailed.status(),
         detailed.description(),
         component.identifier(),
         tabs,

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PageDescriptionRowMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PageDescriptionRowMapperTest.java
@@ -19,6 +19,7 @@ class PageDescriptionRowMapperTest {
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.getLong(columns.identifier())).thenReturn(2143L);
     when(resultSet.getString(columns.name())).thenReturn("name-value");
+    when(resultSet.getString(columns.status())).thenReturn("status-value");
     when(resultSet.getString(columns.description())).thenReturn("description-value");
 
     PageDescriptionRowMapper mapper = new PageDescriptionRowMapper(columns);
@@ -27,6 +28,7 @@ class PageDescriptionRowMapperTest {
 
     assertThat(actual.identifier()).isEqualTo(2143L);
     assertThat(actual.name()).isEqualTo("name-value");
+    assertThat(actual.status()).isEqualTo("status-value");
     assertThat(actual.description()).isEqualTo("description-value");
   }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapperTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
 
 class PagesResponseMapperTest {
 
@@ -21,6 +22,7 @@ class PagesResponseMapperTest {
     PageDescription description = new PageDescription(
         1381L,
         "page-name-value",
+        "page-status-value",
         "page-description-value"
     );
 
@@ -30,17 +32,14 @@ class PagesResponseMapperTest {
 
     assertThat(response.id()).isEqualTo(1381L);
     assertThat(response.name()).isEqualTo("page-name-value");
+    assertThat(response.status()).isEqualTo("page-status-value");
     assertThat(response.description()).isEqualTo("page-description-value");
     assertThat(response.root()).isZero();
   }
 
   @Test
   void should_map_page_with_rules_to_response() {
-    PageDescription description = new PageDescription(
-        1381L,
-        "page-name-value",
-        "page-description-value"
-    );
+    PageDescription description = mock(PageDescription.class);
 
     List<PagesRule> rules = List.of(
         new PagesRule(
@@ -92,11 +91,7 @@ class PagesResponseMapperTest {
         )
     );
 
-    PageDescription description = new PageDescription(
-        1381L,
-        "page-name-value",
-        "page-description-value"
-    );
+    PageDescription description = mock(PageDescription.class);
 
     PagesResponseMapper mapper = new PagesResponseMapper();
 
@@ -145,11 +140,7 @@ class PagesResponseMapperTest {
         )
     );
 
-    PageDescription description = new PageDescription(
-        1381L,
-        "page-name-value",
-        "page-description-value"
-    );
+    PageDescription description = mock(PageDescription.class);
 
     PagesResponseMapper mapper = new PagesResponseMapper();
 
@@ -210,11 +201,7 @@ class PagesResponseMapperTest {
         )
     );
 
-    PageDescription description = new PageDescription(
-        1381L,
-        "page-name-value",
-        "page-description-value"
-    );
+    PageDescription description = mock(PageDescription.class);
 
     PagesResponseMapper mapper = new PagesResponseMapper();
 
@@ -302,11 +289,7 @@ class PagesResponseMapperTest {
         )
     );
 
-    PageDescription description = new PageDescription(
-        1381L,
-        "page-name-value",
-        "page-description-value"
-    );
+    PageDescription description = mock(PageDescription.class);
 
     PagesResponseMapper mapper = new PagesResponseMapper();
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseSteps.java
@@ -6,7 +6,6 @@ import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.JsonPathResultMatchers;
 
@@ -17,13 +16,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class PagesResponseSteps {
 
-  @Autowired
-  Active<PageIdentifier> page;
 
-  @Autowired
-  PagesRequest request;
+  private final Active<PageIdentifier> page;
+
+  private final PagesRequest request;
 
   private final Active<ResultActions> response = new Active<>();
+
+   PagesResponseSteps(
+       final Active<PageIdentifier> page,
+       final PagesRequest request
+   ) {
+    this.page = page;
+    this.request = request;
+  }
 
   @Before("@page-components")
   public void reset() {
@@ -58,6 +64,7 @@ public class PagesResponseSteps {
   private JsonPathResultMatchers resolvePageProperty(final String property) {
     return switch (property.toLowerCase()) {
       case "name" -> jsonPath("$.name");
+      case "status" -> jsonPath("$.status");
       case "description" -> jsonPath("$.description");
       default -> throw new AssertionError(String.format("Unexpected Page property %s", property));
     };

--- a/apps/question-bank/src/test/resources/features/page/components/Details.feature
+++ b/apps/question-bank/src/test/resources/features/page/components/Details.feature
@@ -6,12 +6,26 @@ Feature: Page Components
     And I can "LDFAdministration" any "System"
     And I have a page
 
-  Scenario: I can retrieve a Page
+  Scenario: I can retrieve a draft Page
     Given I have a page named "Front Page"
     And the page has a "description" of "description value"
     When I view the components of a page
     Then the page should have a "name" equal to "Front Page"
+    And the page should have a "status" equal to "Draft"
+    And the page should have a "description" equal to "description value"
     And the page should have a component root
+
+  Scenario: I can retrieve a published Page
+    Given I have a page named "Front Page"
+    And the page is Published
+    When I view the components of a page
+    Then the page should have a "status" equal to "Published"
+
+  Scenario: I can retrieve a draft of a published Page
+    Given I have a page named "Front Page"
+    And the page is Published with draft
+    When I view the components of a page
+    Then the page should have a "status" equal to "Draft"
 
   Scenario: I can retrieve the tabs of a Page
     Given the page has a tab


### PR DESCRIPTION
## Description

Adds the Page status to the GET `/page-builder/api/v1/pages/{page}` endpoint to enable / disable functionality on the web interface based on status.

## Tickets

* [CNFT2-1529](https://cdc-nbs.atlassian.net/browse/CNFT2-1529)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1529]: https://cdc-nbs.atlassian.net/browse/CNFT2-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ