### PR TITLE
Clear date of birth field and its message when there is an error

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/patientSearch/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/patientSearch/PatientSearch.tsx
@@ -103,6 +103,7 @@ export const PatientSearch = ({ handleSubmission, personFilter, clearAll }: Pati
                             name="dateOfBirth"
                             render={({ field: { onChange, value, name } }) => (
                                 <DatePickerInput
+                                    control={form.control}
                                     defaultValue={value}
                                     onChange={onChange}
                                     name={name}
@@ -286,8 +287,14 @@ export const PatientSearch = ({ handleSubmission, personFilter, clearAll }: Pati
                         className="width-full clear-btn"
                         type={'button'}
                         onClick={() => {
-                            form.reset({}, { keepDefaultValues: true });
-                            clearAll();
+                            // Because of the customized nature of Date picker errors, the date picker doesn't reset when the clear all is clicked.
+                            // So you need to set the error to false and then run the form reset and clearAll methods.
+                            // None instead of empty string because Trusswork's DatePicker doesn't update with empty string.
+                            form.setValue('dateOfBirth', 'none');
+                            setTimeout(() => {
+                                form.reset({}, { keepDefaultValues: true });
+                                clearAll();
+                            });
                         }}
                         outline>
                         Clear all

--- a/apps/modernization-ui/src/components/FormInputs/DatePickerInput.tsx
+++ b/apps/modernization-ui/src/components/FormInputs/DatePickerInput.tsx
@@ -1,9 +1,11 @@
 import { DatePicker } from '@trussworks/react-uswds';
 import './DatePickerInput.scss';
-import React, { KeyboardEvent, useState } from 'react';
+import React, { KeyboardEvent, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { isFuture } from 'date-fns';
 import { EntryWrapper } from 'components/Entry';
+import { Control, useWatch } from 'react-hook-form';
+import { PersonFilter } from 'generated/graphql/schema';
 
 type OnChange = (val?: string) => void;
 type OnBlur = (event: React.FocusEvent<HTMLInputElement> | React.FocusEvent<HTMLDivElement>) => void;
@@ -22,6 +24,7 @@ type DatePickerProps = {
     required?: boolean;
     disabled?: boolean;
     disableFutureDates?: boolean;
+    control?: Control<PersonFilter, any>;
 };
 
 const inputFormat = /^[0-3]?[0-9]\/[0-3]?[0-9]\/(19|20)[0-9]{2}$/;
@@ -45,6 +48,15 @@ export const DatePickerInput = (props: DatePickerProps) => {
     const intialDefault = validDefaultValue ? interalize(props.defaultValue) : undefined;
 
     const [error, setError] = useState(!(emptyDefaultValue || validDefaultValue));
+
+    const watchDateChange = useWatch({ control: props.control, name: 'dateOfBirth' });
+
+    // Reset the error state to false when the form is cleared.
+    useEffect(() => {
+        if (props.defaultValue == 'none') {
+            setError(false);
+        }
+    }, [watchDateChange]);
 
     const checkValidity = (event: React.FocusEvent<HTMLInputElement> | React.FocusEvent<HTMLDivElement>) => {
         const currentVal = (event.target as HTMLInputElement).value;


### PR DESCRIPTION
## Description

Patient Search- Clear date of birth field and its message when there is an error.

## Tickets

* [CNFT1-1768](https://cdc-nbs.atlassian.net/browse/CNFT1-1768)

## Steps to verify
1. Login to NBS and in Advance Search 
2. Under Date of birth field type in any invalid date then an error message will pop up
3. Click on Clear All button and it should clear date of birth input and error message

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
