### PR TITLE
Use page size for initial search

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.spec.tsx
@@ -92,4 +92,14 @@ describe('ConditionSearch', () => {
         expect(cells[7]).toHaveTextContent('No Data');
         expect(cells[8]).toHaveTextContent('Active');
     });
+
+    it('should search with appropriate page size', () => {
+        render(
+            <MemoryRouter>
+                <ConditionSearch onConditionSelect={onConditionSelect} onCancel={onCancel} onCreateNew={onCreateNew} />
+            </MemoryRouter>
+        );
+
+        expect(search).toBeCalledWith({ page: 0, pageSize: 10, sort: undefined });
+    });
 });

--- a/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.spec.tsx
@@ -1,0 +1,95 @@
+import { render } from '@testing-library/react';
+import { ConditionSearch } from './ConditionSearch';
+import { MemoryRouter } from 'react-router-dom';
+import { Condition } from 'apps/page-builder/generated';
+
+const mockCondition: Condition = {
+    coinfectionGroup: 'coinfection',
+    conditionFamily: 'conditionFamily',
+    id: 'id',
+    name: 'conditionName',
+    nndInd: 'T',
+    page: undefined,
+    programArea: 'program area',
+    status: 'A'
+};
+
+const search = jest.fn();
+const reset = jest.fn();
+
+const mockUsConditionSearch = {
+    search: search,
+    response: { content: [mockCondition] },
+    error: undefined,
+    isLoading: false,
+    reset
+};
+
+jest.mock('./useConditionSearch', () => ({
+    ...jest.requireActual('./useConditionSearch'),
+    useConditionSearch: () => mockUsConditionSearch
+}));
+
+describe('ConditionSearch', () => {
+    const onConditionSelect = jest.fn();
+    const onCancel = jest.fn();
+    const onCreateNew = jest.fn();
+
+    it('should have a modal heading', () => {
+        const { getByText } = render(
+            <MemoryRouter>
+                <ConditionSearch onConditionSelect={onConditionSelect} onCancel={onCancel} onCreateNew={onCreateNew} />
+            </MemoryRouter>
+        );
+        expect(getByText('Search and add condition(s)')).toBeInTheDocument();
+    });
+
+    it('should have a title', () => {
+        const { getByText } = render(
+            <MemoryRouter>
+                <ConditionSearch onConditionSelect={onConditionSelect} onCancel={onCancel} onCreateNew={onCreateNew} />
+            </MemoryRouter>
+        );
+        expect(getByText('You can search for existing condition(s) or create a new one.')).toBeInTheDocument();
+    });
+
+    it('should have expected buttons', () => {
+        const { getByText } = render(
+            <MemoryRouter>
+                <ConditionSearch onConditionSelect={onConditionSelect} onCancel={onCancel} onCreateNew={onCreateNew} />
+            </MemoryRouter>
+        );
+        const createBtn = getByText('Create new condition');
+        expect(createBtn).toBeInTheDocument();
+        expect(createBtn.nodeName).toBe('BUTTON');
+        expect(createBtn).not.toHaveAttribute('disabled');
+
+        const cancelBtn = getByText('Cancel');
+        expect(cancelBtn).toBeInTheDocument();
+        expect(cancelBtn.nodeName).toBe('BUTTON');
+        expect(cancelBtn).not.toHaveAttribute('disabled');
+
+        const addBtn = getByText('Add conditions');
+        expect(addBtn).toBeInTheDocument();
+        expect(addBtn.nodeName).toBe('BUTTON');
+        expect(addBtn).toHaveAttribute('disabled');
+    });
+
+    it('should pass data to the table', () => {
+        const { getAllByRole } = render(
+            <MemoryRouter>
+                <ConditionSearch onConditionSelect={onConditionSelect} onCancel={onCancel} onCreateNew={onCreateNew} />
+            </MemoryRouter>
+        );
+
+        const cells = getAllByRole('cell');
+        expect(cells[1]).toHaveTextContent('conditionName');
+        expect(cells[2]).toHaveTextContent('id');
+        expect(cells[3]).toHaveTextContent('program area');
+        expect(cells[4]).toHaveTextContent('conditionFamily');
+        expect(cells[5]).toHaveTextContent('coinfection');
+        expect(cells[6]).toHaveTextContent('T');
+        expect(cells[7]).toHaveTextContent('No Data');
+        expect(cells[8]).toHaveTextContent('Active');
+    });
+});

--- a/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.tsx
@@ -32,7 +32,7 @@ const ConditionSearchContent = ({ onConditionSelect, onCancel, onCreateNew }: Pr
     const [resetTable, setResetTable] = useState<boolean>(false);
 
     useEffect(() => {
-        search({ page: 0, sort });
+        search({ page: 0, pageSize: page.pageSize, sort });
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
## Description

When the Condition search modal was initially opened, it was not passing the page size. This resulted in the size indicator showing `10` while the table contained `20` results.

This PR updates the initial load to include the `pageSize`.

## Tickets

* [CNFT2-1701](https://cdc-nbs.atlassian.net/browse/CNFT2-1701)
![10results](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/0db2aa1d-301a-4316-b41d-f3c0d4c80b68)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1701]: https://cdc-nbs.atlassian.net/browse/CNFT2-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ