### PR TITLE
Add text on each side of toggles

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/CreateQuestion/CreateQuestion.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/CreateQuestion/CreateQuestion.scss
@@ -98,6 +98,11 @@
         .mandatory-indicator {
             color: #d83933;
         }
+        .create-question-toggle-group {
+          display: flex;
+          gap: 1rem;
+          align-items: center;
+        }
     }
     .submit-btn {
         float: right;

--- a/apps/modernization-ui/src/apps/page-builder/components/CreateQuestion/CreateQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/CreateQuestion/CreateQuestion.tsx
@@ -672,15 +672,16 @@ export const CreateQuestion = ({ onAddQuestion, question, onCloseModal, addValue
                             control={control}
                             name="includedInMessage"
                             render={({ field: { onChange, value } }) => (
-                                <>
+                                <div className="create-question-toggle-group">
+                                    <div>Not required</div>
                                     <ToggleButton
-                                        className="margin-bottom-1em"
                                         checked={value}
                                         disabled={readOnlyControl}
                                         name="includedInMessage"
                                         onChange={onChange}
                                     />
-                                </>
+                                    <div>Required</div>
+                                </div>
                             )}
                         />
                         <Controller
@@ -748,7 +749,8 @@ export const CreateQuestion = ({ onAddQuestion, question, onCloseModal, addValue
                             control={control}
                             name="requiredInMessage"
                             render={({ field: { onChange, value } }) => (
-                                <>
+                                <div className="create-question-toggle-group">
+                                    <div>Not required</div>
                                     <ToggleButton
                                         className="requiredInMessage"
                                         checked={value}
@@ -756,7 +758,8 @@ export const CreateQuestion = ({ onAddQuestion, question, onCloseModal, addValue
                                         disabled={IsIncludedInMessage}
                                         onChange={onChange}
                                     />
-                                </>
+                                    <div>Required</div>
+                                </div>
                             )}
                         />
                         <br></br>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -45,8 +45,9 @@ export const QuestionHeader = ({ question, onRequiredChange, onEditQuestion, onD
                 <Icon.Edit style={{ cursor: 'pointer' }} size={3} className="primary-color" onClick={onEditQuestion} />
                 {!question.isStandard && <DeleteQuestion onDelete={onDeleteQuestion} />}
                 <div className={styles.divider}>|</div>
-                <div className={styles.requiredToggle}>Required</div>
+                <div className={styles.requiredToggle}>Not required</div>
                 <ToggleButton defaultChecked={question.required} onChange={onRequiredChange} />
+                <div className={styles.requiredToggle}>Required</div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Description

Any toggle in Page Builder should have text on each side making it clear as to what the current setting indicates

## Tickets

* [CNFT2-1766](https://cdc-nbs.atlassian.net/browse/CNFT2-1766)
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/6507f34b-7bdd-448a-9260-6c1fa67d0f6e)
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/fde8f9b4-c475-450c-a359-3bdfc7c754ee)
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/bc9200f9-d018-4a0a-8038-ab32f667ee93)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-1766]: https://cdc-nbs.atlassian.net/browse/CNFT2-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ