### PR TITLE
Implement error display functionality for duplicate Unique Name

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
@@ -70,11 +70,12 @@ public class QuestionFinder {
     }
 
     public boolean checkUnique(QuestionValidationRequest request) {
-        if (request.fieldName().equals(FieldName.UNIQUE_ID.getValue())) {
+        if (request.fieldName().equals(FieldName.UNIQUE_ID.getValue()))
             return questionRepository.findIdByQuestionIdentifier(request.value()).isEmpty();
-        } else {
+        if (request.fieldName().equals(FieldName.UNIQUE_NAME.getValue()))
+            return questionRepository.findIdByQuestionNm(request.value()).isEmpty();
+        else
             throw new UniqueQuestionException("invalid unique field name");
-        }
     }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/WaQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/WaQuestionRepository.java
@@ -35,7 +35,8 @@ public interface WaQuestionRepository extends JpaRepository<WaQuestion, Long> {
     @Query("SELECT q.questionLabel, q.questionIdentifier FROM WaQuestion q WHERE q.questionIdentifier IN :identifiers")
     public List<Object[]> findLabelsByIdentifiers(@Param("identifiers") List<String> identifiers);
 
-    public List<Object[]> findIdByQuestionIdentifier(@Param("questionIdentifier") String questionIdentifier);
+    List<Object[]> findIdByQuestionIdentifier(@Param("questionIdentifier") String questionIdentifier);
 
+    List<Object[]> findIdByQuestionNm(@Param("questionNm") String questionNm);
 
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionFinderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionFinderTest.java
@@ -130,17 +130,27 @@ class QuestionFinderTest {
   }
 
   @Test
-  void should_return_true_for_unique_id() {
+  void should_return_true_for_unique_fields() {
     when(questionRepository.findIdByQuestionIdentifier(anyString())).thenReturn(Collections.EMPTY_LIST);
-    assertTrue(finder.checkUnique(new QuestionValidationRequest("uniqueId", "unique")));
+    when(questionRepository.findIdByQuestionNm(anyString())).thenReturn(Collections.EMPTY_LIST);
+
+    assertTrue(finder.checkUnique(
+        new QuestionValidationRequest(QuestionValidationRequest.FieldName.UNIQUE_ID.getValue(), "unique")));
+    assertTrue(finder.checkUnique(
+        new QuestionValidationRequest(QuestionValidationRequest.FieldName.UNIQUE_NAME.getValue(), "unique")));
   }
 
   @Test
-  void should_return_false_for_duplicate_id() {
+  void should_return_false_for_duplicate_fields() {
     List<Object[]> result = new ArrayList<>();
     result.add(new Object[] {"Sample"});
     when(questionRepository.findIdByQuestionIdentifier(anyString())).thenReturn(result);
-    assertFalse(finder.checkUnique(new QuestionValidationRequest("uniqueId", "duplicate")));
+    when(questionRepository.findIdByQuestionNm(anyString())).thenReturn(result);
+
+    assertFalse(finder.checkUnique(
+        new QuestionValidationRequest(QuestionValidationRequest.FieldName.UNIQUE_ID.getValue(), "duplicate")));
+    assertFalse(finder.checkUnique(
+        new QuestionValidationRequest(QuestionValidationRequest.FieldName.UNIQUE_NAME.getValue(), "duplicate")));
   }
 
   @Test

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
@@ -4,6 +4,7 @@ package gov.cdc.nbs.questionbank.question;
 import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
 import gov.cdc.nbs.questionbank.support.ExceptionHolder;
+import gov.cdc.nbs.questionbank.support.QuestionMother;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,9 @@ public class ValidateQuestionSteps {
   @Autowired
   private QuestionControllerHelper controllerHelper;
 
+  @Autowired
+  private QuestionMother questionMother;
+
   QuestionValidationRequest request;
 
   private boolean validationResult;
@@ -31,11 +35,7 @@ public class ValidateQuestionSteps {
   @When("I validate unique field {string}")
   public void i_validate_unique_field(String field) {
     try {
-      if (field.equals(FieldName.UNIQUE_ID.getValue())) {
-        request = new QuestionValidationRequest(field, "TEST9900001");
-      } else {// invalid unique field name
-        request = new QuestionValidationRequest(field, "value");
-      }
+      request = prepareRequest(field);
       validationResult = controllerHelper.validate(request);
     } catch (UniqueQuestionException e) {
       exceptionHolder.setException(e);
@@ -45,7 +45,6 @@ public class ValidateQuestionSteps {
       exceptionHolder.setException(e);
     }
   }
-
 
   @Then("return valid")
   public void return_valid() {
@@ -64,5 +63,13 @@ public class ValidateQuestionSteps {
     assertEquals("invalid unique field name", exceptionHolder.getException().getMessage());
   }
 
+  private QuestionValidationRequest prepareRequest(String field) {
+    if (field.equals(FieldName.UNIQUE_ID.getValue()))
+      return new QuestionValidationRequest(field, "TEST9900001");
+    if (field.equals(FieldName.UNIQUE_NAME.getValue()))
+      return new QuestionValidationRequest(field, "Text Question Unique Name");
+    else // invalid unique field name
+      return new QuestionValidationRequest(field, "any value");
+  }
 
 }

--- a/apps/question-bank/src/test/resources/features/question/ValidateQuestion.feature
+++ b/apps/question-bank/src/test/resources/features/question/ValidateQuestion.feature
@@ -4,14 +4,24 @@ Feature: Validate question
     Scenario: I can use a valid unique field
         Given I am an admin user
         And No questions exist
-        When I validate unique field "uniqueId"
+        When I validate unique field "<unique-field>"
         Then return valid
+
+        Examples:
+                | unique-field       |
+                | uniqueId           |
+                | uniqueName         |
 
     Scenario: I cannot use invalid unique field
         Given I am an admin user
         And A text question exists
-        When I validate unique field "uniqueId"
+        When I validate unique field "<unique-field>"
         Then return not valid
+
+        Examples:
+                 | unique-field       |
+                 | uniqueId           |
+                 | uniqueName         |
 
     Scenario: I cannot validate non unique field
         Given I am an admin user


### PR DESCRIPTION
## Description

When creating a question with the same Unique Name previously used, the Create and add to page button (when clicked) is inoperable. The application should return an error message similar to "Unique Name cannot be duplicated.”

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1842
