### PR TITLE
CNFT2-1758 Fix: Value set concepts

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/Concept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/Concept.tsx
@@ -23,11 +23,11 @@ export const Concept = ({ valueset }: Props) => {
     const { searchQuery, sortDirection, currentPage, pageSize } = useContext(ConceptsContext);
     const [summaries, setSummaries] = useState([]);
     const [totalElements, setTotalElements] = useState(0);
-    const [isShowFrom, setShowForm] = useState(false);
+    const [showForm, setShowForm] = useState(false);
     const [codeSystemOptionList, setCodeSystemOptionList] = useState<CodeSystemOption[]>([]);
     const [editMode, setEditMode] = useState(false);
     const [alertMessage, setAlertMessage] = useState<AlertMessage | undefined>(undefined);
-    type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number };
+    type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number | undefined };
 
     const fetchContent = async () => {
         try {
@@ -46,11 +46,11 @@ export const Concept = ({ valueset }: Props) => {
     }, [searchQuery, currentPage, pageSize, sortDirection]);
 
     useEffect(() => {
-        selectedConcept.status && setShowForm(!isShowFrom);
+        selectedConcept.status && setShowForm(!showForm);
     }, [selectedConcept]);
 
     useEffect(() => {
-        setTimeout(() => setAlertMessage(undefined), 3000);
+        setTimeout(() => setAlertMessage(undefined), 5000);
     }, [alertMessage]);
 
     const updateCallback = () => {
@@ -99,7 +99,7 @@ export const Concept = ({ valueset }: Props) => {
                     {alertMessage.message}
                 </AlertBanner>
             )}
-            {isShowFrom ? (
+            {showForm ? (
                 editMode ? (
                     <EditConcept
                         valueset={valueset}
@@ -108,6 +108,7 @@ export const Concept = ({ valueset }: Props) => {
                         setShowForm={() => setShowForm(false)}
                         updateCallback={updateCallback}
                         setAlertMessage={setAlertMessage}
+                        closeForm={() => setShowForm(false)}
                     />
                 ) : (
                     <CreateConcept
@@ -116,6 +117,7 @@ export const Concept = ({ valueset }: Props) => {
                         setShowForm={() => setShowForm(false)}
                         updateCallback={updateCallback}
                         setAlertMessage={setAlertMessage}
+                        closeForm={() => setShowForm(false)}
                     />
                 )
             ) : (
@@ -151,7 +153,7 @@ export const Concept = ({ valueset }: Props) => {
                             type="submit"
                             onClick={() => {
                                 setEditMode(false);
-                                setShowForm(!isShowFrom);
+                                setShowForm(!showForm);
                             }}>
                             <span>Add New concept</span>
                         </Button>

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.spec.tsx
@@ -38,7 +38,7 @@ describe('When EditConcept form renders', () => {
                 pageSize: 10,
                 setPageSize: () => {}
             }}>
-                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
+                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} closeForm={jest.fn()} />
             </ConceptsProvider>
         );
 
@@ -66,7 +66,7 @@ describe('When EditConcept form renders', () => {
                 pageSize: 10,
                 setPageSize: () => {}
             }}>
-                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
+                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} closeForm={jest.fn()} />
             </ConceptsProvider>
         );
         const inputs = container.getElementsByClassName('usa-input');
@@ -88,7 +88,7 @@ describe('When EditConcept form renders', () => {
                 pageSize: 10,
                 setPageSize: () => {}
             }}>
-                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
+                <CreateConcept valueset={valueset} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} closeForm={jest.fn()} />
             </ConceptsProvider>
         );
         const buttons = container.getElementsByTagName('button');

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
@@ -102,7 +102,6 @@ export const CreateConcept = ({
                 return response;
             })
             .catch((error: any) => {
-                console.log(error.body);
                 setAlertMessage({
                     type: 'error',
                     expiration: undefined,

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/CreateConcept/CreateConcept.tsx
@@ -32,7 +32,7 @@ const init = {
     shortDisplayName: undefined,
     statusCode: AddConceptRequest.statusCode.A
 };
-type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number };
+type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number | undefined };
 
 type Props = {
     valueset: ValueSet;
@@ -40,6 +40,7 @@ type Props = {
     setShowForm: () => void;
     updateCallback: () => void;
     setAlertMessage: (message: AlertMessage) => void;
+    closeForm: () => void;
 };
 
 export const CreateConcept = ({
@@ -47,7 +48,8 @@ export const CreateConcept = ({
     codeSystemOptionList,
     setShowForm,
     updateCallback,
-    setAlertMessage
+    setAlertMessage,
+    closeForm
 }: Props) => {
     const [duration, setDuration] = useState(false);
     const conceptForm = useForm<AddConceptRequest>({
@@ -100,11 +102,13 @@ export const CreateConcept = ({
                 return response;
             })
             .catch((error: any) => {
+                console.log(error.body);
                 setAlertMessage({
                     type: 'error',
-                    expiration: 3000,
-                    message: <p>{error.message}</p>
+                    expiration: undefined,
+                    message: <p>{error.body.message}</p>
                 });
+                closeForm();
             });
     };
 

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.spec.tsx
@@ -25,7 +25,7 @@ describe('When EditConcept form renders', () => {
 
     it('should disable Local code field', () => {
         const { container } = render(
-            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
+            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} closeForm={jest.fn()} />
         );
         const inputs = container.getElementsByClassName('usa-input');
         expect(inputs[1]).toBeDisabled();
@@ -33,7 +33,7 @@ describe('When EditConcept form renders', () => {
 
     it('should display UI display name', async () => {
         const { container } = render(
-            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
+            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} closeForm={jest.fn()} />
         );
         const inputs = container.getElementsByTagName('input');
         expect(inputs.length).toBe(13);
@@ -41,7 +41,7 @@ describe('When EditConcept form renders', () => {
 
     it('should display UI display name', async () => {
         const { container } = render(
-            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} />
+            <EditConcept valueset={valueset} selectedConcept={selectedConcept} codeSystemOptionList={options} setShowForm={jest.fn()} updateCallback={jest.fn()} setAlertMessage={jest.fn()} closeForm={jest.fn()} />
         );
         expect(screen.getAllByDisplayValue('Test concept display')).toHaveLength(1);
         expect(screen.getAllByDisplayValue('ZZZ')).toHaveLength(2);

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
@@ -26,8 +26,9 @@ type Props = {
     setShowForm: () => void;
     updateCallback: () => void;
     setAlertMessage: (message: AlertMessage) => void;
+    closeForm: () => void;
 };
-type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number };
+type AlertMessage = { type: 'error' | 'success'; message: string | ReactNode; expiration: number | undefined };
 
 export const EditConcept = ({
     valueset,
@@ -35,7 +36,8 @@ export const EditConcept = ({
     codeSystemOptionList,
     setShowForm,
     updateCallback,
-    setAlertMessage
+    setAlertMessage,
+    closeForm
 }: Props) => {
     const [duration, setDuration] = useState(false);
     const init = {
@@ -106,11 +108,13 @@ export const EditConcept = ({
                 return response;
             })
             .catch((error: any) => {
+                console.log(error.body);
                 setAlertMessage({
                     type: 'error',
-                    expiration: 3000,
-                    message: <p>{error.message}</p>
+                    expiration: undefined,
+                    message: <p>{error.body.message}</p>
                 });
+                closeForm();
             });
     };
 

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/EditConcept/EditConcept.tsx
@@ -108,7 +108,6 @@ export const EditConcept = ({
                 return response;
             })
             .catch((error: any) => {
-                console.log(error.body);
                 setAlertMessage({
                     type: 'error',
                     expiration: undefined,

--- a/apps/modernization-ui/src/apps/page-builder/components/Concept/SearchBar.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/Concept/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { Input } from 'components/FormInputs/Input';
 import { Button, Icon, Tag } from '@trussworks/react-uswds';
 import { useState } from 'react';
+import '../../pages/QuestionLibrary/QuestionLibrary.scss';
 export const SearchBar = ({ onChange }: any) => {
     const [searchTags, setSearchTags] = useState<any>([]);
     const [search, setSearch] = useState<string>('');


### PR DESCRIPTION
## Description
Here we improve the user experience by improving the alerts when a Value set concept cannot be created/edited.

## Tickets

* [CNFT2-1758](https://cdc-nbs.atlassian.net/browse/CNFT2-1758)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1758]: https://cdc-nbs.atlassian.net/browse/CNFT2-1758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ