### PR TITLE
Implement error display functionality for duplicate Unique ID

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionController.java
@@ -1,6 +1,5 @@
 package gov.cdc.nbs.questionbank.question;
 
-import gov.cdc.nbs.questionbank.question.model.DisplayControlOptions;
 import gov.cdc.nbs.questionbank.question.request.update.UpdateCodedQuestionRequest;
 import gov.cdc.nbs.questionbank.question.request.update.UpdateDateQuestionRequest;
 import gov.cdc.nbs.questionbank.question.request.update.UpdateNumericQuestionRequest;
@@ -135,9 +134,5 @@ public class QuestionController {
         return question;
     }
 
-    @GetMapping("/displayControlOptions")
-    public DisplayControlOptions getDisplayControlOptions() {
-        return creator.getDisplayControlOptions();
-    }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionControllerHelper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionControllerHelper.java
@@ -1,0 +1,32 @@
+package gov.cdc.nbs.questionbank.question;
+
+
+import gov.cdc.nbs.questionbank.question.model.DisplayControlOptions;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/questions")
+@PreAuthorize("hasAuthority('LDFADMINISTRATION-SYSTEM')")
+@RequiredArgsConstructor
+public class QuestionControllerHelper {
+
+  private final QuestionFinder finder;
+  private final QuestionManagementUtil managementUtil;
+
+
+  @GetMapping("/displayControlOptions")
+  public DisplayControlOptions getDisplayControlOptions() {
+    return managementUtil.getDisplayControlOptions();
+  }
+
+  @PostMapping("/validate")
+  public Boolean validate(@RequestBody QuestionValidationRequest request) {
+    return finder.checkUnique(request);
+  }
+
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionCreator.java
@@ -2,7 +2,7 @@ package gov.cdc.nbs.questionbank.question;
 
 import java.time.Instant;
 
-import gov.cdc.nbs.questionbank.question.model.DisplayControlOptions;
+
 import gov.cdc.nbs.questionbank.question.request.QuestionRequest;
 import org.springframework.stereotype.Component;
 import gov.cdc.nbs.id.IdGeneratorService;
@@ -32,187 +32,185 @@ import gov.cdc.nbs.questionbank.question.request.create.CreateTextQuestionReques
 @Component
 class QuestionCreator {
 
-    private final IdGeneratorService idGenerator;
-    private final WaQuestionRepository repository;
-    private final NbsConfigurationRepository configRepository;
-    private final CodesetRepository codesetRepository;
-    private final QuestionManagementUtil managementUtil;
-    private final QuestionMapper questionMapper;
+  private final IdGeneratorService idGenerator;
+  private final WaQuestionRepository repository;
+  private final NbsConfigurationRepository configRepository;
+  private final CodesetRepository codesetRepository;
+  private final QuestionManagementUtil managementUtil;
+  private final QuestionMapper questionMapper;
 
-    public QuestionCreator(
-        final IdGeneratorService idGenerator,
-        final WaQuestionRepository repository,
-        final NbsConfigurationRepository configRepository,
-        final CodesetRepository codesetRepository,
-        final QuestionManagementUtil managementUtil,
-        final QuestionMapper questionMapper) {
-        this.idGenerator = idGenerator;
-        this.repository = repository;
-        this.configRepository = configRepository;
-        this.codesetRepository = codesetRepository;
-        this.managementUtil = managementUtil;
-        this.questionMapper = questionMapper;
+  public QuestionCreator(
+      final IdGeneratorService idGenerator,
+      final WaQuestionRepository repository,
+      final NbsConfigurationRepository configRepository,
+      final CodesetRepository codesetRepository,
+      final QuestionManagementUtil managementUtil,
+      final QuestionMapper questionMapper) {
+    this.idGenerator = idGenerator;
+    this.repository = repository;
+    this.configRepository = configRepository;
+    this.codesetRepository = codesetRepository;
+    this.managementUtil = managementUtil;
+    this.questionMapper = questionMapper;
+  }
+
+  public TextQuestion create(Long userId, CreateTextQuestionRequest request) {
+    TextQuestionEntity question = new TextQuestionEntity(asAdd(userId, request));
+    managementUtil.verifyUnique(question);
+    question = repository.save(question);
+    return questionMapper.toTextQuestion(question);
+  }
+
+  public DateQuestion create(Long userId, CreateDateQuestionRequest request) {
+    DateQuestionEntity question = new DateQuestionEntity(asAdd(userId, request));
+    managementUtil.verifyUnique(question);
+    question = repository.save(question);
+    return questionMapper.toDateQuestion(question);
+  }
+
+  public NumericQuestion create(Long userId, CreateNumericQuestionRequest request) {
+    NumericQuestionEntity question = new NumericQuestionEntity(asAdd(userId, request));
+    managementUtil.verifyUnique(question);
+    question = repository.save(question);
+    return questionMapper.toNumericQuestion(question);
+  }
+
+  public CodedQuestion create(Long userId, CreateCodedQuestionRequest request) {
+    CodedQuestionEntity question = new CodedQuestionEntity(asAdd(userId, request));
+    managementUtil.verifyUnique(question);
+    verifyValueSetExists(request.getValueSet());
+    question = repository.save(question);
+    return questionMapper.toCodedQuestion(question);
+  }
+
+  void verifyValueSetExists(Long valueSet) {
+    if (codesetRepository.findOneByCodeSetGroupId(valueSet).isEmpty()) {
+      throw new CreateQuestionException("Unable to find ValueSet with id: " + valueSet);
     }
+  }
 
-    public TextQuestion create(Long userId, CreateTextQuestionRequest request) {
-        TextQuestionEntity question = new TextQuestionEntity(asAdd(userId, request));
-        managementUtil.verifyUnique(question);
-        question = repository.save(question);
-        return questionMapper.toTextQuestion(question);
-    }
+  private AddNumericQuestion asAdd(Long userId, CreateNumericQuestionRequest request) {
+    return new QuestionCommand.AddNumericQuestion(
+        request.getMask(),
+        request.getFieldLength(),
+        request.getDefaultValue(),
+        request.getMinValue(),
+        request.getMaxValue(),
+        request.getRelatedUnitsLiteral(),
+        request.getRelatedUnitsValueSet(),
+        asQuestionData(request),
+        asReportingData(
+            request.getDataMartInfo(),
+            request.getSubgroup()),
+        asMessagingData(request.getMessagingInfo()),
+        userId,
+        Instant.now());
+  }
 
-    public DateQuestion create(Long userId, CreateDateQuestionRequest request) {
-        DateQuestionEntity question = new DateQuestionEntity(asAdd(userId, request));
-        managementUtil.verifyUnique(question);
-        question = repository.save(question);
-        return questionMapper.toDateQuestion(question);
-    }
+  private AddDateQuestion asAdd(Long userId, CreateDateQuestionRequest request) {
+    return new QuestionCommand.AddDateQuestion(
+        request.getMask(),
+        request.isAllowFutureDates(),
+        asQuestionData(request),
+        asReportingData(
+            request.getDataMartInfo(),
+            request.getSubgroup()),
+        asMessagingData(request.getMessagingInfo()),
+        userId,
+        Instant.now());
+  }
 
-    public NumericQuestion create(Long userId, CreateNumericQuestionRequest request) {
-        NumericQuestionEntity question = new NumericQuestionEntity(asAdd(userId, request));
-        managementUtil.verifyUnique(question);
-        question = repository.save(question);
-        return questionMapper.toNumericQuestion(question);
-    }
+  QuestionCommand.AddTextQuestion asAdd(Long userId, CreateTextQuestionRequest request) {
+    return new QuestionCommand.AddTextQuestion(
+        request.getMask(),
+        request.getFieldLength(),
+        request.getDefaultValue(),
+        asQuestionData(request),
+        asReportingData(
+            request.getDataMartInfo(),
+            request.getSubgroup()),
+        asMessagingData(request.getMessagingInfo()),
+        userId,
+        Instant.now());
+  }
 
-    public CodedQuestion create(Long userId, CreateCodedQuestionRequest request) {
-        CodedQuestionEntity question = new CodedQuestionEntity(asAdd(userId, request));
-        managementUtil.verifyUnique(question);
-        verifyValueSetExists(request.getValueSet());
-        question = repository.save(question);
-        return questionMapper.toCodedQuestion(question);
-    }
+  QuestionCommand.AddCodedQuestion asAdd(Long userId, CreateCodedQuestionRequest request) {
+    return new QuestionCommand.AddCodedQuestion(
+        request.getValueSet(),
+        request.getDefaultValue(),
+        asQuestionData(request),
+        asReportingData(
+            request.getDataMartInfo(),
+            request.getSubgroup()),
+        asMessagingData(request.getMessagingInfo()),
+        userId,
+        Instant.now());
+  }
 
-    void verifyValueSetExists(Long valueSet) {
-        if (codesetRepository.findOneByCodeSetGroupId(valueSet).isEmpty()) {
-            throw new CreateQuestionException("Unable to find ValueSet with id: " + valueSet);
-        }
-    }
-
-    private AddNumericQuestion asAdd(Long userId, CreateNumericQuestionRequest request) {
-        return new QuestionCommand.AddNumericQuestion(
-            request.getMask(),
-            request.getFieldLength(),
-            request.getDefaultValue(),
-            request.getMinValue(),
-            request.getMaxValue(),
-            request.getRelatedUnitsLiteral(),
-            request.getRelatedUnitsValueSet(),
-            asQuestionData(request),
-            asReportingData(
-                request.getDataMartInfo(),
-                request.getSubgroup()),
-            asMessagingData(request.getMessagingInfo()),
-            userId,
-            Instant.now());
-    }
-
-    private AddDateQuestion asAdd(Long userId, CreateDateQuestionRequest request) {
-        return new QuestionCommand.AddDateQuestion(
-            request.getMask(),
-            request.isAllowFutureDates(),
-            asQuestionData(request),
-            asReportingData(
-                request.getDataMartInfo(),
-                request.getSubgroup()),
-            asMessagingData(request.getMessagingInfo()),
-            userId,
-            Instant.now());
-    }
-
-    QuestionCommand.AddTextQuestion asAdd(Long userId, CreateTextQuestionRequest request) {
-        return new QuestionCommand.AddTextQuestion(
-            request.getMask(),
-            request.getFieldLength(),
-            request.getDefaultValue(),
-            asQuestionData(request),
-            asReportingData(
-                request.getDataMartInfo(),
-                request.getSubgroup()),
-            asMessagingData(request.getMessagingInfo()),
-            userId,
-            Instant.now());
-    }
-
-    QuestionCommand.AddCodedQuestion asAdd(Long userId, CreateCodedQuestionRequest request) {
-        return new QuestionCommand.AddCodedQuestion(
-            request.getValueSet(),
-            request.getDefaultValue(),
-            asQuestionData(request),
-            asReportingData(
-                request.getDataMartInfo(),
-                request.getSubgroup()),
-            asMessagingData(request.getMessagingInfo()),
-            userId,
-            Instant.now());
-    }
-
-    QuestionCommand.QuestionData asQuestionData(CreateQuestionRequest request) {
-        var messagingInfo = request.getMessagingInfo();
-        return new QuestionCommand.QuestionData(
-            request.getCodeSet(),
-            getLocalId(request),
-            request.getUniqueName(),
-            request.getSubgroup(),
-            request.getDescription(),
-            request.getLabel(),
-            request.getTooltip(),
-            request.getDisplayControl(),
-            request.getAdminComments(),
-            managementUtil.getQuestionOid(
-                messagingInfo.includedInMessage(),
-                messagingInfo.codeSystem(),
-                request.getCodeSet()));
-    }
-
-    QuestionCommand.ReportingData asReportingData(QuestionRequest.ReportingInfo dataMartInfo, String subgroup) {
-        return new QuestionCommand.ReportingData(
-            dataMartInfo.reportLabel(),
-            dataMartInfo.defaultRdbTableName(),
-            subgroup + "_" + dataMartInfo.rdbColumnName(),
-            // Legacy appends the subgroup to the beginning of the rdbColumnName
-            dataMartInfo.dataMartColumnName());
-    }
-
-    QuestionCommand.MessagingData asMessagingData(QuestionRequest.MessagingInfo messagingInfo) {
-        return new QuestionCommand.MessagingData(
+  QuestionCommand.QuestionData asQuestionData(CreateQuestionRequest request) {
+    var messagingInfo = request.getMessagingInfo();
+    return new QuestionCommand.QuestionData(
+        request.getCodeSet(),
+        getLocalId(request),
+        request.getUniqueName(),
+        request.getSubgroup(),
+        request.getDescription(),
+        request.getLabel(),
+        request.getTooltip(),
+        request.getDisplayControl(),
+        request.getAdminComments(),
+        managementUtil.getQuestionOid(
             messagingInfo.includedInMessage(),
-            messagingInfo.messageVariableId(),
-            messagingInfo.labelInMessage(),
             messagingInfo.codeSystem(),
-            messagingInfo.requiredInMessage(),
-            messagingInfo.hl7DataType());
-    }
+            request.getCodeSet()));
+  }
+
+  QuestionCommand.ReportingData asReportingData(QuestionRequest.ReportingInfo dataMartInfo, String subgroup) {
+    return new QuestionCommand.ReportingData(
+        dataMartInfo.reportLabel(),
+        dataMartInfo.defaultRdbTableName(),
+        subgroup + "_" + dataMartInfo.rdbColumnName(),
+        // Legacy appends the subgroup to the beginning of the rdbColumnName
+        dataMartInfo.dataMartColumnName());
+  }
+
+  QuestionCommand.MessagingData asMessagingData(QuestionRequest.MessagingInfo messagingInfo) {
+    return new QuestionCommand.MessagingData(
+        messagingInfo.includedInMessage(),
+        messagingInfo.messageVariableId(),
+        messagingInfo.labelInMessage(),
+        messagingInfo.codeSystem(),
+        messagingInfo.requiredInMessage(),
+        messagingInfo.hl7DataType());
+  }
 
 
-    /**
-     * If the request is of 'LOCAL' type and no Id is specified, generate the next available Id from the database. Else,
-     * return the specified request.uniqueId
-     *
-     * @param request
-     * @return
-     */
-    String getLocalId(CreateQuestionRequest request) {
-        if (request.getCodeSet().equals(CodeSet.LOCAL)
-            && (request.getUniqueId() == null || request.getUniqueId().isBlank())) {
-            // Question Ids are a combination of the
-            // `NBS_ODSE.NBS_configuration NBS_CLASS_CODE config value + the next valid Id
-            // Ex. GA13004
-            String nbsClassCode = getNbsClassCode();
-            return nbsClassCode + idGenerator.getNextValidId(EntityType.NBS_QUESTION_ID_LDF).getId();
-        } else {
-            return request.getUniqueId().trim();
-        }
+  /**
+   * If the request is of 'LOCAL' type and no Id is specified, generate the next available Id from the database. Else,
+   * return the specified request.uniqueId
+   *
+   * @param request
+   * @return
+   */
+  String getLocalId(CreateQuestionRequest request) {
+    if (request.getCodeSet().equals(CodeSet.LOCAL)
+        && (request.getUniqueId() == null || request.getUniqueId().isBlank())) {
+      // Question Ids are a combination of the
+      // `NBS_ODSE.NBS_configuration NBS_CLASS_CODE config value + the next valid Id
+      // Ex. GA13004
+      String nbsClassCode = getNbsClassCode();
+      return nbsClassCode + idGenerator.getNextValidId(EntityType.NBS_QUESTION_ID_LDF).getId();
+    } else {
+      return request.getUniqueId().trim();
     }
+  }
 
-    String getNbsClassCode() {
-        return configRepository.findById("NBS_CLASS_CODE")
-            .orElseThrow(() -> new CreateQuestionException("Failed to lookup NBS_CLASS_CODE"))
-            .getConfigValue();
-    }
+  String getNbsClassCode() {
+    return configRepository.findById("NBS_CLASS_CODE")
+        .orElseThrow(() -> new CreateQuestionException("Failed to lookup NBS_CLASS_CODE"))
+        .getConfigValue();
+  }
 
-    public DisplayControlOptions getDisplayControlOptions() {
-        return managementUtil.getDisplayControlOptions();
-    }
+
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.FieldName;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -69,7 +70,7 @@ public class QuestionFinder {
     }
 
     public boolean checkUnique(QuestionValidationRequest request) {
-        if (request.field().equals("uniqueId")) {
+        if (request.fieldName().equals(FieldName.UNIQUE_ID.getValue())) {
             return questionRepository.findIdByQuestionIdentifier(request.value()).isEmpty();
         } else {
             throw new UniqueQuestionException("invalid unique field name");

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
@@ -1,6 +1,10 @@
 package gov.cdc.nbs.questionbank.question;
 
 import java.util.List;
+
+
+import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -20,9 +24,9 @@ public class QuestionFinder {
     private final QuestionMapper questionMapper;
 
     public QuestionFinder(
-            final WaQuestionRepository questionRepository,
-            final QuestionMapper questionMapper,
-            WaUiMetadataRepository uiMetadataRepository) {
+        final WaQuestionRepository questionRepository,
+        final QuestionMapper questionMapper,
+        WaUiMetadataRepository uiMetadataRepository) {
         this.questionRepository = questionRepository;
         this.questionMapper = questionMapper;
         this.uiMetadataRepository = uiMetadataRepository;
@@ -30,8 +34,8 @@ public class QuestionFinder {
 
     public GetQuestionResponse find(Long id) {
         Question question = questionRepository.findById(id)
-                .map(questionMapper::toQuestion)
-                .orElseThrow(() -> new QuestionNotFoundException(id));
+            .map(questionMapper::toQuestion)
+            .orElseThrow(() -> new QuestionNotFoundException(id));
         boolean isInUse = checkQuestionInUse(question.uniqueId());
         return new GetQuestionResponse(question, isInUse);
     }
@@ -44,10 +48,10 @@ public class QuestionFinder {
 
     public Page<Question> find(FindQuestionRequest request, Pageable pageable) {
         Page<WaQuestion> page = questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(
-                request.search(),
-                tryConvert(request.search()),
-                request.questionType(),
-                pageable);
+            request.search(),
+            tryConvert(request.search()),
+            request.questionType(),
+            pageable);
         List<Question> questions = page.get().map(questionMapper::toQuestion).toList();
         return new PageImpl<>(questions, pageable, page.getTotalElements());
     }
@@ -61,6 +65,14 @@ public class QuestionFinder {
             return Long.valueOf(search);
         } catch (NumberFormatException e) {
             return -1L;
+        }
+    }
+
+    public boolean checkUnique(QuestionValidationRequest request) {
+        if (request.field().equals("uniqueId")) {
+            return questionRepository.findIdByQuestionIdentifier(request.value()).isEmpty();
+        } else {
+            throw new UniqueQuestionException("invalid unique field name");
         }
     }
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/WaQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/WaQuestionRepository.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.questionbank.question.repository;
 
 import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,19 +12,21 @@ import gov.cdc.nbs.questionbank.entity.question.WaQuestion;
 
 public interface WaQuestionRepository extends JpaRepository<WaQuestion, Long> {
 
-    @Query("Select q from WaQuestion q WHERE q.questionNm=:questionNm OR q.questionIdentifier=:questionIdentifier OR q.userDefinedColumnNm=:userDefinedColumnNm OR q.rdbColumnNm=:rdbColumnNm")
+    @Query(
+        "Select q from WaQuestion q WHERE q.questionNm=:questionNm OR q.questionIdentifier=:questionIdentifier OR q.userDefinedColumnNm=:userDefinedColumnNm OR q.rdbColumnNm=:rdbColumnNm")
     public List<WaQuestion> findAllByUniqueFields(
-            @Param("questionNm") String questionNm,
-            @Param("questionIdentifier") String questionIdentifier,
-            @Param("userDefinedColumnNm") String userDefinedColumnNm,
-            @Param("rdbColumnNm") String rdbColumnNm);
+        @Param("questionNm") String questionNm,
+        @Param("questionIdentifier") String questionIdentifier,
+        @Param("userDefinedColumnNm") String userDefinedColumnNm,
+        @Param("rdbColumnNm") String rdbColumnNm);
 
-    @Query("Select q from WaQuestion q WHERE (q.questionNm LIKE %:search% OR q.questionIdentifier LIKE %:search% OR q.questionLabel LIKE %:search% OR q.subGroupNm LIKE %:search% OR q.id =:searchId) AND q.questionType LIKE %:questionType%")
+    @Query(
+        "Select q from WaQuestion q WHERE (q.questionNm LIKE %:search% OR q.questionIdentifier LIKE %:search% OR q.questionLabel LIKE %:search% OR q.subGroupNm LIKE %:search% OR q.id =:searchId) AND q.questionType LIKE %:questionType%")
     public Page<WaQuestion> findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(
-            @Param("search") String search,
-            @Param("searchId") Long id,
-            @Param("questionType") String questionType,
-            Pageable pageable);
+        @Param("search") String search,
+        @Param("searchId") Long id,
+        @Param("questionType") String questionType,
+        Pageable pageable);
 
     @Modifying
     @Query("Update WaQuestion SET data_type =:type WHERE id=:id")
@@ -31,6 +34,8 @@ public interface WaQuestionRepository extends JpaRepository<WaQuestion, Long> {
 
     @Query("SELECT q.questionLabel, q.questionIdentifier FROM WaQuestion q WHERE q.questionIdentifier IN :identifiers")
     public List<Object[]> findLabelsByIdentifiers(@Param("identifiers") List<String> identifiers);
+
+    public List<Object[]> findIdByQuestionIdentifier(@Param("questionIdentifier") String questionIdentifier);
 
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
@@ -1,5 +1,22 @@
 package gov.cdc.nbs.questionbank.question.request;
 
-public record QuestionValidationRequest(String field, String value) {
+public record QuestionValidationRequest(String fieldName, String value) {
+
+  public enum FieldName {
+    UNIQUE_ID("uniqueId"),
+    UNIQUE_NAME("uniqueName"),
+    RDB_TABLE_NAME("rdbTableName"),
+    DATA_MART_COLUMN_NAME("dataMartColumnName");
+
+    private final String value;
+
+    FieldName(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
@@ -1,0 +1,5 @@
+package gov.cdc.nbs.questionbank.question.request;
+
+public record QuestionValidationRequest(String field, String value) {
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/DisplayControlOptionsSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/DisplayControlOptionsSteps.java
@@ -1,0 +1,48 @@
+package gov.cdc.nbs.questionbank.question;
+
+import gov.cdc.nbs.questionbank.question.model.DisplayControlOptions;
+import gov.cdc.nbs.questionbank.support.ExceptionHolder;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+
+import static org.junit.Assert.*;
+
+
+public class DisplayControlOptionsSteps {
+
+  @Autowired
+  private ExceptionHolder exceptionHolder;
+
+  @Autowired
+  private QuestionControllerHelper controllerHelper;
+
+  DisplayControlOptions displayControlOptions;
+
+
+  @When("I get list of question display control options")
+  public void I_get_list_of_question_display_control_options() {
+    try {
+      displayControlOptions = controllerHelper.getDisplayControlOptions();
+    } catch (AccessDeniedException e) {
+      exceptionHolder.setException(e);
+    } catch (AuthenticationCredentialsNotFoundException e) {
+      exceptionHolder.setException(e);
+    }
+  }
+
+
+  @Then("return list of question display control options")
+  public void return_list_of_question_display_control_options() {
+    assertNotNull(displayControlOptions);
+    assertFalse(displayControlOptions.codedDisplayControl().isEmpty());
+    assertFalse(displayControlOptions.textDisplayControl().isEmpty());
+    assertFalse(displayControlOptions.numericDisplayControl().isEmpty());
+    assertFalse(displayControlOptions.dateDisplayControl().isEmpty());
+  }
+
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionControllerTest.java
@@ -1,12 +1,10 @@
 package gov.cdc.nbs.questionbank.question;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertFalse;
+
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import gov.cdc.nbs.questionbank.question.model.DisplayOption;
-import gov.cdc.nbs.questionbank.question.model.DisplayControlOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,7 +18,7 @@ import gov.cdc.nbs.questionbank.question.model.Question.TextQuestion;
 import gov.cdc.nbs.questionbank.question.request.create.CreateTextQuestionRequest;
 import gov.cdc.nbs.questionbank.support.QuestionRequestMother;
 
-import java.util.Arrays;
+
 
 @ExtendWith(MockitoExtension.class)
 class QuestionControllerTest {
@@ -31,8 +29,6 @@ class QuestionControllerTest {
     @Mock
     private UserDetailsProvider provider;
 
-    @Mock
-    private QuestionManagementUtil questionManagementUtil;
 
     @InjectMocks
     private QuestionController controller;
@@ -87,23 +83,5 @@ class QuestionControllerTest {
             true);
     }
 
-    @Test
-    void should_return_displayControlOptions() {
-        when(creator.getDisplayControlOptions()).thenReturn(getDisplayControlOptions());
-        DisplayControlOptions result = controller.getDisplayControlOptions();
-        assertNotNull(result);
-        assertFalse(result.codedDisplayControl().isEmpty());
-        assertFalse(result.dateDisplayControl().isEmpty());
-        assertFalse(result.numericDisplayControl().isEmpty());
-        assertFalse(result.textDisplayControl().isEmpty());
 
-    }
-
-    private DisplayControlOptions getDisplayControlOptions() {
-        return new DisplayControlOptions(
-            Arrays.asList(new DisplayOption(101l, "mock_101"), new DisplayOption(102l, "mock_102")),
-            Arrays.asList(new DisplayOption(201l, "mock_201"), new DisplayOption(202l, "mock_202")),
-            Arrays.asList(new DisplayOption(301l, "mock_301"), new DisplayOption(302l, "mock_302")),
-            Arrays.asList(new DisplayOption(401l, "mock_401"), new DisplayOption(401l, "mock_402")));
-    }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionFinderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionFinderTest.java
@@ -5,11 +5,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Optional;
+
+import java.util.*;
+
+import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -32,96 +36,119 @@ import gov.cdc.nbs.questionbank.support.QuestionEntityMother;
 @ExtendWith(MockitoExtension.class)
 class QuestionFinderTest {
 
-    @Mock
-    private WaQuestionRepository questionRepository;
+  @Mock
+  private WaQuestionRepository questionRepository;
 
-    @Spy
-    private QuestionMapper questionMapper = new QuestionMapper();
+  @Spy
+  private QuestionMapper questionMapper = new QuestionMapper();
 
-    @Mock
-    private WaUiMetadataRepository metadatumRepository;
+  @Mock
+  private WaUiMetadataRepository metadatumRepository;
 
-    @InjectMocks
-    private QuestionFinder finder;
+  @InjectMocks
+  private QuestionFinder finder;
 
-    @Test
-    void find_test() {
-        // given a question exists
-        DateQuestionEntity spy = QuestionEntityMother.dateQuestion();
-        when(questionRepository.findById(1L)).thenReturn(Optional.of(spy));
+  @Test
+  void find_test() {
+    // given a question exists
+    DateQuestionEntity spy = QuestionEntityMother.dateQuestion();
+    when(questionRepository.findById(1L)).thenReturn(Optional.of(spy));
 
-        // and it is not in use
-        when(metadatumRepository.findAllByQuestionIdentifier(spy.getQuestionIdentifier()))
-                .thenReturn(new ArrayList<>());
+    // and it is not in use
+    when(metadatumRepository.findAllByQuestionIdentifier(spy.getQuestionIdentifier()))
+        .thenReturn(new ArrayList<>());
 
-        // when i try to find a question
-        GetQuestionResponse response = finder.find(1L);
+    // when i try to find a question
+    GetQuestionResponse response = finder.find(1L);
 
-        // then a question is found
-        assertNotNull(response);
-        assertFalse(response.isInUse());
-    }
+    // then a question is found
+    assertNotNull(response);
+    assertFalse(response.isInUse());
+  }
 
-    @Test
-    void not_found() {
-        // given a question doesn't exist
+  @Test
+  void not_found() {
+    // given a question doesn't exist
 
-        // when i try to find a question
-        // then a question not found exception is thrown
-        assertThrows(QuestionNotFoundException.class, () -> finder.find(1L));
-    }
+    // when i try to find a question
+    // then a question not found exception is thrown
+    assertThrows(QuestionNotFoundException.class, () -> finder.find(1L));
+  }
 
-    @Test
-    void in_use_test() {
-        // given a question exists
-        DateQuestionEntity spy = QuestionEntityMother.dateQuestion();
-        when(questionRepository.findById(1L)).thenReturn(Optional.of(spy));
+  @Test
+  void in_use_test() {
+    // given a question exists
+    DateQuestionEntity spy = QuestionEntityMother.dateQuestion();
+    when(questionRepository.findById(1L)).thenReturn(Optional.of(spy));
 
-        // and it is in use
-        when(metadatumRepository.findAllByQuestionIdentifier(spy.getQuestionIdentifier()))
-                .thenReturn(Collections.singletonList(new WaUiMetadata()));
+    // and it is in use
+    when(metadatumRepository.findAllByQuestionIdentifier(spy.getQuestionIdentifier()))
+        .thenReturn(Collections.singletonList(new WaUiMetadata()));
 
-        // when i try to find a question
-        GetQuestionResponse response = finder.find(1L);
+    // when i try to find a question
+    GetQuestionResponse response = finder.find(1L);
 
-        // then a question is found
-        assertNotNull(response);
-        assertTrue(response.isInUse());
-    }
+    // then a question is found
+    assertNotNull(response);
+    assertTrue(response.isInUse());
+  }
 
-    @Test
-    void should_try_search_id() {
-        // given a request that can be converted to an id
-        FindQuestionRequest request = new FindQuestionRequest("123", "LOCAL");
+  @Test
+  void should_try_search_id() {
+    // given a request that can be converted to an id
+    FindQuestionRequest request = new FindQuestionRequest("123", "LOCAL");
 
-        // and a question exists
-        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
-        when(questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(eq("123"), captor.capture(),
-                Mockito.anyString(), Mockito.any()))
-                        .thenReturn(new PageImpl<>(new ArrayList<>()));
+    // and a question exists
+    ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+    when(questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(eq("123"), captor.capture(),
+        Mockito.anyString(), Mockito.any()))
+        .thenReturn(new PageImpl<>(new ArrayList<>()));
 
-        // when a query is run
-        finder.find(request, PageRequest.ofSize(10));
+    // when a query is run
+    finder.find(request, PageRequest.ofSize(10));
 
-        // then the Id is queried
-        assertEquals(123L, captor.getValue().longValue());
-    }
+    // then the Id is queried
+    assertEquals(123L, captor.getValue().longValue());
+  }
 
-    @Test
-    void should_try_not_fail_if_search_not_id() {
-        // given a request that can be converted to an id
-        FindQuestionRequest request = new FindQuestionRequest("abc", "LOCAL");
+  @Test
+  void should_try_not_fail_if_search_not_id() {
+    // given a request that can be converted to an id
+    FindQuestionRequest request = new FindQuestionRequest("abc", "LOCAL");
 
-        // and a question exists
-        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
-        when(questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(eq("abc"), captor.capture(),
-                Mockito.anyString(), Mockito.any()))
-                        .thenReturn(new PageImpl<>(new ArrayList<>()));
+    // and a question exists
+    ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+    when(questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(eq("abc"), captor.capture(),
+        Mockito.anyString(), Mockito.any()))
+        .thenReturn(new PageImpl<>(new ArrayList<>()));
 
-        // when a query is run
-        finder.find(request, PageRequest.ofSize(10));
+    // when a query is run
+    finder.find(request, PageRequest.ofSize(10));
 
-        // then the Id is queried
-        assertEquals(-1L, captor.getValue().longValue());
-    }
+    // then the Id is queried
+    assertEquals(-1L, captor.getValue().longValue());
+  }
+
+  @Test
+  void should_return_true_for_unique_id() {
+    when(questionRepository.findIdByQuestionIdentifier(anyString())).thenReturn(Collections.EMPTY_LIST);
+    assertTrue(finder.checkUnique(new QuestionValidationRequest("uniqueId", "unique")));
+  }
+
+  @Test
+  void should_return_false_for_duplicate_id() {
+    List<Object[]> result = new ArrayList<>();
+    result.add(new Object[] {"Sample"});
+    when(questionRepository.findIdByQuestionIdentifier(anyString())).thenReturn(result);
+    assertFalse(finder.checkUnique(new QuestionValidationRequest("uniqueId", "duplicate")));
+  }
+
+  @Test
+  void should_throw_exception_for_invalid_unique_field_name() {
+    QuestionValidationRequest invalidFieldRequest = new QuestionValidationRequest("invalid_Field", "value");
+    UniqueQuestionException exception =
+        assertThrows(UniqueQuestionException.class, () -> finder.checkUnique(invalidFieldRequest));
+    assertEquals("invalid unique field name", exception.getMessage());
+
+  }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
@@ -9,6 +9,7 @@ import io.cucumber.java.en.When;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.FieldName;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertTrue;
@@ -30,7 +31,7 @@ public class ValidateQuestionSteps {
   @When("I validate unique field {string}")
   public void i_validate_unique_field(String field) {
     try {
-      if (field.equals("uniqueId")) {
+      if (field.equals(FieldName.UNIQUE_ID.getValue())) {
         request = new QuestionValidationRequest(field, "TEST9900001");
       } else {// invalid unique field name
         request = new QuestionValidationRequest(field, "value");

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
@@ -1,0 +1,67 @@
+package gov.cdc.nbs.questionbank.question;
+
+
+import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
+import gov.cdc.nbs.questionbank.support.ExceptionHolder;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
+
+public class ValidateQuestionSteps {
+
+  @Autowired
+  private ExceptionHolder exceptionHolder;
+
+  @Autowired
+  private QuestionControllerHelper controllerHelper;
+
+  QuestionValidationRequest request;
+
+  private boolean validationResult;
+
+
+  @When("I validate unique field {string}")
+  public void i_validate_unique_field(String field) {
+    try {
+      if (field.equals("uniqueId")) {
+        request = new QuestionValidationRequest(field, "TEST9900001");
+      } else {// invalid unique field name
+        request = new QuestionValidationRequest(field, "value");
+      }
+      validationResult = controllerHelper.validate(request);
+    } catch (UniqueQuestionException e) {
+      exceptionHolder.setException(e);
+    } catch (AccessDeniedException e) {
+      exceptionHolder.setException(e);
+    } catch (AuthenticationCredentialsNotFoundException e) {
+      exceptionHolder.setException(e);
+    }
+  }
+
+
+  @Then("return valid")
+  public void return_valid() {
+    assertTrue(validationResult);
+  }
+
+  @Then("return not valid")
+  public void return_not_valid() {
+    assertFalse(validationResult);
+  }
+
+  @Then("a validate unique question exception is thrown")
+  public void a_validate_unique_question_exception_is_thrown() {
+    assertNotNull(exceptionHolder.getException());
+    assertTrue(exceptionHolder.getException() instanceof UniqueQuestionException);
+    assertEquals("invalid unique field name", exceptionHolder.getException().getMessage());
+  }
+
+
+}

--- a/apps/question-bank/src/test/resources/features/question/DisplayControlOptions.feature
+++ b/apps/question-bank/src/test/resources/features/question/DisplayControlOptions.feature
@@ -1,0 +1,23 @@
+@display_control_options
+Feature: display control options
+
+    Scenario: I can get list of question display control options
+        Given I am an admin user
+        When I get list of question display control options
+        Then return list of question display control options
+
+
+    Scenario: I cannot get list of question display control options without logging in
+        Given I am not logged in
+        When I get list of question display control options
+        Then a no credentials found exception is thrown
+
+    Scenario: I cannot get list of question display control options without permissions
+        Given I am a user without permissions
+        When I get list of question display control options
+        Then an accessdenied exception is thrown
+
+
+
+
+

--- a/apps/question-bank/src/test/resources/features/question/ValidateQuestion.feature
+++ b/apps/question-bank/src/test/resources/features/question/ValidateQuestion.feature
@@ -1,0 +1,35 @@
+@validate_question
+Feature: Validate question
+
+    Scenario: I can use a valid unique field
+        Given I am an admin user
+        And No questions exist
+        When I validate unique field "uniqueId"
+        Then return valid
+
+    Scenario: I cannot use invalid unique field
+        Given I am an admin user
+        And A text question exists
+        When I validate unique field "uniqueId"
+        Then return not valid
+
+    Scenario: I cannot validate non unique field
+        Given I am an admin user
+        And A text question exists
+        When I validate unique field "non-unique"
+        Then a validate unique question exception is thrown
+
+    Scenario: I cannot validate unique field without logging in
+        Given I am not logged in
+        When I validate unique field "uniqueId"
+        Then a no credentials found exception is thrown
+
+    Scenario: I cannot validate unique field without permissions
+        Given I am a user without permissions
+        When I validate unique field "uniqueId"
+        Then an accessdenied exception is thrown
+
+
+
+
+


### PR DESCRIPTION
## Description

When creating a question with the same Unique ID previously used, the Create and add to page button (when clicked) is inoperable. The application should return an error message similar to "Unique ID cannot be duplicated.”

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1815