### PR TITLE
Rename MMG -> Reporting mechanism in create page form

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.spec.tsx
@@ -144,14 +144,14 @@ describe('Add New Page', () => {
     });
 
     it('should display form when Investigation type is selected', async () => {
-        const { queryByText } = render(
+        const { queryByText, getByText } = render(
             <MemoryRouter>
                 <AlertProvider>
                     <AddNewPage />
                 </AlertProvider>
             </MemoryRouter>
         );
-        const label = screen.getByText('Event type');
+        const label = getByText('Event type');
         expect(label).toBeInTheDocument();
 
         const select = screen.getByTestId('eventTypeDropdown');
@@ -161,7 +161,11 @@ describe('Add New Page', () => {
         const warning = queryByText('event type is not supported');
         expect(warning).not.toBeInTheDocument();
 
-        const conditionSelect = screen.getByText('Condition(s)');
-        expect(conditionSelect).toBeInTheDocument();
+        expect(getByText('Condition(s)')).toBeInTheDocument();
+        expect(getByText('Page name')).toBeInTheDocument();
+        expect(getByText('Template')).toBeInTheDocument();
+        expect(getByText('Reporting mechanism')).toBeInTheDocument();
+        expect(getByText('Page description')).toBeInTheDocument();
+        expect(getByText('Data mart name')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
@@ -89,7 +89,7 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                 }}
                 render={({ field: { onBlur, onChange, value }, fieldState: { error } }) => (
                     <SelectInput
-                        label="Templates"
+                        label="Template"
                         defaultValue={value}
                         onChange={onChange}
                         onBlur={onBlur}

--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
@@ -65,13 +65,14 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                     required: { value: true, message: 'Name is required.' },
                     ...validPageNameRule
                 }}
-                render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         onChange={onChange}
                         onBlur={() => {
                             onBlur();
                             validatePageName(value);
                         }}
+                        name={name}
                         defaultValue={value}
                         label="Page name"
                         className="pageName"
@@ -87,9 +88,10 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                 rules={{
                     required: { value: true, message: 'Template is required.' }
                 }}
-                render={({ field: { onBlur, onChange, value }, fieldState: { error } }) => (
+                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SelectInput
                         label="Template"
+                        name={name}
                         defaultValue={value}
                         onChange={onChange}
                         onBlur={onBlur}
@@ -114,10 +116,10 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                 control={form.control}
                 name="messageMappingGuide"
                 rules={{ required: { value: true, message: 'Reporting mechanism is required.' } }}
-                render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <SelectInput
                         label="Reporting mechanism"
-                        name="messageMappingGuide"
+                        name={name}
                         onChange={onChange}
                         onBlur={onBlur}
                         defaultValue={value}
@@ -140,12 +142,13 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
             <Controller
                 control={form.control}
                 name="pageDescription"
-                render={({ field: { onChange, value } }) => (
+                render={({ field: { onChange, value, name } }) => (
                     <Input
                         onChange={(d: any) => {
                             onChange(d);
                         }}
                         label="Page description"
+                        name={name}
                         type="text"
                         multiline
                         defaultValue={value}
@@ -156,9 +159,10 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                 control={form.control}
                 name="dataMartName"
                 rules={dataMartNameRule}
-                render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Data mart name"
+                        name={name}
                         type="text"
                         onChange={onChange}
                         defaultValue={value}

--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
@@ -113,10 +113,10 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
             <Controller
                 control={form.control}
                 name="messageMappingGuide"
-                rules={{ required: { value: true, message: 'MMG is required.' } }}
+                rules={{ required: { value: true, message: 'Reporting mechanism is required.' } }}
                 render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
                     <SelectInput
-                        label="MMG"
+                        label="Reporting mechanism"
                         name="messageMappingGuide"
                         onChange={onChange}
                         onBlur={onBlur}
@@ -128,7 +128,8 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                             };
                         })}
                         error={error?.message}
-                        required></SelectInput>
+                        required
+                    />
                 )}
             />
             <p>


### PR DESCRIPTION
## Description

The MMG field is misleading the page creation form as not all options in the selection are Message Mapping Guides. Per feedback from GDIT this would be better as `Reporting mechanism`.

Also fixes the `template` field as it was plural in the code but singular in the Figma design

## Tickets

* [CNFT2-1747](https://cdc-nbs.atlassian.net/browse/CNFT2-1747)
### Before
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/28ba6521-843a-4953-8dcc-e6e00535214e)
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/ad4ea827-15a4-4d2f-b5cb-09934a10bca8)



### After
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/d68606c3-ac60-4529-9b85-9a0687e09ae8)
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/dfe118ea-c184-4e7e-9924-e4551263eb5e)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1747]: https://cdc-nbs.atlassian.net/browse/CNFT2-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ