### PR TITLE
Fix menu size, hide filter on click

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
@@ -20,14 +20,14 @@ const PageLibraryMenu = ({ properties, filters, onSearch, onFilter, onDownload, 
     const [overlayVisible, setOverlayVisible] = useState<boolean>(false);
     return (
         <section className={styles.menu}>
-            <FilterDisplay onClickFilter={() => setOverlayVisible(true)} filters={filters} />
+            <FilterDisplay onClickFilter={() => setOverlayVisible(!overlayVisible)} filters={filters} />
             <OverlayPanel
                 position="right"
                 overlayVisible={overlayVisible}
                 toggle={() => (
                     <Button
                         type="button"
-                        onClick={() => setOverlayVisible(true)}
+                        onClick={() => setOverlayVisible(!overlayVisible)}
                         outline
                         className={styles.filterButton}>
                         <Icon.FilterAlt />

--- a/apps/modernization-ui/src/apps/page-builder/page/library/menu/page-library-menu.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/menu/page-library-menu.module.scss
@@ -14,6 +14,7 @@
     }
 
     .search {
+        height: 2.5rem;
         input {
             min-width: 36ch;
         }
@@ -23,11 +24,13 @@
         padding-inline-start: 0;
         margin: 0;
         display: flex;
-        align-items: center;
+        height: 2.5rem;
 
         > a,
         > button {
             background-color: colors.$base-white;
+            display: flex;
+            align-items: center;
 
             &:hover {
                 background-color: colors.$base-white;


### PR DESCRIPTION
## Description

CNFT2-1788 - Menu button sizes were inconsistent by a couple of px. Updated to have fixed size
CNFT2-1787 - Made the filter button toggle instead of open only

## Tickets

* [CNFT2-1788](https://cdc-nbs.atlassian.net/browse/CNFT2-1788)
* [CNFT2-1787](https://cdc-nbs.atlassian.net/browse/CNFT2-1787)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1788]: https://cdc-nbs.atlassian.net/browse/CNFT2-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT2-1787]: https://cdc-nbs.atlassian.net/browse/CNFT2-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ