### PR TITLE
Edit question placeholder

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/generated/models/PagesQuestion.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/models/PagesQuestion.ts
@@ -9,6 +9,7 @@ export type PagesQuestion = {
     defaultValue?: string;
     description?: string;
     display?: boolean;
+    displayComponent?: number;
     enabled?: boolean;
     id: number;
     isStandard?: boolean;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/content/PageSideMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/content/PageSideMenu.tsx
@@ -14,7 +14,7 @@ export const PageSideMenu = () => {
                 </li>
                 <li>
                     <EQIcon name="reorder" />
-                    Add section
+                    Reorder
                 </li>
             </ul>
         </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/Question.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/Question.tsx
@@ -21,7 +21,11 @@ export const Question = ({ question, onRequiredChange, onEditQuestion, onDeleteQ
                     onEditQuestion={() => onEditQuestion(question.id)}
                     onDeleteQuestion={() => onDeleteQuestion(question.id)}
                 />
-                <QuestionContent name={question.name} type={question.dataType ?? ''} />
+                <QuestionContent
+                    name={question.name}
+                    type={question.dataType ?? ''}
+                    displayComponent={question.displayComponent}
+                />
             </div>
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/Question.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/Question.tsx
@@ -1,0 +1,28 @@
+import { PagesQuestion } from 'apps/page-builder/generated';
+import { QuestionHeader } from './QuestionHeader';
+
+import styles from './question.module.scss';
+import { QuestionContent } from './QuestionContent';
+
+type Props = {
+    question: PagesQuestion;
+    onRequiredChange: (id: number) => void;
+    onEditQuestion: (id: number) => void;
+    onDeleteQuestion: (id: number) => void;
+};
+export const Question = ({ question, onRequiredChange, onEditQuestion, onDeleteQuestion }: Props) => {
+    return (
+        <div className={styles.question}>
+            <div className={styles.borderedContainer}>
+                <QuestionHeader
+                    isStandard={question.isStandard ?? false}
+                    isRequired={question.required ?? false}
+                    onRequiredChange={() => onRequiredChange(question.id)}
+                    onEditQuestion={() => onEditQuestion(question.id)}
+                    onDeleteQuestion={() => onDeleteQuestion(question.id)}
+                />
+                <QuestionContent name={question.name} type={question.dataType ?? ''} />
+            </div>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-
-import styles from './question-content.module.scss';
 import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
+import { Heading } from 'components/heading';
+import styles from './question-content.module.scss';
 
 type Props = {
     name: string;
@@ -12,7 +11,7 @@ export const QuestionContent = ({ name, type, displayComponent }: Props) => {
     return (
         <div className={styles.question}>
             <AlertBanner type="warning">Work in progress</AlertBanner>
-            <div className={styles.name}>{name}</div>
+            <Heading level={2}>{name}</Heading>
             <div>Type: {type}</div>
             <div>Display component: {displayComponent}</div>
         </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import styles from './question-content.module.scss';
+import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
 
 type Props = {
     name: string;
@@ -10,6 +11,7 @@ type Props = {
 export const QuestionContent = ({ name, type, displayComponent }: Props) => {
     return (
         <div className={styles.question}>
+            <AlertBanner type="warning">Work in progress</AlertBanner>
             <div className={styles.name}>{name}</div>
             <div>Type: {type}</div>
             <div>Display component: {displayComponent}</div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
@@ -5,12 +5,14 @@ import styles from './question-content.module.scss';
 type Props = {
     name: string;
     type: string;
+    displayComponent?: number;
 };
-export const QuestionContent = ({ name, type }: Props) => {
+export const QuestionContent = ({ name, type, displayComponent }: Props) => {
     return (
         <div className={styles.question}>
             <div className={styles.name}>{name}</div>
             <div>Type: {type}</div>
+            <div>Display component: {displayComponent}</div>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import styles from './question-content.module.scss';
+
+type Props = {
+    name: string;
+    type: string;
+};
+export const QuestionContent = ({ name, type }: Props) => {
+    return (
+        <div className={styles.question}>
+            <div className={styles.name}>{name}</div>
+            <div>Type: {type}</div>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from './question-header.module.scss';
 import { Icon } from '@trussworks/react-uswds';
 import { ToggleButton } from 'apps/page-builder/components/ToggleButton';
+import { Heading } from 'components/heading';
 type Props = {
     isStandard: boolean;
     isRequired: boolean;
@@ -20,7 +21,7 @@ export const QuestionHeader = ({
         <div className={styles.header}>
             <div className={styles.typeDisplay}>
                 {isStandard && <div className={styles.standardIndicator}>S</div>}
-                Question
+                <Heading level={3}>Question</Heading>
             </div>
             <div className={styles.questionButtons}>
                 <Icon.Edit onClick={onEditQuestion} />

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styles from './question-header.module.scss';
+import { Icon } from '@trussworks/react-uswds';
+import { ToggleButton } from 'apps/page-builder/components/ToggleButton';
+type Props = {
+    isStandard: boolean;
+    isRequired: boolean;
+    onRequiredChange?: () => void;
+    onEditQuestion?: () => void;
+    onDeleteQuestion?: () => void;
+};
+export const QuestionHeader = ({
+    isStandard,
+    isRequired,
+    onRequiredChange,
+    onEditQuestion,
+    onDeleteQuestion
+}: Props) => {
+    return (
+        <div className={styles.header}>
+            <div className={styles.typeDisplay}>
+                {isStandard && <div className={styles.standardIndicator}>S</div>}
+                Question
+            </div>
+            <div className={styles.questionButtons}>
+                <Icon.Edit onClick={onEditQuestion} />
+                <Icon.Delete onClick={onDeleteQuestion} />
+                <div className={styles.divider}>|</div>
+                <div className={styles.requiredToggle}>Required</div>
+                <ToggleButton defaultChecked={isRequired} onChange={onRequiredChange} />
+            </div>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-content.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-content.module.scss
@@ -1,0 +1,20 @@
+@use 'styles/colors';
+
+.question {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    width: 54rem;
+    align-items: flex-start;
+    gap: 0.75rem;
+
+    border-radius: 0rem 0rem 0.3125rem 0.3125rem;
+    border: 1px solid colors.$base-lightest;
+    background: colors.$base-white;
+
+    .name {
+        color: colors.$base-black;
+        font-size: 1.375rem;
+        font-weight: 700;
+    }
+}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-content.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-content.module.scss
@@ -11,10 +11,4 @@
     border-radius: 0rem 0rem 0.3125rem 0.3125rem;
     border: 1px solid colors.$base-lightest;
     background: colors.$base-white;
-
-    .name {
-        color: colors.$base-black;
-        font-size: 1.375rem;
-        font-weight: 700;
-    }
 }

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-header.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-header.module.scss
@@ -1,0 +1,55 @@
+@use 'styles/colors';
+
+.header {
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    width: 100%;
+    border-radius: 0.3125rem 0.3125rem 0rem 0rem;
+    border: 1px solid colors.$base-lightest;
+    background: colors.$base-white;
+    justify-content: space-between;
+
+    .typeDisplay {
+        display: flex;
+        align-items: center;
+
+        .standardIndicator {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            border-radius: 0.125rem;
+            background: colors.$warm-accent;
+            width: 1.5rem;
+            height: 1.5rem;
+            margin-right: 0.75rem;
+
+            color: colors.$base-white;
+            text-align: center;
+            font-size: 0.875rem;
+            font-style: normal;
+            font-weight: 700;
+            line-height: 1.4175rem;
+        }
+    }
+
+    .questionButtons {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 1rem;
+        color: colors.$primary;
+        font-size: 1.25rem;
+        cursor: pointer;
+
+        .divider {
+            color: colors.$base-light;
+        }
+
+        .requiredToggle {
+            color: colors.$base-darker;
+            font-size: 0.875rem;
+            font-weight: 400;
+            line-height: 1.4175rem;
+        }
+    }
+}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question.module.scss
@@ -1,0 +1,14 @@
+@use 'styles/borders';
+.question {
+    padding: 1.5rem;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .borderedContainer {
+        border-radius: 0.3125rem 0.3125rem;
+
+        @extend %thin;
+    }
+}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
@@ -2,6 +2,7 @@ import { PagesSubSection } from 'apps/page-builder/generated';
 import { SubsectionHeader } from './SubsectionHeader';
 import styles from './subsection.module.scss';
 import { useState } from 'react';
+import { Question } from '../question/Question';
 
 type Props = {
     subsection: PagesSubSection;
@@ -14,6 +15,17 @@ export const Subsection = ({ subsection, onAddQuestion }: Props) => {
         setIsExpanded(expanded);
     };
 
+    const handleEditQuestion = (id: number) => {
+        console.log('edit question NYI', id);
+    };
+    const handleDeleteQuestion = (id: number) => {
+        console.log('delete question NYI', id);
+    };
+
+    const handleRequiredChange = (id: number) => {
+        console.log('update question NYI', id);
+    };
+
     return (
         <div className={styles.subsection}>
             <SubsectionHeader
@@ -24,6 +36,15 @@ export const Subsection = ({ subsection, onAddQuestion }: Props) => {
                 onExpandedChange={handleExpandedChange}
                 isExpanded={isExpanded}
             />
+            {subsection.questions.map((q, k) => (
+                <Question
+                    question={q}
+                    key={k}
+                    onEditQuestion={handleEditQuestion}
+                    onDeleteQuestion={handleDeleteQuestion}
+                    onRequiredChange={handleRequiredChange}
+                />
+            ))}
         </div>
     );
 };

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/component/tree/FlattenedComponentFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/component/tree/FlattenedComponentFinder.java
@@ -29,11 +29,11 @@ class FlattenedComponentFinder {
           [component].question_tool_tip         as [tool_tip],
           [component].default_value             as [default_value],
           [set].[code_set_nm]                   as [value_set]
-      from WA_UI_metadata [component]\
-            
+      from WA_UI_metadata [component]
+
           left join [NBS_SRTE]..Codeset [set] on
                   [set].code_set_group_id = [component].[code_set_group_id]
-            
+
       where   [component].wa_template_uid = ?
           and [component].order_nbr > 0
       order by

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponse.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponse.java
@@ -102,7 +102,8 @@ public record PagesResponse(
       boolean enabled,
       boolean required,
       String defaultValue,
-      String valueSet
+      String valueSet,
+      long displayComponent
   ) {
   }
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapper.java
@@ -114,6 +114,7 @@ class PagesResponseMapper {
     boolean required = content.attributes().required();
     String defaultValue = content.attributes().defaultValue();
     String valueSet = content instanceof SelectionNode selection ? selection.valueSet() : null;
+    long displayComponent = content.type().identifier();
     return new PagesResponse.PagesQuestion(
         id,
         isStandard,
@@ -132,7 +133,8 @@ class PagesResponseMapper {
         enabled,
         required,
         defaultValue,
-        valueSet
+        valueSet,
+        displayComponent
     );
   }
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapperTest.java
@@ -318,7 +318,8 @@ class PagesResponseMapperTest {
                                 () -> assertThat(question.coInfection()).isTrue(),
                                 () -> assertThat(question.mask()).isEqualTo("mask-value"),
                                 () -> assertThat(question.tooltip()).isEqualTo("tool-tip-value"),
-                                () -> assertThat(question.defaultValue()).isEqualTo("default-value-value")
+                                () -> assertThat(question.defaultValue()).isEqualTo("default-value-value"),
+                                () -> assertThat(question.displayComponent()).isEqualTo(1003L)
                             )
                         )
                     )


### PR DESCRIPTION
## Description

Placeholder shell for questions on the Edit page. This will allow the development of `Edit` and `Delete`.

Temporarily adds a `displayComponent` field to the `PagesQuestion` object returned so that the UI can be aware of the selected display control. This will be changed in the future to not expose the Ids to the UI.

![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/4aba99e8-fd6e-4b41-b904-1cb2474524fa)

## Tickets

N/A

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
