### PR TITLE
CNFT1-1795 Patient Profile Name Count

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
@@ -12,81 +12,87 @@ import java.util.List;
 @Component
 class PatientNameFinder {
 
-    private static final String ACTIVE_CODE = "ACTIVE";
-    private static final String NAME_USE_CODE_SET = "P_NM_USE";
-    private static final String NAME_PREFIX_CODE_SET = "P_NM_PFX";
-    private static final String NAME_DEGREE_CODE_SET = "P_NM_DEG";
-    private static final String PATIENT_CODE = "PAT";
+        private static final String ACTIVE_CODE = "ACTIVE";
+        private static final String NAME_USE_CODE_SET = "P_NM_USE";
+        private static final String NAME_PREFIX_CODE_SET = "P_NM_PFX";
+        private static final String NAME_DEGREE_CODE_SET = "P_NM_DEG";
+        private static final String PATIENT_CODE = "PAT";
 
-    private final JPAQueryFactory factory;
-    private final PatientNameTupleMapper.Tables tables;
-    private final PatientNameTupleMapper mapper;
+        private final JPAQueryFactory factory;
+        private final PatientNameTupleMapper.Tables tables;
+        private final PatientNameTupleMapper mapper;
 
-    PatientNameFinder(final JPAQueryFactory factory) {
-        this.factory = factory;
-        this.tables = new PatientNameTupleMapper.Tables();
-        mapper = new PatientNameTupleMapper(tables);
-    }
+        PatientNameFinder(final JPAQueryFactory factory) {
+                this.factory = factory;
+                this.tables = new PatientNameTupleMapper.Tables();
+                mapper = new PatientNameTupleMapper(tables);
+        }
 
-    private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
-        return query.from(this.tables.patient())
-                .where(
-                        this.tables.patient().id.eq(patient),
-                        this.tables.patient().cd.eq(PATIENT_CODE))
-                .join(this.tables.name()).on(
-                        this.tables.name().id.personUid.eq(this.tables.patient().id),
-                        this.tables.name().recordStatusCd.eq(ACTIVE_CODE))
-                .join(this.tables.use()).on(
-                        this.tables.use().id.codeSetNm.eq(NAME_USE_CODE_SET),
-                        this.tables.use().id.code.eq(tables.name().nmUseCd));
-    }
+        private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
+                return query.from(this.tables.patient())
+                                .where(
+                                                this.tables.patient().id.eq(patient),
+                                                this.tables.patient().cd.eq(PATIENT_CODE))
+                                .join(this.tables.name()).on(
+                                                this.tables.name().id.personUid.eq(this.tables.patient().id),
+                                                this.tables.name().recordStatusCd.eq(ACTIVE_CODE))
+                                .join(this.tables.use()).on(
+                                                this.tables.use().id.codeSetNm.eq(NAME_USE_CODE_SET),
+                                                this.tables.use().id.code.eq(tables.name().nmUseCd));
+        }
 
-    private long resolveTotal(final long patient) {
-        Long total = applyCriteria(this.factory.select(this.tables.name().id.personNameSeq.max()), patient).fetchOne()
-                .longValue();
-        return total == null ? 0L : total;
-    }
+        private long resolveTotal(final long patient) {
+                Long total = applyCriteria(this.factory.select(this.tables.name().id.personNameSeq.countDistinct()),
+                                patient)
+                                .fetchOne()
+                                .longValue();
+                return total == null ? 0L : total;
+        }
 
-    private List<PatientName> resolvePage(final long patient, final Pageable pageable) {
-        return applyCriteria(
-                this.factory.select(
-                        tables.name().id.personUid,
-                        tables.patient().versionCtrlNbr,
-                        tables.name().asOfDate,
-                        tables.name().id.personNameSeq,
-                        tables.name().nmUseCd,
-                        tables.use().codeShortDescTxt,
-                        tables.name().nmPrefix,
-                        tables.prefix().codeShortDescTxt,
-                        tables.name().firstNm,
-                        tables.name().middleNm,
-                        tables.name().middleNm2,
-                        tables.name().lastNm,
-                        tables.name().lastNm2,
-                        tables.name().nmSuffix,
-                        tables.name().nmDegree,
-                        tables.degree().codeDescTxt),
-                patient)
-                        .leftJoin(this.tables.prefix()).on(
-                                this.tables.prefix().id.codeSetNm.eq(NAME_PREFIX_CODE_SET),
-                                this.tables.prefix().id.code.eq(this.tables.name().nmPrefix))
-                        .leftJoin(this.tables.degree()).on(
-                                this.tables.degree().id.codeSetNm.eq(NAME_DEGREE_CODE_SET),
-                                this.tables.degree().id.code.eq(this.tables.name().nmDegree))
-                        .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize())
-                        .fetch()
-                        .stream()
-                        .map(mapper::map)
-                        .toList();
-    }
+        private List<PatientName> resolvePage(final long patient, final Pageable pageable) {
+                return applyCriteria(
+                                this.factory.select(
+                                                tables.name().id.personUid,
+                                                tables.patient().versionCtrlNbr,
+                                                tables.name().asOfDate,
+                                                tables.name().id.personNameSeq,
+                                                tables.name().nmUseCd,
+                                                tables.use().codeShortDescTxt,
+                                                tables.name().nmPrefix,
+                                                tables.prefix().codeShortDescTxt,
+                                                tables.name().firstNm,
+                                                tables.name().middleNm,
+                                                tables.name().middleNm2,
+                                                tables.name().lastNm,
+                                                tables.name().lastNm2,
+                                                tables.name().nmSuffix,
+                                                tables.name().nmDegree,
+                                                tables.degree().codeDescTxt),
+                                patient)
+                                .leftJoin(this.tables.prefix()).on(
+                                                this.tables.prefix().id.codeSetNm
+                                                                .eq(NAME_PREFIX_CODE_SET),
+                                                this.tables.prefix().id.code
+                                                                .eq(this.tables.name().nmPrefix))
+                                .leftJoin(this.tables.degree()).on(
+                                                this.tables.degree().id.codeSetNm
+                                                                .eq(NAME_DEGREE_CODE_SET),
+                                                this.tables.degree().id.code
+                                                                .eq(this.tables.name().nmDegree))
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize())
+                                .fetch()
+                                .stream()
+                                .map(mapper::map)
+                                .toList();
+        }
 
-    Page<PatientName> find(final long patient, final Pageable pageable) {
-        long total = resolveTotal(patient);
+        Page<PatientName> find(final long patient, final Pageable pageable) {
+                long total = resolveTotal(patient);
 
-        return total > 0
-                ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
-                : Page.empty(pageable);
-    }
+                return total > 0
+                                ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
+                                : Page.empty(pageable);
+        }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
@@ -12,92 +12,80 @@ import java.util.List;
 @Component
 class PatientNameFinder {
 
-  private static final String ACTIVE_CODE = "ACTIVE";
-  private static final String NAME_USE_CODE_SET = "P_NM_USE";
-  private static final String NAME_PREFIX_CODE_SET = "P_NM_PFX";
-  private static final String NAME_DEGREE_CODE_SET = "P_NM_DEG";
-  private static final String PATIENT_CODE = "PAT";
+    private static final String ACTIVE_CODE = "ACTIVE";
+    private static final String NAME_USE_CODE_SET = "P_NM_USE";
+    private static final String NAME_PREFIX_CODE_SET = "P_NM_PFX";
+    private static final String NAME_DEGREE_CODE_SET = "P_NM_DEG";
+    private static final String PATIENT_CODE = "PAT";
 
-  private final JPAQueryFactory factory;
-  private final PatientNameTupleMapper.Tables tables;
-  private final PatientNameTupleMapper mapper;
+    private final JPAQueryFactory factory;
+    private final PatientNameTupleMapper.Tables tables;
+    private final PatientNameTupleMapper mapper;
 
-  PatientNameFinder(final JPAQueryFactory factory) {
-    this.factory = factory;
-    this.tables = new PatientNameTupleMapper.Tables();
-    mapper = new PatientNameTupleMapper(tables);
-  }
+    PatientNameFinder(final JPAQueryFactory factory) {
+        this.factory = factory;
+        this.tables = new PatientNameTupleMapper.Tables();
+        mapper = new PatientNameTupleMapper(tables);
+    }
 
-  private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
-    return query.from(this.tables.patient())
-        .where(
-            this.tables.patient().id.eq(patient),
-            this.tables.patient().cd.eq(PATIENT_CODE)
-        )
-        .join(this.tables.name()).on(
-            this.tables.name().id.personUid.eq(this.tables.patient().id),
-            this.tables.name().recordStatusCd.eq(ACTIVE_CODE)
-        )
-        .join(this.tables.use()).on(
-            this.tables.use().id.codeSetNm.eq(NAME_USE_CODE_SET),
-            this.tables.use().id.code.eq(tables.name().nmUseCd)
-        );
-  }
+    private <R> JPAQuery<R> applyCriteria(final JPAQuery<R> query, final long patient) {
+        return query.from(this.tables.patient())
+                .where(
+                        this.tables.patient().id.eq(patient),
+                        this.tables.patient().cd.eq(PATIENT_CODE))
+                .join(this.tables.name()).on(
+                        this.tables.name().id.personUid.eq(this.tables.patient().id),
+                        this.tables.name().recordStatusCd.eq(ACTIVE_CODE))
+                .join(this.tables.use()).on(
+                        this.tables.use().id.codeSetNm.eq(NAME_USE_CODE_SET),
+                        this.tables.use().id.code.eq(tables.name().nmUseCd));
+    }
 
-  private long resolveTotal(final long patient) {
-    Long total = applyCriteria(
-        factory.selectDistinct(this.tables.patient().countDistinct()),
-        patient
-    )
-        .fetchOne();
-    return total == null ? 0L : total;
-  }
+    private long resolveTotal(final long patient) {
+        Long total = factory.select(this.tables.name().id.personNameSeq.max()).fetchOne().longValue();
+        return total == null ? 0L : total;
+    }
 
-  private List<PatientName> resolvePage(final long patient, final Pageable pageable) {
-    return applyCriteria(
-        this.factory.select(
-            tables.name().id.personUid,
-            tables.patient().versionCtrlNbr,
-            tables.name().asOfDate,
-            tables.name().id.personNameSeq,
-            tables.name().nmUseCd,
-            tables.use().codeShortDescTxt,
-            tables.name().nmPrefix,
-            tables.prefix().codeShortDescTxt,
-            tables.name().firstNm,
-            tables.name().middleNm,
-            tables.name().middleNm2,
-            tables.name().lastNm,
-            tables.name().lastNm2,
-            tables.name().nmSuffix,
-            tables.name().nmDegree,
-            tables.degree().codeDescTxt
-        ),
-        patient
-    )
-        .leftJoin(this.tables.prefix()).on(
-            this.tables.prefix().id.codeSetNm.eq(NAME_PREFIX_CODE_SET),
-            this.tables.prefix().id.code.eq(this.tables.name().nmPrefix)
-        )
-        .leftJoin(this.tables.degree()).on(
-            this.tables.degree().id.codeSetNm.eq(NAME_DEGREE_CODE_SET),
-            this.tables.degree().id.code.eq(this.tables.name().nmDegree)
-        )
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .fetch()
-        .stream()
-        .map(mapper::map)
-        .toList()
-        ;
-  }
+    private List<PatientName> resolvePage(final long patient, final Pageable pageable) {
+        return applyCriteria(
+                this.factory.select(
+                        tables.name().id.personUid,
+                        tables.patient().versionCtrlNbr,
+                        tables.name().asOfDate,
+                        tables.name().id.personNameSeq,
+                        tables.name().nmUseCd,
+                        tables.use().codeShortDescTxt,
+                        tables.name().nmPrefix,
+                        tables.prefix().codeShortDescTxt,
+                        tables.name().firstNm,
+                        tables.name().middleNm,
+                        tables.name().middleNm2,
+                        tables.name().lastNm,
+                        tables.name().lastNm2,
+                        tables.name().nmSuffix,
+                        tables.name().nmDegree,
+                        tables.degree().codeDescTxt),
+                patient)
+                        .leftJoin(this.tables.prefix()).on(
+                                this.tables.prefix().id.codeSetNm.eq(NAME_PREFIX_CODE_SET),
+                                this.tables.prefix().id.code.eq(this.tables.name().nmPrefix))
+                        .leftJoin(this.tables.degree()).on(
+                                this.tables.degree().id.codeSetNm.eq(NAME_DEGREE_CODE_SET),
+                                this.tables.degree().id.code.eq(this.tables.name().nmDegree))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch()
+                        .stream()
+                        .map(mapper::map)
+                        .toList();
+    }
 
-  Page<PatientName> find(final long patient, final Pageable pageable) {
-    long total = resolveTotal(patient);
+    Page<PatientName> find(final long patient, final Pageable pageable) {
+        long total = resolveTotal(patient);
 
-    return total > 0
-        ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
-        : Page.empty(pageable);
-  }
+        return total > 0
+                ? new PageImpl<>(resolvePage(patient, pageable), pageable, total)
+                : Page.empty(pageable);
+    }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
@@ -44,8 +44,7 @@ class PatientNameFinder {
         private long resolveTotal(final long patient) {
                 Long total = applyCriteria(this.factory.select(this.tables.name().id.personNameSeq.countDistinct()),
                                 patient)
-                                .fetchOne()
-                                .longValue();
+                                                .fetchOne();
                 return total == null ? 0L : total;
         }
 
@@ -69,22 +68,22 @@ class PatientNameFinder {
                                                 tables.name().nmDegree,
                                                 tables.degree().codeDescTxt),
                                 patient)
-                                .leftJoin(this.tables.prefix()).on(
-                                                this.tables.prefix().id.codeSetNm
-                                                                .eq(NAME_PREFIX_CODE_SET),
-                                                this.tables.prefix().id.code
-                                                                .eq(this.tables.name().nmPrefix))
-                                .leftJoin(this.tables.degree()).on(
-                                                this.tables.degree().id.codeSetNm
-                                                                .eq(NAME_DEGREE_CODE_SET),
-                                                this.tables.degree().id.code
-                                                                .eq(this.tables.name().nmDegree))
-                                .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
-                                .fetch()
-                                .stream()
-                                .map(mapper::map)
-                                .toList();
+                                                .leftJoin(this.tables.prefix()).on(
+                                                                this.tables.prefix().id.codeSetNm
+                                                                                .eq(NAME_PREFIX_CODE_SET),
+                                                                this.tables.prefix().id.code
+                                                                                .eq(this.tables.name().nmPrefix))
+                                                .leftJoin(this.tables.degree()).on(
+                                                                this.tables.degree().id.codeSetNm
+                                                                                .eq(NAME_DEGREE_CODE_SET),
+                                                                this.tables.degree().id.code
+                                                                                .eq(this.tables.name().nmDegree))
+                                                .offset(pageable.getOffset())
+                                                .limit(pageable.getPageSize())
+                                                .fetch()
+                                                .stream()
+                                                .map(mapper::map)
+                                                .toList();
         }
 
         Page<PatientName> find(final long patient, final Pageable pageable) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/PatientNameFinder.java
@@ -42,7 +42,8 @@ class PatientNameFinder {
     }
 
     private long resolveTotal(final long patient) {
-        Long total = factory.select(this.tables.name().id.personNameSeq.max()).fetchOne().longValue();
+        Long total = applyCriteria(this.factory.select(this.tables.name().id.personNameSeq.max()), patient).fetchOne()
+                .longValue();
         return total == null ? 0L : total;
     }
 


### PR DESCRIPTION
## Description

Patient Profile does not display more than ten Names.  We are doing a select count/distinct on names when we should be doing a max sequence number

## Tickets

* [CNFT1-1795](https://cdc-nbs.atlassian.net/browse/CNFT1-1795)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-1795]: https://cdc-nbs.atlassian.net/browse/CNFT1-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Before**:
<img width="1174" alt="Screenshot 2024-01-10 at 8 00 19 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/34244063/3191d582-e788-4b6e-991d-f5e2d9b25d7c">

**After**:
<img width="1284" alt="Screenshot 2024-01-10 at 7 59 03 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/34244063/7bf40cff-5490-405c-a238-7741dbaa2631">

<img width="1275" alt="Screenshot 2024-01-10 at 7 59 19 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/34244063/b9f04033-6b34-4690-8681-3b20f1cd27d4">
