### PR TITLE
Standardize object structure for Create and View APIs for business rules

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleController.java
@@ -6,7 +6,6 @@ import gov.cdc.nbs.authentication.UserDetailsProvider;
 import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import gov.cdc.nbs.questionbank.page.content.rule.PageRuleDeleter;
 import gov.cdc.nbs.questionbank.pagerules.exceptions.RuleException;
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
 import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
 import springfox.documentation.annotations.ApiIgnore;
 import org.springframework.data.domain.Page;
@@ -46,15 +45,11 @@ public class PageRuleController {
 
   @PostMapping()
   @ResponseStatus(HttpStatus.CREATED)
-  public CreateRuleResponse createBusinessRule(
+  public ViewRuleResponse createBusinessRule(
       @RequestBody CreateRuleRequest request,
       @PathVariable("id") Long page,
       @ApiIgnore @AuthenticationPrincipal final NbsUserDetails details) {
-    try {
-      return pageRuleCreator.createPageRule(details.getId(), request, page);
-    } catch (RuleException e) {
-      return new CreateRuleResponse(null, "Error in Creating a Rules");
-    }
+    return pageRuleCreator.createPageRule(details.getId(), request, page);
   }
 
   @DeleteMapping("{ruleId}")
@@ -66,8 +61,8 @@ public class PageRuleController {
   }
 
   @PutMapping("/{ruleId}")
-  public CreateRuleResponse updatePageRule(@PathVariable Long ruleId,
-      @RequestBody CreateRuleRequest request, @PathVariable Long page) throws RuleException {
+  public ViewRuleResponse updatePageRule(@PathVariable Long ruleId,
+      @RequestBody CreateRuleRequest request, @PathVariable("id") Long page) throws RuleException {
     Long userId = userDetailsProvider.getCurrentUserDetails().getId();
     return pageRuleService.updatePageRule(ruleId, request, userId, page);
   }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreator.java
@@ -1,44 +1,49 @@
 package gov.cdc.nbs.questionbank.pagerules;
 
 import java.time.Instant;
+
+import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
 import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
 import gov.cdc.nbs.questionbank.pagerules.command.PageRuleCommand;
 import gov.cdc.nbs.questionbank.pagerules.repository.WaRuleMetaDataRepository;
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
 
 @Component
 @Transactional
 public class PageRuleCreator {
 
-        private final WaRuleMetaDataRepository waRuleMetaDataRepository;
+  private final WaRuleMetaDataRepository waRuleMetaDataRepository;
 
-        private final PageRuleHelper pageRuleHelper;
+  private final PageRuleHelper pageRuleHelper;
 
-        public PageRuleCreator(
-                        WaRuleMetaDataRepository waRuleMetaDataRepository,
-                        PageRuleHelper pageRuleHelper) {
-                this.waRuleMetaDataRepository = waRuleMetaDataRepository;
-                this.pageRuleHelper = pageRuleHelper;
-        }
+  private final RuleResponseMapper ruleResponseMapper;
 
-        public CreateRuleResponse createPageRule(Long userId, CreateRuleRequest request, Long page) {
-                long availableId = waRuleMetaDataRepository.findNextAvailableID();
+  public PageRuleCreator(
+      WaRuleMetaDataRepository waRuleMetaDataRepository,
+      PageRuleHelper pageRuleHelper,
+      RuleResponseMapper ruleResponseMapper) {
+    this.waRuleMetaDataRepository = waRuleMetaDataRepository;
+    this.pageRuleHelper = pageRuleHelper;
+    this.ruleResponseMapper = ruleResponseMapper;
+  }
 
-                RuleData ruleData = pageRuleHelper.createRuleData(request, availableId);
-                WaRuleMetadata ruleMetadata = new WaRuleMetadata(asAddPageRule(ruleData, request, userId, page));
-                
-                waRuleMetaDataRepository.save(ruleMetadata);
-                return new CreateRuleResponse(ruleMetadata.getId(), "Rule Created Successfully");
-        }
+  public ViewRuleResponse createPageRule(Long userId, CreateRuleRequest request, Long page) {
+    long availableId = waRuleMetaDataRepository.findNextAvailableID();
 
-        private PageRuleCommand.AddPageRule asAddPageRule(
-                        RuleData ruleData,
-                        CreateRuleRequest request,
-                        long userId,
-                        long page) {
-                return new PageRuleCommand.AddPageRule(ruleData, request, Instant.now(), userId, page);
-        }
+    RuleData ruleData = pageRuleHelper.createRuleData(request, availableId);
+    WaRuleMetadata ruleMetadata = new WaRuleMetadata(asAddPageRule(ruleData, request, userId, page));
+
+    waRuleMetaDataRepository.save(ruleMetadata);
+    return ruleResponseMapper.mapRuleResponse(ruleMetadata);
+  }
+
+  private PageRuleCommand.AddPageRule asAddPageRule(
+      RuleData ruleData,
+      CreateRuleRequest request,
+      long userId,
+      long page) {
+    return new PageRuleCommand.AddPageRule(ruleData, request, Instant.now(), userId, page);
+  }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinderServiceImpl.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinderServiceImpl.java
@@ -3,92 +3,42 @@ package gov.cdc.nbs.questionbank.pagerules;
 import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
 import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import gov.cdc.nbs.questionbank.pagerules.repository.WaRuleMetaDataRepository;
-import gov.cdc.nbs.questionbank.question.repository.WaQuestionRepository;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
 
 @Service
 public class PageRuleFinderServiceImpl implements PageRuleFinderService {
 
-    private final WaRuleMetaDataRepository waRuleMetaDataRepository;
+  private final WaRuleMetaDataRepository waRuleMetaDataRepository;
+  private final RuleResponseMapper ruleResponseMapper;
 
-    private final WaQuestionRepository waQuestionRepository;
+  public PageRuleFinderServiceImpl(
+      WaRuleMetaDataRepository waRuleMetaDataRepository, RuleResponseMapper ruleResponseMapper) {
+    this.waRuleMetaDataRepository = waRuleMetaDataRepository;
+    this.ruleResponseMapper = ruleResponseMapper;
+  }
+
+  @Override
+  public ViewRuleResponse getRuleResponse(Long ruleId) {
+    WaRuleMetadata ruleMetadata = waRuleMetaDataRepository.getReferenceById(ruleId);
+    return ruleResponseMapper.mapRuleResponse(ruleMetadata);
+  }
+
+  @Override
+  public Page<ViewRuleResponse> getAllPageRule(Pageable pageRequest, Long page) {
+    Page<WaRuleMetadata> ruleMetadataPage = waRuleMetaDataRepository.findByWaTemplateUid(page, pageRequest);
+    return ruleResponseMapper.mapRuleResponse(ruleMetadataPage);
+  }
+
+  @Override
+  public Page<ViewRuleResponse> findPageRule(SearchPageRuleRequest request, Pageable pageable) {
+    Page<WaRuleMetadata> ruleMetadataPage = waRuleMetaDataRepository
+        .findAllBySourceValuesContainingIgnoreCaseOrTargetQuestionIdentifierContainingIgnoreCase(
+            request.searchValue(), request.searchValue(), pageable);
+    return ruleResponseMapper.mapRuleResponse(ruleMetadataPage);
+  }
 
 
-    public PageRuleFinderServiceImpl(
-            WaRuleMetaDataRepository waRuleMetaDataRepository, WaQuestionRepository waQuestionRepository) {
-        this.waRuleMetaDataRepository = waRuleMetaDataRepository;
-        this.waQuestionRepository = waQuestionRepository;
-    }
-
-    @Override
-    public ViewRuleResponse getRuleResponse(Long ruleId) {
-        WaRuleMetadata ruleMetadata = waRuleMetaDataRepository.getReferenceById(ruleId);
-        List<String> sourceValues = new ArrayList<>();
-        List<QuestionInfo> targetQuestions = new ArrayList<>();
-        if (ruleMetadata.getSourceValues() != null && ruleMetadata.getTargetQuestionIdentifier() != null) {
-            String[] sourceValue = ruleMetadata.getSourceValues().split(",");
-            sourceValues = Arrays.asList(sourceValue);
-            targetQuestions = findLabelsByIdentifiers(Arrays.asList(ruleMetadata.getTargetQuestionIdentifier().split(",")));
-        }
-        return new ViewRuleResponse(ruleId, ruleMetadata.getWaTemplateUid(), ruleMetadata.getRuleCd(),
-                ruleMetadata.getRuleDescText(), ruleMetadata.getSourceQuestionIdentifier(), sourceValues,
-                ruleMetadata.getLogic(), ruleMetadata.getTargetType(), ruleMetadata.getErrormsgText(), targetQuestions);
-    }
-
-    @Override
-    public Page<ViewRuleResponse> getAllPageRule(Pageable pageRequest, Long page) {
-        Page<WaRuleMetadata> ruleMetadataPage = waRuleMetaDataRepository.findByWaTemplateUid(page, pageRequest);
-        return buildViewRuleResponse(ruleMetadataPage);
-    }
-
-    @Override
-    public Page<ViewRuleResponse> findPageRule(SearchPageRuleRequest request, Pageable pageable) {
-        Page<WaRuleMetadata> ruleMetadataPage = waRuleMetaDataRepository
-                .findAllBySourceValuesContainingIgnoreCaseOrTargetQuestionIdentifierContainingIgnoreCase(
-                        request.searchValue(), request.searchValue(), pageable);
-        return buildViewRuleResponse(ruleMetadataPage);
-    }
-
-    private Page<ViewRuleResponse> buildViewRuleResponse(Page<WaRuleMetadata> ruleMetadataPage) {
-        List<ViewRuleResponse> ruleMetadata =
-                ruleMetadataPage.getContent().stream()
-                        .map(rule -> new ViewRuleResponse(rule.getId(), rule.getWaTemplateUid(), rule.getRuleCd(),
-                                rule.getRuleDescText(), rule.getSourceQuestionIdentifier(),
-                                buildSourceTargetValues(rule, true),
-                                rule.getLogic(), rule.getTargetType(), rule.getErrormsgText(),
-                                findLabelsByIdentifiers(buildSourceTargetValues(rule, false))))
-                        .toList();
-        return new PageImpl<>(ruleMetadata, ruleMetadataPage.getPageable(), ruleMetadataPage.getTotalElements());
-    }
-
-    private List<String> buildSourceTargetValues(WaRuleMetadata ruleMetadata, boolean isSource) {
-
-        List<String> sourceValues = new ArrayList<>();
-        List<String> targetValues = new ArrayList<>();
-        if (isSource) {
-            if (ruleMetadata.getSourceValues() == null || ruleMetadata.getTargetQuestionIdentifier() == null) {
-                return sourceValues;
-            } else {
-                return Arrays.asList(ruleMetadata.getSourceValues().split(","));
-            }
-        } else {
-            if (ruleMetadata.getSourceValues() == null || ruleMetadata.getTargetQuestionIdentifier() == null) {
-                return targetValues;
-            } else {
-                return Arrays.stream(ruleMetadata.getTargetQuestionIdentifier().split(",")).toList();
-            }
-
-        }
-
-    }
-
-    private List<QuestionInfo> findLabelsByIdentifiers(List<String> targetValue) {
-        return waQuestionRepository.findLabelsByIdentifiers(targetValue).stream().map(
-                question -> new QuestionInfo(question[0].toString(), question[1].toString())).toList();
-    }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleService.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleService.java
@@ -1,14 +1,13 @@
 package gov.cdc.nbs.questionbank.pagerules;
 
 import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
+import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import gov.cdc.nbs.questionbank.pagerules.exceptions.RuleException;
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
+
 
 public interface PageRuleService {
 
-    CreateRuleResponse createPageRule(Long userId, CreateRuleRequest request,Long page) throws RuleException;
 
-
-    CreateRuleResponse updatePageRule(Long ruleId, CreateRuleRequest request, Long userId,Long page) throws RuleException;
+  ViewRuleResponse updatePageRule(Long ruleId, CreateRuleRequest request, Long userId, Long page) throws RuleException;
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleServiceImpl.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleServiceImpl.java
@@ -1,12 +1,13 @@
 package gov.cdc.nbs.questionbank.pagerules;
 
+import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import gov.cdc.nbs.questionbank.pagerules.exceptions.RuleException;
 import gov.cdc.nbs.questionbank.pagerules.repository.WaRuleMetaDataRepository;
 import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
 import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
 
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -15,768 +16,737 @@ import java.util.*;
 @Slf4j
 @Service
 public class PageRuleServiceImpl implements PageRuleService {
-    private static final String DATE_COMPARE = "Date Compare";
-    private static final String ELSE = " } else { \n";
-    private static final String IF = "\n if(";
-    private static final String ARRAY = "($j.inArray('";
-    private static final String DISABLE = "Disable";
-    private static final String ENABLE = "Enable";
-    private static final String REQUIRE_IF = "Require If";
-    private static final String HIDE = "Hide";
-    private static final String UNHIDE = "Unhide";
-    private static final String MUST_BE = "must be";
-    private static final String PARANTHESIS = "');\n";
-    private static final String DOLLARCLOSING = "$j('#";
-    private static final String ANY_SOURCE_VALUE = "( Any Source Value )";
-    private static final String PG_ENABLE_ELEMENT = "pgEnableElement('";
-    private static final String PG_DISABLE_ELEMENT = "pgDisableElement('";
-    private static final String SELECTED = " :selected').each(function(i, selected){";
-    private static final String LINESEPERATOR_PARANTHESIS = " });\n";
-    private static final String FUNCTION = "function ";
-    private static final String ACTION_1 = "()\n{";
+  private static final String DATE_COMPARE = "Date Compare";
+  private static final String ELSE = " } else { \n";
+  private static final String IF = "\n if(";
+  private static final String ARRAY = "($j.inArray('";
+  private static final String DISABLE = "Disable";
+  private static final String ENABLE = "Enable";
+  private static final String REQUIRE_IF = "Require If";
+  private static final String HIDE = "Hide";
+  private static final String UNHIDE = "Unhide";
+  private static final String MUST_BE = "must be";
+  private static final String PARANTHESIS = "');\n";
+  private static final String DOLLARCLOSING = "$j('#";
+  private static final String ANY_SOURCE_VALUE = "( Any Source Value )";
+  private static final String PG_ENABLE_ELEMENT = "pgEnableElement('";
+  private static final String PG_DISABLE_ELEMENT = "pgDisableElement('";
+  private static final String SELECTED = " :selected').each(function(i, selected){";
+  private static final String LINESEPERATOR_PARANTHESIS = " });\n";
+  private static final String FUNCTION = "function ";
+  private static final String ACTION_1 = "()\n{";
 
-    private final WaRuleMetaDataRepository waRuleMetaDataRepository;
+  private final WaRuleMetaDataRepository waRuleMetaDataRepository;
+  private final RuleResponseMapper ruleResponseMapper;
 
+  public PageRuleServiceImpl(
+      WaRuleMetaDataRepository waRuleMetaDataRepository,
+      RuleResponseMapper ruleResponseMapper) {
+    this.waRuleMetaDataRepository = waRuleMetaDataRepository;
+    this.ruleResponseMapper = ruleResponseMapper;
+  }
 
-    public PageRuleServiceImpl(
-            WaRuleMetaDataRepository waRuleMetaDataRepository) {
-        this.waRuleMetaDataRepository = waRuleMetaDataRepository;
+  private RuleData createRuleData(
+      CreateRuleRequest request,
+      WaRuleMetadata ruleMetadata) {
+    SourceValuesHelper sourceValuesHelper = sourceValuesHelper(request);
+    TargetValuesHelper targetValuesHelper = targetValuesHelper(request);
+    RuleExpressionHelper expressionValues = null;
+
+    if (DATE_COMPARE.equals(request.ruleFunction())) {
+      expressionValues = dateCompareFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
     }
+    if (DISABLE.equals(request.ruleFunction()) || ENABLE.equals(request.ruleFunction())) {
+      expressionValues = enableOrDisableFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
+    }
+    if (HIDE.equals(request.ruleFunction())) {
+      expressionValues = hideFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
+    }
+    if (REQUIRE_IF.equals(request.ruleFunction())) {
+      expressionValues = requireIfFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
+    }
+    if (UNHIDE.equals(request.ruleFunction())) {
+      expressionValues = unHideFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
+    }
+    if (expressionValues != null) {
+      return new RuleData(
+          targetValuesHelper.targetIdentifier(),
+          expressionValues.ruleExpression(),
+          expressionValues.errorMessage(),
+          sourceValuesHelper.sourceIdentifiers(),
+          sourceValuesHelper.sourceText(),
+          sourceValuesHelper.sourceValueText(),
+          expressionValues.jsFunctionNameHelper());
+    } else {
+      throw new RuleException("Error in Creating Rule Expression and Error Message Text", 400);
+    }
+  }
 
-    @Override
-    public CreateRuleResponse createPageRule(Long userId, CreateRuleRequest request,Long page) {
-        WaRuleMetadata waRuleMetadata = setRuleDataValues(userId, request,page);
-        waRuleMetaDataRepository.save(waRuleMetadata);
-        return new CreateRuleResponse(waRuleMetadata.getId(), "Rule Created Successfully");
+  private SourceValuesHelper sourceValuesHelper(CreateRuleRequest request) {
+    String sourceText = request.sourceText();
+    String sourceIdentifier = request.sourceIdentifier();
+    CreateRuleRequest.SourceValues sourceValues = request.sourceValue();
+    String sourceIds = null;
+    String sourceValueText = null;
+    if (request.sourceValue() != null) {
+      sourceIds = String.join(",", sourceValues.sourceValueId());
+      sourceValueText = String.join(",", sourceValues.sourceValueText());
+    }
+    return new SourceValuesHelper(sourceIds, sourceValueText, sourceText, sourceIdentifier);
+  }
+
+  private TargetValuesHelper targetValuesHelper(CreateRuleRequest request) {
+    List<String> targetTextList = request.targetValueText();
+    List<String> targetValueIdentifierList = request.targetValueIdentifier();
+    String targetIdentifier = String.join(",", targetValueIdentifierList);
+
+    return new TargetValuesHelper(targetIdentifier, targetTextList);
+  }
+
+  public RuleExpressionHelper dateCompareFunction(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      TargetValuesHelper targetValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    List<String> errorMessageList = new ArrayList<>();
+    String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
+    String sourceText = sourceValuesHelper.sourceText();
+    String targetIdentifier = targetValuesHelper.targetIdentifier();
+    List<String> targetTextList = targetValuesHelper.targetTextList();
+    String ruleExpression = sourceIdentifier.concat(" ")
+        .concat(request.comparator())
+        .concat(" ")
+        .concat("^ DT")
+        .concat(" ")
+        .concat("( " + targetIdentifier + " )");
+    for (String targetText : targetTextList) {
+      String errMsg = sourceText.concat(" ")
+          .concat(MUST_BE)
+          .concat(" ")
+          .concat(request.comparator())
+          .concat(" ")
+          .concat(targetText);
+      errorMessageList.add(errMsg);
+    }
+    String errorMessageText = String.join(",", errorMessageList);
+    JSFunctionNameHelper jsFunctionNameHelper = jsForDateCompare(
+        request,
+        sourceValuesHelper,
+        targetValuesHelper,
+        ruleMetadata);
+
+    return new RuleExpressionHelper(errorMessageText, ruleExpression,
+        new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
+  }
+
+  public RuleExpressionHelper enableOrDisableFunction(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      TargetValuesHelper targetValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    String ruleExpression;
+    List<String> errorMessageList = new ArrayList<>();
+    String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
+    String sourceText = sourceValuesHelper.sourceText();
+    String targetIdentifier = targetValuesHelper.targetIdentifier();
+    List<String> targetTextList = targetValuesHelper.targetTextList();
+    String sourceIds = sourceValuesHelper.sourceValueIds();
+    String sourceValueText = sourceValuesHelper.sourceValueText();
+    String indicator = ENABLE.equals(request.ruleFunction()) ? "E" : "D";
+
+    String commonErrMsgForAnySource = sourceText.concat(" ")
+        .concat(" ")
+        .concat(MUST_BE)
+        .concat(" ")
+        .concat(ANY_SOURCE_VALUE)
+        .concat(" ");
+    String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
+        .concat("( )")
+        .concat(" ");
+    String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
+        .concat("(" + sourceIds + ")")
+        .concat(" ");
+
+    if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
+      ruleExpression = commonRuleExpressionForAnySource.concat("^ ")
+          .concat(indicator)
+          .concat(" ")
+          .concat("( " + targetIdentifier + " )");
+      for (String targetText : targetTextList) {
+        String errMsg = commonErrMsgForAnySource.concat(targetText);
+        errorMessageList.add(errMsg);
+      }
+    } else {
+      ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
+          .concat(" ")
+          .concat("^ ")
+          .concat(indicator)
+          .concat(" ")
+          .concat("(" + targetIdentifier + ")");
+      for (String targetText : targetTextList) {
+        String errMsg = sourceText.concat(" ")
+            .concat(request.comparator())
+            .concat(" ")
+            .concat(MUST_BE)
+            .concat(" ")
+            .concat("(" + sourceValueText + ")")
+            .concat(" ")
+            .concat(targetText);
+        errorMessageList.add(errMsg);
+      }
+    }
+    String errorMessageText = String.join(",", errorMessageList);
+    JSFunctionNameHelper jsFunctionNameHelper = jsForEnableAndDisable(request, sourceValuesHelper, ruleMetadata);
+    return new RuleExpressionHelper(
+        errorMessageText,
+        ruleExpression,
+        new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
+  }
+
+  public RuleExpressionHelper hideFunction(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      TargetValuesHelper targetValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    String ruleExpression;
+    List<String> errorMessageList = new ArrayList<>();
+    String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
+    String sourceText = sourceValuesHelper.sourceText();
+    String targetIdentifier = targetValuesHelper.targetIdentifier();
+    List<String> targetTextList = targetValuesHelper.targetTextList();
+    String sourceIds = sourceValuesHelper.sourceValueIds();
+    String sourceValueText = sourceValuesHelper.sourceValueText();
+    String commonErrMsgForAnySource = sourceText.concat(" ")
+        .concat(" ")
+        .concat(MUST_BE)
+        .concat(" ")
+        .concat(ANY_SOURCE_VALUE)
+        .concat(" ");
+    String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
+        .concat("( )")
+        .concat(" ");
+    String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
+        .concat("(" + sourceIds + ")")
+        .concat(" ");
+
+    if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
+      ruleExpression =
+          commonRuleExpressionForAnySource.concat("^ H")
+              .concat(" ")
+              .concat("( " + targetIdentifier + " )");
+      for (String targetText : targetTextList) {
+        String errMsg = commonErrMsgForAnySource.concat(targetText);
+        errorMessageList.add(errMsg);
+      }
+    } else {
+      ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
+          .concat(" ")
+          .concat("^ H")
+          .concat(" ")
+          .concat("(" + targetIdentifier + ")");
+      for (String targetText : targetTextList) {
+        String errMsg = sourceText.concat(" ")
+            .concat(request.comparator())
+            .concat(" ")
+            .concat(MUST_BE)
+            .concat(" ")
+            .concat("(" + sourceValueText + ")")
+            .concat(" ")
+            .concat(targetText);
+        errorMessageList.add(errMsg);
+      }
+    }
+    String errorMessageText = String.join(",", errorMessageList);
+    JSFunctionNameHelper jsFunctionNameHelper = jsForHideAndUnhide(request, sourceValuesHelper, ruleMetadata);
+    return new RuleExpressionHelper(errorMessageText, ruleExpression,
+        new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
+  }
+
+  public RuleExpressionHelper requireIfFunction(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      TargetValuesHelper targetValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    String ruleExpression;
+    List<String> errorMessageList = new ArrayList<>();
+    String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
+    String sourceText = sourceValuesHelper.sourceText();
+    String targetIdentifier = targetValuesHelper.targetIdentifier();
+    List<String> targetTextList = targetValuesHelper.targetTextList();
+    String sourceIds = sourceValuesHelper.sourceValueIds();
+    String sourceValueText = sourceValuesHelper.sourceValueText();
+    String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
+        .concat("( )")
+        .concat(" ");
+    String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
+        .concat("(" + sourceIds + ")")
+        .concat(" ");
+
+    if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
+      ruleExpression =
+          commonRuleExpressionForAnySource.concat("^ R")
+              .concat(" ")
+              .concat("( " + targetIdentifier + " )");
+      for (String targetText : targetTextList) {
+        String errMsg = sourceText.concat(" ")
+            .concat(" ")
+            .concat(" ")
+            .concat(ANY_SOURCE_VALUE)
+            .concat(" ")
+            .concat(targetText)
+            .concat(" ")
+            .concat("is required");
+        errorMessageList.add(errMsg);
+      }
+    } else {
+      ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
+          .concat(" ")
+          .concat("^ R")
+          .concat(" ")
+          .concat("(" + targetIdentifier + ")");
+      for (String targetText : targetTextList) {
+        String errMsg = sourceText.concat(" ")
+            .concat(request.comparator())
+            .concat(" ")
+            .concat("(" + sourceValueText + ")")
+            .concat(" ")
+            .concat(targetText)
+            .concat(" ")
+            .concat("is required");
+        errorMessageList.add(errMsg);
+      }
+    }
+    String errorMessageText = String.join(",", errorMessageList);
+    JSFunctionNameHelper jsFunctionNameHelper =
+        requireIfJsFunction(request, sourceValuesHelper, ruleMetadata, targetValuesHelper);
+    return new RuleExpressionHelper(errorMessageText, ruleExpression,
+        new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
+  }
+
+  public RuleExpressionHelper unHideFunction(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      TargetValuesHelper targetValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    String ruleExpression;
+    List<String> errorMessageList = new ArrayList<>();
+    String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
+    String sourceText = sourceValuesHelper.sourceText();
+    String targetIdentifier = targetValuesHelper.targetIdentifier();
+    List<String> targetTextList = targetValuesHelper.targetTextList();
+    String sourceIds = sourceValuesHelper.sourceValueIds();
+    String sourceValueText = sourceValuesHelper.sourceValueText();
+    String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
+        .concat("( )")
+        .concat(" ");
+    String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
+        .concat("(" + sourceIds + ")")
+        .concat(" ");
+    String targetText = String.join(",", targetTextList);
+    if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
+      ruleExpression = commonRuleExpressionForAnySource.concat("^ S")
+          .concat(" ")
+          .concat("( " + targetIdentifier + " )");
+      String errMsg = sourceText.concat(" ")
+          .concat(" ")
+          .concat(MUST_BE)
+          .concat(" ")
+          .concat("(" + ANY_SOURCE_VALUE + ")")
+          .concat(" ")
+          .concat(targetText);
+      errorMessageList.add(errMsg);
+
+    } else {
+      ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
+          .concat(" ")
+          .concat("^ S")
+          .concat(" ")
+          .concat("(" + targetIdentifier + ")");
+      String errMsg = sourceText.concat(" ")
+          .concat(request.comparator())
+          .concat(MUST_BE)
+          .concat("(" + sourceValueText + ")")
+          .concat(" ")
+          .concat(targetText);
+      errorMessageList.add(errMsg);
 
     }
+    String errorMessageText = String.join(",", errorMessageList);
+    JSFunctionNameHelper jsFunctionNameHelper = jsForHideAndUnhide(request, sourceValuesHelper, ruleMetadata);
+    return new RuleExpressionHelper(errorMessageText, ruleExpression,
+        new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
+  }
 
-    private WaRuleMetadata setRuleDataValues(Long userId, CreateRuleRequest request,Long page) {
-        WaRuleMetadata ruleMetadata = new WaRuleMetadata();
-        RuleData ruleData = createRuleData(request, ruleMetadata);
-        ruleMetadata.setRuleCd(request.ruleFunction());
-        ruleMetadata.setRuleDescText(request.ruleDescription());
-        ruleMetadata.setSourceValues(ruleData.sourceValues());
-        ruleMetadata.setLogic(request.comparator());
-        ruleMetadata.setSourceQuestionIdentifier(ruleData.sourceIdentifier());
-        ruleMetadata.setTargetQuestionIdentifier(ruleData.targetIdentifiers());
-        ruleMetadata.setTargetType(request.targetType());
-        ruleMetadata.setAddTime(Instant.now());
-        ruleMetadata.setAddUserId(userId);
-        ruleMetadata.setLastChgTime(Instant.now());
-        ruleMetadata.setRecordStatusCd("ACTIVE");
-        ruleMetadata.setLastChgUserId(userId);
-        ruleMetadata.setRecordStatusTime(Instant.now());
-        ruleMetadata.setErrormsgText(ruleData.errorMsgText());
-        ruleMetadata.setJsFunction(ruleData.jsFunctionNameHelper().jsFunction());
-        ruleMetadata.setJsFunctionName(ruleData.jsFunctionNameHelper().jsFunctionName());
-        ruleMetadata.setWaTemplateUid(page);
-        ruleMetadata.setRuleExpression(ruleData.ruleExpression());
-
-        return ruleMetadata;
-    }
-
-    private RuleData createRuleData(
-            CreateRuleRequest request,
-            WaRuleMetadata ruleMetadata) {
-        SourceValuesHelper sourceValuesHelper = sourceValuesHelper(request);
-        TargetValuesHelper targetValuesHelper = targetValuesHelper(request);
-        RuleExpressionHelper expressionValues = null;
-
-        if (DATE_COMPARE.equals(request.ruleFunction())) {
-            expressionValues = dateCompareFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
-        }
-        if (DISABLE.equals(request.ruleFunction()) || ENABLE.equals(request.ruleFunction())) {
-            expressionValues = enableOrDisableFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
-        }
-        if (HIDE.equals(request.ruleFunction())) {
-            expressionValues = hideFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
-        }
-        if (REQUIRE_IF.equals(request.ruleFunction())) {
-            expressionValues = requireIfFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
-        }
-        if (UNHIDE.equals(request.ruleFunction())) {
-            expressionValues = unHideFunction(request, sourceValuesHelper, targetValuesHelper, ruleMetadata);
-        }
-        if (expressionValues != null) {
-            return new RuleData(
-                    targetValuesHelper.targetIdentifier(),
-                    expressionValues.ruleExpression(),
-                    expressionValues.errorMessage(),
-                    sourceValuesHelper.sourceIdentifiers(),
-                    sourceValuesHelper.sourceText(),
-                    sourceValuesHelper.sourceValueText(),
-                    expressionValues.jsFunctionNameHelper());
-        } else {
-            throw new RuleException("Error in Creating Rule Expression and Error Message Text", 400);
-        }
-    }
-
-    private SourceValuesHelper sourceValuesHelper(CreateRuleRequest request) {
-        String sourceText = request.sourceText();
-        String sourceIdentifier = request.sourceIdentifier();
-        CreateRuleRequest.SourceValues sourceValues = request.sourceValue();
-        String sourceIds = null;
-        String sourceValueText = null;
-        if (request.sourceValue() != null) {
-            sourceIds = String.join(",", sourceValues.sourceValueId());
-            sourceValueText = String.join(",", sourceValues.sourceValueText());
-        }
-        return new SourceValuesHelper(sourceIds, sourceValueText, sourceText, sourceIdentifier);
-    }
-
-    private TargetValuesHelper targetValuesHelper(CreateRuleRequest request) {
-        List<String> targetTextList = request.targetValueText();
-        List<String> targetValueIdentifierList = request.targetValueIdentifier();
-        String targetIdentifier = String.join(",", targetValueIdentifierList);
-
-        return new TargetValuesHelper(targetIdentifier, targetTextList);
-    }
-
-    public RuleExpressionHelper dateCompareFunction(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            TargetValuesHelper targetValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        List<String> errorMessageList = new ArrayList<>();
-        String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
-        String sourceText = sourceValuesHelper.sourceText();
-        String targetIdentifier = targetValuesHelper.targetIdentifier();
-        List<String> targetTextList = targetValuesHelper.targetTextList();
-        String ruleExpression = sourceIdentifier.concat(" ")
-                .concat(request.comparator())
-                .concat(" ")
-                .concat("^ DT")
-                .concat(" ")
-                .concat("( " + targetIdentifier + " )");
-        for (String targetText : targetTextList) {
-            String errMsg = sourceText.concat(" ")
-                    .concat(MUST_BE)
-                    .concat(" ")
-                    .concat(request.comparator())
-                    .concat(" ")
-                    .concat(targetText);
-            errorMessageList.add(errMsg);
-        }
-        String errorMessageText = String.join(",", errorMessageList);
-        JSFunctionNameHelper jsFunctionNameHelper = jsForDateCompare(
-                request,
-                sourceValuesHelper,
-                targetValuesHelper,
-                ruleMetadata);
-
-        return new RuleExpressionHelper(errorMessageText, ruleExpression,
-                new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
-    }
-
-    public RuleExpressionHelper enableOrDisableFunction(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            TargetValuesHelper targetValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        String ruleExpression;
-        List<String> errorMessageList = new ArrayList<>();
-        String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
-        String sourceText = sourceValuesHelper.sourceText();
-        String targetIdentifier = targetValuesHelper.targetIdentifier();
-        List<String> targetTextList = targetValuesHelper.targetTextList();
-        String sourceIds = sourceValuesHelper.sourceValueIds();
-        String sourceValueText = sourceValuesHelper.sourceValueText();
-        String indicator = ENABLE.equals(request.ruleFunction()) ? "E" : "D";
-
-        String commonErrMsgForAnySource = sourceText.concat(" ")
-                .concat(" ")
-                .concat(MUST_BE)
-                .concat(" ")
-                .concat(ANY_SOURCE_VALUE)
-                .concat(" ");
-        String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
-                .concat("( )")
-                .concat(" ");
-        String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
-                .concat("(" + sourceIds + ")")
-                .concat(" ");
-
-        if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
-            ruleExpression = commonRuleExpressionForAnySource.concat("^ ")
-                    .concat(indicator)
-                    .concat(" ")
-                    .concat("( " + targetIdentifier + " )");
-            for (String targetText : targetTextList) {
-                String errMsg = commonErrMsgForAnySource.concat(targetText);
-                errorMessageList.add(errMsg);
-            }
-        } else {
-            ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
-                    .concat(" ")
-                    .concat("^ ")
-                    .concat(indicator)
-                    .concat(" ")
-                    .concat("(" + targetIdentifier + ")");
-            for (String targetText : targetTextList) {
-                String errMsg = sourceText.concat(" ")
-                        .concat(request.comparator())
-                        .concat(" ")
-                        .concat(MUST_BE)
-                        .concat(" ")
-                        .concat("(" + sourceValueText + ")")
-                        .concat(" ")
-                        .concat(targetText);
-                errorMessageList.add(errMsg);
-            }
-        }
-        String errorMessageText = String.join(",", errorMessageList);
-        JSFunctionNameHelper jsFunctionNameHelper = jsForEnableAndDisable(request, sourceValuesHelper, ruleMetadata);
-        return new RuleExpressionHelper(
-                errorMessageText,
-                ruleExpression,
-                new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
-    }
-
-    public RuleExpressionHelper hideFunction(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            TargetValuesHelper targetValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        String ruleExpression;
-        List<String> errorMessageList = new ArrayList<>();
-        String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
-        String sourceText = sourceValuesHelper.sourceText();
-        String targetIdentifier = targetValuesHelper.targetIdentifier();
-        List<String> targetTextList = targetValuesHelper.targetTextList();
-        String sourceIds = sourceValuesHelper.sourceValueIds();
-        String sourceValueText = sourceValuesHelper.sourceValueText();
-        String commonErrMsgForAnySource = sourceText.concat(" ")
-                .concat(" ")
-                .concat(MUST_BE)
-                .concat(" ")
-                .concat(ANY_SOURCE_VALUE)
-                .concat(" ");
-        String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
-                .concat("( )")
-                .concat(" ");
-        String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
-                .concat("(" + sourceIds + ")")
-                .concat(" ");
-
-        if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
-            ruleExpression =
-                    commonRuleExpressionForAnySource.concat("^ H")
-                            .concat(" ")
-                            .concat("( " + targetIdentifier + " )");
-            for (String targetText : targetTextList) {
-                String errMsg = commonErrMsgForAnySource.concat(targetText);
-                errorMessageList.add(errMsg);
-            }
-        } else {
-            ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
-                    .concat(" ")
-                    .concat("^ H")
-                    .concat(" ")
-                    .concat("(" + targetIdentifier + ")");
-            for (String targetText : targetTextList) {
-                String errMsg = sourceText.concat(" ")
-                        .concat(request.comparator())
-                        .concat(" ")
-                        .concat(MUST_BE)
-                        .concat(" ")
-                        .concat("(" + sourceValueText + ")")
-                        .concat(" ")
-                        .concat(targetText);
-                errorMessageList.add(errMsg);
-            }
-        }
-        String errorMessageText = String.join(",", errorMessageList);
-        JSFunctionNameHelper jsFunctionNameHelper = jsForHideAndUnhide(request, sourceValuesHelper, ruleMetadata);
-        return new RuleExpressionHelper(errorMessageText, ruleExpression,
-                new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
-    }
-
-    public RuleExpressionHelper requireIfFunction(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            TargetValuesHelper targetValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        String ruleExpression;
-        List<String> errorMessageList = new ArrayList<>();
-        String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
-        String sourceText = sourceValuesHelper.sourceText();
-        String targetIdentifier = targetValuesHelper.targetIdentifier();
-        List<String> targetTextList = targetValuesHelper.targetTextList();
-        String sourceIds = sourceValuesHelper.sourceValueIds();
-        String sourceValueText = sourceValuesHelper.sourceValueText();
-        String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
-                .concat("( )")
-                .concat(" ");
-        String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
-                .concat("(" + sourceIds + ")")
-                .concat(" ");
-
-        if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
-            ruleExpression =
-                    commonRuleExpressionForAnySource.concat("^ R")
-                            .concat(" ")
-                            .concat("( " + targetIdentifier + " )");
-            for (String targetText : targetTextList) {
-                String errMsg = sourceText.concat(" ")
-                        .concat(" ")
-                        .concat(" ")
-                        .concat(ANY_SOURCE_VALUE)
-                        .concat(" ")
-                        .concat(targetText)
-                        .concat(" ")
-                        .concat("is required");
-                errorMessageList.add(errMsg);
-            }
-        } else {
-            ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
-                    .concat(" ")
-                    .concat("^ R")
-                    .concat(" ")
-                    .concat("(" + targetIdentifier + ")");
-            for (String targetText : targetTextList) {
-                String errMsg = sourceText.concat(" ")
-                        .concat(request.comparator())
-                        .concat(" ")
-                        .concat("(" + sourceValueText + ")")
-                        .concat(" ")
-                        .concat(targetText)
-                        .concat(" ")
-                        .concat("is required");
-                errorMessageList.add(errMsg);
-            }
-        }
-        String errorMessageText = String.join(",", errorMessageList);
-        JSFunctionNameHelper jsFunctionNameHelper =
-                requireIfJsFunction(request, sourceValuesHelper, ruleMetadata, targetValuesHelper);
-        return new RuleExpressionHelper(errorMessageText, ruleExpression,
-                new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
-    }
-
-    public RuleExpressionHelper unHideFunction(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            TargetValuesHelper targetValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        String ruleExpression;
-        List<String> errorMessageList = new ArrayList<>();
-        String sourceIdentifier = sourceValuesHelper.sourceIdentifiers();
-        String sourceText = sourceValuesHelper.sourceText();
-        String targetIdentifier = targetValuesHelper.targetIdentifier();
-        List<String> targetTextList = targetValuesHelper.targetTextList();
-        String sourceIds = sourceValuesHelper.sourceValueIds();
-        String sourceValueText = sourceValuesHelper.sourceValueText();
-        String commonRuleExpressionForAnySource = sourceIdentifier.concat(" ")
-                .concat("( )")
-                .concat(" ");
-        String commonRuleExpForSourceValue = sourceIdentifier.concat(" ")
-                .concat("(" + sourceIds + ")")
-                .concat(" ");
-        String targetText = String.join(",", targetTextList);
-        if (request.anySourceValue() && Objects.equals(request.comparator(), "=")) {
-            ruleExpression = commonRuleExpressionForAnySource.concat("^ S")
-                    .concat(" ")
-                    .concat("( " + targetIdentifier + " )");
-            String errMsg = sourceText.concat(" ")
-                    .concat(" ")
-                    .concat(MUST_BE)
-                    .concat(" ")
-                    .concat("(" + ANY_SOURCE_VALUE + ")")
-                    .concat(" ")
-                    .concat(targetText);
-            errorMessageList.add(errMsg);
-
-        } else {
-            ruleExpression = commonRuleExpForSourceValue.concat(request.comparator())
-                    .concat(" ")
-                    .concat("^ S")
-                    .concat(" ")
-                    .concat("(" + targetIdentifier + ")");
-            String errMsg = sourceText.concat(" ")
-                    .concat(request.comparator())
-                    .concat(MUST_BE)
-                    .concat("(" + sourceValueText + ")")
-                    .concat(" ")
-                    .concat(targetText);
-            errorMessageList.add(errMsg);
-
-        }
-        String errorMessageText = String.join(",", errorMessageList);
-        JSFunctionNameHelper jsFunctionNameHelper = jsForHideAndUnhide(request, sourceValuesHelper, ruleMetadata);
-        return new RuleExpressionHelper(errorMessageText, ruleExpression,
-                new JSFunctionNameHelper(jsFunctionNameHelper.jsFunction(), jsFunctionNameHelper.jsFunctionName()));
-    }
-
-    public JSFunctionNameHelper jsForDateCompare(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            TargetValuesHelper targetValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        StringBuilder stringBuffer = new StringBuilder();
-        StringBuilder firstSB = new StringBuilder();
-        StringBuilder secondSB = new StringBuilder();
-        String sourceQuestionIdentifier = request.sourceIdentifier();
-        String jsFunctionName = "ruleDComp" + sourceQuestionIdentifier + ruleMetadata.getId();
-        stringBuffer.append(FUNCTION + jsFunctionName + "() {\n");
-        stringBuffer.append("    var i = 0;\n    var errorElts = new Array(); \n    var errorMsgs = new Array(); \n");
-        firstSB.append("\n if ((getElementByIdOrByName(\"").append(sourceValuesHelper.sourceIdentifiers())
-                .append("\").value)==''){ \n return {elements : errorElts, labels : errorMsgs}; }");
-        secondSB.append("\n var sourceStr =getElementByIdOrByName(\"").append(sourceValuesHelper.sourceIdentifiers())
-                .append("\").value;");
+  public JSFunctionNameHelper jsForDateCompare(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      TargetValuesHelper targetValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    StringBuilder stringBuffer = new StringBuilder();
+    StringBuilder firstSB = new StringBuilder();
+    StringBuilder secondSB = new StringBuilder();
+    String sourceQuestionIdentifier = request.sourceIdentifier();
+    String jsFunctionName = "ruleDComp" + sourceQuestionIdentifier + ruleMetadata.getId();
+    stringBuffer.append(FUNCTION + jsFunctionName + "() {\n");
+    stringBuffer.append("    var i = 0;\n    var errorElts = new Array(); \n    var errorMsgs = new Array(); \n");
+    firstSB.append("\n if ((getElementByIdOrByName(\"").append(sourceValuesHelper.sourceIdentifiers())
+        .append("\").value)==''){ \n return {elements : errorElts, labels : errorMsgs}; }");
+    secondSB.append("\n var sourceStr =getElementByIdOrByName(\"").append(sourceValuesHelper.sourceIdentifiers())
+        .append("\").value;");
+    secondSB.append(
+        "\n var srcDate = sourceStr.substring(6,10) + sourceStr.substring(0,2) + sourceStr.substring(3,5);");
+    secondSB.append("\n var targetElt;\n var targetStr = ''; \n var targetDate = '';");
+    Collection<String> coll = request.targetValueIdentifier();
+    for (String targetQuestionIdentifier : coll) {
+      //check for null just in case the target got deleted or is not visible except for edit
+      secondSB.append("\n targetStr =getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
+          .append("\") == null ? \"\" :getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
+          .append("\").value;");
+      secondSB.append("\n if (targetStr!=\"\") {");
+      secondSB.append(
+          "\n    targetDate = targetStr.substring(6,10) + targetStr.substring(0,2) + targetStr.substring(3,5);");
+      secondSB.append("\n if (!(srcDate ");
+      secondSB.append(request.comparator());
+      secondSB.append(" targetDate)) {");
+      secondSB.append("\n var srcDateEle=getElementByIdOrByName(\"")
+          .append(sourceValuesHelper.sourceIdentifiers()).append("\");");
+      secondSB.append("\n var targetDateEle=getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
+          .append("\");");
+      try {
+        secondSB.append("\n var srca2str=buildErrorAnchorLink(srcDateEle," + "\"");
         secondSB.append(
-                "\n var srcDate = sourceStr.substring(6,10) + sourceStr.substring(0,2) + sourceStr.substring(3,5);");
-        secondSB.append("\n var targetElt;\n var targetStr = ''; \n var targetDate = '';");
-        Collection<String> coll = request.targetValueIdentifier();
-        for (String targetQuestionIdentifier : coll) {
-            //check for null just in case the target got deleted or is not visible except for edit
-            secondSB.append("\n targetStr =getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
-                    .append("\") == null ? \"\" :getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
-                    .append("\").value;");
-            secondSB.append("\n if (targetStr!=\"\") {");
-            secondSB.append(
-                    "\n    targetDate = targetStr.substring(6,10) + targetStr.substring(0,2) + targetStr.substring(3,5);");
-            secondSB.append("\n if (!(srcDate ");
-            secondSB.append(request.comparator());
-            secondSB.append(" targetDate)) {");
-            secondSB.append("\n var srcDateEle=getElementByIdOrByName(\"")
-                    .append(sourceValuesHelper.sourceIdentifiers()).append("\");");
-            secondSB.append("\n var targetDateEle=getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
-                    .append("\");");
-            try {
-                secondSB.append("\n var srca2str=buildErrorAnchorLink(srcDateEle," + "\"");
-                secondSB.append(
-                        sourceValuesHelper.sourceText().substring(0, sourceValuesHelper.sourceText().indexOf("("))
-                                .trim())
-                        .append("\");");
-            } catch (Exception e) {
-                secondSB.append(
-                        sourceValuesHelper.sourceText().trim()).append("\");");
+                sourceValuesHelper.sourceText().substring(0, sourceValuesHelper.sourceText().indexOf("("))
+                    .trim())
+            .append("\");");
+      } catch (Exception e) {
+        secondSB.append(
+            sourceValuesHelper.sourceText().trim()).append("\");");
 
-            }
-            secondSB.append("\n var targeta2str=buildErrorAnchorLink(targetDateEle,\"")
-                    .append(targetValuesHelper.targetTextList().get(0)).append("\");");
-            secondSB.append("\n    errorMsgs[i]=srca2str + \" must be ").append(request.comparator())
-                    .append(" \" + targeta2str; ");
-            secondSB.append("\n    colorElementLabelRed(srcDateEle); ");
-            secondSB.append("\n    colorElementLabelRed(targetDateEle); \n");
+      }
+      secondSB.append("\n var targeta2str=buildErrorAnchorLink(targetDateEle,\"")
+          .append(targetValuesHelper.targetTextList().get(0)).append("\");");
+      secondSB.append("\n    errorMsgs[i]=srca2str + \" must be ").append(request.comparator())
+          .append(" \" + targeta2str; ");
+      secondSB.append("\n    colorElementLabelRed(srcDateEle); ");
+      secondSB.append("\n    colorElementLabelRed(targetDateEle); \n");
 
-            secondSB.append("errorElts[i++]=getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
-                    .append("\"); \n");
-            secondSB.append("}\n  }");
-        }
-        stringBuffer.append(firstSB);
-        stringBuffer.append(secondSB);
-        stringBuffer.append("\n return {elements : errorElts, labels : errorMsgs}\n}");
-        return new JSFunctionNameHelper(stringBuffer.toString(), jsFunctionName + "()");
+      secondSB.append("errorElts[i++]=getElementByIdOrByName(\"").append(targetQuestionIdentifier.trim())
+          .append("\"); \n");
+      secondSB.append("}\n  }");
+    }
+    stringBuffer.append(firstSB);
+    stringBuffer.append(secondSB);
+    stringBuffer.append("\n return {elements : errorElts, labels : errorMsgs}\n}");
+    return new JSFunctionNameHelper(stringBuffer.toString(), jsFunctionName + "()");
+  }
+
+  public JSFunctionNameHelper jsForEnableAndDisable(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    StringBuilder builder = new StringBuilder();
+    String functionName = "ruleEnDis" + sourceValuesHelper.sourceIdentifiers() + ruleMetadata.getId();
+    builder.append(FUNCTION).append(functionName).append(ACTION_1);
+    builder.append("\n var foo = [];\n");
+    builder.append(DOLLARCLOSING).append(request.sourceIdentifier()).append(SELECTED);
+    builder.append("\n foo[i] = $j(selected).val();\n");
+    builder.append(LINESEPERATOR_PARANTHESIS);
+
+    firstPartForEnDs(request, sourceValuesHelper, builder);
+    String sourceValues = sourceValuesHelper.sourceValueIds();
+    if (sourceValues != null) {
+      List<String> sourceValueList = Arrays.asList(sourceValues.split(","));
+      for (int i = 0; i < sourceValueList.size(); i++) {
+        builder = thirdPartForEnDs(request, builder);
+      }
     }
 
-    public JSFunctionNameHelper jsForEnableAndDisable(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        StringBuilder builder = new StringBuilder();
-        String functionName = "ruleEnDis" + sourceValuesHelper.sourceIdentifiers() + ruleMetadata.getId();
-        builder.append(FUNCTION).append(functionName).append(ACTION_1);
-        builder.append("\n var foo = [];\n");
-        builder.append(DOLLARCLOSING).append(request.sourceIdentifier()).append(SELECTED);
-        builder.append("\n foo[i] = $j(selected).val();\n");
-        builder.append(LINESEPERATOR_PARANTHESIS);
+    builder.append("\n}");
 
-        firstPartForEnDs(request, sourceValuesHelper, builder);
-        String sourceValues = sourceValuesHelper.sourceValueIds();
-        if (sourceValues != null) {
-            List<String> sourceValueList = Arrays.asList(sourceValues.split(","));
-            for (int i = 0; i < sourceValueList.size(); i++) {
-                builder = thirdPartForEnDs(request, builder);
-            }
-        }
+    return new JSFunctionNameHelper(builder.toString(), functionName);
+  }
 
-        builder.append("\n}");
-
-        return new JSFunctionNameHelper(builder.toString(), functionName);
+  private StringBuilder firstPartForEnDs(CreateRuleRequest request, SourceValuesHelper sourceValuesHelper,
+      StringBuilder stringBuilder) {
+    String sourceValues = sourceValuesHelper.sourceValueIds();
+    if (sourceValues == null) {
+      log.info("Any SourceValue is true for this request");
+      sourceValues = ",";
     }
-
-    private StringBuilder firstPartForEnDs(CreateRuleRequest request, SourceValuesHelper sourceValuesHelper,
-            StringBuilder stringBuilder) {
-        String sourceValues = sourceValuesHelper.sourceValueIds();
-        if (sourceValues == null) {
-            log.info("Any SourceValue is true for this request");
-            sourceValues = ",";
+    List<String> sourceValueList = Arrays.asList(sourceValues.split(","));
+    if (request.anySourceValue()) {
+      stringBuilder.append("if(foo.length>0 && foo[0] != '') {\n"); //anything selected
+    } else {
+      stringBuilder.append(IF);
+      for (int i = 0; i < sourceValueList.size(); i++) {
+        String sourceId = sourceValueList.get(i);
+        stringBuilder.append(ARRAY).append(sourceId).append("',foo) > -1)");
+        stringBuilder.append(" || ($j.inArray('").append(sourceId)
+            .append("'.replace(/^\\s+|\\s+$/g,''),foo) > -1)");//added for the business rule view
+        try {
+          sourceValueList.get(i + 1);
+          stringBuilder.append("||");
+        } catch (Exception e) {
+          break;
         }
-        List<String> sourceValueList = Arrays.asList(sourceValues.split(","));
-        if (request.anySourceValue()) {
-            stringBuilder.append("if(foo.length>0 && foo[0] != '') {\n"); //anything selected
+
+      }
+      stringBuilder.append("){\n");
+    }
+    return stringBuilder;
+
+  }
+
+  private StringBuilder commonElementPartForEnDs(CreateRuleRequest request, StringBuilder stringBuilder) {
+    List<String> targetQuestionIdentifiers = request.targetValueIdentifier();
+
+    if ("Question".equalsIgnoreCase(request.targetType())) {
+      for (String targetId : targetQuestionIdentifiers) {
+        if (ENABLE.equalsIgnoreCase(request.ruleFunction()) && Objects.equals(request.comparator(), "=")) {
+          stringBuilder.append(PG_ENABLE_ELEMENT).append(targetId).append(PARANTHESIS).append(" }");
+          stringBuilder.append(" else { \n").append(PG_DISABLE_ELEMENT).append(targetId).append(PARANTHESIS)
+              .append(" }");
+        }
+        if (!Objects.equals(ENABLE, request.ruleFunction()) && Objects.equals(request.comparator(), "=")) {
+          stringBuilder.append(PG_DISABLE_ELEMENT).append(targetId).append(PARANTHESIS);
+          stringBuilder.append(" else { \n").append(PG_ENABLE_ELEMENT).append(targetId).append(PARANTHESIS)
+              .append(" }");
+        }
+      }
+    }
+    return stringBuilder;
+  }
+
+
+  private StringBuilder thirdPartForEnDs(CreateRuleRequest request, StringBuilder stringBuilder) {
+    return commonElementPartForEnDs(request, stringBuilder);
+  }
+
+  public JSFunctionNameHelper requireIfJsFunction(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      WaRuleMetadata ruleMetadata,
+      TargetValuesHelper targetValuesHelper) {
+    String functionName = "ruleRequireIf" + request.sourceIdentifier() + ruleMetadata.getId();
+    StringBuilder buffer = new StringBuilder();
+    buffer.append(FUNCTION + functionName + ACTION_1);
+    buffer.append("\n var foo = [];\n");
+    buffer.append(DOLLARCLOSING).append(request.sourceIdentifier()).append(SELECTED);
+    buffer.append("\n foo[i] = $j(selected).val();\n");
+    buffer.append(LINESEPERATOR_PARANTHESIS);
+    if (request.sourceIdentifier() != null) {
+
+      String sourceValueText = sourceValuesHelper.sourceValueText();
+
+      if (request.anySourceValue()) {
+        buffer.append("if(foo.length>0 && foo[0] != '') {\n");
+      } else {
+        buffer.append("if(foo.length==0) return;\n");
+        buffer.append(IF);
+        buffer.append(ARRAY).append(sourceValueText.toUpperCase(), 0, 3).append("',foo) > -1)");
+        buffer.append("){\n");
+      }
+      String secondPart = frameSecondPartOfRequireIf(request, targetValuesHelper);
+      buffer.append(secondPart);
+    }
+    buffer.append("   \n}");
+    return new JSFunctionNameHelper(buffer.toString(), functionName);
+
+  }
+
+  private String frameSecondPartOfRequireIf(CreateRuleRequest request, TargetValuesHelper targetValuesHelper) {
+    StringBuilder buffer = new StringBuilder();
+    String targetIdentifier = targetValuesHelper.targetIdentifier();
+    if (Objects.equals(request.comparator(), "=")) {
+      buffer.append("pgRequireElement('").append(targetIdentifier).append(PARANTHESIS);
+    } else {
+      buffer.append("pgRequireNotElement('").append(targetIdentifier).append(PARANTHESIS);
+    }
+    buffer.append(ELSE);
+    if (Objects.equals(request.comparator(), "=")) {
+      buffer.append("pgRequireNotElement('").append(targetIdentifier).append(PARANTHESIS);
+    } else {
+      buffer.append("pgRequireElement('").append(targetIdentifier).append(PARANTHESIS);
+    }
+    buffer.append(" }");
+
+    return buffer.toString();
+  }
+
+  public JSFunctionNameHelper jsForHideAndUnhide(
+      CreateRuleRequest request,
+      SourceValuesHelper sourceValuesHelper,
+      WaRuleMetadata ruleMetadata) {
+    String sourceText = sourceValuesHelper.sourceValueText();
+    if (sourceText == null) {
+      log.info("Any SourceValue is true for this request");
+      sourceText = ",";
+    }
+    List<String> sourceValueTextList = Arrays.asList(sourceText.split(","));
+    StringBuilder stringBuilder = new StringBuilder();
+    String functionName = "ruleHideUnh" + request.sourceIdentifier() + ruleMetadata.getId();
+    stringBuilder.append(FUNCTION).append(functionName).append(ACTION_1);
+    ruleLeftAndRightInvestigation(request, stringBuilder, "", sourceValueTextList);
+    ruleLeftAndRightInvestigation(request, stringBuilder, "_2", sourceValueTextList);
+    stringBuilder.append("   \n}");
+    return new JSFunctionNameHelper(stringBuilder.toString(), functionName);
+  }
+
+  private StringBuilder ruleLeftAndRightInvestigation(
+      CreateRuleRequest request,
+      StringBuilder stringBuilder,
+      String suffix,
+      List<String> sourceValueTextList) {
+    String questionIdentifier = request.sourceIdentifier();
+    stringBuilder.append("\n var foo").append(suffix).append(" = [];\n");
+    stringBuilder.append(DOLLARCLOSING).append(questionIdentifier).append(suffix).append(SELECTED);
+    stringBuilder.append("\n foo").append(suffix).append("[i] = $j(selected).val();\n");
+
+    stringBuilder.append(LINESEPERATOR_PARANTHESIS);
+    stringBuilder.append("if(foo").append(suffix).append("=='' && ").append(DOLLARCLOSING)
+        .append(questionIdentifier).append(suffix).append("').html()!=null){");//added for the business rule view
+    stringBuilder.append("foo").append(suffix).append("[0]=$j('#").append(questionIdentifier).append(suffix)
+        .append("').html().replace(/^\\s+|\\s+$/g,'');}");//added for the business rule view
+    if (questionIdentifier != null) {
+      if (request.anySourceValue()) {
+        stringBuilder.append("if(foo").append(suffix).append(".length>0 && foo").append(suffix)
+            .append("[0] != '') {\n");
+      } else {
+        stringBuilder.append(IF);
+        int i = 0;
+        for (String sourcetext : sourceValueTextList) {
+          if (i != 0) {
+            stringBuilder.append(" || ");
+          }
+          i++;
+          stringBuilder.append(ARRAY).append(sourcetext.charAt(0)).append("',foo").append(suffix)
+              .append(") > -1)");
+          stringBuilder.append(" || ($j.inArray('").append(sourcetext)
+              .append("'.replace(/^\\s+|\\s+$/g,''),foo").append(suffix).append(") > -1");
+          stringBuilder.append(" || indexOfArray(foo,'").append(sourcetext).append("')==true)");
+          //added for the business rule view
+        }
+        stringBuilder.append("){\n");
+      }
+    }
+    framingJSforUnhideAndHide(request, stringBuilder, suffix);
+    return stringBuilder;
+  }
+
+  private StringBuilder framingJSforUnhideAndHide(
+      CreateRuleRequest request,
+      StringBuilder stringBuilder,
+      String suffix) {
+    frameSecondPartForUnhideAndHide(request, stringBuilder, suffix);
+    partForSubSection(request, stringBuilder, suffix);
+    return stringBuilder;
+  }
+
+  private StringBuilder frameCommonPartForUnhideAndHide(
+      CreateRuleRequest request,
+      StringBuilder stringBuilder,
+      String suffix) {
+    List<String> targetQuestionIdentifiers = request.targetValueIdentifier();
+    if ("Question".equalsIgnoreCase(request.targetType())) {
+      for (String targetId : targetQuestionIdentifiers) {
+        targetId += suffix;
+        if (Objects.equals(request.ruleFunction(), UNHIDE) && Objects.equals(request.comparator(), "=")) {
+          stringBuilder.append("pgUnhideElement('").append(targetId).append(PARANTHESIS);
+          stringBuilder.append(ELSE);
+          stringBuilder.append("pgHideElement('").append(targetId).append(PARANTHESIS);
         } else {
-            stringBuilder.append(IF);
-            for (int i = 0; i < sourceValueList.size(); i++) {
-                String sourceId = sourceValueList.get(i);
-                stringBuilder.append(ARRAY).append(sourceId).append("',foo) > -1)");
-                stringBuilder.append(" || ($j.inArray('").append(sourceId)
-                        .append("'.replace(/^\\s+|\\s+$/g,''),foo) > -1)");//added for the business rule view
-                try {
-                    sourceValueList.get(i + 1);
-                    stringBuilder.append("||");
-                } catch (Exception e) {
-                    break;
-                }
-
-            }
-            stringBuilder.append("){\n");
+          stringBuilder.append("pgHideElement('").append(targetId).append(PARANTHESIS);
+          stringBuilder.append(ELSE);
+          stringBuilder.append("pgUnhideElement('").append(targetId).append(PARANTHESIS);
         }
-        return stringBuilder;
-
+      }
     }
+    return stringBuilder;
+  }
 
-    private StringBuilder commonElementPartForEnDs(CreateRuleRequest request, StringBuilder stringBuilder) {
-        List<String> targetQuestionIdentifiers = request.targetValueIdentifier();
+  private StringBuilder frameSecondPartForUnhideAndHide(CreateRuleRequest request,
+      StringBuilder stringBuilder, String suffix) {
+    frameCommonPartForUnhideAndHide(request, stringBuilder, suffix);
+    stringBuilder.append(" }");
+    return stringBuilder;
+  }
 
-        if ("Question".equalsIgnoreCase(request.targetType())) {
-            for (String targetId : targetQuestionIdentifiers) {
-                if (ENABLE.equalsIgnoreCase(request.ruleFunction()) && Objects.equals(request.comparator(), "=")) {
-                    stringBuilder.append(PG_ENABLE_ELEMENT).append(targetId).append(PARANTHESIS).append(" }");
-                    stringBuilder.append(" else { \n").append(PG_DISABLE_ELEMENT).append(targetId).append(PARANTHESIS)
-                            .append(" }");
-                }
-                if (!Objects.equals(ENABLE, request.ruleFunction()) && Objects.equals(request.comparator(), "=")) {
-                    stringBuilder.append(PG_DISABLE_ELEMENT).append(targetId).append(PARANTHESIS);
-                    stringBuilder.append(" else { \n").append(PG_ENABLE_ELEMENT).append(targetId).append(PARANTHESIS)
-                            .append(" }");
-                }
-            }
-        }
-        return stringBuilder;
-    }
+  private StringBuilder frameSubSectionPartForUnhideAndHide(CreateRuleRequest request,
+      StringBuilder stringBuilder, String suffix) {
+    return nestedSubSection(request, stringBuilder, suffix);
+  }
 
-
-    private StringBuilder thirdPartForEnDs(CreateRuleRequest request, StringBuilder stringBuilder) {
-        return commonElementPartForEnDs(request, stringBuilder);
-    }
-
-    public JSFunctionNameHelper requireIfJsFunction(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            WaRuleMetadata ruleMetadata,
-            TargetValuesHelper targetValuesHelper) {
-        String functionName = "ruleRequireIf" + request.sourceIdentifier() + ruleMetadata.getId();
-        StringBuilder buffer = new StringBuilder();
-        buffer.append(FUNCTION + functionName + ACTION_1);
-        buffer.append("\n var foo = [];\n");
-        buffer.append(DOLLARCLOSING).append(request.sourceIdentifier()).append(SELECTED);
-        buffer.append("\n foo[i] = $j(selected).val();\n");
-        buffer.append(LINESEPERATOR_PARANTHESIS);
-        if (request.sourceIdentifier() != null) {
-
-            String sourceValueText = sourceValuesHelper.sourceValueText();
-
-            if (request.anySourceValue()) {
-                buffer.append("if(foo.length>0 && foo[0] != '') {\n");
-            } else {
-                buffer.append("if(foo.length==0) return;\n");
-                buffer.append(IF);
-                buffer.append(ARRAY).append(sourceValueText.toUpperCase(), 0, 3).append("',foo) > -1)");
-                buffer.append("){\n");
-            }
-            String secondPart = frameSecondPartOfRequireIf(request, targetValuesHelper);
-            buffer.append(secondPart);
-        }
-        buffer.append("   \n}");
-        return new JSFunctionNameHelper(buffer.toString(), functionName);
-
-    }
-
-    private String frameSecondPartOfRequireIf(CreateRuleRequest request, TargetValuesHelper targetValuesHelper) {
-        StringBuilder buffer = new StringBuilder();
-        String targetIdentifier = targetValuesHelper.targetIdentifier();
-        if (Objects.equals(request.comparator(), "=")) {
-            buffer.append("pgRequireElement('").append(targetIdentifier).append(PARANTHESIS);
+  private StringBuilder nestedSubSection(
+      CreateRuleRequest request,
+      StringBuilder stringBuilder,
+      String suffix) {
+    List<String> targetQuestionIdentifiers = request.targetValueIdentifier();
+    if ("Subsection".equalsIgnoreCase(request.targetType())) {
+      for (String targetId : targetQuestionIdentifiers) {
+        targetId += suffix;
+        if (Objects.equals(request.ruleFunction(), UNHIDE) && Objects.equals(request.comparator(), "=")) {
+          stringBuilder.append("pgSubSectionShown('").append(targetId).append(PARANTHESIS);
         } else {
-            buffer.append("pgRequireNotElement('").append(targetIdentifier).append(PARANTHESIS);
+          stringBuilder.append("pgSubSectionHidden('").append(targetId).append(PARANTHESIS);
         }
-        buffer.append(ELSE);
-        if (Objects.equals(request.comparator(), "=")) {
-            buffer.append("pgRequireNotElement('").append(targetIdentifier).append(PARANTHESIS);
+        if (!Objects.equals(request.ruleFunction(), UNHIDE) && Objects.equals(request.comparator(), "=")) {
+          stringBuilder.append("pgSubSectionHidden('").append(targetId).append(PARANTHESIS);
         } else {
-            buffer.append("pgRequireElement('").append(targetIdentifier).append(PARANTHESIS);
+          stringBuilder.append("pgSubSectionShown('").append(targetId).append(PARANTHESIS);
         }
-        buffer.append(" }");
-
-        return buffer.toString();
+      }
     }
+    return stringBuilder;
+  }
 
-    public JSFunctionNameHelper jsForHideAndUnhide(
-            CreateRuleRequest request,
-            SourceValuesHelper sourceValuesHelper,
-            WaRuleMetadata ruleMetadata) {
-        String sourceText = sourceValuesHelper.sourceValueText();
-        if (sourceText == null) {
-            log.info("Any SourceValue is true for this request");
-            sourceText = ",";
-        }
-        List<String> sourceValueTextList = Arrays.asList(sourceText.split(","));
-        StringBuilder stringBuilder = new StringBuilder();
-        String functionName = "ruleHideUnh" + request.sourceIdentifier() + ruleMetadata.getId();
-        stringBuilder.append(FUNCTION).append(functionName).append(ACTION_1);
-        ruleLeftAndRightInvestigation(request, stringBuilder, "", sourceValueTextList);
-        ruleLeftAndRightInvestigation(request, stringBuilder, "_2", sourceValueTextList);
-        stringBuilder.append("   \n}");
-        return new JSFunctionNameHelper(stringBuilder.toString(), functionName);
+  private StringBuilder partForSubSection(CreateRuleRequest request, StringBuilder stringBuilder,
+      String suffix) {
+    stringBuilder = frameSubSectionPartForUnhideAndHide(request, stringBuilder, suffix);
+    return stringBuilder;
+  }
+
+
+  @Override
+  public ViewRuleResponse updatePageRule(Long ruleId, CreateRuleRequest request, Long userId, Long page) {
+    boolean isPresent = waRuleMetaDataRepository.existsById(ruleId);
+    if (!isPresent) {
+      throw new RuleException("RuleId Not Found", HttpStatus.NOT_FOUND.value());
+    } else {
+      WaRuleMetadata waRuleMetadata = waRuleMetaDataRepository.getReferenceById(ruleId);
+      RuleData ruleData = createRuleData(request, waRuleMetadata);
+      WaRuleMetadata updatedValues = setUpdatedValues(ruleData, waRuleMetadata, request, userId, page);
+      waRuleMetaDataRepository.save(updatedValues);
+      return ruleResponseMapper.mapRuleResponse(updatedValues);
     }
+  }
 
-    private StringBuilder ruleLeftAndRightInvestigation(
-            CreateRuleRequest request,
-            StringBuilder stringBuilder,
-            String suffix,
-            List<String> sourceValueTextList) {
-        String questionIdentifier = request.sourceIdentifier();
-        stringBuilder.append("\n var foo").append(suffix).append(" = [];\n");
-        stringBuilder.append(DOLLARCLOSING).append(questionIdentifier).append(suffix).append(SELECTED);
-        stringBuilder.append("\n foo").append(suffix).append("[i] = $j(selected).val();\n");
+  private WaRuleMetadata setUpdatedValues(
+      RuleData ruleData,
+      WaRuleMetadata ruleMetadata,
+      CreateRuleRequest request,
+      Long userId, Long page) {
+    Instant now = Instant.now();
+    ruleMetadata.setRuleCd(request.ruleFunction());
+    ruleMetadata.setLogic(request.comparator());
+    ruleMetadata.setJsFunction(ruleData.jsFunctionNameHelper().jsFunction());
+    ruleMetadata.setSourceValues(ruleData.sourceValues());
+    ruleMetadata.setErrormsgText(ruleData.errorMsgText());
+    ruleMetadata.setSourceQuestionIdentifier(ruleData.sourceIdentifier());
+    ruleMetadata.setTargetQuestionIdentifier(ruleData.targetIdentifiers());
+    ruleMetadata.setTargetType(request.targetType());
+    ruleMetadata.setAddTime(now);
+    ruleMetadata.setAddUserId(userId);
+    ruleMetadata.setLastChgTime(now);
+    ruleMetadata.setRecordStatusCd("ACTIVE");
+    ruleMetadata.setLastChgUserId(userId);
+    ruleMetadata.setRecordStatusTime(now);
+    ruleMetadata.setErrormsgText(ruleData.errorMsgText());
+    ruleMetadata.setJsFunction(ruleData.jsFunctionNameHelper().jsFunction());
+    ruleMetadata.setJsFunctionName(ruleData.jsFunctionNameHelper().jsFunctionName());
+    ruleMetadata.setWaTemplateUid(page);
+    ruleMetadata.setRuleExpression(ruleData.ruleExpression());
+    ruleMetadata.setId(ruleMetadata.getId());
 
-        stringBuilder.append(LINESEPERATOR_PARANTHESIS);
-        stringBuilder.append("if(foo").append(suffix).append("=='' && ").append(DOLLARCLOSING)
-                .append(questionIdentifier).append(suffix).append("').html()!=null){");//added for the business rule view
-        stringBuilder.append("foo").append(suffix).append("[0]=$j('#").append(questionIdentifier).append(suffix)
-                .append("').html().replace(/^\\s+|\\s+$/g,'');}");//added for the business rule view
-        if (questionIdentifier != null) {
-            if (request.anySourceValue()) {
-                stringBuilder.append("if(foo").append(suffix).append(".length>0 && foo").append(suffix)
-                        .append("[0] != '') {\n");
-            } else {
-                stringBuilder.append(IF);
-                int i = 0;
-                for (String sourcetext : sourceValueTextList) {
-                    if (i != 0) {
-                        stringBuilder.append(" || ");
-                    }
-                    i++;
-                    stringBuilder.append(ARRAY).append(sourcetext.charAt(0)).append("',foo").append(suffix)
-                            .append(") > -1)");
-                    stringBuilder.append(" || ($j.inArray('").append(sourcetext)
-                            .append("'.replace(/^\\s+|\\s+$/g,''),foo").append(suffix).append(") > -1");
-                    stringBuilder.append(" || indexOfArray(foo,'").append(sourcetext).append("')==true)");
-                    //added for the business rule view
-                }
-                stringBuilder.append("){\n");
-            }
-        }
-        framingJSforUnhideAndHide(request, stringBuilder, suffix);
-        return stringBuilder;
-    }
-
-    private StringBuilder framingJSforUnhideAndHide(
-            CreateRuleRequest request,
-            StringBuilder stringBuilder,
-            String suffix) {
-        frameSecondPartForUnhideAndHide(request, stringBuilder, suffix);
-        partForSubSection(request, stringBuilder, suffix);
-        return stringBuilder;
-    }
-
-    private StringBuilder frameCommonPartForUnhideAndHide(
-            CreateRuleRequest request,
-            StringBuilder stringBuilder,
-            String suffix) {
-        List<String> targetQuestionIdentifiers = request.targetValueIdentifier();
-        if ("Question".equalsIgnoreCase(request.targetType())) {
-            for (String targetId : targetQuestionIdentifiers) {
-                targetId += suffix;
-                if (Objects.equals(request.ruleFunction(), UNHIDE) && Objects.equals(request.comparator(), "=")) {
-                    stringBuilder.append("pgUnhideElement('").append(targetId).append(PARANTHESIS);
-                    stringBuilder.append(ELSE);
-                    stringBuilder.append("pgHideElement('").append(targetId).append(PARANTHESIS);
-                } else {
-                    stringBuilder.append("pgHideElement('").append(targetId).append(PARANTHESIS);
-                    stringBuilder.append(ELSE);
-                    stringBuilder.append("pgUnhideElement('").append(targetId).append(PARANTHESIS);
-                }
-            }
-        }
-        return stringBuilder;
-    }
-
-    private StringBuilder frameSecondPartForUnhideAndHide(CreateRuleRequest request,
-            StringBuilder stringBuilder, String suffix) {
-        frameCommonPartForUnhideAndHide(request, stringBuilder, suffix);
-        stringBuilder.append(" }");
-        return stringBuilder;
-    }
-
-    private StringBuilder frameSubSectionPartForUnhideAndHide(CreateRuleRequest request,
-            StringBuilder stringBuilder, String suffix) {
-        return nestedSubSection(request, stringBuilder, suffix);
-    }
-
-    private StringBuilder nestedSubSection(
-            CreateRuleRequest request,
-            StringBuilder stringBuilder,
-            String suffix) {
-        List<String> targetQuestionIdentifiers = request.targetValueIdentifier();
-        if ("Subsection".equalsIgnoreCase(request.targetType())) {
-            for (String targetId : targetQuestionIdentifiers) {
-                targetId += suffix;
-                if (Objects.equals(request.ruleFunction(), UNHIDE) && Objects.equals(request.comparator(), "=")) {
-                    stringBuilder.append("pgSubSectionShown('").append(targetId).append(PARANTHESIS);
-                } else {
-                    stringBuilder.append("pgSubSectionHidden('").append(targetId).append(PARANTHESIS);
-                }
-                if (!Objects.equals(request.ruleFunction(), UNHIDE) && Objects.equals(request.comparator(), "=")) {
-                    stringBuilder.append("pgSubSectionHidden('").append(targetId).append(PARANTHESIS);
-                } else {
-                    stringBuilder.append("pgSubSectionShown('").append(targetId).append(PARANTHESIS);
-                }
-            }
-        }
-        return stringBuilder;
-    }
-
-    private StringBuilder partForSubSection(CreateRuleRequest request, StringBuilder stringBuilder,
-            String suffix) {
-        stringBuilder = frameSubSectionPartForUnhideAndHide(request, stringBuilder, suffix);
-        return stringBuilder;
-    }
-
-
-    @Override
-    public CreateRuleResponse updatePageRule(Long ruleId, CreateRuleRequest request, Long userId,Long page) {
-        boolean isPresent = waRuleMetaDataRepository.existsById(ruleId);
-        if (!isPresent) {
-            return new CreateRuleResponse(ruleId, "RuleId Not Found");
-        } else {
-            WaRuleMetadata waRuleMetadata = waRuleMetaDataRepository.getReferenceById(ruleId);
-            RuleData ruleData = createRuleData(request, waRuleMetadata);
-            WaRuleMetadata updatedValues = setUpdatedValues(ruleData, waRuleMetadata, request, userId,page);
-            waRuleMetaDataRepository.save(updatedValues);
-            return new CreateRuleResponse(updatedValues.getId(), "Rule Successfully Updated");
-        }
-    }
-
-    private WaRuleMetadata setUpdatedValues(
-            RuleData ruleData,
-            WaRuleMetadata ruleMetadata,
-            CreateRuleRequest request,
-            Long userId,Long page) {
-        Instant now = Instant.now();
-        ruleMetadata.setRuleCd(request.ruleFunction());
-        ruleMetadata.setLogic(request.comparator());
-        ruleMetadata.setJsFunction(ruleData.jsFunctionNameHelper().jsFunction());
-        ruleMetadata.setSourceValues(ruleData.sourceValues());
-        ruleMetadata.setErrormsgText(ruleData.errorMsgText());
-        ruleMetadata.setSourceQuestionIdentifier(ruleData.sourceIdentifier());
-        ruleMetadata.setTargetQuestionIdentifier(ruleData.targetIdentifiers());
-        ruleMetadata.setTargetType(request.targetType());
-        ruleMetadata.setAddTime(now);
-        ruleMetadata.setAddUserId(userId);
-        ruleMetadata.setLastChgTime(now);
-        ruleMetadata.setRecordStatusCd("ACTIVE");
-        ruleMetadata.setLastChgUserId(userId);
-        ruleMetadata.setRecordStatusTime(now);
-        ruleMetadata.setErrormsgText(ruleData.errorMsgText());
-        ruleMetadata.setJsFunction(ruleData.jsFunctionNameHelper().jsFunction());
-        ruleMetadata.setJsFunctionName(ruleData.jsFunctionNameHelper().jsFunctionName());
-        ruleMetadata.setWaTemplateUid(page);
-        ruleMetadata.setRuleExpression(ruleData.ruleExpression());
-        ruleMetadata.setId(ruleMetadata.getId());
-
-        return ruleMetadata;
-    }
+    return ruleMetadata;
+  }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/RuleResponseMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/RuleResponseMapper.java
@@ -1,0 +1,72 @@
+package gov.cdc.nbs.questionbank.pagerules;
+
+import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
+import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
+import gov.cdc.nbs.questionbank.question.repository.WaQuestionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class RuleResponseMapper {
+
+  private final WaQuestionRepository waQuestionRepository;
+
+  public RuleResponseMapper(WaQuestionRepository waQuestionRepository) {
+    this.waQuestionRepository = waQuestionRepository;
+  }
+
+  public ViewRuleResponse mapRuleResponse(WaRuleMetadata ruleMetadata) {
+    List<String> sourceValues = new ArrayList<>();
+    List<QuestionInfo> targetQuestions = new ArrayList<>();
+    if (ruleMetadata.getSourceValues() != null && ruleMetadata.getTargetQuestionIdentifier() != null) {
+      String[] sourceValue = ruleMetadata.getSourceValues().split(",");
+      sourceValues = Arrays.asList(sourceValue);
+      targetQuestions = findLabelsByIdentifiers(Arrays.asList(ruleMetadata.getTargetQuestionIdentifier().split(",")));
+    }
+    return new ViewRuleResponse(ruleMetadata.getId(), ruleMetadata.getWaTemplateUid(), ruleMetadata.getRuleCd(),
+        ruleMetadata.getRuleDescText(), ruleMetadata.getSourceQuestionIdentifier(), sourceValues,
+        ruleMetadata.getLogic(), ruleMetadata.getTargetType(), ruleMetadata.getErrormsgText(), targetQuestions);
+  }
+
+
+  public Page<ViewRuleResponse> mapRuleResponse(Page<WaRuleMetadata> ruleMetadataPage) {
+    List<ViewRuleResponse> ruleMetadata =
+        ruleMetadataPage.getContent().stream()
+            .map(rule -> new ViewRuleResponse(rule.getId(), rule.getWaTemplateUid(), rule.getRuleCd(),
+                rule.getRuleDescText(), rule.getSourceQuestionIdentifier(),
+                buildSourceTargetValues(rule, true),
+                rule.getLogic(), rule.getTargetType(), rule.getErrormsgText(),
+                findLabelsByIdentifiers(buildSourceTargetValues(rule, false))))
+            .toList();
+    return new PageImpl<>(ruleMetadata, ruleMetadataPage.getPageable(), ruleMetadataPage.getTotalElements());
+  }
+
+  private List<String> buildSourceTargetValues(WaRuleMetadata ruleMetadata, boolean isSource) {
+
+    List<String> sourceValues = new ArrayList<>();
+    List<String> targetValues = new ArrayList<>();
+    if (isSource) {
+      if (ruleMetadata.getSourceValues() == null || ruleMetadata.getTargetQuestionIdentifier() == null) {
+        return sourceValues;
+      } else {
+        return Arrays.asList(ruleMetadata.getSourceValues().split(","));
+      }
+    } else {
+      if (ruleMetadata.getSourceValues() == null || ruleMetadata.getTargetQuestionIdentifier() == null) {
+        return targetValues;
+      } else {
+        return Arrays.stream(ruleMetadata.getTargetQuestionIdentifier().split(",")).toList();
+      }
+    }
+  }
+
+  private List<QuestionInfo> findLabelsByIdentifiers(List<String> targetValue) {
+    return waQuestionRepository.findLabelsByIdentifiers(targetValue).stream().map(
+        question -> new QuestionInfo(question[0].toString(), question[1].toString())).toList();
+  }
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/response/CreateRuleResponse.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/response/CreateRuleResponse.java
@@ -1,4 +1,0 @@
-package gov.cdc.nbs.questionbank.pagerules.response;
-
-public record CreateRuleResponse(Long ruleId, String message) {
-}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleControllerTest.java
@@ -6,7 +6,6 @@ import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
 import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import gov.cdc.nbs.questionbank.page.content.rule.PageRuleDeleter;
 import gov.cdc.nbs.questionbank.pagerules.exceptions.RuleException;
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
 import gov.cdc.nbs.questionbank.support.RuleRequestMother;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,6 +26,7 @@ class PageRuleControllerTest {
 
   @InjectMocks
   private PageRuleController pageRuleController;
+
   @Mock
   private PageRuleService pageRuleService;
 
@@ -55,9 +56,9 @@ class PageRuleControllerTest {
     NbsUserDetails nbsUserDetails =
         NbsUserDetails.builder().id(123L).firstName("test user").lastName("test").build();
     when(pageRuleService.updatePageRule(ruleId, ruleRequest, userId, 123456L))
-        .thenReturn(new CreateRuleResponse(ruleId, "Rule Successfully Updated"));
+        .thenReturn(getViewRuleResponse());
     when(userDetailsProvider.getCurrentUserDetails()).thenReturn(nbsUserDetails);
-    CreateRuleResponse ruleResponse = pageRuleController.updatePageRule(ruleId, ruleRequest, 123456L);
+    ViewRuleResponse ruleResponse = pageRuleController.updatePageRule(ruleId, ruleRequest, 123456L);
     assertNotNull(ruleResponse);
   }
 
@@ -124,4 +125,20 @@ class PageRuleControllerTest {
     Page<ViewRuleResponse> ruleResponse = pageRuleController.findPageRule(request, pageRequest);
     assertNotNull(ruleResponse);
   }
+
+  private ViewRuleResponse getViewRuleResponse() {
+    return new ViewRuleResponse(
+        99l,
+        123l,
+        "Enable",
+        "TestDescription",
+        "sourceIdentifier",
+        new ArrayList<>(),
+        "comparator",
+        "Question",
+        "errorMsgText",
+        Arrays.asList(new QuestionInfo("label1", "test456"), new QuestionInfo("label2", "test789"))
+    );
+  }
+
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleServiceImplTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleServiceImplTest.java
@@ -1,13 +1,8 @@
 package gov.cdc.nbs.questionbank.pagerules;
 
 import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
-import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
 import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
-import gov.cdc.nbs.questionbank.pagerules.exceptions.RuleException;
 import gov.cdc.nbs.questionbank.pagerules.repository.WaRuleMetaDataRepository;
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
-import gov.cdc.nbs.questionbank.question.repository.WaQuestionRepository;
-import gov.cdc.nbs.questionbank.support.RuleRequestMother;
 import org.springframework.data.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,179 +11,191 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 class PageRuleServiceImplTest {
-    @InjectMocks
-    private PageRuleServiceImpl pageRuleServiceImpl;
+  //  @InjectMocks
+  //  private PageRuleServiceImpl pageRuleServiceImpl;
 
-    @Mock
-    private WaRuleMetaDataRepository waRuleMetaDataRepository;
+  @Mock
+  private WaRuleMetaDataRepository waRuleMetaDataRepository;
 
-    @Mock
-    private WaQuestionRepository waQuestionRepository;
+  @Mock
+  private RuleResponseMapper ruleResponseMapper;
 
+  @InjectMocks
+  private PageRuleFinderServiceImpl pageRuleFinderServiceImpl;
 
-    @InjectMocks
-    private PageRuleFinderServiceImpl pageRuleFinderServiceImpl;
-
-    @BeforeEach
-    void setup() {
-        Mockito.reset(waRuleMetaDataRepository);
-    }
-
-    @Test
-    void shouldThrowAnExceptionIfThereIsSomethingWrongInFunctionName() {
-        CreateRuleRequest ruleRequest = RuleRequestMother.InvalidRuleRequest();
-        Long userId = 99L;
-        RuleException exception =
-                assertThrows(RuleException.class,
-                        () -> pageRuleServiceImpl.createPageRule(userId, ruleRequest, 123456L));
-
-        assertEquals(
-                "gov.cdc.nbs.questionbank.pagerules.exceptions.RuleException: Error in Creating Rule Expression and Error Message Text",
-                exception.toString());
-    }
-
-
-    // @Test
-    // void shouldReturnNotFoundWhenRuleIdIsNotThere() throws RuleException {
-    //     Long ruleId = 99L;
-    //     Long userId = 99L;
-    //     CreateRuleRequest ruleRequest = RuleRequestMother.RequireIfRuleTestData();
-    //     WaRuleMetadata ruleMetadata = new WaRuleMetadata();
-    //     ruleMetadata.setId(99L);
-    //     ruleMetadata.setRuleCd("Hide");
-    //     ruleMetadata.setRuleExpression("testRuleExpression");
-    //     CreateRuleResponse ruleResponse = pageRuleServiceImpl.updatePageRule(ruleId, ruleRequest, userId, 123456L);
-    //     Mockito.verify(waRuleMetaDataRepository, Mockito.times(1)).existsById(ruleId);
-    //     assertEquals("RuleId Not Found", ruleResponse.message());
-    // }
-
-    // @Test
-    // void shouldUpdateRule() throws RuleException {
-    //     Long ruleId = 99L;
-    //     Long userId = 99L;
-    //     CreateRuleRequest ruleRequest = RuleRequestMother.RequireIfRuleTestData();
-    //     WaRuleMetadata ruleMetadata = new WaRuleMetadata();
-    //     ruleMetadata.setId(99L);
-    //     ruleMetadata.setRuleCd("Hide");
-    //     ruleMetadata.setRuleExpression("testRuleExpression");
-    //     Mockito.when(waRuleMetaDataRepository.existsById(ruleId)).thenReturn(true);
-    //     Mockito.when(waRuleMetaDataRepository.getReferenceById(ruleId)).thenReturn(ruleMetadata);
-    //     CreateRuleResponse ruleResponse = pageRuleServiceImpl.updatePageRule(ruleId, ruleRequest, userId, 123456L);
-    //     Mockito.verify(waRuleMetaDataRepository, Mockito.times(1)).existsById(ruleId);
-    //     assertEquals("Rule Successfully Updated", ruleResponse.message());
-    // }
+  @BeforeEach
+  void setup() {
+    Mockito.reset(waRuleMetaDataRepository);
+  }
 
 
 
+  // @Test
+  // void shouldReturnNotFoundWhenRuleIdIsNotThere() throws RuleException {
+  //     Long ruleId = 99L;
+  //     Long userId = 99L;
+  //     CreateRuleRequest ruleRequest = RuleRequestMother.RequireIfRuleTestData();
+  //     WaRuleMetadata ruleMetadata = new WaRuleMetadata();
+  //     ruleMetadata.setId(99L);
+  //     ruleMetadata.setRuleCd("Hide");
+  //     ruleMetadata.setRuleExpression("testRuleExpression");
+  //     CreateRuleResponse ruleResponse = pageRuleServiceImpl.updatePageRule(ruleId, ruleRequest, userId, 123456L);
+  //     Mockito.verify(waRuleMetaDataRepository, Mockito.times(1)).existsById(ruleId);
+  //     assertEquals("RuleId Not Found", ruleResponse.message());
+  // }
 
-
-    @Test
-    void shouldGiveTheDetailsOfRule() {
-        List<Object[]>  targetQuestions= Arrays.asList(new Object[]{"label1","test456"},new Object[]{"label2", " test789"});
-        Long ruleId = 99L;
-        WaRuleMetadata ruleMetadata = new WaRuleMetadata();
-        ruleMetadata.setId(99L);
-        ruleMetadata.setRuleCd("Hide");
-        ruleMetadata.setRuleExpression("testRuleExpression");
-        ruleMetadata.setErrormsgText("testErrorMsg");
-        ruleMetadata.setLogic(">=");
-        ruleMetadata.setSourceValues("test123,test345");
-        ruleMetadata.setTargetType("Question");
-        ruleMetadata.setTargetQuestionIdentifier("test456,test789");
-        Mockito.when(waRuleMetaDataRepository.getReferenceById(ruleId)).thenReturn(ruleMetadata);
-        Mockito.when(waQuestionRepository.findLabelsByIdentifiers(any())).
-                thenReturn(targetQuestions);
-        ViewRuleResponse ruleresponse = pageRuleFinderServiceImpl.getRuleResponse(ruleId);
-        assertNotNull(ruleresponse);
-        assertEquals(2, ruleresponse.targetQuestions().size());
-    }
-
-    @Test
-    void shouldGiveTheDetailsOfRuleEvenSourceAndTargetValuesAreNull() {
-        Long ruleId = 99L;
-        WaRuleMetadata ruleMetadata = new WaRuleMetadata();
-        ruleMetadata.setId(99L);
-        ruleMetadata.setRuleCd("Hide");
-        ruleMetadata.setRuleExpression("testRuleExpression");
-        ruleMetadata.setErrormsgText("testErrorMsg");
-        ruleMetadata.setLogic(">=");
-        ruleMetadata.setSourceValues(null);
-        ruleMetadata.setTargetType("Question");
-        ruleMetadata.setTargetQuestionIdentifier(null);
-        Mockito.when(waRuleMetaDataRepository.getReferenceById(ruleId)).thenReturn(ruleMetadata);
-        ViewRuleResponse ruleresponse = pageRuleFinderServiceImpl.getRuleResponse(ruleId);
-        assertNotNull(ruleresponse);
-    }
+  // @Test
+  // void shouldUpdateRule() throws RuleException {
+  //     Long ruleId = 99L;
+  //     Long userId = 99L;
+  //     CreateRuleRequest ruleRequest = RuleRequestMother.RequireIfRuleTestData();
+  //     WaRuleMetadata ruleMetadata = new WaRuleMetadata();
+  //     ruleMetadata.setId(99L);
+  //     ruleMetadata.setRuleCd("Hide");
+  //     ruleMetadata.setRuleExpression("testRuleExpression");
+  //     Mockito.when(waRuleMetaDataRepository.existsById(ruleId)).thenReturn(true);
+  //     Mockito.when(waRuleMetaDataRepository.getReferenceById(ruleId)).thenReturn(ruleMetadata);
+  //     CreateRuleResponse ruleResponse = pageRuleServiceImpl.updatePageRule(ruleId, ruleRequest, userId, 123456L);
+  //     Mockito.verify(waRuleMetaDataRepository, Mockito.times(1)).existsById(ruleId);
+  //     assertEquals("Rule Successfully Updated", ruleResponse.message());
+  // }
 
 
 
-    @Test
-    void getAllPageRuleTest() {
-        Pageable pageable = null;
-        Page<WaRuleMetadata> ruleMetadataPage = new PageImpl<>(Collections.singletonList(morbWaRuleMetadata()));
-        Mockito.when(waRuleMetaDataRepository.findByWaTemplateUid(123456L, pageable)).thenReturn(ruleMetadataPage);
-        Page<ViewRuleResponse> ruleResponse = pageRuleFinderServiceImpl.getAllPageRule(pageable, 123456L);
-        assertNotNull(ruleResponse);
-        List<ViewRuleResponse> actualResponse = ruleResponse.stream().toList();
-        assertNotNull(actualResponse);
-        assertEquals(1, actualResponse.size());
-        assertEquals(99, actualResponse.get(0).ruleId());
-        assertEquals("Question", actualResponse.get(0).targetType());
+  @Test
+  void shouldGiveTheDetailsOfRule() {
+    Long ruleId = 99L;
+    WaRuleMetadata ruleMetadata = new WaRuleMetadata();
+    ruleMetadata.setId(99L);
+    ruleMetadata.setRuleCd("Hide");
+    ruleMetadata.setRuleExpression("testRuleExpression");
+    ruleMetadata.setErrormsgText("testErrorMsg");
+    ruleMetadata.setLogic(">=");
+    ruleMetadata.setSourceValues("test123,test345");
+    ruleMetadata.setTargetType("Question");
+    ruleMetadata.setTargetQuestionIdentifier("test456,test789");
+    Mockito.when(waRuleMetaDataRepository.getReferenceById(ruleId)).thenReturn(ruleMetadata);
+    Mockito.when(ruleResponseMapper.mapRuleResponse(any(WaRuleMetadata.class))).thenReturn(getViewRuleResponse());
+    ViewRuleResponse ruleresponse = pageRuleFinderServiceImpl.getRuleResponse(ruleId);
+    assertNotNull(ruleresponse);
+    assertEquals(2, ruleresponse.targetQuestions().size());
+  }
 
-        WaRuleMetadata data = morbWaRuleMetadata();
-        data.setSourceValues("Test Source values");
-        data.setTargetQuestionIdentifier("Test target questions identifier");
-        ruleMetadataPage = new PageImpl<>(Collections.singletonList(data));
-        Mockito.when(waRuleMetaDataRepository.findByWaTemplateUid(123456L, pageable)).thenReturn(ruleMetadataPage);
-        ruleResponse = pageRuleFinderServiceImpl.getAllPageRule(pageable, 123456L);
-        assertNotNull(ruleResponse);
-        actualResponse = ruleResponse.stream().toList();
-        assertNotNull(actualResponse);
-        assertEquals(1, actualResponse.size());
-        assertEquals(99, actualResponse.get(0).ruleId());
-    }
+  @Test
+  void shouldGiveTheDetailsOfRuleEvenSourceAndTargetValuesAreNull() {
+    Long ruleId = 99L;
+    WaRuleMetadata ruleMetadata = new WaRuleMetadata();
+    ruleMetadata.setId(99L);
+    ruleMetadata.setRuleCd("Hide");
+    ruleMetadata.setRuleExpression("testRuleExpression");
+    ruleMetadata.setErrormsgText("testErrorMsg");
+    ruleMetadata.setLogic(">=");
+    ruleMetadata.setSourceValues(null);
+    ruleMetadata.setTargetType("Question");
+    ruleMetadata.setTargetQuestionIdentifier(null);
+    Mockito.when(waRuleMetaDataRepository.getReferenceById(ruleId)).thenReturn(ruleMetadata);
+    Mockito.when(ruleResponseMapper.mapRuleResponse(any(WaRuleMetadata.class))).thenReturn(getViewRuleResponse());
+    ViewRuleResponse ruleresponse = pageRuleFinderServiceImpl.getRuleResponse(ruleId);
+    assertNotNull(ruleresponse);
+  }
 
-    private WaRuleMetadata morbWaRuleMetadata() {
-        WaRuleMetadata ruleMetadata = new WaRuleMetadata();
-        ruleMetadata.setId(99L);
-        ruleMetadata.setRuleCd("Hide");
-        ruleMetadata.setRuleExpression("testRuleExpression");
-        ruleMetadata.setErrormsgText("testErrorMsg");
-        ruleMetadata.setLogic(">=");
-        ruleMetadata.setSourceValues(null);
-        ruleMetadata.setTargetType("Question");
-        ruleMetadata.setTargetQuestionIdentifier(null);
-        return ruleMetadata;
-    }
 
-    @Test
-    void findPageRuleTest() {
-        int page = 0;
-        int size = 1;
-        String sort = "id";
-        Pageable pageRequest = PageRequest.of(page, size, Sort.by(sort));
-        SearchPageRuleRequest request = new SearchPageRuleRequest("searchValue");
-        Page<WaRuleMetadata> ruleMetadataPage = new PageImpl<>(Collections.singletonList(morbWaRuleMetadata()));
-        Mockito.when(waRuleMetaDataRepository
-                        .findAllBySourceValuesContainingIgnoreCaseOrTargetQuestionIdentifierContainingIgnoreCase(
-                                request.searchValue(), request.searchValue(), pageRequest))
-                .thenReturn(ruleMetadataPage);
-        Page<ViewRuleResponse> ruleResponse = pageRuleFinderServiceImpl.findPageRule(request, pageRequest);
-        assertNotNull(ruleResponse);
 
-        List<ViewRuleResponse> actualResponse = ruleResponse.stream().toList();
-        assertNotNull(actualResponse);
-        assertEquals(1, actualResponse.size());
-        assertEquals(99, actualResponse.get(0).ruleId());
-        assertEquals("Question", actualResponse.get(0).targetType());
-    }
+  @Test
+  void getAllPageRuleTest() {
+    Pageable pageable = null;
+    Page<WaRuleMetadata> ruleMetadataPage = new PageImpl<>(Collections.singletonList(morbWaRuleMetadata()));
+    Mockito.when(waRuleMetaDataRepository.findByWaTemplateUid(123456L, pageable)).thenReturn(ruleMetadataPage);
+    Mockito.when(ruleResponseMapper.mapRuleResponse(any(Page.class))).thenReturn(getViewRuleResponsePage());
+    Page<ViewRuleResponse> ruleResponse = pageRuleFinderServiceImpl.getAllPageRule(pageable, 123456L);
+    assertNotNull(ruleResponse);
+    List<ViewRuleResponse> actualResponse = ruleResponse.stream().toList();
+    assertNotNull(actualResponse);
+    assertEquals(1, actualResponse.size());
+    assertEquals(99, actualResponse.get(0).ruleId());
+    assertEquals("Question", actualResponse.get(0).targetType());
+
+    WaRuleMetadata data = morbWaRuleMetadata();
+    data.setSourceValues("Test Source values");
+    data.setTargetQuestionIdentifier("Test target questions identifier");
+    ruleMetadataPage = new PageImpl<>(Collections.singletonList(data));
+    Mockito.when(waRuleMetaDataRepository.findByWaTemplateUid(123456L, pageable)).thenReturn(ruleMetadataPage);
+    Mockito.when(ruleResponseMapper.mapRuleResponse(any(Page.class))).thenReturn(getViewRuleResponsePage());
+    ruleResponse = pageRuleFinderServiceImpl.getAllPageRule(pageable, 123456L);
+    assertNotNull(ruleResponse);
+    actualResponse = ruleResponse.stream().toList();
+    assertNotNull(actualResponse);
+    assertEquals(1, actualResponse.size());
+    assertEquals(99, actualResponse.get(0).ruleId());
+  }
+
+  private WaRuleMetadata morbWaRuleMetadata() {
+    WaRuleMetadata ruleMetadata = new WaRuleMetadata();
+    ruleMetadata.setId(99L);
+    ruleMetadata.setRuleCd("Hide");
+    ruleMetadata.setRuleExpression("testRuleExpression");
+    ruleMetadata.setErrormsgText("testErrorMsg");
+    ruleMetadata.setLogic(">=");
+    ruleMetadata.setSourceValues(null);
+    ruleMetadata.setTargetType("Question");
+    ruleMetadata.setTargetQuestionIdentifier(null);
+    return ruleMetadata;
+  }
+
+  @Test
+  void findPageRuleTest() {
+    int page = 0;
+    int size = 1;
+    String sort = "id";
+    Pageable pageRequest = PageRequest.of(page, size, Sort.by(sort));
+    SearchPageRuleRequest request = new SearchPageRuleRequest("searchValue");
+    Page<WaRuleMetadata> ruleMetadataPage = new PageImpl<>(Collections.singletonList(morbWaRuleMetadata()));
+    Mockito.when(waRuleMetaDataRepository
+            .findAllBySourceValuesContainingIgnoreCaseOrTargetQuestionIdentifierContainingIgnoreCase(
+                request.searchValue(), request.searchValue(), pageRequest))
+        .thenReturn(ruleMetadataPage);
+    Mockito.when(ruleResponseMapper.mapRuleResponse(any(Page.class))).thenReturn(getViewRuleResponsePage());
+    Page<ViewRuleResponse> ruleResponse = pageRuleFinderServiceImpl.findPageRule(request, pageRequest);
+    assertNotNull(ruleResponse);
+
+    List<ViewRuleResponse> actualResponse = ruleResponse.stream().toList();
+    assertNotNull(actualResponse);
+    assertEquals(1, actualResponse.size());
+    assertEquals(99, actualResponse.get(0).ruleId());
+    assertEquals("Question", actualResponse.get(0).targetType());
+  }
+
+  private ViewRuleResponse getViewRuleResponse() {
+    return new ViewRuleResponse(
+        99l,
+        123l,
+        "ruleFunction",
+        "ruleDescription",
+        "sourceIdentifier",
+        new ArrayList<>(),
+        "comparator",
+        "Question",
+        "errorMsgText",
+        Arrays.asList(new QuestionInfo("label1", "test456"), new QuestionInfo("label2", "test789"))
+    );
+  }
+
+  Page<ViewRuleResponse> getViewRuleResponsePage() {
+    List<ViewRuleResponse> viewRuleResponseList = Arrays.asList(getViewRuleResponse());
+    Pageable pageable = PageRequest.of(0, 1);
+    return new PageImpl<>(viewRuleResponseList, pageable, 5);
+
+  }
 
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleSteps.java
@@ -2,7 +2,7 @@ package gov.cdc.nbs.questionbank.pagerules;
 
 import gov.cdc.nbs.questionbank.model.CreateRuleRequest;
 import gov.cdc.nbs.questionbank.model.CreateRuleRequest.SourceValues;
-import gov.cdc.nbs.questionbank.pagerules.response.CreateRuleResponse;
+import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
 import gov.cdc.nbs.questionbank.support.ExceptionHolder;
 import gov.cdc.nbs.questionbank.support.PageIdentifier;
 import gov.cdc.nbs.testing.support.Active;
@@ -17,8 +17,10 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -82,7 +84,7 @@ public class PageRuleSteps {
   @Given("the business rule has {string} of:")
   public void the_business_rule_has(final String property, List<List<String>> values) {
     List<String> actValues = new ArrayList<>();
-    for(List<String> val : values) {
+    for (List<String> val : values) {
       actValues.add(val.get(0));
     }
     switch (property.toLowerCase()) {
@@ -107,9 +109,9 @@ public class PageRuleSteps {
 
   @Then("I retrieve the information of the page rule")
   public void i_retrieve_the_information_of_the_page_rule() throws Exception {
-    CreateRuleResponse test = objectMapper.readValue(
+    ViewRuleResponse test = objectMapper.readValue(
         this.response.active().andReturn().getResponse().getContentAsString(),
-        CreateRuleResponse.class);
+        ViewRuleResponse.class);
 
     this.detailResponse.active(
         this.requester.request(

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/RuleResponseMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/RuleResponseMapperTest.java
@@ -1,0 +1,82 @@
+package gov.cdc.nbs.questionbank.pagerules;
+
+import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
+import gov.cdc.nbs.questionbank.model.ViewRuleResponse;
+import gov.cdc.nbs.questionbank.question.repository.WaQuestionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RuleResponseMapperTest {
+
+
+  @InjectMocks
+  private RuleResponseMapper ruleResponseMapper;
+
+  @Mock
+  WaQuestionRepository waQuestionRepository;
+
+
+  @Test
+  void should_return_viewRuleResponse() {
+    WaRuleMetadata ruleMetadata = getWaRuleMetadata();
+    List<Object[]> targetQuestions = getTargetQuestions();
+    when(waQuestionRepository.findLabelsByIdentifiers(any())).thenReturn(targetQuestions);
+    ViewRuleResponse result = ruleResponseMapper.mapRuleResponse(ruleMetadata);
+    assertEquals(ruleMetadata.getId(), result.ruleId());
+    assertEquals(ruleMetadata.getWaTemplateUid(), result.templateUid());
+    assertEquals(ruleMetadata.getRuleDescText(), result.ruleDescription());
+  }
+
+  @Test
+  void should_return_page_of_viewRuleResponse() {
+    Page<WaRuleMetadata> waRuleMetadataPage = getPageOfWaRuleMetadata();
+    List<Object[]> targetQuestions = getTargetQuestions();
+    when(waQuestionRepository.findLabelsByIdentifiers(any())).thenReturn(targetQuestions);
+    Page<ViewRuleResponse> result = ruleResponseMapper.mapRuleResponse(waRuleMetadataPage);
+    assertNotNull(result);
+    assertEquals(1, result.toList().size());
+
+  }
+
+
+  private WaRuleMetadata getWaRuleMetadata() {
+    WaRuleMetadata ruleMetadata = new WaRuleMetadata();
+    ruleMetadata.setId(1L);
+    ruleMetadata.setWaTemplateUid(123l);
+    ruleMetadata.setRuleDescText("ruleDescription");
+    ruleMetadata.setSourceQuestionIdentifier("sourceQuestionIdentifier");
+    ruleMetadata.setSourceValues("value1,value2");
+    ruleMetadata.setTargetType("targetType");
+    ruleMetadata.setErrormsgText("errorMessage");
+    ruleMetadata.setTargetQuestionIdentifier("targetId1,targetId2");
+    return ruleMetadata;
+  }
+
+  private Page<WaRuleMetadata> getPageOfWaRuleMetadata() {
+    List<WaRuleMetadata> ruleMetadataList = Arrays.asList(getWaRuleMetadata());
+    Pageable pageable = PageRequest.of(0, 1);
+    return new PageImpl<>(ruleMetadataList, pageable, 5);
+  }
+
+  private List<Object[]> getTargetQuestions() {
+    return Arrays.asList(new Object[] {"label1", "targetId1"}, new Object[] {"label2", "targetId2"});
+  }
+
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/RuleResponseMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/RuleResponseMapperTest.java
@@ -16,8 +16,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +40,22 @@ class RuleResponseMapperTest {
     assertEquals(ruleMetadata.getId(), result.ruleId());
     assertEquals(ruleMetadata.getWaTemplateUid(), result.templateUid());
     assertEquals(ruleMetadata.getRuleDescText(), result.ruleDescription());
+    assertFalse( result.sourceValue().isEmpty());
+    assertFalse( result.targetQuestions().isEmpty());
   }
+  @Test
+  void should_return_viewRuleResponse_null_SourceTargetValues() {
+    WaRuleMetadata ruleMetadata = getWaRuleMetadata();
+    ruleMetadata.setSourceValues(null);
+    ruleMetadata.setTargetQuestionIdentifier(null);
+    ViewRuleResponse result = ruleResponseMapper.mapRuleResponse(ruleMetadata);
+    assertEquals(ruleMetadata.getId(), result.ruleId());
+    assertEquals(ruleMetadata.getWaTemplateUid(), result.templateUid());
+    assertEquals(ruleMetadata.getRuleDescText(), result.ruleDescription());
+    assertTrue( result.sourceValue().isEmpty());
+    assertTrue( result.targetQuestions().isEmpty());
+  }
+
 
   @Test
   void should_return_page_of_viewRuleResponse() {
@@ -51,8 +65,20 @@ class RuleResponseMapperTest {
     Page<ViewRuleResponse> result = ruleResponseMapper.mapRuleResponse(waRuleMetadataPage);
     assertNotNull(result);
     assertEquals(1, result.toList().size());
-
+    assertFalse(result.toList().get(0).sourceValue().isEmpty());
+    assertFalse( result.toList().get(0).targetQuestions().isEmpty());
   }
+
+  @Test
+  void should_return_page_of_viewRuleResponse_null_SourceTargetValues() {
+    Page<WaRuleMetadata> waRuleMetadataPage = getPageOfWaRuleMetadataWithNullSourceTarget();
+    Page<ViewRuleResponse> result = ruleResponseMapper.mapRuleResponse(waRuleMetadataPage);
+    assertNotNull(result);
+    assertEquals(1, result.toList().size());
+    assertTrue(result.toList().get(0).sourceValue().isEmpty());
+    assertTrue( result.toList().get(0).targetQuestions().isEmpty());
+  }
+
 
 
   private WaRuleMetadata getWaRuleMetadata() {
@@ -70,6 +96,14 @@ class RuleResponseMapperTest {
 
   private Page<WaRuleMetadata> getPageOfWaRuleMetadata() {
     List<WaRuleMetadata> ruleMetadataList = Arrays.asList(getWaRuleMetadata());
+    Pageable pageable = PageRequest.of(0, 1);
+    return new PageImpl<>(ruleMetadataList, pageable, 5);
+  }
+  private Page<WaRuleMetadata> getPageOfWaRuleMetadataWithNullSourceTarget() {
+    WaRuleMetadata ruleMetadata =getWaRuleMetadata();
+    ruleMetadata.setSourceValues(null);
+    ruleMetadata.setTargetQuestionIdentifier(null);
+    List<WaRuleMetadata> ruleMetadataList = Arrays.asList(ruleMetadata);
     Pageable pageable = PageRequest.of(0, 1);
     return new PageImpl<>(ruleMetadataList, pageable, 5);
   }


### PR DESCRIPTION
## Description

The create and view APIs for business rules handle the sourceValue differently. To make the edit and create of a business rule easier, the objects should be updated to have the same structure.

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1768


