### PR TITLE
CNFT2-1649 Published with Draft filter

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
@@ -6,7 +6,7 @@ import { useConditionOptionsAutocomplete } from 'options/condition';
 import { useUserOptionsAutocomplete } from 'options/users';
 
 const statusOptions: Selectable[] = [
-    { label: 'Draft', value: 'Draft', name: 'Draft' },
+    { label: 'Initial Draft', value: 'Initial Draft', name: 'Initial Draft' },
     { label: 'Published', value: 'Published', name: 'Published' },
     { label: 'Published with Draft', value: 'Published with Draft', name: 'Published with Draft' }
 ];

--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageLibraryProperties.ts
@@ -8,7 +8,7 @@ import { useUserOptionsAutocomplete } from 'options/users';
 const statusOptions: Selectable[] = [
     { label: 'Draft', value: 'Draft', name: 'Draft' },
     { label: 'Published', value: 'Published', name: 'Published' },
-    { label: 'Published with draft', value: 'Published with draft', name: 'Published with draft' }
+    { label: 'Published with Draft', value: 'Published with Draft', name: 'Published with Draft' }
 ];
 
 const startsWith = (criteria: string) => (option: Selectable) =>

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryTables.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummaryTables.java
@@ -28,7 +28,7 @@ record PageSummaryTables(
         QAuthUser.authUser,
         QAuthUser.authUser.userFirstNm.concat(" ").concat(QAuthUser.authUser.userLastNm),
         new CaseBuilder().when(
-                QWaTemplate.waTemplate.templateNm.eq("Draft")
+                QWaTemplate.waTemplate.templateType.eq("Draft")
                     .and(QWaTemplate.waTemplate.publishVersionNbr.isNotNull())
             ).then(PageStatus.PUBLISHED_WITH_DRAFT.display())
             .when(QWaTemplate.waTemplate.templateType.eq("Draft")).then(PageStatus.INITIAL_DRAFT.display())


### PR DESCRIPTION
## Description

1. Fixes an issue where searching by a page status was failing to return results. The problem was the `case` statement that was being created was referencing the wrong column.
2. Corrects the capitalization to match the table display.
3. Corrects `Draft` to `Initial Draft` as no Page in the UI will display the status `Draft`

## Tickets

* [CNFT2-1649](https://cdc-nbs.atlassian.net/browse/CNFT2-1649)

These changes may also resolve [CNFT2-1654](https://cdc-nbs.atlassian.net/browse/CNFT2-1654)

![publishedWithDraftFilter](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/67a589f4-a14f-4dd9-84f5-09cb14431d70)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1649]: https://cdc-nbs.atlassian.net/browse/CNFT2-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNFT2-1654]: https://cdc-nbs.atlassian.net/browse/CNFT2-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ