### PR TITLE
move page create validation to validator. add tests

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPage.tsx
@@ -1,4 +1,5 @@
 import { Button, Form, Modal, ModalRef } from '@trussworks/react-uswds';
+import { useAlert } from 'alert';
 import { CreateCondition } from 'apps/page-builder/components/CreateCondition/CreateCondition';
 import { ImportTemplate } from 'apps/page-builder/components/ImportTemplate/ImportTemplate';
 import { PagesBreadcrumb } from 'apps/page-builder/components/PagesBreadcrumb/PagesBreadcrumb';
@@ -7,10 +8,10 @@ import {
     Concept,
     Condition,
     ConditionControllerService,
+    PageControllerService,
     PageCreateRequest,
     Template
 } from 'apps/page-builder/generated';
-import { createPage } from 'apps/page-builder/services/pagesAPI';
 import { fetchTemplates } from 'apps/page-builder/services/templatesAPI';
 import { fetchMMGOptions } from 'apps/page-builder/services/valueSetAPI';
 import { authorization } from 'authorization';
@@ -41,6 +42,7 @@ export const AddNewPage = () => {
     const [conditions, setConditions] = useState<Condition[]>([]);
     const [mmgs, setMmgs] = useState<Concept[]>([]);
     const [templates, setTemplates] = useState<Template[]>([]);
+    const { alertError } = useAlert();
     const form = useForm<PageCreateRequest>({
         mode: 'onBlur',
         defaultValues: {
@@ -82,14 +84,21 @@ export const AddNewPage = () => {
     };
 
     const onSubmit = form.handleSubmit((data) => {
-        createPage(authorization(), data).then((response) => {
-            if (config.features.pageBuilder.page.management.edit.enabled) {
-                form.reset();
-                navigate(`/page-builder/pages/${response.pageId}/edit`);
-            } else {
-                window.location.href = `/nbs/page-builder/api/v1/pages/${response.pageId}/edit`;
-            }
-        });
+        PageControllerService.createPageUsingPost({
+            authorization: authorization(),
+            request: data
+        })
+            .then((response) => {
+                if (config.features.pageBuilder.page.management.edit.enabled) {
+                    form.reset();
+                    navigate(`/page-builder/pages/${response.pageId}/edit`);
+                } else {
+                    window.location.href = `/nbs/page-builder/api/v1/pages/${response.pageId}/edit`;
+                }
+            })
+            .catch(() => {
+                alertError({ message: 'Failed to create page' });
+            });
     });
 
     const handleConditionCreated = (condition: Condition) => {

--- a/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/AddNewPage/AddNewPageFields.tsx
@@ -126,7 +126,7 @@ export const AddNewPageFields = (props: AddNewPageFieldProps) => {
                         options={props.mmgs.map((m) => {
                             return {
                                 name: m.display ?? '',
-                                value: m.conceptCode ?? ''
+                                value: m.localCode ?? ''
                             };
                         })}
                         error={error?.message}

--- a/apps/modernization-ui/src/apps/page-builder/services/pagesAPI.ts
+++ b/apps/modernization-ui/src/apps/page-builder/services/pagesAPI.ts
@@ -1,10 +1,9 @@
 /* eslint-disable camelcase */
 import {
     PageControllerService,
-    Page_PageSummary_,
-    PagesService,
     PageSummaryService,
-    PageCreateRequest
+    Page_PageSummary_,
+    PagesService
 } from 'apps/page-builder/generated';
 
 export const fetchPageSummaries = (
@@ -20,15 +19,6 @@ export const fetchPageSummaries = (
         page: currentPage && currentPage > 1 ? currentPage - 1 : 0,
         size: pageSize,
         sort
-    });
-};
-
-export const createPage = (token: string, request: PageCreateRequest) => {
-    return PageControllerService.createPageUsingPost({
-        authorization: token,
-        request
-    }).then((response: any) => {
-        return response;
     });
 };
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageCreator.java
@@ -14,7 +14,6 @@ import gov.cdc.nbs.questionbank.entity.repository.WaTemplateRepository;
 import gov.cdc.nbs.questionbank.entity.repository.WaUiMetadataRepository;
 import gov.cdc.nbs.questionbank.page.exception.PageCreateException;
 import gov.cdc.nbs.questionbank.page.request.PageCreateRequest;
-import gov.cdc.nbs.questionbank.page.request.PageValidationRequest;
 import gov.cdc.nbs.questionbank.page.response.PageCreateResponse;
 import gov.cdc.nbs.questionbank.page.util.PageConstants;
 
@@ -39,26 +38,7 @@ public class PageCreator {
   }
 
     public PageCreateResponse createPage(PageCreateRequest request, Long userId) {
-        if (request.name() == null || request.name().isEmpty()) {
-            throw new PageCreateException(PageConstants.ADD_PAGE_NAME_EMPTY);
-        }
-
-        if (request.eventType() == null || request.eventType().isEmpty()) {
-            throw new PageCreateException(PageConstants.ADD_PAGE_EVENTTYPE_EMPTY);
-        }
-
-        if (request.templateId() == null || request.templateId().intValue() < 1) {
-            throw new PageCreateException(PageConstants.ADD_PAGE_TEMPLATE_EMPTY);
-        }
-
-        if (request.messageMappingGuide() == null || request.messageMappingGuide().isEmpty()) {
-            throw new PageCreateException(PageConstants.ADD_PAGE_MMG_EMPTY);
-        }
-
-        if (!validator.validate(new PageValidationRequest(request.name()))) {
-            String finalMessage = String.format(PageConstants.ADD_PAGE_TEMPLATENAME_EXISTS, request.name());
-            throw new PageCreateException(finalMessage);
-        }
+       validator.validate(request);
 
         if (request.dataMartName() != null && !request.dataMartName().isEmpty()) {
             Optional<WaTemplate> existingDataMartNm = templateRepository.findFirstByDatamartNm(request.dataMartName());

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageValidator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageValidator.java
@@ -2,12 +2,17 @@ package gov.cdc.nbs.questionbank.page;
 
 import org.springframework.stereotype.Component;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.questionbank.entity.QCodeValueGeneral;
 import gov.cdc.nbs.questionbank.entity.QWaTemplate;
+import gov.cdc.nbs.questionbank.page.exception.PageCreateException;
+import gov.cdc.nbs.questionbank.page.request.PageCreateRequest;
 import gov.cdc.nbs.questionbank.page.request.PageValidationRequest;
+import gov.cdc.nbs.questionbank.page.util.PageConstants;
 
 @Component
 public class PageValidator {
   private static final QWaTemplate pageTable = QWaTemplate.waTemplate;
+  private static final QCodeValueGeneral codeValueGeneral = QCodeValueGeneral.codeValueGeneral;
 
   private final JPAQueryFactory factory;
 
@@ -15,11 +20,46 @@ public class PageValidator {
     this.factory = factory;
   }
 
-  public boolean validate(PageValidationRequest request) {
+  boolean validate(PageValidationRequest request) {
     return factory.select(pageTable.id.count())
         .from(pageTable)
         .where(pageTable.templateNm.toLowerCase().eq(request.name().toLowerCase()))
         .fetchFirst() == 0;
+  }
+
+  void validate(PageCreateRequest request) {
+    if (request.name() == null || request.name().isEmpty()) {
+      throw new PageCreateException(PageConstants.ADD_PAGE_NAME_EMPTY);
+    }
+
+    if (request.eventType() == null || request.eventType().isEmpty()) {
+      throw new PageCreateException(PageConstants.ADD_PAGE_EVENTTYPE_EMPTY);
+    }
+
+    if (request.templateId() == null || request.templateId().intValue() < 1) {
+      throw new PageCreateException(PageConstants.ADD_PAGE_TEMPLATE_EMPTY);
+    }
+
+    if (request.messageMappingGuide() == null || request.messageMappingGuide().isEmpty()) {
+      throw new PageCreateException(PageConstants.ADD_PAGE_MMG_EMPTY);
+    }
+
+    if (!validate(new PageValidationRequest(request.name()))) {
+      String finalMessage = String.format(PageConstants.ADD_PAGE_TEMPLATENAME_EXISTS, request.name());
+      throw new PageCreateException(finalMessage);
+    }
+
+    validateMmg(request.messageMappingGuide());
+  }
+
+  void validateMmg(String code) {
+    boolean exists = factory.select(codeValueGeneral.id.code.count())
+        .from(codeValueGeneral)
+        .where(codeValueGeneral.id.code.equalsIgnoreCase(code))
+        .fetchFirst() == 1;
+    if (!exists) {
+      throw new PageCreateException(PageConstants.ADD_PAGE_MMG_INVALID);
+    }
   }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/PageConstants.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/util/PageConstants.java
@@ -23,7 +23,8 @@ public class PageConstants {
 	public static final String ADD_PAGE_EVENTTYPE_EMPTY = "EventType is required.";
 	public static final String ADD_PAGE_TEMPLATE_EMPTY = "Template is required.";
 	public static final String ADD_PAGE_DATAMART_NAME_EXISTS = "A Page with Data Mart Name %s already exists in the system";
-	public static final String ADD_PAGE_MMG_EMPTY = "MMG is required.";
+	public static final String ADD_PAGE_MMG_EMPTY = "Reporting mechanism is required.";
+	public static final String ADD_PAGE_MMG_INVALID = "Invalid reporting mechanism provided.";
 	
 	//Page Details
 	public static final Long PAGE_COMPONENT = 1002L;

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageValidatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageValidatorTest.java
@@ -1,7 +1,9 @@
 package gov.cdc.nbs.questionbank.page;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -10,11 +12,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import gov.cdc.nbs.questionbank.entity.QCodeValueGeneral;
 import gov.cdc.nbs.questionbank.entity.QWaTemplate;
+import gov.cdc.nbs.questionbank.page.exception.PageCreateException;
+import gov.cdc.nbs.questionbank.page.request.PageCreateRequest;
 import gov.cdc.nbs.questionbank.page.request.PageValidationRequest;
 
 @ExtendWith(MockitoExtension.class)
 class PageValidatorTest {
+  private static final QWaTemplate pageTable = QWaTemplate.waTemplate;
+  private static final QCodeValueGeneral codeValueGeneral = QCodeValueGeneral.codeValueGeneral;
 
   @Mock
   private JPAQueryFactory factory;
@@ -29,9 +36,9 @@ class PageValidatorTest {
     // Given a page name that is not being used
     PageValidationRequest request = new PageValidationRequest("some name");
     JPAQuery<Long> query = Mockito.mock(JPAQuery.class);
-    when(factory.select(QWaTemplate.waTemplate.id.count())).thenReturn(query);
-    when(query.from(QWaTemplate.waTemplate)).thenReturn(query);
-    when(query.where(QWaTemplate.waTemplate.templateNm.toLowerCase().eq(request.name().toLowerCase())))
+    when(factory.select(pageTable.id.count())).thenReturn(query);
+    when(query.from(pageTable)).thenReturn(query);
+    when(query.where(pageTable.templateNm.toLowerCase().eq(request.name().toLowerCase())))
         .thenReturn(query);
     when(query.fetchFirst()).thenReturn(0l);
 
@@ -48,9 +55,9 @@ class PageValidatorTest {
     // Given a page name that is used
     PageValidationRequest request = new PageValidationRequest("some name");
     JPAQuery<Long> query = Mockito.mock(JPAQuery.class);
-    when(factory.select(QWaTemplate.waTemplate.id.count())).thenReturn(query);
-    when(query.from(QWaTemplate.waTemplate)).thenReturn(query);
-    when(query.where(QWaTemplate.waTemplate.templateNm.toLowerCase().eq(request.name().toLowerCase())))
+    when(factory.select(pageTable.id.count())).thenReturn(query);
+    when(query.from(pageTable)).thenReturn(query);
+    when(query.where(pageTable.templateNm.toLowerCase().eq(request.name().toLowerCase())))
         .thenReturn(query);
     when(query.fetchFirst()).thenReturn(1l);
 
@@ -59,5 +66,227 @@ class PageValidatorTest {
 
     // Then the name is valid
     assertThat(isValid).isFalse();
+  }
+
+  @Test
+  void should_be_valid_mmg() {
+    // Given a mmg code that is valid
+    String code = "mmgCode";
+    validMmg(code);
+    validator.validateMmg(code);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void should_be_invalid_mmg() {
+    // Given a mmg code that is valid
+    String code = "mmgCode";
+    JPAQuery<Long> query = Mockito.mock(JPAQuery.class);
+    when(factory.select(codeValueGeneral.id.code.count())).thenReturn(query);
+    when(query.from(codeValueGeneral)).thenReturn(query);
+    when(query.where(codeValueGeneral.id.code.equalsIgnoreCase(code)))
+        .thenReturn(query);
+    when(query.fetchFirst()).thenReturn(0l);
+    assertThrows(PageCreateException.class, () -> validator.validateMmg(code));
+  }
+
+  @Test
+  void page_name_is_blank() {
+    PageCreateRequest request =
+        new PageCreateRequest("INV",
+            Arrays.asList("1023"),
+            "",
+            10l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void page_name_is_null() {
+    PageCreateRequest request =
+        new PageCreateRequest("INV",
+            Arrays.asList("1023"),
+            null,
+            10l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void event_type_is_blank() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "",
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void event_type_is_null() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            null,
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void template_id_is_0() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            0l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void template_id_is_null() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            null,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void mmg_is_blank() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            "",
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  void mmg_is_null() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            null,
+            "unit test",
+            "dataMart");
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mmg_is_invalid() {
+    // Given an invalid MMG
+    String code = "mmgCode";
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            code,
+            "unit test",
+            "dataMart");
+    JPAQuery<Long> query = Mockito.mock(JPAQuery.class);
+    when(factory.select(codeValueGeneral.id.code.count())).thenReturn(query);
+    when(query.from(codeValueGeneral)).thenReturn(query);
+    when(query.where(codeValueGeneral.id.code.equalsIgnoreCase(code)))
+        .thenReturn(query);
+    when(query.fetchFirst()).thenReturn(0l);
+
+    // and a valid name
+    JPAQuery<Long> nameQuery = Mockito.mock(JPAQuery.class);
+    when(factory.select(pageTable.id.count())).thenReturn(nameQuery);
+    when(nameQuery.from(pageTable)).thenReturn(nameQuery);
+    when(nameQuery.where(pageTable.templateNm.toLowerCase().eq(request.name().toLowerCase())))
+        .thenReturn(nameQuery);
+    when(nameQuery.fetchFirst()).thenReturn(0l);
+
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void name_is_invalid() {
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+
+    // and an ivalid name
+    JPAQuery<Long> nameQuery = Mockito.mock(JPAQuery.class);
+    when(factory.select(pageTable.id.count())).thenReturn(nameQuery);
+    when(nameQuery.from(pageTable)).thenReturn(nameQuery);
+    when(nameQuery.where(pageTable.templateNm.toLowerCase().eq(request.name().toLowerCase())))
+        .thenReturn(nameQuery);
+    when(nameQuery.fetchFirst()).thenReturn(1l);
+
+    assertThrows(PageCreateException.class, () -> validator.validate(request));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void should_validate() {
+    // given a valid mmg
+    validMmg("HEP_Case_Map_V1.0");
+    PageCreateRequest request =
+        new PageCreateRequest(
+            "INV",
+            Arrays.asList("1023"),
+            "page name",
+            10l,
+            "HEP_Case_Map_V1.0",
+            "unit test",
+            "dataMart");
+    // and a valid name
+    JPAQuery<Long> nameQuery = Mockito.mock(JPAQuery.class);
+    when(factory.select(pageTable.id.count())).thenReturn(nameQuery);
+    when(nameQuery.from(pageTable)).thenReturn(nameQuery);
+    when(nameQuery.where(pageTable.templateNm.toLowerCase().eq(request.name().toLowerCase())))
+        .thenReturn(nameQuery);
+    when(nameQuery.fetchFirst()).thenReturn(0l);
+    validator.validate(request);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void validMmg(String code) {
+    JPAQuery<Long> query = Mockito.mock(JPAQuery.class);
+    when(factory.select(codeValueGeneral.id.code.count())).thenReturn(query);
+    when(query.from(codeValueGeneral)).thenReturn(query);
+    when(query.where(codeValueGeneral.id.code.equalsIgnoreCase(code)))
+        .thenReturn(query);
+    when(query.fetchFirst()).thenReturn(1l);
   }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/create/PageCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/create/PageCreatorTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -62,48 +61,10 @@ class PageCreatorTest {
     WaTemplate page = pageCreator.buildPage(request, "INV", 10l);
     page.setId(id);
     when(templateRepository.save(Mockito.any())).thenReturn(page);
-    when(validator.validate(Mockito.any())).thenReturn(true);
     PageCreateResponse response = pageCreator.createPage(request, 1l);
     assertEquals(page.getId(), response.pageId());
     assertEquals(page.getTemplateNm(), response.pageName());
     assertEquals(page.getTemplateNm() + PageConstants.ADD_PAGE_MESSAGE, response.message());
-  }
-
-  @Test
-  void testCreatePageTemplateNameExists() {
-    WaTemplate existing = getTemplate(10l);
-    String templateName = "TestPageExist";
-    PageCreateRequest request =
-        new PageCreateRequest("INV", Arrays.asList("1023"), templateName, 10l, "HEP_Case_Map_V1.0",
-            "unit test", "dataMart");
-
-    existing.setTemplateNm(templateName);
-    when(validator.validate(Mockito.any())).thenReturn(false);
-
-
-    String finalMessage = String.format(PageConstants.ADD_PAGE_TEMPLATENAME_EXISTS, templateName);
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(finalMessage, exception.getMessage());
-  }
-
-
-  @Test
-  void testCreatePageDataMartNameExist() {
-    when(validator.validate(Mockito.any())).thenReturn(true);
-    WaTemplate existing = getTemplate(10l);
-    String dataMartNm = "dataMartExist";
-    PageCreateRequest request =
-        new PageCreateRequest("INV", Arrays.asList("1023"), "TestPage", 10l, "HEP_Case_Map_V1.0",
-            "unit test", dataMartNm);
-
-    String finalMessage = String.format(PageConstants.ADD_PAGE_DATAMART_NAME_EXISTS,
-        dataMartNm);
-    existing.setDatamartNm(dataMartNm);
-    when(templateRepository.findFirstByDatamartNm(Mockito.any())).thenReturn(Optional.of(existing));
-
-
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(finalMessage, exception.getMessage());
   }
 
   @Test
@@ -165,16 +126,6 @@ class PageCreatorTest {
 
     var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
     assertEquals(PageConstants.ADD_PAGE_MMG_EMPTY, exception.getMessage());
-  }
-
-  @Test
-  void testCreatePageException() {
-    when(validator.validate(Mockito.any())).thenReturn(true);
-    final String message = "Could not find page invalid id provided";
-    when(templateRepository.save(Mockito.any())).thenThrow(new IllegalArgumentException(message));
-    PageCreateRequest request = pageRequest();
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(PageConstants.ADD_PAGE_FAIL, exception.getMessage());
   }
 
   @Test

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/create/PageCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/create/PageCreatorTest.java
@@ -2,7 +2,6 @@ package gov.cdc.nbs.questionbank.page.create;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,7 +20,6 @@ import gov.cdc.nbs.questionbank.entity.repository.WaTemplateRepository;
 import gov.cdc.nbs.questionbank.entity.repository.WaUiMetadataRepository;
 import gov.cdc.nbs.questionbank.page.PageCreator;
 import gov.cdc.nbs.questionbank.page.PageValidator;
-import gov.cdc.nbs.questionbank.page.exception.PageCreateException;
 import gov.cdc.nbs.questionbank.page.request.PageCreateRequest;
 import gov.cdc.nbs.questionbank.page.response.PageCreateResponse;
 import gov.cdc.nbs.questionbank.page.util.PageConstants;
@@ -67,66 +65,6 @@ class PageCreatorTest {
     assertEquals(page.getTemplateNm() + PageConstants.ADD_PAGE_MESSAGE, response.message());
   }
 
-  @Test
-  void testCreatePageNOName() {
-    PageCreateRequest request = new PageCreateRequest(
-        null,
-        Arrays.asList(),
-        null,
-        0l,
-        "HEP_Case_Map_V1.0",
-        "unit test", "dataMart");
-
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(PageConstants.ADD_PAGE_NAME_EMPTY, exception.getMessage());
-  }
-
-  @Test
-  void testCreatePageNOEventType() {
-    PageCreateRequest request =
-        new PageCreateRequest(
-            null,
-            Arrays.asList("1023"),
-            "TestPage",
-            0l,
-            "HEP_Case_Map_V1.0",
-            "unit test",
-            "dataMart");
-
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(PageConstants.ADD_PAGE_EVENTTYPE_EMPTY, exception.getMessage());
-  }
-
-  @Test
-  void testCreatePageNOTemplate() {
-    PageCreateRequest request =
-        new PageCreateRequest(
-            "INV",
-            Arrays.asList("1023"),
-            "TestPage",
-            0l,
-            "HEP_Case_Map_V1.0",
-            "unit test",
-            "dataMart");
-
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(PageConstants.ADD_PAGE_TEMPLATE_EMPTY, exception.getMessage());
-  }
-
-  @Test
-  void testCreatePageNOMMG() {
-    PageCreateRequest request = new PageCreateRequest(
-        "INV",
-        Arrays.asList("1023"),
-        "TestPage",
-        10l,
-        null,
-        "unit test",
-        "dataMart");
-
-    var exception = assertThrows(PageCreateException.class, () -> pageCreator.createPage(request, 1l));
-    assertEquals(PageConstants.ADD_PAGE_MMG_EMPTY, exception.getMessage());
-  }
 
   @Test
   void testCopyWaTemplateUIMetaData() {


### PR DESCRIPTION
## Description

When creating a new page and specifying the reporting mechanism, the selected entry is not visible in the NBS Classic edit details screen. 

This was due to the create page form providing an incorrect value for the reporting mechanism, and the back-end did no validation of it.

To resolve the issue, this PR updates the frontend to provide the correct value and adds validation to the page create to verify the specified reporting mechanism exists.

## Tickets

* [CNFT2-1831](https://cdc-nbs.atlassian.net/browse/CNFT2-1831)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1831]: https://cdc-nbs.atlassian.net/browse/CNFT2-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ