### PR TITLE
CNFT2-1773 Fix: Create value set concept effective date

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
@@ -8,6 +8,7 @@ import { Heading } from 'components/heading';
 import { Input } from 'components/FormInputs/Input';
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { initialEntry } from 'apps/patient/add';
+import { externalizeDateTime } from 'date';
 
 interface CodeSystemOption {
     label: string;
@@ -71,7 +72,7 @@ export const CreateConcept = ({
             displayName: data.displayName,
             shortDisplayName: data.displayName,
             effectiveFromTime,
-            effectiveToTime: data.effectiveToTime,
+            effectiveToTime: duration ? externalizeDateTime(data.effectiveToTime)! : undefined,
             statusCode: data.statusCode,
             messagingInfo: {
                 codeSystem: data.messagingInfo.codeSystem,
@@ -218,7 +219,7 @@ export const CreateConcept = ({
                                         <DatePickerInput
                                             id="effectivDate"
                                             name="effectivDate"
-                                            defaultValue={value}
+                                            defaultValue={!duration ? undefined : value}
                                             flexBox
                                             onChange={onChange}
                                             disableFutureDates={false}

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
@@ -72,7 +72,7 @@ export const CreateConcept = ({
             displayName: data.displayName,
             shortDisplayName: data.displayName,
             effectiveFromTime,
-            effectiveToTime: duration ? externalizeDateTime(data.effectiveToTime)! : undefined,
+            effectiveToTime: duration ? externalizeDateTime(data.effectiveToTime) ?? undefined : undefined,
             statusCode: data.statusCode,
             messagingInfo: {
                 codeSystem: data.messagingInfo.codeSystem,

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
@@ -84,7 +84,7 @@ export const EditConcept = ({
                 preferredConceptName: data.messagingInfo.preferredConceptName
             },
             displayName: data.displayName,
-            effectiveToTime: duration ? externalizeDateTime(data.effectiveToTime)! : undefined
+            effectiveToTime: duration ? externalizeDateTime(data.effectiveToTime) ?? undefined : undefined
         };
         await ValueSetControllerService.updateConceptUsingPut({
             authorization: authorization(),

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
@@ -12,6 +12,7 @@ import { authorization } from 'authorization';
 import { Heading } from 'components/heading';
 import { Input } from 'components/FormInputs/Input';
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
+import { externalizeDateTime } from 'date';
 
 interface CodeSystemOption {
     label: string;
@@ -83,7 +84,7 @@ export const EditConcept = ({
                 preferredConceptName: data.messagingInfo.preferredConceptName
             },
             displayName: data.displayName,
-            effectiveToTime: data.effectiveToTime
+            effectiveToTime: duration ? externalizeDateTime(data.effectiveToTime)! : undefined
         };
         await ValueSetControllerService.updateConceptUsingPut({
             authorization: authorization(),


### PR DESCRIPTION
## Description

There was a bug with the format of the effectiveToDate when creating/editing value set concept.

## Tickets

[* [Jira Ticket](url)](https://cdc-nbs.atlassian.net/browse/CNFT2-1773)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
