### PR TITLE
CNFT1-1880 Provider Autocompletion- API development

### DIFF
--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionAutocompleteController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionAutocompleteController.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.option.providers.autocomplete;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+@RequestMapping("nbs/api/options/providers/search")
+class ProviderOptionAutocompleteController {
+
+  private final ProviderOptionResolver resolver;
+
+  ProviderOptionAutocompleteController(final ProviderOptionResolver finder) {
+    this.resolver = finder;
+  }
+
+  @Operation(operationId = "provider-autocomplete", summary = "NBS Provider Option Autocomplete",
+      description = "Provides options from Providers that have a name matching a criteria.", tags = "ProviderOptions")
+  @ApiOperation(value = "NBS Provider Option Autocomplete", nickname = "provider-autocomplete",
+      tags = "ProviderOptions")
+  @GetMapping
+  Collection<Option> complete(
+      @RequestParam final String criteria,
+      @RequestParam(defaultValue = "15") final int limit) {
+    return this.resolver.resolve(criteria, limit);
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
@@ -1,0 +1,36 @@
+package gov.cdc.nbs.option.providers.autocomplete;
+
+import gov.cdc.nbs.option.jdbc.autocomplete.SQLBasedOptionResolver;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProviderOptionResolver extends SQLBasedOptionResolver {
+
+    private static final String QUERY = """
+            with [user]([value], [name]) as (
+                select
+                    person_uid,
+                    ISNULL(first_nm + ' ', '') + ISNULL(last_nm, '')
+                from Person
+                where
+                    cd='PRV'
+            )
+            select
+                [value],
+                [name],
+                row_number() over( order by [name])
+            from [user]
+            where [name] like :criteria
+
+            order by
+                [name]
+
+            offset 0 rows
+            fetch next :limit rows only
+            """;
+
+    public ProviderOptionResolver(final NamedParameterJdbcTemplate template) {
+        super(QUERY, template);
+    }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderAutocompleteRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderAutocompleteRequester.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.provider.autocomplete;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+class ProviderAutocompleteRequester {
+
+  private final MockMvc mvc;
+
+  ProviderAutocompleteRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions complete(final String criteria) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/providers/search")
+            .param("criteria", criteria))
+        .andDo(print());
+  }
+
+  ResultActions complete(final String criteria, final int limit) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/providers/search")
+            .param("criteria", criteria)
+            .param("limit", String.valueOf(limit)))
+        .andDo(print());
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderAutocompleteSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderAutocompleteSteps.java
@@ -1,0 +1,37 @@
+package gov.cdc.nbs.option.provider.autocomplete;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class ProviderAutocompleteSteps {
+
+  private final ProviderAutocompleteRequester request;
+  private final Active<ResultActions> response;
+
+  ProviderAutocompleteSteps(
+      final ProviderAutocompleteRequester request,
+      final Active<ResultActions> response) {
+    this.request = request;
+    this.response = response;
+  }
+
+  @Before("@providers")
+  public void reset() {
+    response.reset();
+  }
+
+  @When("I am trying to find providers that start with {string}")
+  public void i_am_trying_to_find_providers_that_start_with(final String criteria) throws Exception {
+    response.active(request.complete(criteria));
+  }
+
+  @When("I am trying to find at most {int} providers(s) that start with {string}")
+  public void i_am_trying_to_find_n_providers_that_start_with(
+      final int limit,
+      final String criteria) throws Exception {
+    response.active(request.complete(criteria, limit));
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionMother.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionMother.java
@@ -1,0 +1,112 @@
+package gov.cdc.nbs.option.provider.autocomplete;
+
+import gov.cdc.nbs.option.Option;
+import gov.cdc.nbs.testing.support.Available;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+class ProviderOptionMother {
+
+  private static final String DELETE_IN = """
+      delete from Participation where subject_class_cd = 'PSN' and subject_entity_uid in (:identifiers)
+      delete from Person_name where person_uid in (:identifiers);
+      delete from Person where person_uid in (:identifiers);
+      delete from Entity where entity_uid in (:identifiers) and class_cd = 'PSN';
+      """;
+
+  private static final String CREATE =
+      """
+          insert into Entity(entity_uid, class_cd) values (:identifier, 'PSN');
+          insert into Person(person_uid, version_ctrl_nbr, cd, first_nm, last_nm) values (:identifier, 1, 'PRV', :first, :last);
+
+          insert into Person_name(
+            person_uid,
+            person_name_seq,
+            first_nm,
+            last_nm,
+            status_cd,
+            status_time
+          ) values (
+            :identifier,
+            1,
+            :first,
+            :last,
+            'A',
+            GETDATE()
+          )
+          """;
+
+  private final NamedParameterJdbcTemplate template;
+  private final Available<Option> available;
+  private final AtomicLong identifier;
+
+  ProviderOptionMother(final JdbcTemplate template) {
+    this.template = new NamedParameterJdbcTemplate(template);
+    this.available = new Available<>();
+    this.identifier = new AtomicLong(Long.MIN_VALUE);
+  }
+
+  void reset() {
+
+    List<String> codes = this.available.all()
+        .map(Option::value)
+        .toList();
+
+    if (!codes.isEmpty()) {
+
+      Map<String, List<String>> parameters = Map.of("identifiers", codes);
+
+      template.execute(
+          DELETE_IN,
+          new MapSqlParameterSource(parameters),
+          PreparedStatement::executeUpdate);
+      this.available.reset();
+    }
+  }
+
+  private long nextIdentifier() {
+    return identifier.getAndIncrement();
+  }
+
+  void create(final String first, final String last) {
+
+    String username = UUID.randomUUID().toString()
+        .replace("-", "")
+        .substring(0, 20);
+
+    int order = this.available.all()
+        .map(Option::order)
+        .max(Comparator.naturalOrder())
+        .orElse(1);
+
+    long next = nextIdentifier();
+
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "username", username,
+        "first", first,
+        "last", last,
+        "identifier", next);
+
+    template.execute(
+        CREATE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+
+    String name = String.format("%s %s", first, last);
+
+    this.available.available(new Option(String.valueOf(next), name, name, order));
+
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionSteps.java
@@ -1,0 +1,24 @@
+package gov.cdc.nbs.option.provider.autocomplete;
+
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+
+public class ProviderOptionSteps {
+
+  private final ProviderOptionMother mother;
+
+  ProviderOptionSteps(final ProviderOptionMother mother) {
+    this.mother = mother;
+  }
+
+  @Before("@condition")
+  public void clean() {
+    mother.reset();
+  }
+
+  @Given("there is a provider for {string} {string}")
+  public void there_is_a_condition(final String first, final String last) {
+    mother.create(first, last);
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionSteps.java
@@ -11,7 +11,7 @@ public class ProviderOptionSteps {
     this.mother = mother;
   }
 
-  @Before("@condition")
+  @Before("@providers")
   public void clean() {
     mother.reset();
   }

--- a/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
+++ b/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
@@ -1,5 +1,5 @@
 @providers
-Feature: User Options REST API
+Feature: Provider Options REST API
 
   Background:
     Given there is a provider for "Tommy" "Oliver"

--- a/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
+++ b/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
@@ -1,0 +1,27 @@
+@providers
+Feature: User Options REST API
+
+  Background:
+    Given there is a provider for "Tommy" "Oliver"
+    And there is a provider for "Tyler" "Durden"
+    And there is a provider for "Tywin" "Lanister"
+    And there is a provider for "Howard" "Moon"
+    And there is a provider for "Vince" "Nior"
+    And there is a provider for "Tommy" "Callahan III"
+    And there is a provider for "Tracy" "Turnblad"
+    And there is a provider for "Tommy" "Pickles"
+
+  Scenario: I can find specific providers
+    When I am trying to find providers that start with "tom"
+    Then there are options available
+    And the option named "Tommy Oliver" is included
+    And the option named "Tommy Callahan III" is included
+    And the option named "Tommy Pickles" is not included
+
+  Scenario: I can find a specific number of providers
+    When I am trying to find at most 4 providers that start with "t"
+    Then there are 4 options included
+
+  Scenario: I cannot find specific providers that do not exist
+    When I am trying to find providers that start with "zzzzzzzzz"
+    Then there aren't any options available


### PR DESCRIPTION
## Description

API at `nbs/api/options/providers/search`.  Response return the Provider/Person `person_uid` as value and first_nm, last_nm as `name`.  The master record Person should contain the appropriate name.  Note our db isn't optimized for this query as we are doing a like on the concatenation of first_name last_name

## Tickets

* [CNFT1-1880](https://cdc-nbs.atlassian.net/browse/CNFT1-1880)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-1880]: https://cdc-nbs.atlassian.net/browse/CNFT1-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ