### PR TITLE
Reset page on search

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@trussworks/react-uswds';
-import { Icon } from '@trussworks/react-uswds';
+import { Button, Icon } from '@trussworks/react-uswds';
 import { OverlayPanel } from 'overlay';
 import { Filter, FilterPanel, Property } from 'filters';
 import { LinkButton } from 'components/button';

--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
@@ -11,7 +11,7 @@ type Sorting = {
     direction: 'asc' | 'desc';
 };
 
-type Status = 'initialize' | 'idle' | 'searching' | 'found' | 'resetPage';
+type Status = 'initialize' | 'idle' | 'searching' | 'found' | 'new-search';
 
 type State = { status: Status; keyword?: string; filters: APIFilter[]; sorting?: Sorting; pages: PageSummary[] };
 
@@ -30,7 +30,7 @@ const reducer = (current: State, action: Action): State => {
             return { ...current, status: 'searching', sorting: action.sorting };
         case 'search': {
             return action.keyword !== current.keyword
-                ? { ...current, status: 'resetPage', keyword: action.keyword, pages: [] }
+                ? { ...current, status: 'new-search', keyword: action.keyword, pages: [] }
                 : current;
         }
         case 'doSearch':
@@ -69,7 +69,7 @@ const usePageSummarySearch = () => {
     }, [sorting, dispatch]);
 
     useEffect(() => {
-        if (state.status === 'resetPage') {
+        if (state.status === 'new-search') {
             if (page.current === 1) {
                 dispatch({ type: 'doSearch', keyword: state.keyword });
             } else {
@@ -79,7 +79,7 @@ const usePageSummarySearch = () => {
     }, [state.status]);
 
     useEffect(() => {
-        if (state.status === 'resetPage' && page.current == 1) {
+        if (state.status === 'new-search' && page.current == 1) {
             dispatch({ type: 'doSearch', keyword: state.keyword });
         }
     }, [page.current]);

--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
@@ -19,7 +19,7 @@ type Action =
     | { type: 'reset' }
     | { type: 'sort'; sorting: Sorting }
     | { type: 'search'; keyword?: string }
-    | { type: 'doSearch'; keyword?: string }
+    | { type: 'fetch'; keyword?: string }
     | { type: 'filter'; filters: APIFilter[] }
     | { type: 'found'; result: PageSummary[] }
     | { type: 'refresh' };
@@ -33,7 +33,7 @@ const reducer = (current: State, action: Action): State => {
                 ? { ...current, status: 'new-search', keyword: action.keyword, pages: [] }
                 : current;
         }
-        case 'doSearch':
+        case 'fetch':
             return { ...current, status: 'searching', keyword: action.keyword, pages: [] };
         case 'filter':
             return { ...current, status: 'searching', filters: action.filters, pages: [] };
@@ -71,7 +71,7 @@ const usePageSummarySearch = () => {
     useEffect(() => {
         if (state.status === 'new-search') {
             if (page.current === 1) {
-                dispatch({ type: 'doSearch', keyword: state.keyword });
+                dispatch({ type: 'fetch', keyword: state.keyword });
             } else {
                 firstPage();
             }
@@ -80,7 +80,7 @@ const usePageSummarySearch = () => {
 
     useEffect(() => {
         if (state.status === 'new-search' && page.current == 1) {
-            dispatch({ type: 'doSearch', keyword: state.keyword });
+            dispatch({ type: 'fetch', keyword: state.keyword });
         }
     }, [page.current]);
 

--- a/apps/modernization-ui/src/page/usePage.tsx
+++ b/apps/modernization-ui/src/page/usePage.tsx
@@ -86,19 +86,8 @@ const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, childr
         }
     };
 
-    const dispatchGoTo = (page: number) => {
-        if (appendToUrl) {
-            setSearchParams((current) => {
-                current.set(PAGE_PARAMETER, page.toString());
-                return current;
-            });
-        }
-        dispatch({ type: 'go-to', page });
-    };
-
-    const requestFromDispatch = (page: number) => dispatchGoTo(page);
-
-    const firstPage = () => dispatchGoTo(1);
+    const requestFromDispatch = (page: number) => dispatch({ type: 'go-to', page });
+    const firstPage = appendToUrl ? () => requestFromUrl(1) : () => requestFromDispatch(1);
     const reload = () => dispatch({ type: 'reload' });
     const request = appendToUrl ? requestFromUrl : requestFromDispatch;
     const ready = (total: number, page: number) => dispatch({ type: 'ready', total, page });

--- a/apps/modernization-ui/src/page/usePage.tsx
+++ b/apps/modernization-ui/src/page/usePage.tsx
@@ -87,7 +87,7 @@ const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, childr
     };
 
     const requestFromDispatch = (page: number) => dispatch({ type: 'go-to', page });
-    const firstPage = appendToUrl ? () => requestFromUrl(1) : () => requestFromDispatch(1);
+    const firstPage = () => request(1);
     const reload = () => dispatch({ type: 'reload' });
     const request = appendToUrl ? requestFromUrl : requestFromDispatch;
     const ready = (total: number, page: number) => dispatch({ type: 'ready', total, page });

--- a/apps/modernization-ui/src/page/usePage.tsx
+++ b/apps/modernization-ui/src/page/usePage.tsx
@@ -86,9 +86,19 @@ const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, childr
         }
     };
 
-    const requestFromDispatch = (page: number) => dispatch({ type: 'go-to', page });
+    const dispatchGoTo = (page: number) => {
+        if (appendToUrl) {
+            setSearchParams((current) => {
+                current.set(PAGE_PARAMETER, page.toString());
+                return current;
+            });
+        }
+        dispatch({ type: 'go-to', page });
+    };
 
-    const firstPage = () => dispatch({ type: 'go-to', page: 1 });
+    const requestFromDispatch = (page: number) => dispatchGoTo(page);
+
+    const firstPage = () => dispatchGoTo(1);
     const reload = () => dispatch({ type: 'reload' });
     const request = appendToUrl ? requestFromUrl : requestFromDispatch;
     const ready = (total: number, page: number) => dispatch({ type: 'ready', total, page });

--- a/apps/modernization-ui/src/page/usePage.tsx
+++ b/apps/modernization-ui/src/page/usePage.tsx
@@ -87,9 +87,9 @@ const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, childr
     };
 
     const requestFromDispatch = (page: number) => dispatch({ type: 'go-to', page });
-    const firstPage = () => request(1);
     const reload = () => dispatch({ type: 'reload' });
     const request = appendToUrl ? requestFromUrl : requestFromDispatch;
+    const firstPage = () => request(1);
     const ready = (total: number, page: number) => dispatch({ type: 'ready', total, page });
     const resize = (size: number) => dispatch({ type: 'resize', size });
 


### PR DESCRIPTION
## Description

Updates the `usePage` to set the search params on `firstPage`. Updates the `usePageSummarySearch` to reset the page to `1` when a new search is executed.

## Tickets

* [CNFT2-1337](https://cdc-nbs.atlassian.net/browse/CNFT2-1337)
![ResetSearchPage](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/0d2f2efc-fd29-4be4-b7d8-39d4cf052361)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1337]: https://cdc-nbs.atlassian.net/browse/CNFT2-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ