### PR TITLE
Removed delete prop for detail element in Profile Admin Table preventing User from being able to delete admin comment

### DIFF
--- a/apps/modernization-ui/src/apps/patient/profile/administrative/AdministrativeTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/administrative/AdministrativeTable.tsx
@@ -237,7 +237,6 @@ export const AdministrativeTable = ({ patient }: Props) => {
                     details={asDetail(selected.item)}
                     onClose={actions.reset}
                     onEdit={() => actions.selectForEdit(selected.item)}
-                    onDelete={() => actions.selectForDelete(selected.item)}
                 />
             )}
         </>


### PR DESCRIPTION
## Description

User should not be able to delete administrative comment. 

## Tickets

* [CNFT1-1730](https://cdc-nbs.atlassian.net/browse/CNFT1-1730)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-1730]: https://cdc-nbs.atlassian.net/browse/CNFT1-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ