### PR TITLE
Bug/unable-to-search-new-conditions

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
@@ -41,6 +41,7 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
     }, []);
 
     const onSubmit = handleSubmit(async (data) => {
+        console.log('submitting', data);
         await createCondition(token, data)
             .then((response: Condition) => {
                 showAlert({ type: 'success', header: 'Created', message: 'Condition created successfully' });
@@ -59,6 +60,8 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
     const resetInput = () => {
         reset();
     };
+
+    console.log('test');
 
     return (
         <div className="create-condition">
@@ -313,7 +316,7 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
                         Cancel
                     </Button>
                 )}
-                <Button className="submit-btn" type="submit">
+                <Button className="submit-btn" type="submit" onClick={onSubmit}>
                     Create and add to page
                 </Button>
             </div>

--- a/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
@@ -41,7 +41,6 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
     }, []);
 
     const onSubmit = handleSubmit(async (data) => {
-        console.log('submitting', data);
         await createCondition(token, data)
             .then((response: Condition) => {
                 showAlert({ type: 'success', header: 'Created', message: 'Condition created successfully' });
@@ -60,8 +59,6 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
     const resetInput = () => {
         reset();
     };
-
-    console.log('test');
 
     return (
         <div className="create-condition">


### PR DESCRIPTION
## Description

There was a bug reported that we were not able to search for new conditions once created.  However, upon investigating, I was not able to even create a new condition.  Found that I just had to connect the form submit button with the handler and all was fixed.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-1459)

## Checklist before requesting a review
- [ x] PR focuses on a single story
- [ x] Code has been fully tested to meet acceptance criteria
- [ x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ x] All new functions/classes/components reasonably small
- [x ] Functions/classes/components focused on one responsibility
- [ x] Code easy to understand and modify (clarity over concise/clever)
- [ x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x ] PR does not contain hardcoded values (Uses constants)
- [ x] All code is covered by unit or feature tests
