### PR TITLE
[CNFT2-1586] adds display for Date Period filter

### DIFF
--- a/apps/modernization-ui/src/filters/applied/AppliedFilters.spec.tsx
+++ b/apps/modernization-ui/src/filters/applied/AppliedFilters.spec.tsx
@@ -1,0 +1,97 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DateFilter, DateRangeFilter, Filter, MultiValueFilter, SingleValueFilter } from 'filters';
+import { AppliedFilters } from './AppliedFilters';
+
+describe('when there are applied filters', () => {
+    it('should display a single value filter when applied', () => {
+        const { getByText } = render(<AppliedFilters label={'Testing'} filters={[]} onRemove={jest.fn} />);
+
+        const title = getByText('All Testing');
+
+        expect(title).toHaveClass('title');
+    });
+
+    it('should remove the filter when X clicked', async () => {
+        const filters: Filter[] = [
+            {
+                id: 'single-value-identifier',
+                property: { value: 'single-value', name: 'Single Value', type: 'value' },
+                operator: { name: 'Starts with', value: 'STARTS_WITH' },
+                value: 'prefix-value'
+            },
+            {
+                id: 'multi-value-identifier',
+                property: { value: 'multi-value', name: 'Multi Value', type: 'value' },
+                operator: { name: 'equals', value: 'EQUALS' },
+                values: ['value-one', 'value-two']
+            }
+        ];
+
+        const onRemove = jest.fn();
+
+        const { getAllByRole } = render(<AppliedFilters label={'Testing'} filters={filters} onRemove={onRemove} />);
+
+        const close = getAllByRole('button', {
+            name: /close/i
+        });
+
+        expect(close).toHaveLength(2);
+
+        await userEvent.click(close[0]);
+
+        expect(onRemove).toHaveBeenCalledWith('single-value-identifier');
+    });
+
+    it('should display a single value filter when applied', () => {
+        const filter: SingleValueFilter = {
+            id: 'single-value-identifier',
+            property: { value: 'single-value', name: 'Single Value', type: 'value' },
+            operator: { name: 'Starts with', value: 'STARTS_WITH' },
+            value: 'prefix-value'
+        };
+
+        const { getByText } = render(<AppliedFilters label={'Testing'} filters={[filter]} onRemove={jest.fn} />);
+
+        expect(getByText('Single Value Starts with prefix-value')).toBeInTheDocument();
+    });
+
+    it('should display a multi value filter when applied', () => {
+        const filter: MultiValueFilter = {
+            id: 'multi-value-identifier',
+            property: { value: 'multi-value', name: 'Multi Value', type: 'value' },
+            operator: { name: 'equals', value: 'EQUALS' },
+            values: ['value-one', 'value-two']
+        };
+
+        const { getByText } = render(<AppliedFilters label={'Testing'} filters={[filter]} onRemove={jest.fn} />);
+
+        expect(getByText('Multi Value equals value-one OR value-two')).toBeInTheDocument();
+    });
+
+    it('should display a date filter when applied', () => {
+        const filter: DateFilter = {
+            id: 'date-identifier',
+            property: { value: 'date-period', name: 'Date Period', type: 'date' },
+            operator: { name: 'today', value: 'TODAY' }
+        };
+
+        const { getByText } = render(<AppliedFilters label={'Testing'} filters={[filter]} onRemove={jest.fn} />);
+
+        expect(getByText('Date Period today')).toBeInTheDocument();
+    });
+
+    it('should display a date range filter when applied', () => {
+        const filter: DateRangeFilter = {
+            id: 'date-range-identifier',
+            property: { value: 'date-range', name: 'Date Range', type: 'date' },
+            operator: { name: 'between', value: 'BETWEEN' },
+            after: '12/01/2023',
+            before: '12/29/2023'
+        };
+
+        const { getByText } = render(<AppliedFilters label={'Testing'} filters={[filter]} onRemove={jest.fn} />);
+
+        expect(getByText('Date Range between 12/01/2023 and 12/29/2023'));
+    });
+});

--- a/apps/modernization-ui/src/filters/applied/AppliedFilters.tsx
+++ b/apps/modernization-ui/src/filters/applied/AppliedFilters.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@trussworks/react-uswds';
-import { Filter, Value } from 'filters';
+import { DateRange, Filter, Value } from 'filters';
 
 import styles from './applied-filters.module.scss';
 
@@ -47,7 +47,7 @@ const AppliedFilter = ({ filter, onRemove }: AppliedFilterProps) => (
         <span>
             {filter.property.name} {filter.operator.name} {display(filter)}
         </span>
-        <Icon.Close onClick={() => onRemove(filter.id)} />
+        <Icon.Close role="button" aria-label="close" onClick={() => onRemove(filter.id)} />
     </li>
 );
 
@@ -56,9 +56,13 @@ const display = (filter: Filter) => {
         return displayValue(filter.value);
     } else if ('values' in filter) {
         return filter.values.map(displayValue).join(' OR ');
+    } else if ('after' in filter && 'before' in filter) {
+        return displayRange(filter);
     }
 };
 
 const displayValue = (value: Value) => (typeof value === 'string' ? value : value.name);
+
+const displayRange = (range: DateRange) => `${range.after} and ${range.before}`;
 
 export { AppliedFilters };

--- a/apps/modernization-ui/src/filters/asDisplayableFilter.spec.ts
+++ b/apps/modernization-ui/src/filters/asDisplayableFilter.spec.ts
@@ -1,0 +1,91 @@
+import { DatePeriodFilterEntry, DateRangeFilterEntry, MultiValueEntry, SingleValueEntry } from './entry/FilterEntry';
+import { Property } from './properties';
+import { asFilter } from './asDisplayableFilter';
+
+Object.defineProperty(globalThis, 'crypto', {
+    value: {
+        randomUUID: () => '69b09298-08e5-43f5-a15d-a37810448b3d'
+    }
+});
+
+describe('when a filter is submitted', () => {
+    it('should create a single value filter from the entry', () => {
+        const properties: Property[] = [{ value: 'single-value', name: 'Single Value', type: 'value' }];
+
+        const entry: SingleValueEntry = {
+            property: 'single-value',
+            operator: 'STARTS_WITH',
+            value: 'prefix-value'
+        };
+
+        const filter = asFilter(properties)(entry);
+
+        expect(filter).toEqual(
+            expect.objectContaining({
+                id: '69b09298-08e5-43f5-a15d-a37810448b3d',
+                operator: expect.objectContaining({ value: 'STARTS_WITH' }),
+                value: 'prefix-value'
+            })
+        );
+    });
+
+    it('should create a multi value filter from the entry', () => {
+        const properties: Property[] = [{ value: 'multi-value', name: 'Multi Value', type: 'value' }];
+
+        const entry: MultiValueEntry = {
+            property: 'multi-value',
+            operator: 'EQUALS',
+            values: ['value-one', 'value-two']
+        };
+
+        const filter = asFilter(properties)(entry);
+
+        expect(filter).toEqual(
+            expect.objectContaining({
+                id: '69b09298-08e5-43f5-a15d-a37810448b3d',
+                operator: expect.objectContaining({ value: 'EQUALS' }),
+                values: expect.arrayContaining(['value-one', 'value-two'])
+            })
+        );
+    });
+
+    it('should create a date filter from the entry', () => {
+        const properties: Property[] = [{ value: 'date', name: 'Date', type: 'date' }];
+
+        const entry: DatePeriodFilterEntry = {
+            property: 'date',
+            operator: 'TODAY'
+        };
+
+        const filter = asFilter(properties)(entry);
+
+        expect(filter).toEqual(
+            expect.objectContaining({
+                id: '69b09298-08e5-43f5-a15d-a37810448b3d',
+                operator: expect.objectContaining({ value: 'TODAY' })
+            })
+        );
+    });
+
+    it('should create a date range filter from the entry', () => {
+        const properties: Property[] = [{ value: 'date-range', name: 'Date Range', type: 'date' }];
+
+        const entry: DateRangeFilterEntry = {
+            property: 'date-range',
+            operator: 'BETWEEN',
+            after: '11/01/2023',
+            before: '11/30/2023'
+        };
+
+        const filter = asFilter(properties)(entry);
+
+        expect(filter).toEqual(
+            expect.objectContaining({
+                id: '69b09298-08e5-43f5-a15d-a37810448b3d',
+                operator: expect.objectContaining({ value: 'BETWEEN' }),
+                after: '11/01/2023',
+                before: '11/30/2023'
+            })
+        );
+    });
+});

--- a/apps/modernization-ui/src/filters/asDisplayableFilter.ts
+++ b/apps/modernization-ui/src/filters/asDisplayableFilter.ts
@@ -79,20 +79,6 @@ const asDateRange = (
             after: entry.after,
             before: entry.before
         };
-    } else if ('after' in entry) {
-        return {
-            id: crypto.randomUUID(),
-            property,
-            operator,
-            after: entry.after
-        };
-    } else if ('before' in entry) {
-        return {
-            id: crypto.randomUUID(),
-            property,
-            operator,
-            before: entry.before
-        };
     }
 
     return undefined;

--- a/apps/modernization-ui/src/filters/externalize.spec.ts
+++ b/apps/modernization-ui/src/filters/externalize.spec.ts
@@ -1,0 +1,79 @@
+import { DateFilter, DateRangeFilter, MultiValueFilter, SingleValueFilter } from 'filters';
+import { externalize } from './externalize';
+
+describe('when a filter is externalized', () => {
+    it('should send a single value filter to the API', () => {
+        const filter: SingleValueFilter = {
+            id: 'single-value-identifier',
+            property: { value: 'single-value', name: 'Single Value', type: 'value' },
+            operator: { name: 'Starts with', value: 'STARTS_WITH' },
+            value: 'prefix-value'
+        };
+
+        const actual = externalize([filter]);
+
+        expect(actual).toEqual([
+            expect.objectContaining({
+                operator: 'STARTS_WITH',
+                property: 'single-value',
+                value: 'prefix-value'
+            })
+        ]);
+    });
+
+    it('should send a multi value filter to the API', () => {
+        const filter: MultiValueFilter = {
+            id: 'multi-value-identifier',
+            property: { value: 'multi-value', name: 'Multi Value', type: 'value' },
+            operator: { name: 'equals', value: 'EQUALS' },
+            values: ['value-one', 'value-two']
+        };
+
+        const actual = externalize([filter]);
+
+        expect(actual).toEqual([
+            expect.objectContaining({
+                operator: 'EQUALS',
+                property: 'multi-value',
+                values: ['value-one', 'value-two']
+            })
+        ]);
+    });
+
+    it('should send a date filter to the API', () => {
+        const filter: DateFilter = {
+            id: 'date-identifier',
+            property: { value: 'date-period', name: 'Date Period', type: 'date' },
+            operator: { name: 'today', value: 'TODAY' }
+        };
+
+        const actual = externalize([filter]);
+
+        expect(actual).toEqual([
+            expect.objectContaining({
+                property: 'date-period',
+                operator: 'TODAY'
+            })
+        ]);
+    });
+
+    it('should send a date range filter to the API', () => {
+        const filter: DateRangeFilter = {
+            id: 'date-range-identifier',
+            property: { value: 'date-range', name: 'Date Range', type: 'date' },
+            operator: { name: 'between', value: 'BETWEEN' },
+            after: '12/01/2023',
+            before: '12/29/2023'
+        };
+
+        const actual = externalize([filter]);
+
+        expect(actual).toEqual([
+            expect.objectContaining({
+                property: 'date-range',
+                after: '2023-12-01',
+                before: '2023-12-29'
+            })
+        ]);
+    });
+});

--- a/apps/modernization-ui/src/filters/externalize.ts
+++ b/apps/modernization-ui/src/filters/externalize.ts
@@ -41,7 +41,7 @@ const asFilter = (displayable: Filter): APIFilter => {
         return asSingleValueFilter(displayable);
     } else if ('values' in displayable) {
         return asMultiValueFilter(displayable);
-    } else if ('after' in displayable || 'before' in displayable) {
+    } else if ('after' in displayable && 'before' in displayable) {
         return asDateRangeFilter(displayable);
     }
 
@@ -79,14 +79,9 @@ const asDateRangeFilter = (displayable: DateRangeFilter): ExternalDateRangeFilte
     };
 };
 
-const asDateRange = (displayable: DateRangeFilter): DateRange => {
-    if ('after' in displayable && 'before' in displayable) {
-        return { after: externalizeDate(displayable.after), before: externalizeDate(displayable.before) };
-    } else if ('after' in displayable) {
-        return { after: externalizeDate(displayable.after) };
-    } else {
-        return { before: externalizeDate(displayable.before) };
-    }
-};
+const asDateRange = (displayable: DateRangeFilter): DateRange => ({
+    after: externalizeDate(displayable.after),
+    before: externalizeDate(displayable.before)
+});
 
 export { externalize };

--- a/apps/modernization-ui/src/filters/filter.ts
+++ b/apps/modernization-ui/src/filters/filter.ts
@@ -10,7 +10,7 @@ import {
 
 type MultiValue = { values: string[] };
 type SingleValue = { value: string };
-type DateRange = { after: string } | { before: string } | { after: string; before: string };
+type DateRange = { after: string; before: string };
 
 export type { MultiValue, SingleValue, DateRange };
 


### PR DESCRIPTION
## Description

Ensures that the date period filter that handles `between` filters displays the selected values correctly.

## Tickets

* [CNFT2-1586](https://cdc-nbs.atlassian.net/browse/CNFT2-1586)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1586]: https://cdc-nbs.atlassian.net/browse/CNFT2-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ