### PR TITLE
Cnft1 1771 508 main content advanced search

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/patientSearch/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/patientSearch/PatientSearch.tsx
@@ -72,6 +72,7 @@ export const PatientSearch = ({ handleSubmission, personFilter, clearAll }: Pati
                                     htmlFor={name}
                                     id={name}
                                     error={error?.message}
+                                    ariaLabel={'Perform a patient search, Last Name'}
                                 />
                             )}
                         />

--- a/apps/modernization-ui/src/components/FormInputs/Input.tsx
+++ b/apps/modernization-ui/src/components/FormInputs/Input.tsx
@@ -23,6 +23,7 @@ type InputProps = {
     textAreaRef?: RefObject<HTMLTextAreaElement>;
     mask?: string;
     pattern?: string;
+    ariaLabel?: string;
 } & Omit<JSX.IntrinsicElements['input'], 'defaultValue'>;
 
 export const Input = ({
@@ -44,6 +45,7 @@ export const Input = ({
     textAreaRef,
     mask,
     pattern,
+    ariaLabel,
     ...props
 }: InputProps) => {
     const orientation = flexBox ? 'horizontal' : 'vertical';
@@ -74,6 +76,7 @@ export const Input = ({
                             type={type}
                             mask={mask}
                             pattern={pattern}
+                            aria-label={ariaLabel}
                         />
                     ) : (
                         <TextInput
@@ -90,6 +93,7 @@ export const Input = ({
                             aria-describedby={`${error}-message`}
                             className={classNames(className)}
                             type={type}
+                            aria-label={ariaLabel}
                         />
                     )
                 ) : (
@@ -103,6 +107,7 @@ export const Input = ({
                         inputRef={textAreaRef}
                         aria-describedby={`${error}-message`}
                         className={classNames(className)}
+                        aria-label={ariaLabel}
                     />
                 )}
             </EntryWrapper>

--- a/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/pages/advancedSearch/AdvancedSearch.tsx
@@ -78,7 +78,7 @@ export const AdvancedSearch = () => {
     const { skipTo } = useSkipLink();
 
     useEffect(() => {
-        skipTo('perform-search');
+        skipTo('lastName');
     }, []);
 
     const [showAddNewDropDown, setShowAddNewDropDown] = useState<boolean>(false);


### PR DESCRIPTION
## Description

As a screen reader I need to be able to navigate to the main content of the advanced search page by tabbing directly to it. 
In this case the last name field should be focused upon skipping to main content for this page


## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT1-1771

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
