### PR TITLE
Fix validation loss onChange

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/QuestionForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/QuestionForm.tsx
@@ -24,28 +24,19 @@ type Props = {
 
 export const QuestionForm = ({ question }: Props) => {
     const form = useFormContext<CreateQuestionForm>();
-    const watch = useWatch<CreateQuestionForm>(form);
+    const displayControl = useWatch<CreateQuestionForm>({
+        control: form.control,
+        name: 'displayControl',
+        exact: true
+    });
 
     useEffect(() => {
-        if (watch.displayControl?.toString() === '1026') {
+        if (displayControl?.toString() === '1026') {
             // Clear data mart / messaging values when `Readonly User text, number, or date` display control is selected
-            form.reset({
-                ...form.getValues(),
-                dataMartInfo: {
-                    reportLabel: undefined,
-                    defaultRdbTableName: undefined,
-                    dataMartColumnName: undefined,
-                    rdbColumnName: undefined
-                },
-                messagingInfo: {
-                    messageVariableId: undefined,
-                    labelInMessage: undefined,
-                    codeSystem: undefined,
-                    hl7DataType: undefined
-                }
-            });
+            form.resetField('dataMartInfo');
+            form.resetField('messagingInfo');
         }
-    }, [watch.displayControl]);
+    }, [displayControl]);
 
     return (
         <div className={styles.form}>
@@ -53,7 +44,7 @@ export const QuestionForm = ({ question }: Props) => {
             <QuestionSpecificFields />
             <div className={styles.divider} />
             <UserInterfaceFields />
-            {watch.displayControl?.toString() !== '1026' && ( // hide data mart and messaging if display control = 'Readonly User text, number, or date'
+            {displayControl?.toString() !== '1026' && ( // hide data mart and messaging if display control = 'Readonly User text, number, or date'
                 <>
                     <div className={styles.divider} />
                     <DataMartFields editing={question !== undefined} />

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/BasicInformationFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/BasicInformationFields.tsx
@@ -24,7 +24,11 @@ type Props = {
 };
 export const BasicInformationFields = ({ editing = false }: Props) => {
     const form = useFormContext<CreateQuestionForm>();
-    const watch = useWatch(form);
+    const [uniqueId, uniqueName, questionType] = useWatch({
+        control: form.control,
+        name: ['uniqueId', 'uniqueName', 'questionType'],
+        exact: true
+    });
     const { options: subgroups } = useOptions('NBS_QUES_SUBGROUP');
     const { isValid: uniqueIdIsValid, validate: validateUniqueId } = useQuestionValidation(
         QuestionValidationRequest.field.UNIQUE_ID
@@ -49,7 +53,7 @@ export const BasicInformationFields = ({ editing = false }: Props) => {
         // check === false to keep undefined from triggering an error
         if (uniqueIdIsValid === false) {
             form.setError('uniqueId', {
-                message: `A question with Unique ID: ${watch.uniqueId} already exists in the system`
+                message: `A question with Unique ID: ${uniqueId} already exists in the system`
             });
         }
     }, [uniqueIdIsValid]);
@@ -58,7 +62,7 @@ export const BasicInformationFields = ({ editing = false }: Props) => {
         // check === false to keep undefined from triggering an error
         if (uniqueNameIsValid === false) {
             form.setError('uniqueName', {
-                message: `A question with Unique name: ${watch.uniqueName} already exists in the system`
+                message: `A question with Unique name: ${uniqueName} already exists in the system`
             });
         }
     }, [uniqueNameIsValid]);
@@ -105,7 +109,7 @@ export const BasicInformationFields = ({ editing = false }: Props) => {
                             onChange={onChange}
                             onBlur={() => {
                                 onBlur();
-                                handleUniqueIdValidation(watch.uniqueId);
+                                handleUniqueIdValidation(uniqueId);
                             }}
                             defaultValue={value}
                             label="Unique ID"
@@ -131,7 +135,7 @@ export const BasicInformationFields = ({ editing = false }: Props) => {
                         onChange={onChange}
                         onBlur={() => {
                             onBlur();
-                            handleUniqueNameValidation(watch.uniqueName);
+                            handleUniqueNameValidation(uniqueName);
                         }}
                         defaultValue={value}
                         label="Unique name"
@@ -207,7 +211,7 @@ export const BasicInformationFields = ({ editing = false }: Props) => {
                                 <Button
                                     key={k}
                                     type="button"
-                                    outline={field.value !== watch.questionType}
+                                    outline={field.value !== questionType}
                                     disabled={editing}
                                     onClick={() => {
                                         onChange(field.value);

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/CodedFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/CodedFields.tsx
@@ -7,7 +7,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 export const CodedFields = () => {
     const form = useFormContext<CreateCodedQuestionRequest>();
-    const watch = useWatch(form);
+    const valueSet = useWatch({ control: form.control, name: 'valueSet', exact: true });
     const [valueSets, setValueSets] = useState<ValueSetOption[]>([]);
     const { options, fetch } = useOptions();
 
@@ -20,10 +20,10 @@ export const CodedFields = () => {
     }, []);
 
     useEffect(() => {
-        const selected = valueSets.find((v) => v.value === watch.valueSet?.toString());
+        const selected = valueSets.find((v) => v.value === valueSet?.toString());
         selected && fetch(selected.codeSetNm);
         form.setValue('defaultValue', undefined);
-    }, [watch.valueSet]);
+    }, [valueSet]);
 
     return (
         <>
@@ -59,7 +59,7 @@ export const CodedFields = () => {
                         label="Default value"
                         onChange={onChange}
                         defaultValue={value}
-                        options={watch.valueSet ? options : []}
+                        options={valueSet ? options : []}
                         error={error?.message}
                         name={name}
                         id={name}

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.spec.tsx
@@ -51,7 +51,7 @@ describe('DataMartFields', () => {
         await waitFor(() => {
             expect(validate).toHaveBeenCalled();
             expect(setError).toHaveBeenNthCalledWith(2, 'dataMartInfo.dataMartColumnName', {
-                message: 'A column name: duplicateDataMartColumnName already exists in the system'
+                message: 'A Data mart column named: duplicateDataMartColumnName already exists in the system'
             });
         });
     });
@@ -73,7 +73,7 @@ describe('DataMartFields', () => {
             expect(validate).toHaveBeenCalled();
             expect(setError).toHaveBeenNthCalledWith(1, 'dataMartInfo.rdbColumnName', {
                 message:
-                    'A column name: duplicateRdbColumnName already exists in the system with the specified subgroup'
+                    'An Rdb column named: duplicateRdbColumnName already exists in the system for the specified subgroup'
             });
         });
     });

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
@@ -15,7 +15,11 @@ type Props = {
 export const DataMartFields = ({ editing = false }: Props) => {
     const { options: rdbTableNames } = useOptions('NBS_PH_DOMAINS');
     const form = useFormContext<CreateQuestionForm>();
-    const watch = useWatch(form);
+    const [displayControl, subgroup, dataMartInfo] = useWatch({
+        control: form.control,
+        name: ['displayControl', 'subgroup', 'dataMartInfo'],
+        exact: true
+    });
     const alphanumericUnderscoreNotStartingWithNumber = /^[a-zA-Z_]\w*$/;
     const { isValid: isValidRdbColumn, validate: validateRdbColumnName } = useQuestionValidation(
         QuestionValidationRequest.field.RDB_COLUMN_NAME
@@ -25,11 +29,11 @@ export const DataMartFields = ({ editing = false }: Props) => {
     );
 
     useEffect(() => {
-        if (watch.displayControl?.toString() !== '1026') {
-            const tableName = rdbTableNames.find((o) => o.value === watch.subgroup);
+        if (displayControl?.toString() !== '1026') {
+            const tableName = rdbTableNames.find((o) => o.value === subgroup);
             form.setValue('dataMartInfo.defaultRdbTableName', tableName?.name);
         }
-    }, [watch.subgroup]);
+    }, [subgroup, rdbTableNames]);
 
     const handleRdbColumnNameValidation = (subgroup: string | undefined, columnName: string | undefined) => {
         if (columnName && subgroup) {
@@ -45,16 +49,16 @@ export const DataMartFields = ({ editing = false }: Props) => {
 
     // If subgroup changes, we have to re-validate the rdbColumnName
     useEffect(() => {
-        if (watch.subgroup && watch.dataMartInfo?.rdbColumnName) {
-            handleRdbColumnNameValidation(watch.subgroup, watch.dataMartInfo.rdbColumnName);
+        if (subgroup && dataMartInfo?.rdbColumnName) {
+            handleRdbColumnNameValidation(subgroup, dataMartInfo.rdbColumnName);
         }
-    }, [watch.subgroup]);
+    }, [subgroup]);
 
     useEffect(() => {
         // check === false to keep undefined from triggering an error
         if (isValidRdbColumn === false) {
             form.setError('dataMartInfo.rdbColumnName', {
-                message: `A column name: ${watch.dataMartInfo?.rdbColumnName} already exists in the system with the specified subgroup`
+                message: `A column name: ${dataMartInfo?.rdbColumnName} already exists in the system with the specified subgroup`
             });
         }
     }, [isValidRdbColumn]);
@@ -62,7 +66,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
     useEffect(() => {
         if (isValidDataMartColumnName === false) {
             form.setError('dataMartInfo.dataMartColumnName', {
-                message: `A column name: ${watch.dataMartInfo?.dataMartColumnName} already exists in the system`
+                message: `A column name: ${dataMartInfo?.dataMartColumnName} already exists in the system`
             });
         }
     }, [isValidDataMartColumnName]);
@@ -138,7 +142,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
                         }}
                         onBlur={() => {
                             onBlur();
-                            handleRdbColumnNameValidation(watch.subgroup, watch.dataMartInfo?.rdbColumnName);
+                            handleRdbColumnNameValidation(subgroup, dataMartInfo?.rdbColumnName);
                         }}
                         defaultValue={value}
                         type="text"
@@ -169,7 +173,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
                         }}
                         onBlur={() => {
                             onBlur();
-                            handleDataMartColumnNameValidation(watch.dataMartInfo?.dataMartColumnName);
+                            handleDataMartColumnNameValidation(dataMartInfo?.dataMartColumnName);
                         }}
                         className="field-space"
                         defaultValue={value}

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
@@ -58,7 +58,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
         // check === false to keep undefined from triggering an error
         if (isValidRdbColumn === false) {
             form.setError('dataMartInfo.rdbColumnName', {
-                message: `A column name: ${dataMartInfo?.rdbColumnName} already exists in the system with the specified subgroup`
+                message: `An Rdb column named: ${dataMartInfo?.rdbColumnName} already exists in the system for the specified subgroup`
             });
         }
     }, [isValidRdbColumn]);
@@ -66,7 +66,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
     useEffect(() => {
         if (isValidDataMartColumnName === false) {
             form.setError('dataMartInfo.dataMartColumnName', {
-                message: `A column name: ${dataMartInfo?.dataMartColumnName} already exists in the system`
+                message: `A Data mart column named: ${dataMartInfo?.dataMartColumnName} already exists in the system`
             });
         }
     }, [isValidDataMartColumnName]);

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
@@ -15,9 +15,9 @@ type Props = {
 export const DataMartFields = ({ editing = false }: Props) => {
     const { options: rdbTableNames } = useOptions('NBS_PH_DOMAINS');
     const form = useFormContext<CreateQuestionForm>();
-    const [displayControl, subgroup, dataMartInfo] = useWatch({
+    const [displayControl, subgroup, dataMartColumnName, rdbColumnName] = useWatch({
         control: form.control,
-        name: ['displayControl', 'subgroup', 'dataMartInfo'],
+        name: ['displayControl', 'subgroup', 'dataMartInfo.dataMartColumnName', 'dataMartInfo.rdbColumnName'],
         exact: true
     });
     const alphanumericUnderscoreNotStartingWithNumber = /^[a-zA-Z_]\w*$/;
@@ -36,6 +36,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
     }, [subgroup, rdbTableNames]);
 
     const handleRdbColumnNameValidation = (subgroup: string | undefined, columnName: string | undefined) => {
+        console.log('doing validation!', subgroup, columnName);
         if (columnName && subgroup) {
             validateRdbColumnName(`${subgroup}_${columnName}`);
         }
@@ -49,8 +50,8 @@ export const DataMartFields = ({ editing = false }: Props) => {
 
     // If subgroup changes, we have to re-validate the rdbColumnName
     useEffect(() => {
-        if (subgroup && dataMartInfo?.rdbColumnName) {
-            handleRdbColumnNameValidation(subgroup, dataMartInfo.rdbColumnName);
+        if (subgroup && rdbColumnName) {
+            handleRdbColumnNameValidation(subgroup, rdbColumnName);
         }
     }, [subgroup]);
 
@@ -58,15 +59,17 @@ export const DataMartFields = ({ editing = false }: Props) => {
         // check === false to keep undefined from triggering an error
         if (isValidRdbColumn === false) {
             form.setError('dataMartInfo.rdbColumnName', {
-                message: `An Rdb column named: ${dataMartInfo?.rdbColumnName} already exists in the system for the specified subgroup`
+                message: `An Rdb column named: ${rdbColumnName} already exists in the system for the specified subgroup`
             });
+        } else {
+            form.clearErrors('dataMartInfo.rdbColumnName');
         }
     }, [isValidRdbColumn]);
 
     useEffect(() => {
         if (isValidDataMartColumnName === false) {
             form.setError('dataMartInfo.dataMartColumnName', {
-                message: `A Data mart column named: ${dataMartInfo?.dataMartColumnName} already exists in the system`
+                message: `A Data mart column named: ${dataMartColumnName} already exists in the system`
             });
         }
     }, [isValidDataMartColumnName]);
@@ -142,7 +145,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
                         }}
                         onBlur={() => {
                             onBlur();
-                            handleRdbColumnNameValidation(subgroup, dataMartInfo?.rdbColumnName);
+                            handleRdbColumnNameValidation(subgroup, rdbColumnName);
                         }}
                         defaultValue={value}
                         type="text"
@@ -173,7 +176,7 @@ export const DataMartFields = ({ editing = false }: Props) => {
                         }}
                         onBlur={() => {
                             onBlur();
-                            handleDataMartColumnNameValidation(dataMartInfo?.dataMartColumnName);
+                            handleDataMartColumnNameValidation(dataMartColumnName);
                         }}
                         className="field-space"
                         defaultValue={value}

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/MessagingFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/MessagingFields.tsx
@@ -16,10 +16,10 @@ export const MessagingFields = ({ editing = false }: Props) => {
     const { options: codeSystems } = useOptions('CODE_SYSTEM');
     const { options: hl7Options } = useOptions('NBS_HL7_DATA_TYPE');
     const form = useFormContext<CreateQuestionForm>();
-    const watch = useWatch(form);
+    const messagingInfo = useWatch({ control: form.control, name: 'messagingInfo', exact: true });
 
     useEffect(() => {
-        if (!watch.messagingInfo?.includedInMessage) {
+        if (!messagingInfo?.includedInMessage) {
             form.reset({
                 ...form.getValues(),
                 messagingInfo: {
@@ -30,7 +30,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 }
             });
         }
-    }, [watch.messagingInfo?.includedInMessage]);
+    }, [messagingInfo?.includedInMessage]);
 
     return (
         <>
@@ -57,7 +57,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.messageVariableId"
                 rules={{
                     required: {
-                        value: watch.messagingInfo?.includedInMessage ?? false,
+                        value: messagingInfo?.includedInMessage ?? false,
                         message: 'Message ID is required'
                     },
                     ...maxLengthRule(50)
@@ -72,8 +72,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        disabled={!watch.messagingInfo?.includedInMessage}
-                        required={watch.messagingInfo?.includedInMessage}
+                        disabled={!messagingInfo?.includedInMessage}
+                        required={messagingInfo?.includedInMessage}
                         error={error?.message}
                     />
                 )}
@@ -83,7 +83,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.labelInMessage"
                 rules={{
                     required: {
-                        value: watch.messagingInfo?.includedInMessage ?? false,
+                        value: messagingInfo?.includedInMessage ?? false,
                         message: 'Message label is required'
                     },
                     ...maxLengthRule(100)
@@ -98,8 +98,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        required={watch.messagingInfo?.includedInMessage}
-                        disabled={!watch.messagingInfo?.includedInMessage}
+                        required={messagingInfo?.includedInMessage}
+                        disabled={!messagingInfo?.includedInMessage}
                         error={error?.message}
                     />
                 )}
@@ -109,7 +109,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.codeSystem"
                 rules={{
                     required: {
-                        value: watch.messagingInfo?.includedInMessage ?? false,
+                        value: messagingInfo?.includedInMessage ?? false,
                         message: 'Code system name is required'
                     }
                 }}
@@ -123,8 +123,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         id={name}
                         htmlFor={name}
                         options={codeSystems}
-                        disabled={!watch.messagingInfo?.includedInMessage}
-                        required={watch.messagingInfo?.includedInMessage}
+                        disabled={!messagingInfo?.includedInMessage}
+                        required={messagingInfo?.includedInMessage}
                     />
                 )}
             />
@@ -143,7 +143,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                                 className="requiredInMessage"
                                 checked={value}
                                 name="includedInMessage"
-                                disabled={!watch.messagingInfo?.includedInMessage}
+                                disabled={!messagingInfo?.includedInMessage}
                                 onChange={onChange}
                             />
                             <div>Required</div>
@@ -156,7 +156,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.hl7DataType"
                 rules={{
                     required: {
-                        value: watch.messagingInfo?.includedInMessage ?? false,
+                        value: messagingInfo?.includedInMessage ?? false,
                         message: 'HL7 data type required'
                     }
                 }}
@@ -170,8 +170,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        disabled={!watch.messagingInfo?.includedInMessage}
-                        required={watch.messagingInfo?.includedInMessage}
+                        disabled={!messagingInfo?.includedInMessage}
+                        required={messagingInfo?.includedInMessage}
                         options={hl7Options}
                     />
                 )}

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/NumericFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/NumericFields.tsx
@@ -15,9 +15,13 @@ type Props = {
 };
 export const NumericFields = ({ maskOptions }: Props) => {
     const form = useFormContext<CreateNumericQuestionRequest & AdditionalQuestionFields>();
-    const watch = useWatch(form);
+    const [mask, relatedUnits, unitType] = useWatch({
+        control: form.control,
+        name: ['mask', 'relatedUnits', 'unitType'],
+        exact: true
+    });
     const [numericMaskOptions, setNumericMaskOptions] = useState<Option[]>([]);
-    const [relatedUnits, setRelatedUnits] = useState(false);
+    const [relatedUnitsToggle, setRelatedUnitsToggle] = useState(false);
     const [valueSets, setValueSets] = useState<Selectable[]>([]);
 
     useEffect(() => {
@@ -44,18 +48,18 @@ export const NumericFields = ({ maskOptions }: Props) => {
     }, [maskOptions]);
 
     useEffect(() => {
-        if (watch.mask !== CreateNumericQuestionRequest.mask.NUM) {
+        if (mask !== CreateNumericQuestionRequest.mask.NUM) {
             form.resetField('fieldLength');
         }
-    }, [watch.mask]);
+    }, [mask]);
 
     useEffect(() => {
         form.resetField('relatedUnitsLiteral');
         form.resetField('relatedUnitsValueSet');
-        if (!watch.relatedUnits) {
+        if (!relatedUnits) {
             form.resetField('unitType');
         }
-    }, [watch.unitType, watch.relatedUnits]);
+    }, [unitType, relatedUnits]);
 
     return (
         <>
@@ -86,7 +90,7 @@ export const NumericFields = ({ maskOptions }: Props) => {
                 name="fieldLength"
                 rules={{
                     required: {
-                        value: watch.mask === CreateNumericQuestionRequest.mask.NUM,
+                        value: mask === CreateNumericQuestionRequest.mask.NUM,
                         message: 'Field length is required'
                     },
                     ...maxLengthRule(10)
@@ -104,8 +108,8 @@ export const NumericFields = ({ maskOptions }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        disabled={watch.mask !== CreateNumericQuestionRequest.mask.NUM}
-                        required
+                        disabled={mask !== CreateNumericQuestionRequest.mask.NUM}
+                        required={mask === CreateNumericQuestionRequest.mask.NUM}
                     />
                 )}
             />
@@ -173,10 +177,10 @@ export const NumericFields = ({ maskOptions }: Props) => {
                     value="yes"
                     label="Yes"
                     onChange={() => {
-                        setRelatedUnits(true);
+                        setRelatedUnitsToggle(true);
                         form.setValue('relatedUnits', true);
                     }}
-                    checked={relatedUnits}
+                    checked={relatedUnitsToggle}
                 />
                 <Radio
                     id="allowFutureDates no"
@@ -184,13 +188,13 @@ export const NumericFields = ({ maskOptions }: Props) => {
                     value="no"
                     label="No"
                     onChange={() => {
-                        setRelatedUnits(false);
+                        setRelatedUnitsToggle(false);
                         form.setValue('relatedUnits', false);
                     }}
-                    checked={!relatedUnits}
+                    checked={!relatedUnitsToggle}
                 />
             </div>
-            {watch.relatedUnits && (
+            {relatedUnits && (
                 <>
                     <Controller
                         control={form.control}
@@ -217,7 +221,7 @@ export const NumericFields = ({ maskOptions }: Props) => {
                             />
                         )}
                     />
-                    {watch.unitType === 'literal' && (
+                    {unitType === 'literal' && (
                         <Controller
                             control={form.control}
                             name="relatedUnitsLiteral"
@@ -241,7 +245,7 @@ export const NumericFields = ({ maskOptions }: Props) => {
                             )}
                         />
                     )}
-                    {watch.unitType === 'coded' && (
+                    {unitType === 'coded' && (
                         <Controller
                             control={form.control}
                             name="relatedUnitsValueSet"

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/QuestionSpecificFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/QuestionSpecificFields.tsx
@@ -7,15 +7,16 @@ import { NumericFields } from './NumericFields';
 import { TextFields } from './TextFields';
 
 export const QuestionSpecificFields = () => {
-    const watch = useWatch(useFormContext<CreateQuestionForm>());
+    const form = useFormContext<CreateQuestionForm>();
+    const questionType = useWatch({ control: form.control, name: 'questionType', exact: true });
     const { options: maskOptions } = useOptions('NBS_MASK_TYPE');
 
     return (
         <>
-            {watch.questionType === 'CODED' && <CodedFields />}
-            {watch.questionType === 'NUMERIC' && <NumericFields maskOptions={maskOptions} />}
-            {watch.questionType === 'TEXT' && <TextFields maskOptions={maskOptions} />}
-            {watch.questionType === 'DATE' && <DateFields maskOptions={maskOptions} />}
+            {questionType === 'CODED' && <CodedFields />}
+            {questionType === 'NUMERIC' && <NumericFields maskOptions={maskOptions} />}
+            {questionType === 'TEXT' && <TextFields maskOptions={maskOptions} />}
+            {questionType === 'DATE' && <DateFields maskOptions={maskOptions} />}
         </>
     );
 };

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/TextFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/TextFields.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 export const TextFields = ({ maskOptions }: Props) => {
     const form = useFormContext<CreateTextQuestionRequest>();
-    const watch = useWatch(form);
+    const mask = useWatch({ control: form.control, name: 'mask', exact: true });
     const [textMaskOptions, setTextMaskOptions] = useState<Option[]>([]);
 
     useEffect(() => {
@@ -29,10 +29,10 @@ export const TextFields = ({ maskOptions }: Props) => {
     }, [maskOptions]);
 
     useEffect(() => {
-        if (watch.mask !== 'TXT') {
+        if (mask !== 'TXT') {
             form.resetField('fieldLength');
         }
-    }, [watch.mask]);
+    }, [mask]);
 
     return (
         <>
@@ -62,7 +62,10 @@ export const TextFields = ({ maskOptions }: Props) => {
                 control={form.control}
                 name="fieldLength"
                 rules={{
-                    required: { value: true, message: 'Field length is required' },
+                    required: {
+                        value: mask === CreateTextQuestionRequest.mask.TXT,
+                        message: 'Field length is required'
+                    },
                     ...maxLengthRule(4)
                 }}
                 render={({ field: { onChange, onBlur, name, value }, fieldState: { error } }) => (
@@ -78,8 +81,8 @@ export const TextFields = ({ maskOptions }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        disabled={watch.mask !== 'TXT'}
-                        required
+                        disabled={mask !== CreateTextQuestionRequest.mask.TXT}
+                        required={mask === CreateTextQuestionRequest.mask.TXT}
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/UserInterfaceFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/UserInterfaceFields.tsx
@@ -79,10 +79,10 @@ const codedDisplayOptions: SelectOption[] = [
 
 export const UserInterfaceFields = () => {
     const form = useFormContext<CreateQuestionForm>();
-    const watch = useWatch(form);
+    const questionType = useWatch({ control: form.control, name: 'questionType', exact: true });
 
     const getDisplayTypeOptions = (): SelectOption[] => {
-        switch (watch.questionType) {
+        switch (questionType) {
             case 'CODED':
                 return codedDisplayOptions;
             case 'DATE':


### PR DESCRIPTION
## Description

Fixes an issue where `onChange` events were clearing the form validation status. This is done by  changing from:

```typescript
const watch = useWatch(form);
```

to

```typescript
const [uniqueId, uniqueName, questionType] = useWatch({
        control: form.control,
        name: ['uniqueId', 'uniqueName', 'questionType'],
        exact: true
    });
```

Also improves some validation messages.


### Before fix:
![before](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/4f42de40-9575-4d72-a284-990dab68e7f5)


### After fix:
![after](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/8ab456b3-61d1-489c-9a72-43f50f195e34)



## Tickets
NA

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
