### PR TITLE
CNFT2-1697 condition not equal

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/DefaultQueryDSLCriteriaResolver.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/DefaultQueryDSLCriteriaResolver.java
@@ -20,13 +20,12 @@ public class DefaultQueryDSLCriteriaResolver implements QueryDSLFilterApplier.Cr
       return Stream.of(QueryDSLSingleValueFilterApplier.apply(single, string));
     } else if (filter instanceof MultiValueFilter multi && expression instanceof StringExpression string) {
       return Stream.of(QueryDSLMultiValueFilterApplier.apply(multi, string));
-    } else if (filter instanceof DateFilter date && expression instanceof TemporalExpression<? extends Comparable> temporal) {
+    } else if (filter instanceof DateFilter date && expression instanceof TemporalExpression<?> temporal) {
       return Stream.of(QueryDSLDateFilterApplier.apply(date, temporal));
-    } else if (filter instanceof DateRangeFilter dateRange && expression instanceof TemporalExpression<? extends Comparable> temporal) {
+    } else if (filter instanceof DateRangeFilter dateRange && expression instanceof TemporalExpression<?> temporal) {
       return Stream.of(QueryDSLDateRangeFilterApplier.apply(dateRange, temporal));
     } else {
       return Stream.empty();
     }
   }
 }
-

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/PageLibraryQueryDSLCriteriaResolver.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/PageLibraryQueryDSLCriteriaResolver.java
@@ -1,0 +1,46 @@
+package gov.cdc.nbs.questionbank.filter.querydsl;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.JPAExpressions;
+import gov.cdc.nbs.questionbank.entity.QPageCondMapping;
+import gov.cdc.nbs.questionbank.entity.QWaTemplate;
+import gov.cdc.nbs.questionbank.entity.condition.QConditionCode;
+import gov.cdc.nbs.questionbank.filter.Filter;
+import gov.cdc.nbs.questionbank.filter.MultiValueFilter;
+import gov.cdc.nbs.questionbank.filter.ValueFilter.Operator;
+
+public class PageLibraryQueryDSLCriteriaResolver extends DefaultQueryDSLCriteriaResolver {
+
+  private static final QWaTemplate pageTable = QWaTemplate.waTemplate;
+  private static final QPageCondMapping mappingTable = QPageCondMapping.pageCondMapping;
+  private static final QConditionCode conditionTable = QConditionCode.conditionCode;
+
+
+  @Override
+  public Stream<BooleanExpression> resolve(Filter filter, Expression<?> expression) {
+    // If query is conditions not in, add custom handler
+    if (filter instanceof MultiValueFilter multi &&
+        expression instanceof StringExpression &&
+        multi.property().equals("conditions") &&
+        Operator.NOT_EQUAL_TO.equals(multi.operator())) {
+      return Stream.of(conditionNotIn(multi.values()));
+    }
+
+    // else provide default resolution
+    return super.resolve(filter, expression);
+  }
+
+  BooleanExpression conditionNotIn(Collection<String> conditions) {
+    return pageTable.id.notIn(JPAExpressions.select(pageTable.id)
+        .from(pageTable)
+        .leftJoin(mappingTable)
+        .on(pageTable.id.eq(mappingTable.waTemplateUid.id))
+        .leftJoin(conditionTable)
+        .on(mappingTable.conditionCd.eq(conditionTable.id))
+        .where(conditionTable.conditionShortNm.in(conditions)));
+  }
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLDateFilterApplier.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLDateFilterApplier.java
@@ -14,8 +14,7 @@ class QueryDSLDateFilterApplier {
   @SuppressWarnings({"unchecked"})
   static BooleanExpression apply(
       final DateFilter filter,
-      final TemporalExpression<? extends Comparable> expression
-  ) {
+      final TemporalExpression<? extends Comparable> expression) {
 
     if (Instant.class.isAssignableFrom(expression.getType())) {
 
@@ -38,7 +37,6 @@ class QueryDSLDateFilterApplier {
 
 
 
-  private QueryDSLDateFilterApplier() {
-  }
+  private QueryDSLDateFilterApplier() {}
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLDateRangeFilterApplier.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLDateRangeFilterApplier.java
@@ -14,8 +14,7 @@ class QueryDSLDateRangeFilterApplier {
   @SuppressWarnings("unchecked")
   static BooleanExpression apply(
       final DateRangeFilter filter,
-      final TemporalExpression<? extends Comparable> expression
-  ) {
+      final TemporalExpression<? extends Comparable> expression) {
 
     if (Instant.class.isAssignableFrom(expression.getType())) {
       TemporalExpression<Instant> instant = (TemporalExpression<Instant>) expression;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLFilterApplier.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLFilterApplier.java
@@ -15,23 +15,20 @@ public class QueryDSLFilterApplier {
     Stream<Expression<?>> resolve(final String property);
   }
 
-
   public interface CriteriaResolver {
     Stream<BooleanExpression> resolve(final Filter filter, final Expression<?> expression);
   }
 
   public static Stream<BooleanExpression> apply(
       final ExpressionResolver expressionResolver,
-      final Collection<Filter> filters
-  ) {
+      final Collection<Filter> filters) {
     return apply(expressionResolver, new DefaultQueryDSLCriteriaResolver(), filters);
   }
 
   public static Stream<BooleanExpression> apply(
       final ExpressionResolver expressionResolver,
       final CriteriaResolver criteriaResolver,
-      final Collection<Filter> filters
-  ) {
+      final Collection<Filter> filters) {
     return filters.stream()
         .flatMap(applyFilter(expressionResolver, criteriaResolver))
         .reduce(BooleanExpression::and)
@@ -40,13 +37,11 @@ public class QueryDSLFilterApplier {
 
   private static Function<Filter, Stream<BooleanExpression>> applyFilter(
       final ExpressionResolver expressionResolver,
-      final CriteriaResolver criteriaResolver
-  ) {
+      final CriteriaResolver criteriaResolver) {
     return filter -> expressionResolver.resolve(filter.property())
         .flatMap(expression -> criteriaResolver.resolve(filter, expression));
   }
 
-  private QueryDSLFilterApplier() {
-  }
+  private QueryDSLFilterApplier() {}
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummarySearcher.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/summary/search/PageSummarySearcher.java
@@ -6,13 +6,13 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.questionbank.filter.querydsl.PageLibraryQueryDSLCriteriaResolver;
 import gov.cdc.nbs.questionbank.filter.querydsl.QueryDSLFilterApplier;
 import gov.cdc.nbs.questionbank.order.QueryDSLOrderResolver;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -95,6 +95,7 @@ public class PageSummarySearcher {
         applySearch(criteria),
         QueryDSLFilterApplier.apply(
             this::resolveProperty,
+            new PageLibraryQueryDSLCriteriaResolver(),
             criteria.filters()))
         .reduce(
             onlyPages,

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/filter/querydsl/PageLibraryQueryDSLCriteriaResolverTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/filter/querydsl/PageLibraryQueryDSLCriteriaResolverTest.java
@@ -1,0 +1,59 @@
+package gov.cdc.nbs.questionbank.filter.querydsl;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import gov.cdc.nbs.questionbank.entity.condition.QConditionCode;
+import gov.cdc.nbs.questionbank.filter.MultiValueFilter;
+import gov.cdc.nbs.questionbank.filter.SingleValueFilter;
+import gov.cdc.nbs.questionbank.filter.ValueFilter.Operator;
+
+@ExtendWith(MockitoExtension.class)
+class PageLibraryQueryDSLCriteriaResolverTest {
+
+  @Spy
+  private final PageLibraryQueryDSLCriteriaResolver resolver = new PageLibraryQueryDSLCriteriaResolver();
+
+  @Test
+  void should_handle_conditions_not_in() {
+    MultiValueFilter filter = new MultiValueFilter(
+        "conditions",
+        Operator.NOT_EQUAL_TO,
+        Collections.singletonList("2019 Novel Coronavirus"));
+    resolver.resolve(filter, QConditionCode.conditionCode.conditionCodesetNm);
+
+    verify(resolver).conditionNotIn(Mockito.any());
+  }
+
+  @Test
+  void should_not_handle_conditions_contains() {
+    MultiValueFilter filter = new MultiValueFilter(
+        "conditions",
+        Operator.STARTS_WITH,
+        Collections.singletonList("2019 Novel Coronavirus"));
+    resolver.resolve(filter, QConditionCode.conditionCode.conditionCodesetNm);
+    verify(resolver, times(0)).conditionNotIn(Mockito.any());
+  }
+
+  @Test
+  void should_not_handle_single_value() {
+    SingleValueFilter filter = new SingleValueFilter("conditions", Operator.NOT_EQUAL_TO, "2019 Novel Coronavirus");
+    resolver.resolve(filter, QConditionCode.conditionCode.conditionCodesetNm);
+    verify(resolver, times(0)).conditionNotIn(Mockito.any());
+  }
+
+  @Test
+  void should_not_handle_string_expression() {
+    MultiValueFilter filter = new MultiValueFilter(
+        "conditions",
+        Operator.NOT_EQUAL_TO,
+        Collections.singletonList("2019 Novel Coronavirus"));
+    resolver.resolve(filter, QConditionCode.conditionCode.nbsUid);
+    verify(resolver, times(0)).conditionNotIn(Mockito.any());
+  }
+}


### PR DESCRIPTION
## Description

The `condition not equal to` filter in the Page Library was not working as expected and still returned pages that were associated with the provided condition. This PR adds custom handling for this query.

## Tickets

* [CNFT2-1697](https://cdc-nbs.atlassian.net/browse/CNFT2-1697)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1697]: https://cdc-nbs.atlassian.net/browse/CNFT2-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ