### PR TITLE
[Fix] Database connection leak issue

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LaboratoryReportDetailFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LaboratoryReportDetailFinder.java
@@ -131,11 +131,11 @@ class LaboratoryReportDetailFinder {
         "identifiers", identifiers
     );
 
-    return this.template.queryForStream(
+    return this.template.query(
         QUERY,
         parameters,
         this.mapper
-    ).collect(
+    ).stream().collect(
         Accumulator.collecting(
             DocumentRequiringReview::id,
             this.merger::merge


### PR DESCRIPTION
## Description

Replaces use of `queryForStream` with `query`.  When using this method the caller is responsible for closing the connection.  Not required to be used for this instance.
