### PR TITLE
Prevent added questions from displaying in search table (pt 2)

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/modal/AddQuestionModal.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/modal/AddQuestionModal.tsx
@@ -1,10 +1,12 @@
 import { Icon, Modal, ModalRef } from '@trussworks/react-uswds';
-import { RefObject, useState } from 'react';
-import { QuestionSearch } from '../search/QuestionSearch';
-import styles from './add-question-modal.module.scss';
-import './AddQuestionModal.scss';
-import { CreateQuestion } from 'apps/page-builder/components/CreateQuestion/CreateQuestion';
 import { CloseableHeader } from 'apps/page-builder/components/CloseableHeader/CloseableHeader';
+import { CreateQuestion } from 'apps/page-builder/components/CreateQuestion/CreateQuestion';
+import { PageProvider, usePage } from 'page';
+import { RefObject, useEffect, useState } from 'react';
+import { QuestionSearch } from '../search/QuestionSearch';
+import './AddQuestionModal.scss';
+import styles from './add-question-modal.module.scss';
+import { usePageManagement } from '../../../usePageManagement';
 
 type Props = {
     modal: RefObject<ModalRef>;
@@ -12,16 +14,34 @@ type Props = {
     onClose?: (questions: number[]) => void;
     valueSetModalRef: RefObject<ModalRef>;
 };
-export const AddQuestionModal = ({ pageId, modal, onClose, valueSetModalRef }: Props) => {
+
+export const AddQuestionModal = (props: Props) => {
+    return (
+        <PageProvider>
+            <AddQuestionModalContent {...props} />
+        </PageProvider>
+    );
+};
+
+const AddQuestionModalContent = ({ pageId, modal, onClose, valueSetModalRef }: Props) => {
     const [state, setState] = useState<'search' | 'add'>('search');
+    const { page } = usePageManagement();
+    const { firstPage } = usePage();
 
     const handleClose = (questions?: number[]) => {
         if (onClose) {
             onClose(questions ?? []);
         }
         setState('search');
+        if (!questions) {
+            firstPage();
+        }
         modal.current?.toggleModal(undefined, false);
     };
+
+    useEffect(() => {
+        firstPage();
+    }, [JSON.stringify(page)]);
 
     return (
         <Modal

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/QuestionSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/QuestionSearch.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@trussworks/react-uswds';
 import { AddableQuestionSort, useFindAddableQuestions } from 'apps/page-builder/hooks/api/useFindAvailableQuestions';
 import { SelectionMode } from 'components/Table';
-import { PageProvider, Status, usePage } from 'page';
+import { Status, usePage } from 'page';
 import { useEffect, useState } from 'react';
 
 import { QuestionSearchTable } from './table/QuestionSearchTable';
@@ -9,25 +9,18 @@ import { CloseableHeader } from 'apps/page-builder/components/CloseableHeader/Cl
 import { ButtonBar } from 'apps/page-builder/components/ButtonBar/ButtonBar';
 import styles from './question-search.module.scss';
 
-export const QuestionSearch = (props: Props) => (
-    <PageProvider>
-        <QuestionSearchContent {...props} />
-    </PageProvider>
-);
-
 type Props = {
     pageId: number;
     onCreateNew: () => void;
     onCancel: () => void;
     onAccept: (questions: number[]) => void;
 };
-const QuestionSearchContent = ({ pageId, onCreateNew, onCancel, onAccept }: Props) => {
+export const QuestionSearch = ({ pageId, onCreateNew, onCancel, onAccept }: Props) => {
     const { page, ready, firstPage, reload } = usePage();
     const [query, setQuery] = useState<string>('');
     const [sort, setSort] = useState<AddableQuestionSort | undefined>(undefined);
     const { isLoading, search, response } = useFindAddableQuestions();
     const [selectedQuestions, setSelectedQuestions] = useState<number[]>([]);
-    const [resetTable, setResetTable] = useState<boolean>(false);
 
     useEffect(() => {
         search({ pageId });
@@ -69,23 +62,15 @@ const QuestionSearchContent = ({ pageId, onCreateNew, onCancel, onAccept }: Prop
 
     const handleAccept = () => {
         setSelectedQuestions([]);
-        setResetTable(true);
+        setQuery('');
         onAccept(selectedQuestions);
     };
 
     const handleClose = () => {
         setQuery('');
         setSelectedQuestions([]);
-        setResetTable(true);
         onCancel();
     };
-
-    useEffect(() => {
-        if (resetTable) {
-            firstPage();
-            setResetTable(false);
-        }
-    }, [resetTable]);
 
     return (
         <>
@@ -94,18 +79,15 @@ const QuestionSearchContent = ({ pageId, onCreateNew, onCancel, onAccept }: Prop
                 <div className={styles.subHeading}>
                     <div className={styles.helpText}>You can search for an existing question or create a new one</div>
                 </div>
-                {!resetTable && (
-                    <QuestionSearchTable
-                        questions={response?.content ?? []}
-                        isLoading={isLoading}
-                        query={query}
-                        onQuerySubmit={(query) => setQuery(query)}
-                        onSortChange={setSort}
-                        onSelectionChange={handleSelectedQuestionChange}
-                        onCreateNew={onCreateNew}
-                    />
-                )}
-
+                <QuestionSearchTable
+                    questions={response?.content ?? []}
+                    isLoading={isLoading}
+                    query={query}
+                    onQuerySubmit={(query) => setQuery(query)}
+                    onSortChange={setSort}
+                    onSelectionChange={handleSelectedQuestionChange}
+                    onCreateNew={onCreateNew}
+                />
                 {response?.content?.length === 0 && (
                     <div className={styles.createNewNotification}>
                         <div className={styles.message}>Can't find what you're looking for?</div>


### PR DESCRIPTION
## Description

Trigger table fetch on page content change. This prevents newly created / added questions from still appearing in the search results.

I was doing some dumb things to force the table to refresh when the modal was closed, i removed that and moved the PageProvider up a level to be able to trigger the `firstPage` call when a close action occurred. I also added a useEffect that monitors the current page content. If this content changes, a new fetch is made to refresh the table content. This prevents questions from showing up in the search that have just been added to the page.

## Tickets

* [CNFT2-1811](https://cdc-nbs.atlassian.net/browse/CNFT2-1811)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1811]: https://cdc-nbs.atlassian.net/browse/CNFT2-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ