### PR TITLE
Rename column  ->  on Page Library

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/table/PageLibraryTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/table/PageLibraryTable.spec.tsx
@@ -13,7 +13,7 @@ describe('when rendered', () => {
         const tableHeads = getAllByRole('columnheader');
 
         expect(tableHeads[0]).toHaveTextContent('Page name');
-        expect(tableHeads[1]).toHaveTextContent('Event name');
+        expect(tableHeads[1]).toHaveTextContent('Event type');
         expect(tableHeads[2]).toHaveTextContent('Related condition(s)');
         expect(tableHeads[3]).toHaveTextContent('Status');
         expect(tableHeads[4]).toHaveTextContent('Last updated');

--- a/apps/modernization-ui/src/apps/page-builder/page/library/table/PageLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/table/PageLibraryTable.tsx
@@ -10,7 +10,7 @@ import styles from './page-library-table.module.scss';
 
 export enum Column {
     PageName = 'Page name',
-    EventType = 'Event name',
+    EventType = 'Event type',
     RelatedConditions = 'Related condition(s)',
     Status = 'Status',
     LastUpdate = 'Last updated',


### PR DESCRIPTION
## Description

Updates the column name in the Page Library table from `Event name` to `Event type` to match Classic™.

## Tickets

* [CNFT2-1231](https://cdc-nbs.atlassian.net/browse/CNFT2-1231)

![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/f4b32a7d-e6c8-4b7c-867d-92c270d912ec)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1231]: https://cdc-nbs.atlassian.net/browse/CNFT2-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ