### PR TITLE
Make filter and keyword search work together

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/PageLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/PageLibrary.tsx
@@ -31,14 +31,18 @@ const PageLibrary = () => {
 const PageLibraryContent = () => {
     const { sorting, sortBy } = useSorting();
     const config = useConfiguration();
-    const { keyword, pages, searching, search, filter } = usePageSummarySearch();
+    const { keyword, pages, searching, search } = usePageSummarySearch();
     const { properties } = usePageLibraryProperties();
 
     const [filters, setFilters] = useState<Filter[]>([]);
 
     const handleFilter = (filters: Filter[]) => {
         setFilters(filters);
-        filter(filters);
+        search(keyword, filters);
+    };
+
+    const handleSearch = (query?: string) => {
+        search(query, filters);
     };
 
     const handleDownloadCSV = () => {
@@ -74,7 +78,7 @@ const PageLibraryContent = () => {
                     <PageLibraryMenu
                         properties={properties}
                         filters={filters}
-                        onSearch={search}
+                        onSearch={handleSearch}
                         onFilter={handleFilter}
                         onDownload={handleDownloadCSV}
                         onPrint={handleDownloadPDF}

--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
@@ -18,9 +18,8 @@ type State = { status: Status; keyword?: string; filters: APIFilter[]; sorting?:
 type Action =
     | { type: 'reset' }
     | { type: 'sort'; sorting: Sorting }
-    | { type: 'search'; keyword?: string }
-    | { type: 'fetch'; keyword?: string }
-    | { type: 'filter'; filters: APIFilter[] }
+    | { type: 'search'; keyword?: string; filters: APIFilter[] }
+    | { type: 'fetch'; keyword?: string; filters: APIFilter[] }
     | { type: 'found'; result: PageSummary[] }
     | { type: 'refresh' };
 
@@ -28,15 +27,10 @@ const reducer = (current: State, action: Action): State => {
     switch (action.type) {
         case 'sort':
             return { ...current, status: 'searching', sorting: action.sorting };
-        case 'search': {
-            return action.keyword !== current.keyword
-                ? { ...current, status: 'new-search', keyword: action.keyword, pages: [] }
-                : current;
-        }
+        case 'search':
+            return { ...current, status: 'new-search', keyword: action.keyword, filters: action.filters, pages: [] };
         case 'fetch':
             return { ...current, status: 'searching', keyword: action.keyword, pages: [] };
-        case 'filter':
-            return { ...current, status: 'searching', filters: action.filters, pages: [] };
         case 'found':
             return { ...current, status: 'found', pages: action.result };
         case 'refresh':
@@ -72,7 +66,7 @@ const usePageSummarySearch = () => {
     useEffect(() => {
         if (state.status === 'new-search') {
             if (page.current === 1) {
-                dispatch({ type: 'fetch', keyword: state.keyword });
+                dispatch({ type: 'fetch', keyword: state.keyword, filters: state.filters });
             } else {
                 firstPage();
             }
@@ -81,7 +75,7 @@ const usePageSummarySearch = () => {
 
     useEffect(() => {
         if (state.status === 'new-search' && page.current == 1) {
-            dispatch({ type: 'fetch', keyword: state.keyword });
+            dispatch({ type: 'fetch', keyword: state.keyword, filters: state.filters });
         }
     }, [page.current]);
 
@@ -112,8 +106,8 @@ const usePageSummarySearch = () => {
     return {
         searching: state.status === 'searching',
         pages: state.pages,
-        search: (keyword?: string) => dispatch({ type: 'search', keyword }),
-        filter: (filters: Filter[]) => dispatch({ type: 'filter', filters: externalize(filters) }),
+        search: (keyword?: string, filters?: Filter[]) =>
+            dispatch({ type: 'search', keyword, filters: externalize(filters ?? []) }),
         keyword: state.keyword
     };
 };


### PR DESCRIPTION
## Description

In the Page Library the `keyword` search and the filters are operating independently of each other. Entering a new keyword should include the filters in the API call.

When changing the filters, the page should be reset to 1.

## Tickets

* [CNFT2-1649](https://cdc-nbs.atlassian.net/browse/CNFT2-1649)


![keywordFilter](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/29bb6d7e-3d03-4c37-81db-6423f288ea5e)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1649]: https://cdc-nbs.atlassian.net/browse/CNFT2-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ