### PR TITLE
CNFT2-1574-create-value-set-concept-api

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/CodeValueGeneral.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/CodeValueGeneral.java
@@ -1,7 +1,6 @@
 package gov.cdc.nbs.questionbank.entity;
 
 import java.time.Instant;
-import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/CodeValueGeneral.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/CodeValueGeneral.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.questionbank.entity;
 
 import java.time.Instant;
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -124,6 +125,9 @@ public class CodeValueGeneral {
         this.codeSystemDescTxt = command.codeSystem();
         this.codeSystemCd = command.codeSystemId();
         this.conceptTypeCd = command.conceptTypeCd();
+
+        this.effectiveFromTime = command.effectiveFromTime();
+        this.effectiveToTime = command.effectiveToTime();
         
         added(command);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/request/AddConceptRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/request/AddConceptRequest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.questionbank.valueset.request;
 
 import java.time.Instant;
+import javax.annotation.Nullable;
 import io.swagger.annotations.ApiModelProperty;
 
 public record AddConceptRequest(
@@ -8,7 +9,7 @@ public record AddConceptRequest(
         @ApiModelProperty(required = true) String displayName,
         @ApiModelProperty(required = true) String shortDisplayName,
         @ApiModelProperty(required = true) Instant effectiveFromTime,
-        Instant effectiveToTime,
+        @Nullable Instant effectiveToTime,
         @ApiModelProperty(required = true, example = "A") StatusCode statusCode,
         String adminComments,
         @ApiModelProperty(required = true) MessagingInfo messagingInfo) {


### PR DESCRIPTION
## Description

Create value set concept api endpoint fix on two fields that were not being set.

## Tickets

* [CNFT2-1574](https://cdc-nbs.atlassian.net/browse/CNFT2-1693)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1574]: https://cdc-nbs.atlassian.net/browse/CNFT2-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ