### PR TITLE
Adding codeSetGroupId to valueSet Search API Response

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/ValueSetFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/ValueSetFinder.java
@@ -23,7 +23,8 @@ public class ValueSetFinder {
           NBS_SRTE.dbo.Codeset.value_set_code,
           NBS_SRTE.dbo.Codeset.value_set_nm,
           NBS_SRTE.dbo.Codeset.code_set_desc_txt,
-          NBS_SRTE.dbo.Codeset.value_set_status_cd
+          NBS_SRTE.dbo.Codeset.value_set_status_cd,
+          NBS_SRTE.dbo.Codeset.code_set_group_id
       FROM NBS_SRTE.dbo.Codeset 
       WHERE (NBS_SRTE.dbo.Codeset.value_set_nm LIKE  ?
           OR NBS_SRTE.dbo.Codeset.code_set_desc_txt LIKE ?

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/ValueSetSearchResponseMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/ValueSetSearchResponseMapper.java
@@ -3,16 +3,18 @@ package gov.cdc.nbs.questionbank.valueset;
 import gov.cdc.nbs.questionbank.valueset.response.ValueSetSearchResponse;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.lang.NonNull;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class ValueSetSearchResponseMapper implements RowMapper<ValueSetSearchResponse> {
 
-  record Column(int type, int valueSetCode, int valueSetName, int valueSetDescription, int status) {
+  record Column(int type, int valueSetCode, int valueSetName, int valueSetDescription, int status, int codeSetGroupId) {
     Column() {
-      this(1, 2, 3, 4, 5);
+      this(1, 2, 3, 4, 5, 6);
     }
   }
+
 
   private final Column columns;
 
@@ -32,12 +34,15 @@ public class ValueSetSearchResponseMapper implements RowMapper<ValueSetSearchRes
     String valueSetName = rs.getString(columns.valueSetName());
     String valueSetDescription = rs.getString(columns.valueSetDescription());
     String status = rs.getString(columns.status());
+    Long codeSetGroupId = rs.getLong(columns.codeSetGroupId());
     return new ValueSetSearchResponse(
         type,
         valueSetCode,
         valueSetName,
         valueSetDescription,
-        status );
+        status,
+        codeSetGroupId);
+
   }
 
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/response/ValueSetSearchResponse.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/valueset/response/ValueSetSearchResponse.java
@@ -5,6 +5,7 @@ public record ValueSetSearchResponse(
     String valueSetCode,
     String valueSetName,
     String valueSetDescription,
-    String valueSetStatus
+    String valueSetStatus,
+    Long codeSetGroupId
 ) {
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/valueset/read/ValueSetFinderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/valueset/read/ValueSetFinderTest.java
@@ -119,10 +119,10 @@ class ValueSetFinderTest {
   private List<ValueSetSearchResponse> getListOfValueSetSearchResponses() {
     List<ValueSetSearchResponse> response = new ArrayList<>();
     response.add(new ValueSetSearchResponse("LOCAL", "setCode_1",
-        "setnm_1", "descText_1", "Active"));
+        "setnm_1", "descText_1", "Active",100l));
 
     response.add(new ValueSetSearchResponse("LOCAL", "setCode_2",
-        "setnm_2", "descText_2", "Active"));
+        "setnm_2", "descText_2", "Active",123l));
     return response;
 
   }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/valueset/read/ValueSetReaderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/valueset/read/ValueSetReaderTest.java
@@ -65,7 +65,7 @@ class ValueSetReaderTest {
   void searchValueSetTest() {
     ValueSetSearchRequest search = new ValueSetSearchRequest("setnm", "setCode", "descText");
     List<ValueSetSearchResponse> searchResult = List.of(new ValueSetSearchResponse("LOCAL", "setCode",
-        "setnm", "descText", "Active"));
+        "setnm", "descText", "Active",100l));
     Pageable pageable = Pageable.ofSize(1);
     int start = (int) pageable.getOffset();
     int end = (start + pageable.getPageSize());


### PR DESCRIPTION
## Description

The current API response contains (type, valueSetCode, valueSetDescription, valueSetName, valueSetStatus), this should be changed to contain extra field [codeSetGroupId]

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1750