### PR TITLE
Set max length of 50 for search input

### DIFF
--- a/apps/modernization-ui/src/components/Search/Search.tsx
+++ b/apps/modernization-ui/src/components/Search/Search.tsx
@@ -42,6 +42,7 @@ const Search = (props: SearchProps) => {
                 defaultValue={props.value}
                 onChange={(event) => setKeyword(event.target.value)}
                 onKeyDown={handleEnter}
+                maxLength={50}
             />
             <Button type="button" onClick={handleSearch}>
                 <Icon.Search size={3} name="Search" />


### PR DESCRIPTION
## Description

Updates search box in page library to stop accepting input after 50 characters.

## Tickets

* [CNFT2-1644](https://cdc-nbs.atlassian.net/browse/CNFT2-1644)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1644]: https://cdc-nbs.atlassian.net/browse/CNFT2-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ