### PR TITLE
[CNFT2-1626] Removes parital match operators from event-type and status

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
@@ -33,6 +33,7 @@ const usePageLibraryProperties = () => {
         value: 'event-type',
         name: 'Event type',
         type: 'value',
+        exactOnly: true,
         complete: completeByName(eventTypeOptions),
         all: eventTypeOptions
     };
@@ -50,6 +51,7 @@ const usePageLibraryProperties = () => {
         value: 'status',
         name: 'Status',
         type: 'value',
+        exactOnly: true,
         complete: completeByName(statusOptions),
         all: statusOptions
     };

--- a/apps/modernization-ui/src/filters/applied/AppliedFilters.spec.tsx
+++ b/apps/modernization-ui/src/filters/applied/AppliedFilters.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { DateFilter, DateRangeFilter, Filter, MultiValueFilter, SingleValueFilter } from 'filters';
+import { DateFilter, DateRangeFilter, Filter, ExactValueFilter, PartialValueFilter } from 'filters';
 import { AppliedFilters } from './AppliedFilters';
 
 describe('when there are applied filters', () => {
@@ -44,7 +44,7 @@ describe('when there are applied filters', () => {
     });
 
     it('should display a single value filter when applied', () => {
-        const filter: SingleValueFilter = {
+        const filter: PartialValueFilter = {
             id: 'single-value-identifier',
             property: { value: 'single-value', name: 'Single Value', type: 'value' },
             operator: { name: 'Starts with', value: 'STARTS_WITH' },
@@ -57,7 +57,7 @@ describe('when there are applied filters', () => {
     });
 
     it('should display a multi value filter when applied', () => {
-        const filter: MultiValueFilter = {
+        const filter: ExactValueFilter = {
             id: 'multi-value-identifier',
             property: { value: 'multi-value', name: 'Multi Value', type: 'value' },
             operator: { name: 'equals', value: 'EQUALS' },

--- a/apps/modernization-ui/src/filters/asDisplayableFilter.spec.ts
+++ b/apps/modernization-ui/src/filters/asDisplayableFilter.spec.ts
@@ -1,4 +1,4 @@
-import { DatePeriodFilterEntry, DateRangeFilterEntry, MultiValueEntry, SingleValueEntry } from './entry/FilterEntry';
+import { DatePeriodFilterEntry, DateRangeFilterEntry, ExactValueEntry, PartialValueEntry } from './entry/FilterEntry';
 import { Property } from './properties';
 import { asFilter } from './asDisplayableFilter';
 
@@ -12,7 +12,7 @@ describe('when a filter is submitted', () => {
     it('should create a single value filter from the entry', () => {
         const properties: Property[] = [{ value: 'single-value', name: 'Single Value', type: 'value' }];
 
-        const entry: SingleValueEntry = {
+        const entry: PartialValueEntry = {
             property: 'single-value',
             operator: 'STARTS_WITH',
             value: 'prefix-value'
@@ -32,7 +32,7 @@ describe('when a filter is submitted', () => {
     it('should create a multi value filter from the entry', () => {
         const properties: Property[] = [{ value: 'multi-value', name: 'Multi Value', type: 'value' }];
 
-        const entry: MultiValueEntry = {
+        const entry: ExactValueEntry = {
             property: 'multi-value',
             operator: 'EQUALS',
             values: ['value-one', 'value-two']

--- a/apps/modernization-ui/src/filters/asDisplayableFilter.ts
+++ b/apps/modernization-ui/src/filters/asDisplayableFilter.ts
@@ -1,12 +1,12 @@
 import { FilterEntry } from './entry/FilterEntry';
 import { DateFilter, DateRangeFilter, Filter, ValueFilter } from './filter';
-import { isMultiValueProperty, isSingleValueProperty } from './operators';
+import { isExactValueProperty, isPartialValueProperty } from './operators';
 import { DateProperty, Property, ValueProperty } from './properties';
 import {
     dateOperators,
-    multiValueOperators,
+    ExactValueOperators,
     SelectableDateRangeOperator,
-    singleValueOperators,
+    PartialValueOperators,
     withValue
 } from './selectables';
 
@@ -25,8 +25,8 @@ const asFilter =
     };
 
 const asValue = (property: ValueProperty, entry: FilterEntry): ValueFilter | undefined => {
-    if ('value' in entry && isSingleValueProperty(entry.operator)) {
-        const operator = singleValueOperators.find(withValue(entry.operator));
+    if ('value' in entry && isPartialValueProperty(entry.operator)) {
+        const operator = PartialValueOperators.find(withValue(entry.operator));
         return (
             operator && {
                 id: crypto.randomUUID(),
@@ -35,8 +35,8 @@ const asValue = (property: ValueProperty, entry: FilterEntry): ValueFilter | und
                 value: entry.value
             }
         );
-    } else if ('values' in entry && isMultiValueProperty(entry.operator)) {
-        const operator = multiValueOperators.find(withValue(entry.operator));
+    } else if ('values' in entry && isExactValueProperty(entry.operator)) {
+        const operator = ExactValueOperators.find(withValue(entry.operator));
         return (
             operator && {
                 id: crypto.randomUUID(),

--- a/apps/modernization-ui/src/filters/entry/ExactValueEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/ExactValueEntryForm.tsx
@@ -8,11 +8,11 @@ const asFilterValue = (selectable: Selectable) => {
     return selectable.name;
 };
 
-type MultiValueEntryFormProps = {
+type ExactValueEntryFormProps = {
     property: ValueProperty;
 };
 
-const MultiValueEntryForm = ({ property }: MultiValueEntryFormProps) => {
+const ExactValueEntryForm = ({ property }: ExactValueEntryFormProps) => {
     const { control } = useFormContext<FilterEntry, Partial<FilterEntry>>();
 
     return (
@@ -40,4 +40,4 @@ const MultiValueEntryForm = ({ property }: MultiValueEntryFormProps) => {
     );
 };
 
-export { MultiValueEntryForm };
+export { ExactValueEntryForm };

--- a/apps/modernization-ui/src/filters/entry/FilterEntry.ts
+++ b/apps/modernization-ui/src/filters/entry/FilterEntry.ts
@@ -1,19 +1,19 @@
-import { MultiValue, SingleValue, DateRange } from 'filters';
-import { DatePeriodOperator, DateRangeOperator, MultiValueOperator, SingleValueOperator } from 'filters/operators';
+import { ExactValue, PartialValue, DateRange } from 'filters';
+import { DatePeriodOperator, DateRangeOperator, ExactValueOperator, PartialValueOperator } from 'filters/operators';
 
 type BaseFilterEntry = {
     property: string;
 };
 
-type MultiValueEntry = BaseFilterEntry & {
-    operator: MultiValueOperator;
-} & MultiValue;
+type ExactValueEntry = BaseFilterEntry & {
+    operator: ExactValueOperator;
+} & ExactValue;
 
-type SingleValueEntry = BaseFilterEntry & {
-    operator: SingleValueOperator;
-} & SingleValue;
+type PartialValueEntry = BaseFilterEntry & {
+    operator: PartialValueOperator;
+} & PartialValue;
 
-type ValueEntry = SingleValueEntry | MultiValueEntry;
+type ValueEntry = PartialValueEntry | ExactValueEntry;
 
 type DatePeriodFilterEntry = BaseFilterEntry & {
     operator: DatePeriodOperator;
@@ -28,8 +28,8 @@ type FilterEntry = ValueEntry | DateFilterEntry;
 export type {
     FilterEntry,
     ValueEntry,
-    SingleValueEntry,
-    MultiValueEntry,
+    PartialValueEntry,
+    ExactValueEntry,
     DateFilterEntry,
     DatePeriodFilterEntry,
     DateRangeFilterEntry

--- a/apps/modernization-ui/src/filters/entry/FilterEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/FilterEntryForm.tsx
@@ -5,8 +5,8 @@ import { SelectInput } from 'components/FormInputs/SelectInput';
 import { Property } from 'filters/properties';
 import { FilterEntry } from './FilterEntry';
 import { DataRangeEntryForm } from './DataRangeEntryForm';
-import { SingleValueEntryForm } from './SingleValueEntryForm';
-import { MultiValueEntryForm } from './MultiValueEntryForm';
+import { PartialValueEntryForm } from './PartialValueEntryForm';
+import { ExactValueEntryForm } from './ExactValueEntryForm';
 import styles from './filter-entry-form.module.scss';
 import { operators } from 'filters/selectables';
 
@@ -35,10 +35,10 @@ const FilterEntryForm = ({ properties, onSave, onCancel }: FilterEditViewProps) 
 
     const selectedOperator = useWatch({ control, name: 'operator' });
 
-    const selectionEntry =
+    const exactEntry =
         property && property.type === 'value' && (selectedOperator === 'EQUALS' || selectedOperator === 'NOT_EQUAL_TO');
 
-    const criterialEntry =
+    const partialEntry =
         property &&
         property.type === 'value' &&
         (selectedOperator === 'CONTAINS' || selectedOperator === 'STARTS_WITH');
@@ -89,8 +89,8 @@ const FilterEntryForm = ({ properties, onSave, onCancel }: FilterEditViewProps) 
                         />
                     )}
                     {selectedOperator === 'BETWEEN' && <DataRangeEntryForm />}
-                    {criterialEntry && <SingleValueEntryForm />}
-                    {selectionEntry && <MultiValueEntryForm property={property} />}
+                    {partialEntry && <PartialValueEntryForm />}
+                    {exactEntry && <ExactValueEntryForm property={property} />}
                 </FormProvider>
             </section>
             <footer>

--- a/apps/modernization-ui/src/filters/entry/PartialValueEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/PartialValueEntryForm.tsx
@@ -2,7 +2,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { Input } from 'components/FormInputs/Input';
 import { FilterEntry } from './FilterEntry';
 
-const SingleValueEntryForm = () => {
+const PartialValueEntryForm = () => {
     const { control } = useFormContext<FilterEntry, Partial<FilterEntry>>();
 
     return (
@@ -30,4 +30,4 @@ const SingleValueEntryForm = () => {
     );
 };
 
-export { SingleValueEntryForm };
+export { PartialValueEntryForm };

--- a/apps/modernization-ui/src/filters/externalize.spec.ts
+++ b/apps/modernization-ui/src/filters/externalize.spec.ts
@@ -1,9 +1,9 @@
-import { DateFilter, DateRangeFilter, MultiValueFilter, SingleValueFilter } from 'filters';
+import { DateFilter, DateRangeFilter, ExactValueFilter, PartialValueFilter } from 'filters';
 import { externalize } from './externalize';
 
 describe('when a filter is externalized', () => {
     it('should send a single value filter to the API', () => {
-        const filter: SingleValueFilter = {
+        const filter: PartialValueFilter = {
             id: 'single-value-identifier',
             property: { value: 'single-value', name: 'Single Value', type: 'value' },
             operator: { name: 'Starts with', value: 'STARTS_WITH' },
@@ -22,7 +22,7 @@ describe('when a filter is externalized', () => {
     });
 
     it('should send a multi value filter to the API', () => {
-        const filter: MultiValueFilter = {
+        const filter: ExactValueFilter = {
             id: 'multi-value-identifier',
             property: { value: 'multi-value', name: 'Multi Value', type: 'value' },
             operator: { name: 'equals', value: 'EQUALS' },

--- a/apps/modernization-ui/src/filters/externalize.ts
+++ b/apps/modernization-ui/src/filters/externalize.ts
@@ -5,13 +5,13 @@ import {
     DateRange,
     DateRangeFilter,
     Filter,
-    MultiValue,
-    MultiValueFilter,
-    SingleValue,
-    SingleValueFilter,
+    ExactValue,
+    ExactValueFilter,
+    PartialValue,
+    PartialValueFilter,
     Value
 } from './filter';
-import { DatePeriodOperator, MultiValueOperator, SingleValueOperator } from './operators';
+import { DatePeriodOperator, ExactValueOperator, PartialValueOperator } from './operators';
 
 type Base = {
     property: string;
@@ -24,23 +24,23 @@ type ExternalDatePeriodFilter = {
 
 type ExternalDateRangeFilter = Base & DateRange;
 
-type ExternalSingleValueFilter = {
-    operator: SingleValueOperator;
+type ExternalPartialValueFilter = {
+    operator: PartialValueOperator;
 } & Base &
-    SingleValue;
+    PartialValue;
 
-type ExternalMultiValueFilter = {
-    operator: MultiValueOperator;
+type ExternalExactValueFilter = {
+    operator: ExactValueOperator;
 } & Base &
-    MultiValue;
+    ExactValue;
 
 const externalize = (displayables: Filter[]): APIFilter[] => displayables.map(asFilter);
 
 const asFilter = (displayable: Filter): APIFilter => {
     if ('value' in displayable) {
-        return asSingleValueFilter(displayable);
+        return asPartialValueFilter(displayable);
     } else if ('values' in displayable) {
-        return asMultiValueFilter(displayable);
+        return asExactValueFilter(displayable);
     } else if ('after' in displayable && 'before' in displayable) {
         return asDateRangeFilter(displayable);
     }
@@ -48,20 +48,20 @@ const asFilter = (displayable: Filter): APIFilter => {
     return asDatePeriodFilter(displayable);
 };
 
-const asSingleValue = (value: Value): string => (typeof value === 'string' ? value : value.value);
+const asPartialValue = (value: Value): string => (typeof value === 'string' ? value : value.value);
 
-const asSingleValueFilter = (displayable: SingleValueFilter): ExternalSingleValueFilter => ({
+const asPartialValueFilter = (displayable: PartialValueFilter): ExternalPartialValueFilter => ({
     property: displayable.property.value,
     operator: displayable.operator.value,
-    value: asSingleValue(displayable.value)
+    value: asPartialValue(displayable.value)
 });
 
-const asMultiValue = (values: Value[]): string[] => values.map(asSingleValue);
+const asExactValue = (values: Value[]): string[] => values.map(asPartialValue);
 
-const asMultiValueFilter = (displayable: MultiValueFilter): ExternalMultiValueFilter => ({
+const asExactValueFilter = (displayable: ExactValueFilter): ExternalExactValueFilter => ({
     property: displayable.property.value,
     operator: displayable.operator.value,
-    values: asMultiValue(displayable.values)
+    values: asExactValue(displayable.values)
 });
 
 const asDatePeriodFilter = (displayable: DatePeriodFilter): ExternalDatePeriodFilter => ({

--- a/apps/modernization-ui/src/filters/filter.ts
+++ b/apps/modernization-ui/src/filters/filter.ts
@@ -4,15 +4,15 @@ import { DateProperty, ValueProperty } from './properties';
 import {
     SelectableDatePeriodOperator,
     SelectableDateRangeOperator,
-    SelectableMultiValueOperator,
+    SelectableExactValueOperator,
     SelectableSinlgeValueOperator
 } from './selectables';
 
-type MultiValue = { values: string[] };
-type SingleValue = { value: string };
+type ExactValue = { values: string[] };
+type PartialValue = { value: string };
 type DateRange = { after: string; before: string };
 
-export type { MultiValue, SingleValue, DateRange };
+export type { ExactValue, PartialValue, DateRange };
 
 type Identifiable = {
     id: string;
@@ -20,19 +20,19 @@ type Identifiable = {
 
 type Value = string | Selectable;
 
-type SingleValueFilter = Identifiable & {
+type PartialValueFilter = Identifiable & {
     property: ValueProperty;
     operator: SelectableSinlgeValueOperator;
     value: Value;
 };
 
-type MultiValueFilter = Identifiable & {
+type ExactValueFilter = Identifiable & {
     property: ValueProperty;
-    operator: SelectableMultiValueOperator;
+    operator: SelectableExactValueOperator;
     values: Value[];
 };
 
-type ValueFilter = SingleValueFilter | MultiValueFilter;
+type ValueFilter = PartialValueFilter | ExactValueFilter;
 
 type DatePeriodFilter = Identifiable & {
     property: DateProperty;
@@ -50,8 +50,8 @@ type Filter = ValueFilter | DateFilter;
 
 export type {
     Value,
-    SingleValueFilter,
-    MultiValueFilter,
+    PartialValueFilter,
+    ExactValueFilter,
     ValueFilter,
     DatePeriodFilter,
     DateRangeFilter,

--- a/apps/modernization-ui/src/filters/operators.ts
+++ b/apps/modernization-ui/src/filters/operators.ts
@@ -1,6 +1,6 @@
-type MultiValueOperator = 'EQUALS' | 'NOT_EQUAL_TO';
-type SingleValueOperator = 'STARTS_WITH' | 'CONTAINS';
-type ValueOperator = SingleValueOperator | MultiValueOperator;
+type ExactValueOperator = 'EQUALS' | 'NOT_EQUAL_TO';
+type PartialValueOperator = 'STARTS_WITH' | 'CONTAINS';
+type ValueOperator = PartialValueOperator | ExactValueOperator;
 
 type DatePeriodOperator = 'TODAY' | 'LAST_7_DAYS' | 'LAST_14_DAYS' | 'LAST_30_DAYS' | 'MORE_THAN_30_DAYS';
 type DateRangeOperator = 'BETWEEN';
@@ -11,14 +11,14 @@ export type {
     DateOperator,
     DatePeriodOperator,
     DateRangeOperator,
-    SingleValueOperator,
-    MultiValueOperator
+    PartialValueOperator,
+    ExactValueOperator
 };
 
-const isSingleValueProperty = (operator?: ValueOperator) =>
+const isPartialValueProperty = (operator?: ValueOperator) =>
     (operator && (operator === 'STARTS_WITH' || operator === 'CONTAINS')) || false;
 
-const isMultiValueProperty = (operator?: ValueOperator) =>
+const isExactValueProperty = (operator?: ValueOperator) =>
     (operator && (operator === 'EQUALS' || operator === 'NOT_EQUAL_TO')) || false;
 
-export { isSingleValueProperty, isMultiValueProperty };
+export { isPartialValueProperty, isExactValueProperty };

--- a/apps/modernization-ui/src/filters/properties.ts
+++ b/apps/modernization-ui/src/filters/properties.ts
@@ -9,6 +9,7 @@ type Complete = (criteria: string) => Promise<Selectable[]>;
 
 type ValueProperty = BaseProperty & {
     type: 'value';
+    exactOnly?: boolean;
     complete?: Complete;
     all?: Selectable[];
 };

--- a/apps/modernization-ui/src/filters/selectables.ts
+++ b/apps/modernization-ui/src/filters/selectables.ts
@@ -1,29 +1,29 @@
 import {
     DatePeriodOperator,
     DateRangeOperator,
-    isMultiValueProperty,
-    isSingleValueProperty,
-    MultiValueOperator,
-    SingleValueOperator
+    isExactValueProperty,
+    isPartialValueProperty,
+    ExactValueOperator,
+    PartialValueOperator
 } from './operators';
-import { Property } from './properties';
+import { Property, ValueProperty } from './properties';
 
-type SelectableSinlgeValueOperator = { name: string; value: SingleValueOperator };
-type SelectableMultiValueOperator = { name: string; value: MultiValueOperator };
+type SelectableSinlgeValueOperator = { name: string; value: PartialValueOperator };
+type SelectableExactValueOperator = { name: string; value: ExactValueOperator };
 
-type SelectableValueOperator = SelectableSinlgeValueOperator | SelectableMultiValueOperator;
+type SelectableValueOperator = SelectableSinlgeValueOperator | SelectableExactValueOperator;
 
-const singleValueOperators: SelectableSinlgeValueOperator[] = [
+const partialValueOperators: SelectableSinlgeValueOperator[] = [
     { name: 'starts with', value: 'STARTS_WITH' },
     { name: 'contains', value: 'CONTAINS' }
 ];
 
-const multiValueOperators: SelectableMultiValueOperator[] = [
+const exactValueOperators: SelectableExactValueOperator[] = [
     { name: 'equals', value: 'EQUALS' },
     { name: 'not equal to', value: 'NOT_EQUAL_TO' }
 ];
 
-const valueOperators: SelectableValueOperator[] = [...singleValueOperators, ...multiValueOperators];
+const valueOperators: SelectableValueOperator[] = [...partialValueOperators, ...exactValueOperators];
 
 type SelectableDatePeriodOperator = { name: string; value: DatePeriodOperator };
 type SelectableDateRangeOperator = { name: string; value: DateRangeOperator };
@@ -42,7 +42,7 @@ type OperatorOption = SelectableValueOperator | SelectableDateOperator;
 
 export type {
     SelectableSinlgeValueOperator,
-    SelectableMultiValueOperator,
+    SelectableExactValueOperator,
     SelectableValueOperator,
     SelectableDateOperator,
     SelectableDatePeriodOperator,
@@ -52,25 +52,26 @@ export type {
 
 const operators: (property?: Property) => OperatorOption[] = (property) => {
     if (property) {
-        return property.type === 'value' ? valueOperators : dateOperators;
+        return property.type === 'value' ? resolveValueOperators(property) : dateOperators;
     }
-
     return [];
 };
 
+const resolveValueOperators = (property: ValueProperty) => (property.exactOnly ? exactValueOperators : valueOperators);
+
 const withValue = (value: string) => (option: OperatorOption) => option.value === value;
 
-const isSingleValueOption = (option?: SelectableValueOperator) => isSingleValueProperty(option?.value);
+const isPartialValueOption = (option?: SelectableValueOperator) => isPartialValueProperty(option?.value);
 
-const isMultiValueOption = (option?: SelectableValueOperator) => isMultiValueProperty(option?.value);
+const isExactValueOption = (option?: SelectableValueOperator) => isExactValueProperty(option?.value);
 
 export {
     valueOperators,
-    singleValueOperators,
-    multiValueOperators,
+    partialValueOperators as PartialValueOperators,
+    exactValueOperators as ExactValueOperators,
     dateOperators,
     withValue,
     operators,
-    isMultiValueOption,
-    isSingleValueOption
+    isExactValueOption,
+    isPartialValueOption
 };


### PR DESCRIPTION
## Description

Removes the partial filter operators from `event type` and `status` on Page library.

## Tickets

* [CNFT2-1626](https://cdc-nbs.atlassian.net/browse/CNFT2-1626)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1626]: https://cdc-nbs.atlassian.net/browse/CNFT2-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ