### PR TITLE
Patient profile lab report collected on default date set to 01/01/1970 when null during UI transformation fixed

### DIFF
--- a/apps/modernization-ui/src/apps/patient/profile/labReport/LabReportTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/labReport/LabReportTable.tsx
@@ -56,7 +56,7 @@ const asTableBody =
             },
             {
                 id: 3,
-                title: format(report?.collectedOn, 'MM/dd/yyyy') || null
+                title: report?.collectedOn ? <>{format(report?.collectedOn, 'MM/dd/yyyy')}</> : null
             },
             {
                 id: 4,

--- a/apps/modernization-ui/src/apps/patient/profile/labReport/LabReportTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/labReport/LabReportTable.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Icon } from '@trussworks/react-uswds';
 import format from 'date-fns/format';
 import { FindLabReportsForPatientQuery, useFindLabReportsForPatientLazyQuery } from 'generated/graphql/schema';
-
+import { internalizeDate } from 'date';
 import { Headers, PatientLabReport, AssociatedWith, TestResult } from './PatientLabReport';
 import { transform } from './PatientLabReportTransformer';
 import { sort } from './PatientLabReportSorter';
@@ -56,7 +56,7 @@ const asTableBody =
             },
             {
                 id: 3,
-                title: report?.collectedOn ? <>{format(report?.collectedOn, 'MM/dd/yyyy')}</> : null
+                title: internalizeDate(report?.collectedOn) || null
             },
             {
                 id: 4,

--- a/apps/modernization-ui/src/apps/patient/profile/labReport/PatientLabReport.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/labReport/PatientLabReport.ts
@@ -26,7 +26,7 @@ type PatientLabReport = {
     reportingFacility: string | null;
     orderingProvider: string | null;
     orderingFacility: string | null;
-    collectedOn: Date;
+    collectedOn: Date | null;
     results: TestResult[];
     associatedWith: AssociatedWith[];
     programArea: string;

--- a/apps/modernization-ui/src/apps/patient/profile/labReport/PatientLabReportTransformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/labReport/PatientLabReportTransformer.spec.ts
@@ -265,4 +265,65 @@ describe('when the result has content', () => {
             ])
         );
     });
+
+
+    it('should return null for collectedOn date and not transform a null effectiveFromTime value to a date with for collectedOn', () => {
+        const result: GraphQLPatientLabReport[] = [
+            {
+                id: '10066376',
+                observationUid: 10066376,
+                addTime: '2023-03-27T00:00:00Z',
+                effectiveFromTime: null,
+                programAreaCd: 'program-area-value',
+                jurisdictionCodeDescTxt: 'jurisdiction-value',
+                localId: 'local-id-value',
+                electronicInd: 'N',
+                associatedInvestigations: [],
+                personParticipations: [
+                    {
+                        typeCd: 'PATSBJ',
+                        personCd: 'PAT',
+                        firstName: 'provider-first-name',
+                        lastName: 'provider-last-name'
+                    }
+                ],
+                organizationParticipations: [
+                    {
+                        typeCd: 'AUT',
+                        name: 'reporting-Facility-value'
+                    },
+                    {
+                        typeCd: 'ORD',
+                        name: 'ordering-Facility-value'
+                    }
+                ],
+                observations: [
+                    {
+                        domainCd: 'OTHER',
+                        cdDescTxt: 'No Information Given',
+                        displayName: null
+                    },
+                    {
+                        domainCd: 'Result',
+                        cdDescTxt: 'Acid-Fast Stain',
+                        displayName: 'abnormal presence of'
+                    }
+                ]
+            }
+        ];
+        const actual = transform(result);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    report: '10066376',
+                    receivedOn: new Date('2023-03-27T05:00:00Z'),
+                    collectedOn: null,
+                    programArea: 'program-area-value',
+                    jurisdiction: 'jurisdiction-value',
+                    event: 'local-id-value'
+                })
+            ])
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/profile/labReport/PatientLabReportTransformer.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/labReport/PatientLabReportTransformer.ts
@@ -36,6 +36,14 @@ const getTestResults = (content: GraphQLPatientLabReport): TestResult[] => {
         .map((result) => ({ test: result.cdDescTxt, result: orNull(result.displayName) }));
 };
 
+const checkCollectedOnDate = (content: string | undefined | null) => {
+    if (content) {
+        return asLocalDate(content);
+    } else {
+        return null;
+    }
+};
+
 const internalized = (content: GraphQLPatientLabReport): PatientLabReport | null => {
     if (content) {
         return {
@@ -44,7 +52,7 @@ const internalized = (content: GraphQLPatientLabReport): PatientLabReport | null
             reportingFacility: orNull(getReportingFacility(content)),
             orderingProvider: getOrderingProviderName(content),
             orderingFacility: orNull(getOrderingFacility(content)),
-            collectedOn: asLocalDate(content.effectiveFromTime),
+            collectedOn: checkCollectedOnDate(content.effectiveFromTime),
             results: getTestResults(content),
             associatedWith: getAssociations(content),
             programArea: content.programAreaCd,


### PR DESCRIPTION
## Description

Fix date collected field is defaulting to 01/01/1970 for all Lab Reports for patients under Events tab. 
## Tickets

* [CNFT1-1911](https://cdc-nbs.atlassian.net/browse/CNFT1-1911)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-1911]: https://cdc-nbs.atlassian.net/browse/CNFT1-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ