### PR TITLE
Implement error display functionality for duplicate rdbColumnName 

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
@@ -6,6 +6,8 @@ import java.util.List;
 import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.FieldName;
+import gov.cdc.nbs.questionbank.valueset.ValueSetReader;
+import gov.cdc.nbs.questionbank.valueset.response.Concept;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -23,14 +25,19 @@ public class QuestionFinder {
     private final WaQuestionRepository questionRepository;
     private final WaUiMetadataRepository uiMetadataRepository;
     private final QuestionMapper questionMapper;
+    private final ValueSetReader valueSetReader;
+
+    private static final String SUBGROUP_CODE_SET = "NBS_QUES_SUBGROUP";
 
     public QuestionFinder(
         final WaQuestionRepository questionRepository,
         final QuestionMapper questionMapper,
-        WaUiMetadataRepository uiMetadataRepository) {
+        WaUiMetadataRepository uiMetadataRepository,
+        ValueSetReader valueSetReader) {
         this.questionRepository = questionRepository;
         this.questionMapper = questionMapper;
         this.uiMetadataRepository = uiMetadataRepository;
+        this.valueSetReader = valueSetReader;
     }
 
     public GetQuestionResponse find(Long id) {
@@ -74,8 +81,22 @@ public class QuestionFinder {
             return questionRepository.findIdByQuestionIdentifier(request.value()).isEmpty();
         if (request.fieldName().equals(FieldName.UNIQUE_NAME.getValue()))
             return questionRepository.findIdByQuestionNm(request.value()).isEmpty();
-        else
-            throw new UniqueQuestionException("invalid unique field name");
+        if (request.fieldName().equals(FieldName.DATA_MART_COLUMN_NAME.getValue()))
+            return questionRepository.findIdByUserDefinedColumnNm(request.value()).isEmpty();
+        if (request.fieldName().equals(FieldName.RDB_COLUMN_NAME.getValue())) {
+            checkSubGroupValidity(request.value());
+            return questionRepository.findIdByRdbColumnNm(request.value()).isEmpty();
+        }
+        throw new UniqueQuestionException("invalid unique field name");
     }
 
+    private void checkSubGroupValidity(String rdbColumnName) {
+        String subGroupCode = rdbColumnName.substring(0, rdbColumnName.indexOf("_"));
+        boolean isMatch = valueSetReader.findConceptCodes(SUBGROUP_CODE_SET)
+            .stream().map(Concept::localCode).anyMatch(code -> code.equals(subGroupCode));
+        if (!isMatch)
+            throw new UniqueQuestionException("invalid subgroup Code");
+    }
 }
+
+

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/WaQuestionRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/repository/WaQuestionRepository.java
@@ -39,4 +39,10 @@ public interface WaQuestionRepository extends JpaRepository<WaQuestion, Long> {
 
     List<Object[]> findIdByQuestionNm(@Param("questionNm") String questionNm);
 
+    List<Object[]> findIdByUserDefinedColumnNm(@Param("userDefinedColumnNm") String dataMart);
+
+    List<Object[]> findIdByRdbColumnNm(@Param("rdbColumnNm") String rdbColumnNm);
+
+
+
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
@@ -5,7 +5,7 @@ public record QuestionValidationRequest(String fieldName, String value) {
   public enum FieldName {
     UNIQUE_ID("uniqueId"),
     UNIQUE_NAME("uniqueName"),
-    RDB_TABLE_NAME("rdbTableName"),
+    RDB_COLUMN_NAME("rdbColumnName"),
     DATA_MART_COLUMN_NAME("dataMartColumnName");
 
     private final String value;

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
@@ -46,6 +46,21 @@ public class ValidateQuestionSteps {
     }
   }
 
+  @When("I validate rdbColumnName with invalid subgroup")
+  public void i_validate_rdbColumnName_with_invalid_subgroup() {
+    try {
+      request = new QuestionValidationRequest(FieldName.RDB_COLUMN_NAME.getValue(), "XXX_RDB_COL_NMM");
+      validationResult = controllerHelper.validate(request);
+    } catch (UniqueQuestionException e) {
+      exceptionHolder.setException(e);
+    } catch (AccessDeniedException e) {
+      exceptionHolder.setException(e);
+    } catch (AuthenticationCredentialsNotFoundException e) {
+      exceptionHolder.setException(e);
+    }
+  }
+
+
   @Then("return valid")
   public void return_valid() {
     assertTrue(validationResult);
@@ -60,7 +75,6 @@ public class ValidateQuestionSteps {
   public void a_validate_unique_question_exception_is_thrown() {
     assertNotNull(exceptionHolder.getException());
     assertTrue(exceptionHolder.getException() instanceof UniqueQuestionException);
-    assertEquals("invalid unique field name", exceptionHolder.getException().getMessage());
   }
 
   private QuestionValidationRequest prepareRequest(String field) {
@@ -68,6 +82,10 @@ public class ValidateQuestionSteps {
       return new QuestionValidationRequest(field, "TEST9900001");
     if (field.equals(FieldName.UNIQUE_NAME.getValue()))
       return new QuestionValidationRequest(field, "Text Question Unique Name");
+    if (field.equals(FieldName.RDB_COLUMN_NAME.getValue()))
+      return new QuestionValidationRequest(field, "ADM_RDB_COL_NM");
+    if (field.equals(FieldName.DATA_MART_COLUMN_NAME.getValue()))
+      return new QuestionValidationRequest(field, "DATA_MRT_COL_NM");
     else // invalid unique field name
       return new QuestionValidationRequest(field, "any value");
   }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionCommandMother.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/support/QuestionCommandMother.java
@@ -136,7 +136,7 @@ public class QuestionCommandMother {
         return new QuestionCommand.ReportingData(
             "report label",
             "RDB_TABLE_NM",
-            "RDB_COL_NM",
+            "ADM_RDB_COL_NM",
             "DATA_MRT_COL_NM");
     }
 

--- a/apps/question-bank/src/test/resources/features/question/ValidateQuestion.feature
+++ b/apps/question-bank/src/test/resources/features/question/ValidateQuestion.feature
@@ -11,6 +11,9 @@ Feature: Validate question
                 | unique-field       |
                 | uniqueId           |
                 | uniqueName         |
+                | rdbColumnName      |
+                | dataMartColumnName |
+
 
     Scenario: I cannot use invalid unique field
         Given I am an admin user
@@ -22,11 +25,19 @@ Feature: Validate question
                  | unique-field       |
                  | uniqueId           |
                  | uniqueName         |
+                 | rdbColumnName      |
+                 | dataMartColumnName |
 
     Scenario: I cannot validate non unique field
         Given I am an admin user
         And A text question exists
         When I validate unique field "non-unique"
+        Then a validate unique question exception is thrown
+
+    Scenario: I cannot validate rdbColumnName with invalid subgroup
+        Given I am an admin user
+        And A text question exists
+        When I validate rdbColumnName with invalid subgroup
         Then a validate unique question exception is thrown
 
     Scenario: I cannot validate unique field without logging in


### PR DESCRIPTION

## Description

When creating a question with the same RDB column name previously used, the Create and add to page button (when clicked) is inoperable. The application should return an error message when    duplicate RDB column name is used or duplicate Data Mart column name is used

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-1843