### PR TITLE
Cnft2 1560 datamart name max length

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
@@ -7,6 +7,7 @@ import { MultiSelectInput } from 'components/selection/multi';
 import { validPageNameRule } from 'validation/entry';
 import { Controller, useFormContext } from 'react-hook-form';
 import { FormValues } from './AddNewPage';
+import { dataMartNameRule } from 'validation/entry/dataMartNameRule';
 
 type AddNewPageFieldProps = {
     conditions: Condition[];
@@ -140,8 +141,16 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
             <Controller
                 control={form.control}
                 name="dataMartName"
-                render={({ field: { onChange, value } }) => (
-                    <Input label="Data mart name" type="text" onChange={onChange} defaultValue={value} />
+                rules={dataMartNameRule}
+                render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+                    <Input
+                        label="Data mart name"
+                        type="text"
+                        onChange={onChange}
+                        defaultValue={value}
+                        error={error?.message}
+                        onBlur={onBlur}
+                    />
                 )}
             />
         </>

--- a/apps/modernization-ui/src/validation/entry/dataMartNameRule.ts
+++ b/apps/modernization-ui/src/validation/entry/dataMartNameRule.ts
@@ -1,0 +1,8 @@
+const dataMartNameRule = {
+    pattern: {
+        value: /^[A-Za-z_-][A-Za-z0-9_-]*$/,
+        message: 'Name cannot start with a number and can only contain alphanumeric and underscore characters.'
+    }
+};
+
+export { dataMartNameRule };

--- a/apps/modernization-ui/src/validation/entry/dataMartNameRule.ts
+++ b/apps/modernization-ui/src/validation/entry/dataMartNameRule.ts
@@ -1,8 +1,11 @@
+import { maxLengthRule } from './maxLengthRule';
+
 const dataMartNameRule = {
     pattern: {
         value: /^[A-Za-z_-][A-Za-z0-9_-]*$/,
         message: 'Name cannot start with a number and can only contain alphanumeric and underscore characters.'
-    }
+    },
+    ...maxLengthRule(21)
 };
 
 export { dataMartNameRule };


### PR DESCRIPTION
## Description
Here we piggy-back off of https://cdc-nbs.atlassian.net/browse/CNFT2-1558.
We add a `maxLength` property to the Datamart name rules we defined in CNFT2-1558.
When you Add a new page, an error will be thrown when Datamart name exceeds 21 characters.

## Tickets

* [Jira Ticket](url)](https://cdc-nbs.atlassian.net/browse/CNFT2-1560)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
