### PR TITLE
Allow sort on last page if only 1 entry on page

### DIFF
--- a/apps/modernization-ui/src/components/Table/Table.spec.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.spec.tsx
@@ -103,7 +103,7 @@ describe('Table component', () => {
 });
 
 describe('when a table has a sortable header', () => {
-    it('should default to no active soriting', async () => {
+    it('should default to no active sorting', async () => {
         const { getAllByRole } = render(
             <TableComponent
                 tableHeader="Test Table Header"
@@ -207,5 +207,27 @@ describe('when a table has a sortable header', () => {
 
         const nonSortableHeader = headers[1];
         expect(nonSortableHeader).not.toHaveClass('sorted');
+    });
+
+    it('should disable sorting if there is only 1 total result', () => {
+        const { getByRole } = render(
+            <TableComponent
+                tableHeader="Test Table Header"
+                tableHead={[
+                    { name: 'A', sortable: true },
+                    { name: 'B', sortable: false }
+                ]}
+                tableBody={[
+                    {
+                        id: 1,
+                        tableDetails: [{ id: 1, title: 'one' }]
+                    }
+                ]}
+                totalResults={1}
+            />
+        );
+        const sortIcon = getByRole('button', { name: 'sort' });
+
+        expect(sortIcon).toBeDisabled();
     });
 });

--- a/apps/modernization-ui/src/components/Table/Table.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.tsx
@@ -78,7 +78,7 @@ export const TableComponent = ({
     isLoading = false,
     contextName
 }: Props) => {
-    const sorting = useTableSorting({ enabled: tableBody && tableBody.length > 1, onSort: sortData });
+    const sorting = useTableSorting({ enabled: tableBody && totalResults > 1, onSort: sortData });
 
     const columns = resolveColumns(selectable, tableHead);
 


### PR DESCRIPTION
## Description

The table component disables the sort if the current page only has 1 result. This PR changes this behavior so that sorting is enabled as long as the `total` results is > 1; 

## Tickets

* [CNFT2-1655](https://cdc-nbs.atlassian.net/browse/CNFT2-1655)

### NOTE - Range toggle was temporarily changed to always show 2 results per page for the demo gif


![sortSingleItemLastPage](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/36b8e392-bba4-4a64-b414-cd4dc51555c6)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1655]: https://cdc-nbs.atlassian.net/browse/CNFT2-1655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ