### PR TITLE
adding totalResults to the aria label and setting the data to load sooner for screen readers

### DIFF
--- a/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
@@ -497,22 +497,10 @@ export const AdvancedSearch = () => {
                                 <div
                                     tabIndex={0}
                                     id="resultsCount"
-                                    aria-label={
-                                        ((lastSearchType === SEARCH_TYPE.PERSON && patientData?.total?.toString()) ||
-                                            (lastSearchType === SEARCH_TYPE.INVESTIGATION &&
-                                                investigationData?.total?.toString()) ||
-                                            (lastSearchType === SEARCH_TYPE.LAB_REPORT &&
-                                                labReportData?.total?.toString())) +
-                                        ' amount of results have been found'
-                                    }
+                                    aria-label={resultTotal + ' amount of results have been found'}
                                     className="margin-0 font-sans-md margin-top-05 text-normal grid-row results-for"
                                     style={{ maxWidth: '55%' }}>
-                                    <strong className="margin-right-1">
-                                        {lastSearchType === SEARCH_TYPE.PERSON && patientData?.total}
-                                        {lastSearchType === SEARCH_TYPE.INVESTIGATION && investigationData?.total}
-                                        {lastSearchType === SEARCH_TYPE.LAB_REPORT && labReportData?.total}
-                                    </strong>{' '}
-                                    Results for
+                                    <strong className="margin-right-1">{resultTotal}</strong> Results for
                                     <AdvancedSearchChips
                                         lastSearchType={lastSearchType}
                                         personFilter={personFilter}

--- a/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
@@ -497,7 +497,7 @@ export const AdvancedSearch = () => {
                                 <div
                                     tabIndex={0}
                                     id="resultsCount"
-                                    aria-label={resultTotal + ' amount of results have been found'}
+                                    aria-label={resultTotal + ' Results have been found'}
                                     className="margin-0 font-sans-md margin-top-05 text-normal grid-row results-for"
                                     style={{ maxWidth: '55%' }}>
                                     <strong className="margin-right-1">{resultTotal}</strong> Results for


### PR DESCRIPTION
## Description

This pr is designed to fix an issue where screen readers were not able to load the data associated with the "Results for" label when it is focused upon making a search. Now for each time there is a search made the screen reader should read the data found in the label associated with the search just made, for example: "5 Results for lastName: s" . 
Also I added an aria-label to include the totalResults found associated with the search just.

## Tickets

* [SSTT-1844](https://cdc-nbs.atlassian.net/browse/CNFT1-1844)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
