### PR TITLE
CNFT2-1748 disable co-infection

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/CreateCondition/CreateCondition.tsx
@@ -11,7 +11,7 @@ import { authorization } from 'authorization';
 import { Input } from 'components/FormInputs/Input';
 import { SelectInput } from 'components/FormInputs/SelectInput';
 import { RefObject, useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { Condition, CreateConditionRequest, ProgramArea } from '../../generated';
 import { Concept } from '../../generated/models/Concept';
 import './CreateCondition.scss';
@@ -24,6 +24,7 @@ type Props = {
 export const CreateCondition = ({ modal, conditionCreated }: Props) => {
     const token = authorization();
     const { handleSubmit, control, reset, formState } = useForm<CreateConditionRequest>({ mode: 'onBlur' });
+    const formWatch = useWatch({ control });
     const { showAlert } = useAlert();
 
     // DropDown Options
@@ -31,6 +32,7 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
     const [groupOptions, setGroupOptions] = useState([] as Concept[]);
     const [programAreaOptions, setProgramAreaOptions] = useState([] as ProgramArea[]);
     const [systemOptions, setSystemOptions] = useState([] as Concept[]);
+    const stdHivCodes = ['HIV', 'STD'];
 
     useEffect(() => {
         fetchFamilyOptions(token).then((response) => setFamilyOptions(response));
@@ -160,6 +162,7 @@ export const CreateCondition = ({ modal, conditionCreated }: Props) => {
                         name="familyCd"
                         render={({ field: { onChange, value } }) => (
                             <SelectInput
+                                disabled={!(formWatch.progAreaCd && stdHivCodes.includes(formWatch.progAreaCd))}
                                 label="Condition family"
                                 defaultValue={value}
                                 onChange={onChange}

--- a/apps/modernization-ui/src/configuration/useConfiguration.ts
+++ b/apps/modernization-ui/src/configuration/useConfiguration.ts
@@ -1,4 +1,5 @@
-import { ConfigurationControllerService } from 'generated';
+import { authorization } from 'authorization';
+import { ConfigurationControllerService, Properties } from 'generated';
 import { useContext, useEffect, useState } from 'react';
 import { UserContext } from 'user';
 
@@ -34,6 +35,7 @@ type Features = {
 type Configuration = {
     settings: Settings;
     features: Features;
+    properties: Properties;
 };
 
 const defaultFeatures: Features = {
@@ -65,12 +67,19 @@ const defaultSettings: Settings = {
     }
 };
 
-const initial: Configuration = {
-    settings: defaultSettings,
-    features: defaultFeatures
+const defaultProperties: Properties = {
+    entries: {},
+    hivProgramAreas: [],
+    stdProgramAreas: []
 };
 
-const useConfiguration = (): { settings: Settings; features: Features; loading: boolean } => {
+const initial: Configuration = {
+    settings: defaultSettings,
+    features: defaultFeatures,
+    properties: defaultProperties
+};
+
+const useConfiguration = (): { settings: Settings; features: Features; loading: boolean; properties: Properties } => {
     const [config, setConfig] = useState<Configuration>(initial);
     const [loading, setLoading] = useState(false);
     const { state } = useContext(UserContext);
@@ -79,7 +88,7 @@ const useConfiguration = (): { settings: Settings; features: Features; loading: 
         if (state.isLoggedIn) {
             setLoading(true);
             ConfigurationControllerService.getConfigurationUsingGet({
-                authorization: `Bearer ${state.getToken()}`
+                authorization: authorization()
             }).then((response) => {
                 setConfig((existing) => ({ ...existing, ...(response as Configuration) }));
                 setLoading(false);

--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -29,6 +29,7 @@ export type { Me } from './models/Me';
 export type { Option } from './models/Option';
 export type { Page } from './models/Page';
 export type { PageBuilder } from './models/PageBuilder';
+export type { Properties } from './models/Properties';
 export { ProviderFacilitySearch } from './models/ProviderFacilitySearch';
 
 export { ConceptOptionsService } from './services/ConceptOptionsService';

--- a/apps/modernization-ui/src/generated/models/Configuration.ts
+++ b/apps/modernization-ui/src/generated/models/Configuration.ts
@@ -3,8 +3,10 @@
 /* eslint-disable */
 
 import type { Features } from './Features';
+import type { Properties } from './Properties';
 
 export type Configuration = {
     features?: Features;
+    properties?: Properties;
 };
 

--- a/apps/modernization-ui/src/generated/models/Properties.ts
+++ b/apps/modernization-ui/src/generated/models/Properties.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Properties = {
+    entries: Record<string, string>;
+    hivProgramAreas: Array<string>;
+    stdProgramAreas: Array<string>;
+};
+

--- a/libs/configuration-api/build.gradle
+++ b/libs/configuration-api/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation project(':authentication')
 
     implementation libs.springBoot.web
+    implementation libs.bundles.jpa
+    implementation libs.mssql.jdbc
 
     implementation libs.bundles.swagger
     implementation libs.bundles.security

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/Configuration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/Configuration.java
@@ -1,7 +1,7 @@
 package gov.cdc.nbs.configuration;
 
-import java.util.Map;
+import gov.cdc.nbs.configuration.nbs.Properties;
 
-public record Configuration(Features features, Map<String, String> configuration) {
+public record Configuration(Features features, Properties properties) {
 
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/Configuration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/Configuration.java
@@ -1,29 +1,7 @@
 package gov.cdc.nbs.configuration;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.util.Map;
 
-@ConfigurationProperties("nbs.ui")
-public record Configuration(Features features) {
-
-  public record Features(Address address, PageBuilder pageBuilder) {
-
-    public record Address(boolean autocomplete, boolean verification) {
-    }
-
-    public record PageBuilder(boolean enabled, Page page) {
-
-      public record Page(Library library, Management management) {
-        public record Library(boolean enabled) {
-        }
-        public record Management(Create create, Edit edit) {
-
-          public record Create(boolean enabled) {
-          }
-          public record Edit(boolean enabled) {
-          }
-        }
-      }
-    }
-  }
+public record Configuration(Features features, Map<String, String> configuration) {
 
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/ConfigurationController.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/ConfigurationController.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.configuration;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import gov.cdc.nbs.configuration.nbs.NbsPropertiesFinder;
 import io.swagger.annotations.ApiImplicitParam;
 
 
@@ -12,11 +13,11 @@ import io.swagger.annotations.ApiImplicitParam;
 public class ConfigurationController {
 
   private final Features features;
-  private final NbsConfigurationFinder finder;
+  private final NbsPropertiesFinder finder;
 
   public ConfigurationController(
       final Features features,
-      final NbsConfigurationFinder finder) {
+      final NbsPropertiesFinder finder) {
     this.features = features;
     this.finder = finder;
   }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/ConfigurationController.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/ConfigurationController.java
@@ -11,19 +11,23 @@ import io.swagger.annotations.ApiImplicitParam;
 @RequestMapping("/nbs/api/configuration")
 public class ConfigurationController {
 
-    private final Configuration configuration;
+  private final Features features;
+  private final NbsConfigurationFinder finder;
 
-    public ConfigurationController(final Configuration configuration) {
-      this.configuration = configuration;
-    }
+  public ConfigurationController(
+      final Features features,
+      final NbsConfigurationFinder finder) {
+    this.features = features;
+    this.finder = finder;
+  }
 
-    @ApiImplicitParam(
-            name = "Authorization",
-            required = true,
-            paramType = "header",
-            dataTypeClass = String.class)
-    @GetMapping
-    public Configuration getConfiguration() {
-        return configuration;
-    }
+  @ApiImplicitParam(
+      name = "Authorization",
+      required = true,
+      paramType = "header",
+      dataTypeClass = String.class)
+  @GetMapping
+  public Configuration getConfiguration() {
+    return new Configuration(features, finder.find());
+  }
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/Features.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/Features.java
@@ -1,0 +1,26 @@
+package gov.cdc.nbs.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("nbs.ui.features")
+public record Features(Address address, PageBuilder pageBuilder) {
+
+  public record Address(boolean autocomplete, boolean verification) {
+  }
+
+  public record PageBuilder(boolean enabled, Page page) {
+
+    public record Page(Library library, Management management) {
+
+      public record Library(boolean enabled) {
+      }
+      public record Management(Create create, Edit edit) {
+
+        public record Create(boolean enabled) {
+        }
+        public record Edit(boolean enabled) {
+        }
+      }
+    }
+  }
+}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/NbsConfigurationFinder.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/NbsConfigurationFinder.java
@@ -1,0 +1,58 @@
+package gov.cdc.nbs.configuration;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NbsConfigurationFinder {
+
+  private final NamedParameterJdbcTemplate template;
+
+  public NbsConfigurationFinder(final NamedParameterJdbcTemplate template) {
+    this.template = template;
+  }
+
+  private static final String QUERY = """
+      SELECT
+        config_key,
+        config_value
+      FROM
+        [NBS_ODSE].[dbo].NBS_configuration
+      WHERE
+        config_key IN (:keys)
+      """;
+
+  // List of configs that will be exposed to the UI
+  private static final List<String> exposedConfigs = Arrays.asList("HIV_PROGRAM_AREAS", "STD_PROGRAM_AREAS");
+
+
+  public Map<String, String> find() {
+    SqlParameterSource parameters = new MapSqlParameterSource("keys", exposedConfigs);
+    return this.template.query(QUERY, parameters, mapper())
+        .stream()
+        .filter(o -> o.getKey() != null && o.getValue() != null)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private RowMapper<AbstractMap.SimpleEntry<String, String>> mapper() {
+    return new RowMapper<AbstractMap.SimpleEntry<String, String>>() {
+
+      @Override
+      public AbstractMap.SimpleEntry<String, String> mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new AbstractMap.SimpleEntry<>(rs.getString(1), rs.getString(2));
+      }
+
+    };
+  }
+
+}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/Properties.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/Properties.java
@@ -1,0 +1,10 @@
+package gov.cdc.nbs.configuration.nbs;
+
+import java.util.List;
+import java.util.Map;
+
+public record Properties(
+    List<String> stdProgramAreas,
+    List<String> hivProgramAreas,
+    Map<String, String> entries) {
+}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/Properties.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/Properties.java
@@ -2,9 +2,10 @@ package gov.cdc.nbs.configuration.nbs;
 
 import java.util.List;
 import java.util.Map;
+import io.swagger.annotations.ApiModelProperty;
 
 public record Properties(
-    List<String> stdProgramAreas,
-    List<String> hivProgramAreas,
-    Map<String, String> entries) {
+    @ApiModelProperty(required = true) List<String> stdProgramAreas,
+    @ApiModelProperty(required = true) List<String> hivProgramAreas,
+    @ApiModelProperty(required = true) Map<String, String> entries) {
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/PropertiesMapper.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/PropertiesMapper.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.configuration.nbs;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,9 @@ public class PropertiesMapper {
 
   // NBS Classic tokenizes STD and HIV program areas in the cachedStdProgramArea method of the PropertyUtil
   private static List<String> tokenize(String original) {
+    if (original == null) {
+      return new ArrayList<>();
+    }
     return Stream.of(original.split(","))
         .map(s -> s.toUpperCase().trim())
         .toList();

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/PropertiesMapper.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/PropertiesMapper.java
@@ -1,0 +1,36 @@
+package gov.cdc.nbs.configuration.nbs;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import static gov.cdc.nbs.configuration.nbs.NbsPropertiesFinder.STD_PROGRAM_AREAS;
+import static gov.cdc.nbs.configuration.nbs.NbsPropertiesFinder.HIV_PROGRAM_AREAS;
+import static gov.cdc.nbs.configuration.nbs.NbsPropertiesFinder.CODE_BASE;
+
+public class PropertiesMapper {
+  private PropertiesMapper() {}
+
+  // entries from the database to be included in the exposed Properties object
+  private static final List<String> includedProperties = Arrays.asList(CODE_BASE);
+
+  public static Properties toProperties(Map<String, String> map) {
+    return new Properties(
+        tokenize(map.get(STD_PROGRAM_AREAS)),
+        tokenize(map.get(HIV_PROGRAM_AREAS)),
+        map.entrySet()
+            .stream()
+            .filter(e -> includedProperties.contains(e.getKey()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
+  }
+
+  // NBS Classic tokenizes STD and HIV program areas in the cachedStdProgramArea method of the PropertyUtil
+  private static List<String> tokenize(String original) {
+    return Stream.of(original.split(","))
+        .map(s -> s.toUpperCase().trim())
+        .toList();
+  }
+
+}

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/ConfigurationControllerTest.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/ConfigurationControllerTest.java
@@ -1,41 +1,53 @@
 package gov.cdc.nbs.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.cdc.nbs.configuration.Configuration.Features;
-import gov.cdc.nbs.configuration.Configuration.Features.Address;
-import gov.cdc.nbs.configuration.Configuration.Features.PageBuilder;
-import gov.cdc.nbs.configuration.Configuration.Features.PageBuilder.Page;
-import gov.cdc.nbs.configuration.Configuration.Features.PageBuilder.Page.Library;
-import gov.cdc.nbs.configuration.Configuration.Features.PageBuilder.Page.Management;
-import gov.cdc.nbs.configuration.Configuration.Features.PageBuilder.Page.Management.Create;
-import gov.cdc.nbs.configuration.Configuration.Features.PageBuilder.Page.Management.Edit;
+import gov.cdc.nbs.configuration.Features.Address;
+import gov.cdc.nbs.configuration.Features.PageBuilder;
+import gov.cdc.nbs.configuration.Features.PageBuilder.Page;
+import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Library;
+import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Management;
+import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Management.Create;
+import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Management.Edit;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigurationControllerTest {
 
   ObjectMapper mapper = new ObjectMapper();
 
-  Configuration configuration =
-      new Configuration(
-          new Features(
-              new Address(true, true),
-              new PageBuilder(true,
-                  new Page(
-                      new Library(true),
-                      new Management(
-                          new Create(true),
-                          new Edit(true))))));
+  @Spy
+  private Features features = new Features(
+      new Address(true, true),
+      new PageBuilder(true,
+          new Page(
+              new Library(true),
+              new Management(
+                  new Create(true),
+                  new Edit(true)))));
 
+  @Mock
+  private NbsConfigurationFinder finder;
 
-  ConfigurationController controller = new ConfigurationController(configuration);
+  @InjectMocks
+  private ConfigurationController controller;
+
 
   @Test
   void should_return_proper_configuration() throws JsonProcessingException {
+    Map<String, String> configs = new HashMap<>();
+    configs.put("key1", "value1");
+    when(finder.find()).thenReturn(configs);
+
     Configuration config = controller.getConfiguration();
 
     String expected =
@@ -62,6 +74,9 @@ class ConfigurationControllerTest {
                     }
                   }
                 }
+              },
+              "configuration" : {
+                "key1" : "value1"
               }
             }""";
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(config);

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/ConfigurationControllerTest.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/ConfigurationControllerTest.java
@@ -2,8 +2,8 @@ package gov.cdc.nbs.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,6 +19,8 @@ import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Library;
 import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Management;
 import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Management.Create;
 import gov.cdc.nbs.configuration.Features.PageBuilder.Page.Management.Edit;
+import gov.cdc.nbs.configuration.nbs.NbsPropertiesFinder;
+import gov.cdc.nbs.configuration.nbs.Properties;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigurationControllerTest {
@@ -36,7 +38,7 @@ class ConfigurationControllerTest {
                   new Edit(true)))));
 
   @Mock
-  private NbsConfigurationFinder finder;
+  private NbsPropertiesFinder finder;
 
   @InjectMocks
   private ConfigurationController controller;
@@ -44,9 +46,9 @@ class ConfigurationControllerTest {
 
   @Test
   void should_return_proper_configuration() throws JsonProcessingException {
-    Map<String, String> configs = new HashMap<>();
-    configs.put("key1", "value1");
-    when(finder.find()).thenReturn(configs);
+    Properties properties = new Properties(Arrays.asList("STD"), Arrays.asList("HIV"),
+        Collections.singletonMap("CODE_BASE", "Release 6.0.15-Beta"));
+    when(finder.find()).thenReturn(properties);
 
     Configuration config = controller.getConfiguration();
 
@@ -75,8 +77,12 @@ class ConfigurationControllerTest {
                   }
                 }
               },
-              "configuration" : {
-                "key1" : "value1"
+              "properties" : {
+                "stdProgramAreas" : [ "STD" ],
+                "hivProgramAreas" : [ "HIV" ],
+                "entries" : {
+                  "CODE_BASE" : "Release 6.0.15-Beta"
+                }
               }
             }""";
     String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(config);

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/nbs/PropertiesMapperTest.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/nbs/PropertiesMapperTest.java
@@ -22,4 +22,14 @@ class PropertiesMapperTest {
     assertThat(props.entries()).containsEntry(NbsPropertiesFinder.CODE_BASE, "nbs 6");
     assertThat(props.entries()).doesNotContainKey("dontInclude");
   }
+
+  @Test
+  void shouldNotFailForNullTokenizeCall() {
+    Map<String, String> map = new HashMap<>();
+    Properties props = PropertiesMapper.toProperties(map);
+    assertThat(props).isNotNull();
+    assertThat(props.stdProgramAreas()).isEmpty();
+    assertThat(props.hivProgramAreas()).isEmpty();
+    assertThat(props.entries().entrySet()).isEmpty();
+  }
 }

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/nbs/PropertiesMapperTest.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/nbs/PropertiesMapperTest.java
@@ -1,0 +1,25 @@
+package gov.cdc.nbs.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PropertiesMapperTest {
+
+  @Test
+  void shouldMapValues() {
+    Map<String, String> map = new HashMap<>();
+    map.put(NbsPropertiesFinder.STD_PROGRAM_AREAS, "STD,   SomethingElse ");
+    map.put(NbsPropertiesFinder.HIV_PROGRAM_AREAS, "HIV");
+    map.put(NbsPropertiesFinder.CODE_BASE, "nbs 6");
+    map.put("dontInclude", "AnyValue");
+
+    Properties props = PropertiesMapper.toProperties(map);
+
+    assertThat(props.stdProgramAreas()).containsExactly("STD", "SOMETHINGELSE");
+    assertThat(props.hivProgramAreas()).containsExactly("HIV");
+    assertThat(props.entries()).containsEntry(NbsPropertiesFinder.CODE_BASE, "nbs 6");
+    assertThat(props.entries()).doesNotContainKey("dontInclude");
+  }
+}

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/nbs/PropertiesMapperTest.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/nbs/PropertiesMapperTest.java
@@ -1,4 +1,4 @@
-package gov.cdc.nbs.configuration;
+package gov.cdc.nbs.configuration.nbs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;


### PR DESCRIPTION
## Description

The Co-infection group drop down should be disabled on the create condition form if the selected program is not an HIV or STD program area. The HIV / STD program areas are defined in the NBS_configuration table in the database (and are STD and HIV by default). 

The configuration-api was updated to return a few properties from this table so the UI could handle the disable / enable appropriately.

## Tickets

* [CNFT2-1748](https://cdc-nbs.atlassian.net/browse/CNFT2-1748)

![disableCo-infection](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/b6132724-4b1c-469d-a639-5e7679ff6013)



## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1748]: https://cdc-nbs.atlassian.net/browse/CNFT2-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ