### PR TITLE
Validate From cannot be greater than To

### DIFF
--- a/apps/modernization-ui/src/filters/entry/DataRangeEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/DataRangeEntryForm.tsx
@@ -1,12 +1,32 @@
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { FilterEntry } from './FilterEntry';
+import { isAfter } from 'date-fns';
+import { internalizeDate } from 'date';
+import { useEffect } from 'react';
 
 const DataRangeEntryForm = () => {
-    const { control } = useFormContext<FilterEntry, Partial<FilterEntry>>();
+    const { control, trigger } = useFormContext<FilterEntry, Partial<FilterEntry>>();
 
     const before = useWatch({ control, name: 'before' });
     const after = useWatch({ control, name: 'after' });
+
+    useEffect(() => {
+        trigger('after');
+    }, [before]);
+
+    const isBeforeTo =
+        (to: string) =>
+        (after: string): string | undefined => {
+            if (to && after) {
+                const toDate = new Date(to);
+                const afterDate = new Date(after);
+
+                if (isAfter(afterDate, toDate)) {
+                    return `Cannot be after 'To' date: ${internalizeDate(toDate)}`;
+                }
+            }
+        };
 
     return (
         <>
@@ -15,7 +35,8 @@ const DataRangeEntryForm = () => {
                 name="after"
                 shouldUnregister
                 rules={{
-                    required: { value: !before, message: 'From date is required when To is not picked.' }
+                    required: { value: !before, message: 'From date is required when To is not picked.' },
+                    validate: isBeforeTo(before)
                 }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput

--- a/apps/modernization-ui/src/filters/entry/DataRangeEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/DataRangeEntryForm.tsx
@@ -11,7 +11,9 @@ const DataRangeEntryForm = () => {
     const after = useWatch({ control, name: 'after' });
 
     useEffect(() => {
-        trigger('after');
+        if (before) {
+            trigger('after');
+        }
     }, [before]);
 
     return (

--- a/apps/modernization-ui/src/filters/entry/DataRangeEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/DataRangeEntryForm.tsx
@@ -1,9 +1,8 @@
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { FilterEntry } from './FilterEntry';
-import { isAfter } from 'date-fns';
-import { internalizeDate } from 'date';
 import { useEffect } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { isBefore } from 'validation/date';
+import { FilterEntry } from './FilterEntry';
 
 const DataRangeEntryForm = () => {
     const { control, trigger } = useFormContext<FilterEntry, Partial<FilterEntry>>();
@@ -15,19 +14,6 @@ const DataRangeEntryForm = () => {
         trigger('after');
     }, [before]);
 
-    const isBeforeTo =
-        (to: string) =>
-        (after: string): string | undefined => {
-            if (to && after) {
-                const toDate = new Date(to);
-                const afterDate = new Date(after);
-
-                if (isAfter(afterDate, toDate)) {
-                    return `Cannot be after 'To' date: ${internalizeDate(toDate)}`;
-                }
-            }
-        };
-
     return (
         <>
             <Controller
@@ -36,7 +22,7 @@ const DataRangeEntryForm = () => {
                 shouldUnregister
                 rules={{
                     required: { value: !before, message: 'From date is required when To is not picked.' },
-                    validate: isBeforeTo(before)
+                    validate: isBefore(before)
                 }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput

--- a/apps/modernization-ui/src/validation/date/index.ts
+++ b/apps/modernization-ui/src/validation/date/index.ts
@@ -1,0 +1,1 @@
+export * from './isBefore';

--- a/apps/modernization-ui/src/validation/date/isBefore.ts
+++ b/apps/modernization-ui/src/validation/date/isBefore.ts
@@ -1,0 +1,17 @@
+import { internalizeDate } from 'date';
+import { isAfter } from 'date-fns';
+
+const isBefore =
+    (max: string) =>
+    (current: string): string | undefined => {
+        if (max && current) {
+            const maxDate = new Date(max);
+            const currentDate = new Date(current);
+
+            if (isAfter(currentDate, maxDate)) {
+                return `Date cannot be after: ${internalizeDate(maxDate)}`;
+            }
+        }
+    };
+
+export { isBefore };

--- a/apps/modernization-ui/src/validation/date/isBefore.ts
+++ b/apps/modernization-ui/src/validation/date/isBefore.ts
@@ -1,4 +1,3 @@
-import { internalizeDate } from 'date';
 import { isAfter } from 'date-fns';
 
 const isBefore =
@@ -9,7 +8,7 @@ const isBefore =
             const currentDate = new Date(current);
 
             if (isAfter(currentDate, maxDate)) {
-                return `Date cannot be after: ${internalizeDate(maxDate)}`;
+                return `Date cannot be after: ${max}`;
             }
         }
     };


### PR DESCRIPTION
## Description

Adds validation to the page library filter to prevent `From` being greater than the `To` date.

## Tickets

* [CNFT2-1640](https://cdc-nbs.atlassian.net/browse/CNFT2-1640)

![from-to](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/48cc890a-fe11-4627-9f26-a91f36bd694f)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1640]: https://cdc-nbs.atlassian.net/browse/CNFT2-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ