### PR TITLE
CNFT2-1773 Fix: Add multiple value set codes

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/Concept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/Concept.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState, ReactNode } from 'react';
 import './Concept.scss';
 import { ConceptsContext } from '../../context/ConceptContext';
 import { useConceptAPI } from './useConceptAPI';
@@ -8,6 +8,7 @@ import { ValueSet, ValueSetControllerService } from '../../generated';
 import { authorization } from 'authorization';
 import { EditConcept } from './EditConcept/EditConcept';
 import { CreateConcept } from './CreateConcept/CreateConcept';
+import { AlertBanner } from '../AlertBanner/AlertBanner';
 
 type Props = {
     valueset: ValueSet;
@@ -25,6 +26,8 @@ export const Concept = ({ valueset }: Props) => {
     const [isShowFrom, setShowForm] = useState(false);
     const [codeSystemOptionList, setCodeSystemOptionList] = useState<CodeSystemOption[]>([]);
     const [editMode, setEditMode] = useState(false);
+    const [alertMessage, setAlertMessage] = useState<AlertMessage | undefined>(undefined);
+    type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number };
 
     const fetchContent = async () => {
         try {
@@ -45,6 +48,10 @@ export const Concept = ({ valueset }: Props) => {
     useEffect(() => {
         selectedConcept.status && setShowForm(!isShowFrom);
     }, [selectedConcept]);
+
+    useEffect(() => {
+        setTimeout(() => setAlertMessage(undefined), 3000);
+    }, [alertMessage]);
 
     const updateCallback = () => {
         fetchContent();
@@ -87,6 +94,11 @@ export const Concept = ({ valueset }: Props) => {
             <h3 className="main-header-title" data-testid="header-title">
                 Add value set concept
             </h3>
+            {alertMessage && (
+                <AlertBanner type={alertMessage.type} expiration={alertMessage.expiration}>
+                    {alertMessage.message}
+                </AlertBanner>
+            )}
             {isShowFrom ? (
                 editMode ? (
                     <EditConcept
@@ -95,6 +107,7 @@ export const Concept = ({ valueset }: Props) => {
                         codeSystemOptionList={codeSystemOptionList}
                         setShowForm={() => setShowForm(false)}
                         updateCallback={updateCallback}
+                        setAlertMessage={setAlertMessage}
                     />
                 ) : (
                     <CreateConcept
@@ -102,6 +115,7 @@ export const Concept = ({ valueset }: Props) => {
                         codeSystemOptionList={codeSystemOptionList}
                         setShowForm={() => setShowForm(false)}
                         updateCallback={updateCallback}
+                        setAlertMessage={setAlertMessage}
                     />
                 )
             ) : (

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.spec.tsx
@@ -38,7 +38,7 @@ describe('When EditConcept form renders', () => {
                 pageSize: 10,
                 setPageSize: () => {}
             }}>
-                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} />
+                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
             </ConceptsProvider>
         );
 
@@ -66,7 +66,7 @@ describe('When EditConcept form renders', () => {
                 pageSize: 10,
                 setPageSize: () => {}
             }}>
-                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} />
+                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
             </ConceptsProvider>
         );
         const inputs = container.getElementsByClassName('usa-input');
@@ -88,7 +88,7 @@ describe('When EditConcept form renders', () => {
                 pageSize: 10,
                 setPageSize: () => {}
             }}>
-                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} />
+                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
             </ConceptsProvider>
         );
         const buttons = container.getElementsByTagName('button');

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
@@ -1,5 +1,5 @@
 import { AddConceptRequest } from 'apps/page-builder/generated';
-import { useState } from 'react';
+import { useState, ReactNode } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Button, FormGroup, Grid, Radio, ComboBox, ErrorMessage } from '@trussworks/react-uswds';
 import { ValueSetControllerService, ValueSet } from 'apps/page-builder/generated';
@@ -31,15 +31,23 @@ const init = {
     shortDisplayName: undefined,
     statusCode: AddConceptRequest.statusCode.A
 };
+type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number };
 
 type Props = {
     valueset: ValueSet;
     codeSystemOptionList: CodeSystemOption[];
     setShowForm: () => void;
     updateCallback: () => void;
+    setAlertMessage: (message: AlertMessage) => void;
 };
 
-export const CreateConcept = ({ valueset, codeSystemOptionList, setShowForm, updateCallback }: Props) => {
+export const CreateConcept = ({
+    valueset,
+    codeSystemOptionList,
+    setShowForm,
+    updateCallback,
+    setAlertMessage
+}: Props) => {
     const [duration, setDuration] = useState(false);
     const conceptForm = useForm<AddConceptRequest>({
         mode: 'onBlur',
@@ -48,6 +56,7 @@ export const CreateConcept = ({ valueset, codeSystemOptionList, setShowForm, upd
     const { control, handleSubmit, reset } = conceptForm;
 
     const resetForm = () => {
+        setShowForm();
         reset();
     };
 
@@ -55,10 +64,10 @@ export const CreateConcept = ({ valueset, codeSystemOptionList, setShowForm, upd
         handleCreateConcept(data);
     });
 
-    const handleCreateConcept = (data: AddConceptRequest) => {
+    const handleCreateConcept = async (data: AddConceptRequest) => {
         const effectiveFromTime = new Date(data.effectiveFromTime).toISOString();
         const request: AddConceptRequest = {
-            code: valueset?.valueSetCode!,
+            code: data.messagingInfo.conceptCode,
             displayName: data.displayName,
             shortDisplayName: data.displayName,
             effectiveFromTime,
@@ -71,16 +80,31 @@ export const CreateConcept = ({ valueset, codeSystemOptionList, setShowForm, upd
                 preferredConceptName: data.messagingInfo.preferredConceptName
             }
         };
-        ValueSetControllerService.addConceptUsingPost({
+        await ValueSetControllerService.addConceptUsingPost({
             authorization: authorization(),
             codeSetNm: valueset!.valueSetCode!,
             request
-        }).then((response: any) => {
-            setShowForm();
-            updateCallback!();
-            return response;
-        });
-        setShowForm();
+        })
+            .then((response: any) => {
+                setAlertMessage({
+                    type: 'success',
+                    expiration: 3000,
+                    message: (
+                        <p>
+                            You've successfully added <span>{data.messagingInfo.conceptName}</span>
+                        </p>
+                    )
+                });
+                updateCallback!();
+                return response;
+            })
+            .catch((error: any) => {
+                setAlertMessage({
+                    type: 'error',
+                    expiration: 3000,
+                    message: <p>{error.message}</p>
+                });
+            });
     };
 
     const handleValidation = (unique = true) => {

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.spec.tsx
@@ -25,7 +25,7 @@ describe('When EditConcept form renders', () => {
 
     it('should disable Local code field', () => {
         const { container } = render(
-            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} />
+            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
         );
         const inputs = container.getElementsByClassName('usa-input');
         expect(inputs[1]).toBeDisabled();
@@ -33,7 +33,7 @@ describe('When EditConcept form renders', () => {
 
     it('should display UI display name', async () => {
         const { container } = render(
-            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} />
+            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
         );
         const inputs = container.getElementsByTagName('input');
         expect(inputs.length).toBe(13);
@@ -41,7 +41,7 @@ describe('When EditConcept form renders', () => {
 
     it('should display UI display name', async () => {
         const { container } = render(
-            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} />
+            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
         );
         expect(screen.getAllByDisplayValue('Test concept display')).toHaveLength(1);
         expect(screen.getAllByDisplayValue('ZZZ')).toHaveLength(2);


### PR DESCRIPTION
## Description

This fixes a bug where after adding a first Value Set Concept to a Value Set, you can't add any more. The wrong value was being passed as Value Set Code which flagged a redundancy error. I've added AlertBanner messages to Creating and Editing Value Set Concepts to improve the user experience.

## Tickets

[* [Jira Ticket](url)](https://cdc-nbs.atlassian.net/browse/CNFT2-1773)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
