### PR TITLE
Perform live validation of uniqueId

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/QuestionForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/QuestionForm.tsx
@@ -14,7 +14,6 @@ export type CreateQuestionForm = Omit<CreateQuestionRequest & AdditionalQuestion
 };
 
 export type AdditionalQuestionFields = {
-    questionType?: QuestionType;
     relatedUnits?: boolean;
     unitType?: 'literal' | 'coded' | '';
 };
@@ -22,7 +21,6 @@ export type AdditionalQuestionFields = {
 type Props = {
     question?: CreateQuestionForm;
 };
-export type QuestionType = 'CODED' | 'NUMERIC' | 'TEXT' | 'DATE';
 
 export const QuestionForm = ({ question }: Props) => {
     const form = useFormContext<CreateQuestionForm>();

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/BasicInformationFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/BasicInformationFields.spec.tsx
@@ -8,6 +8,8 @@ import userEvent from '@testing-library/user-event';
 const { result } = renderHook(() =>
     useForm<CreateQuestionForm>({ mode: 'onBlur', defaultValues: { uniqueId: 'duplicateUniqueId' } })
 );
+
+const setError = jest.fn();
 const validate = jest.fn();
 const mockUseQuestionValidation = {
     validate,
@@ -29,7 +31,7 @@ jest.mock('apps/page-builder/hooks/api/useOptions', () => ({
 describe('BasicInformationFields', () => {
     it('should validate unique Id on blur', async () => {
         const { getByText } = render(
-            <FormProvider {...result.current}>
+            <FormProvider {...result.current} setError={setError}>
                 <BasicInformationFields />
             </FormProvider>
         );
@@ -42,7 +44,9 @@ describe('BasicInformationFields', () => {
 
         await waitFor(() => {
             expect(validate).toHaveBeenCalled();
-            expect(result.current.getFieldState('uniqueId').invalid).toBeTruthy();
+            expect(setError).toHaveBeenCalledWith('uniqueId', {
+                message: 'A question with Unique ID: duplicateUniqueId already exists in the system'
+            });
         });
     });
 });

--- a/apps/modernization-ui/src/apps/page-builder/generated/index.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/index.ts
@@ -141,6 +141,7 @@ export { PageSummaryService } from './services/PageSummaryService';
 export { PageSummaryDownloadControllerService } from './services/PageSummaryDownloadControllerService';
 export { ProgramAreaControllerService } from './services/ProgramAreaControllerService';
 export { QuestionControllerService } from './services/QuestionControllerService';
+export { QuestionControllerHelperService } from './services/QuestionControllerHelperService';
 export { ReorderControllerService } from './services/ReorderControllerService';
 export { SectionControllerService } from './services/SectionControllerService';
 export { SubSectionControllerService } from './services/SubSectionControllerService';

--- a/apps/modernization-ui/src/apps/page-builder/generated/models/QuestionValidationRequest.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/models/QuestionValidationRequest.ts
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type QuestionValidationRequest = {
+  field: QuestionValidationRequest.field;
+  value: string;
+};
+
+export namespace QuestionValidationRequest {
+
+  export enum field {
+      DATA_MART_COLUMN_NAME = 'DATA_MART_COLUMN_NAME',
+      RDB_COLUMN_NAME = 'RDB_COLUMN_NAME',
+      UNIQUE_ID = 'UNIQUE_ID',
+      UNIQUE_NAME = 'UNIQUE_NAME',
+  }
+
+
+}
+

--- a/apps/modernization-ui/src/apps/page-builder/generated/models/QuestionValidationResponse.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/models/QuestionValidationResponse.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type QuestionValidationResponse = {
+    isValid?: boolean;
+};
+

--- a/apps/modernization-ui/src/apps/page-builder/generated/services/QuestionControllerHelperService.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/services/QuestionControllerHelperService.ts
@@ -1,0 +1,69 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DisplayControlOptions } from '../models/DisplayControlOptions';
+import type { QuestionValidationRequest } from '../models/QuestionValidationRequest';
+import type { QuestionValidationResponse } from '../models/QuestionValidationResponse';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+
+export class QuestionControllerHelperService {
+
+    /**
+     * getDisplayControlOptions
+     * @returns DisplayControlOptions OK
+     * @throws ApiError
+     */
+    public static getDisplayControlOptionsUsingGet({
+        authorization,
+    }: {
+        authorization: string,
+    }): CancelablePromise<DisplayControlOptions> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/page-builder/api/v1/questions/displayControlOptions',
+            headers: {
+                'Authorization': authorization,
+            },
+            errors: {
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * validate
+     * @returns QuestionValidationResponse OK
+     * @returns any Created
+     * @throws ApiError
+     */
+    public static validateUsingPost({
+        authorization,
+        request,
+    }: {
+        authorization: string,
+        /**
+         * request
+         */
+        request: QuestionValidationRequest,
+    }): CancelablePromise<QuestionValidationResponse | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/nbs/page-builder/api/v1/questions/validate',
+            headers: {
+                'Authorization': authorization,
+            },
+            body: request,
+            errors: {
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+}

--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useCreateQuestion.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useCreateQuestion.ts
@@ -13,12 +13,11 @@ import {
     TextQuestion
 } from '../../generated';
 
-export type CreateQuestionRequest = (
-    | CreateNumericQuestionRequest
-    | CreateTextQuestionRequest
-    | CreateCodedQuestionRequest
-    | CreateDateQuestionRequest
-) & { questionType: 'CODED' | 'NUMERIC' | 'TEXT' | 'DATE' };
+export type CreateQuestionRequest =
+    | (CreateNumericQuestionRequest & { questionType: 'NUMERIC' })
+    | (CreateTextQuestionRequest & { questionType: 'TEXT' })
+    | (CreateCodedQuestionRequest & { questionType: 'CODED' })
+    | (CreateDateQuestionRequest & { questionType: 'DATE' });
 
 type State =
     | { status: 'idle' }

--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useQuestionValidation.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useQuestionValidation.ts
@@ -1,0 +1,51 @@
+import { QuestionValidationRequest } from 'apps/page-builder/generated/models/QuestionValidationRequest';
+import { QuestionControllerHelperService } from 'apps/page-builder/generated/services/QuestionControllerHelperService';
+import { authorization } from 'authorization';
+import { useEffect, useReducer } from 'react';
+
+type State =
+    | { status: 'idle' }
+    | { status: 'validating'; field: QuestionValidationRequest.field; value: string }
+    | { status: 'complete'; isValid: boolean }
+    | { status: 'error'; error: string };
+
+type Action =
+    | { type: 'validate'; field: QuestionValidationRequest.field; value: string }
+    | { type: 'complete'; isValid: boolean }
+    | { type: 'error'; error: string };
+
+const reducer = (_state: State, action: Action): State => {
+    switch (action.type) {
+        case 'validate':
+            return { status: 'validating', field: action.field, value: action.value };
+        case 'complete':
+            return { status: 'complete', isValid: action.isValid };
+        case 'error':
+            return { status: 'error', error: action.error };
+        default:
+            return { status: 'idle' };
+    }
+};
+
+export const useQuestionValidation = (field: QuestionValidationRequest.field) => {
+    const [state, dispatch] = useReducer(reducer, { status: 'idle' });
+
+    useEffect(() => {
+        if (state.status === 'validating') {
+            QuestionControllerHelperService.validateUsingPost({
+                authorization: authorization(),
+                request: { value: state.value, field: state.field }
+            })
+                .then((response) => dispatch({ type: 'complete', isValid: response.isValid }))
+                .catch(() => console.error(`Failed to validate ${state.field}`));
+        }
+    }, [state.status]);
+
+    const value = {
+        error: state.status === 'error' ? state.error : undefined,
+        isLoading: state.status === 'validating',
+        isValid: state.status === 'complete' ? state.isValid : undefined,
+        validate: (value: string) => dispatch({ type: 'validate', field, value })
+    };
+    return value;
+};

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionControllerHelper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionControllerHelper.java
@@ -1,22 +1,30 @@
 package gov.cdc.nbs.questionbank.question;
 
 
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import gov.cdc.nbs.questionbank.question.model.DisplayControlOptions;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import gov.cdc.nbs.questionbank.question.response.QuestionValidationResponse;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/v1/questions")
 @PreAuthorize("hasAuthority('LDFADMINISTRATION-SYSTEM')")
-@RequiredArgsConstructor
 public class QuestionControllerHelper {
 
   private final QuestionFinder finder;
   private final QuestionManagementUtil managementUtil;
+
+  public QuestionControllerHelper(
+      final QuestionFinder finder,
+      final QuestionManagementUtil managementUtil) {
+    this.finder = finder;
+    this.managementUtil = managementUtil;
+  }
 
 
   @GetMapping("/displayControlOptions")
@@ -25,7 +33,7 @@ public class QuestionControllerHelper {
   }
 
   @PostMapping("/validate")
-  public Boolean validate(@RequestBody QuestionValidationRequest request) {
+  public QuestionValidationResponse validate(@RequestBody QuestionValidationRequest request) {
     return finder.checkUnique(request);
   }
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionFinder.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
-import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.FieldName;
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.Field;
 import gov.cdc.nbs.questionbank.valueset.ValueSetReader;
 import gov.cdc.nbs.questionbank.valueset.response.Concept;
 import org.springframework.data.domain.Page;
@@ -19,84 +19,88 @@ import gov.cdc.nbs.questionbank.question.model.Question;
 import gov.cdc.nbs.questionbank.question.repository.WaQuestionRepository;
 import gov.cdc.nbs.questionbank.question.request.FindQuestionRequest;
 import gov.cdc.nbs.questionbank.question.response.GetQuestionResponse;
+import gov.cdc.nbs.questionbank.question.response.QuestionValidationResponse;
 
 @Component
 public class QuestionFinder {
-    private final WaQuestionRepository questionRepository;
-    private final WaUiMetadataRepository uiMetadataRepository;
-    private final QuestionMapper questionMapper;
-    private final ValueSetReader valueSetReader;
+  private final WaQuestionRepository questionRepository;
+  private final WaUiMetadataRepository uiMetadataRepository;
+  private final QuestionMapper questionMapper;
+  private final ValueSetReader valueSetReader;
 
-    private static final String SUBGROUP_CODE_SET = "NBS_QUES_SUBGROUP";
+  private static final String SUBGROUP_CODE_SET = "NBS_QUES_SUBGROUP";
 
-    public QuestionFinder(
-        final WaQuestionRepository questionRepository,
-        final QuestionMapper questionMapper,
-        WaUiMetadataRepository uiMetadataRepository,
-        ValueSetReader valueSetReader) {
-        this.questionRepository = questionRepository;
-        this.questionMapper = questionMapper;
-        this.uiMetadataRepository = uiMetadataRepository;
-        this.valueSetReader = valueSetReader;
+  public QuestionFinder(
+      final WaQuestionRepository questionRepository,
+      final QuestionMapper questionMapper,
+      WaUiMetadataRepository uiMetadataRepository,
+      ValueSetReader valueSetReader) {
+    this.questionRepository = questionRepository;
+    this.questionMapper = questionMapper;
+    this.uiMetadataRepository = uiMetadataRepository;
+    this.valueSetReader = valueSetReader;
+  }
+
+  public GetQuestionResponse find(Long id) {
+    Question question = questionRepository.findById(id)
+        .map(questionMapper::toQuestion)
+        .orElseThrow(() -> new QuestionNotFoundException(id));
+    boolean isInUse = checkQuestionInUse(question.uniqueId());
+    return new GetQuestionResponse(question, isInUse);
+  }
+
+  public Page<Question> find(Pageable pageable) {
+    Page<WaQuestion> page = questionRepository.findAll(pageable);
+    List<Question> questions = page.get().map(questionMapper::toQuestion).toList();
+    return new PageImpl<>(questions, pageable, page.getTotalElements());
+  }
+
+  public Page<Question> find(FindQuestionRequest request, Pageable pageable) {
+    Page<WaQuestion> page = questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(
+        request.search(),
+        tryConvert(request.search()),
+        request.questionType(),
+        pageable);
+    List<Question> questions = page.get().map(questionMapper::toQuestion).toList();
+    return new PageImpl<>(questions, pageable, page.getTotalElements());
+  }
+
+  public boolean checkQuestionInUse(String identifier) {
+    return !uiMetadataRepository.findAllByQuestionIdentifier(identifier).isEmpty();
+  }
+
+  Long tryConvert(String search) {
+    try {
+      return Long.valueOf(search);
+    } catch (NumberFormatException e) {
+      return -1L;
     }
+  }
 
-    public GetQuestionResponse find(Long id) {
-        Question question = questionRepository.findById(id)
-            .map(questionMapper::toQuestion)
-            .orElseThrow(() -> new QuestionNotFoundException(id));
-        boolean isInUse = checkQuestionInUse(question.uniqueId());
-        return new GetQuestionResponse(question, isInUse);
+  public QuestionValidationResponse checkUnique(QuestionValidationRequest request) {
+    if (request.value() == null || request.field() == null) {
+      throw new UniqueQuestionException("Invalid request");
     }
+    if (Field.UNIQUE_ID.equals(request.field()))
+      return new QuestionValidationResponse(questionRepository.findIdByQuestionIdentifier(request.value()).isEmpty());
+    if (Field.UNIQUE_NAME.equals(request.field()))
+      return new QuestionValidationResponse(questionRepository.findIdByQuestionNm(request.value()).isEmpty());
+    if (Field.DATA_MART_COLUMN_NAME.equals(request.field()))
+      return new QuestionValidationResponse(questionRepository.findIdByUserDefinedColumnNm(request.value()).isEmpty());
+    if (Field.RDB_COLUMN_NAME.equals(request.field())) {
+      checkSubGroupValidity(request.value());
+      return new QuestionValidationResponse(questionRepository.findIdByRdbColumnNm(request.value()).isEmpty());
+    }
+    throw new UniqueQuestionException("invalid unique field name");
+  }
 
-    public Page<Question> find(Pageable pageable) {
-        Page<WaQuestion> page = questionRepository.findAll(pageable);
-        List<Question> questions = page.get().map(questionMapper::toQuestion).toList();
-        return new PageImpl<>(questions, pageable, page.getTotalElements());
-    }
-
-    public Page<Question> find(FindQuestionRequest request, Pageable pageable) {
-        Page<WaQuestion> page = questionRepository.findAllByNameOrIdentifierOrQuestionTypeOrSubGroup(
-            request.search(),
-            tryConvert(request.search()),
-            request.questionType(),
-            pageable);
-        List<Question> questions = page.get().map(questionMapper::toQuestion).toList();
-        return new PageImpl<>(questions, pageable, page.getTotalElements());
-    }
-
-    public boolean checkQuestionInUse(String identifier) {
-        return !uiMetadataRepository.findAllByQuestionIdentifier(identifier).isEmpty();
-    }
-
-    Long tryConvert(String search) {
-        try {
-            return Long.valueOf(search);
-        } catch (NumberFormatException e) {
-            return -1L;
-        }
-    }
-
-    public boolean checkUnique(QuestionValidationRequest request) {
-        if (request.fieldName().equals(FieldName.UNIQUE_ID.getValue()))
-            return questionRepository.findIdByQuestionIdentifier(request.value()).isEmpty();
-        if (request.fieldName().equals(FieldName.UNIQUE_NAME.getValue()))
-            return questionRepository.findIdByQuestionNm(request.value()).isEmpty();
-        if (request.fieldName().equals(FieldName.DATA_MART_COLUMN_NAME.getValue()))
-            return questionRepository.findIdByUserDefinedColumnNm(request.value()).isEmpty();
-        if (request.fieldName().equals(FieldName.RDB_COLUMN_NAME.getValue())) {
-            checkSubGroupValidity(request.value());
-            return questionRepository.findIdByRdbColumnNm(request.value()).isEmpty();
-        }
-        throw new UniqueQuestionException("invalid unique field name");
-    }
-
-    private void checkSubGroupValidity(String rdbColumnName) {
-        String subGroupCode = rdbColumnName.substring(0, rdbColumnName.indexOf("_"));
-        boolean isMatch = valueSetReader.findConceptCodes(SUBGROUP_CODE_SET)
-            .stream().map(Concept::localCode).anyMatch(code -> code.equals(subGroupCode));
-        if (!isMatch)
-            throw new UniqueQuestionException("invalid subgroup Code");
-    }
+  private void checkSubGroupValidity(String rdbColumnName) {
+    String subGroupCode = rdbColumnName.substring(0, rdbColumnName.indexOf("_"));
+    boolean isMatch = valueSetReader.findConceptCodes(SUBGROUP_CODE_SET)
+        .stream().map(Concept::localCode).anyMatch(code -> code.equals(subGroupCode));
+    if (!isMatch)
+      throw new UniqueQuestionException("invalid subgroup Code");
+  }
 }
 
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/request/QuestionValidationRequest.java
@@ -1,22 +1,16 @@
 package gov.cdc.nbs.questionbank.question.request;
 
-public record QuestionValidationRequest(String fieldName, String value) {
+import io.swagger.annotations.ApiModelProperty;
 
-  public enum FieldName {
-    UNIQUE_ID("uniqueId"),
-    UNIQUE_NAME("uniqueName"),
-    RDB_COLUMN_NAME("rdbColumnName"),
-    DATA_MART_COLUMN_NAME("dataMartColumnName");
+public record QuestionValidationRequest(
+    @ApiModelProperty(required = true) Field field,
+    @ApiModelProperty(required = true) String value) {
 
-    private final String value;
-
-    FieldName(String value) {
-      this.value = value;
-    }
-
-    public String getValue() {
-      return value;
-    }
+  public enum Field {
+    UNIQUE_ID,
+    UNIQUE_NAME,
+    RDB_COLUMN_NAME,
+    DATA_MART_COLUMN_NAME
   }
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/response/QuestionValidationResponse.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/response/QuestionValidationResponse.java
@@ -1,0 +1,5 @@
+package gov.cdc.nbs.questionbank.question.response;
+
+public record QuestionValidationResponse(boolean isValid) {
+
+}

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/ValidateQuestionSteps.java
@@ -4,16 +4,14 @@ package gov.cdc.nbs.questionbank.question;
 import gov.cdc.nbs.questionbank.question.exception.UniqueQuestionException;
 import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest;
 import gov.cdc.nbs.questionbank.support.ExceptionHolder;
-import gov.cdc.nbs.questionbank.support.QuestionMother;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.FieldName;
-
+import gov.cdc.nbs.questionbank.question.request.QuestionValidationRequest.Field;
+import gov.cdc.nbs.questionbank.question.response.QuestionValidationResponse;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertTrue;
 
 
 public class ValidateQuestionSteps {
@@ -24,12 +22,9 @@ public class ValidateQuestionSteps {
   @Autowired
   private QuestionControllerHelper controllerHelper;
 
-  @Autowired
-  private QuestionMother questionMother;
-
   QuestionValidationRequest request;
 
-  private boolean validationResult;
+  private QuestionValidationResponse validationResult;
 
 
   @When("I validate unique field {string}")
@@ -49,7 +44,7 @@ public class ValidateQuestionSteps {
   @When("I validate rdbColumnName with invalid subgroup")
   public void i_validate_rdbColumnName_with_invalid_subgroup() {
     try {
-      request = new QuestionValidationRequest(FieldName.RDB_COLUMN_NAME.getValue(), "XXX_RDB_COL_NMM");
+      request = new QuestionValidationRequest(Field.RDB_COLUMN_NAME, "XXX_RDB_COL_NMM");
       validationResult = controllerHelper.validate(request);
     } catch (UniqueQuestionException e) {
       exceptionHolder.setException(e);
@@ -63,12 +58,12 @@ public class ValidateQuestionSteps {
 
   @Then("return valid")
   public void return_valid() {
-    assertTrue(validationResult);
+    assertTrue(validationResult.isValid());
   }
 
   @Then("return not valid")
   public void return_not_valid() {
-    assertFalse(validationResult);
+    assertFalse(validationResult.isValid());
   }
 
   @Then("a validate unique question exception is thrown")
@@ -78,16 +73,16 @@ public class ValidateQuestionSteps {
   }
 
   private QuestionValidationRequest prepareRequest(String field) {
-    if (field.equals(FieldName.UNIQUE_ID.getValue()))
-      return new QuestionValidationRequest(field, "TEST9900001");
-    if (field.equals(FieldName.UNIQUE_NAME.getValue()))
-      return new QuestionValidationRequest(field, "Text Question Unique Name");
-    if (field.equals(FieldName.RDB_COLUMN_NAME.getValue()))
-      return new QuestionValidationRequest(field, "ADM_RDB_COL_NM");
-    if (field.equals(FieldName.DATA_MART_COLUMN_NAME.getValue()))
-      return new QuestionValidationRequest(field, "DATA_MRT_COL_NM");
+    if ("uniqueId".equals(field))
+      return new QuestionValidationRequest(Field.UNIQUE_ID, "TEST9900001");
+    if ("uniqueName".equals(field))
+      return new QuestionValidationRequest(Field.UNIQUE_NAME, "Text Question Unique Name");
+    if ("rdbColumnName".equals(field))
+      return new QuestionValidationRequest(Field.RDB_COLUMN_NAME, "ADM_RDB_COL_NM");
+    if ("dataMartColumnName".equals(field))
+      return new QuestionValidationRequest(Field.DATA_MART_COLUMN_NAME, "DATA_MRT_COL_NM");
     else // invalid unique field name
-      return new QuestionValidationRequest(field, "any value");
+      return new QuestionValidationRequest(null, "any value");
   }
 
 }


### PR DESCRIPTION
## Description

Performs live validation of the `unique ID` field in the create question form. Validation is triggered on blur.
Does some light cleanup on the create question type and on the enum for the validation API.

## Tickets

* [CNFT2-1815](https://cdc-nbs.atlassian.net/browse/CNFT2-1815)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
