### PR TITLE
CNFT2-1605 Preview page header fix

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/layout/PageManagementLayout.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/layout/PageManagementLayout.tsx
@@ -27,11 +27,11 @@ const PageManagementLayout = ({ name, mode, children }: PageBuilderLayoutProps) 
                         [styles.published]: mode === 'Published'
                     })}>
                     {mode === 'Published' ? (
-                        <>Previewing Published</>
+                        <>Previewing: Published</>
                     ) : mode === 'Draft' ? (
-                        <>Previewing initial draft</>
+                        <>Previewing: Initial Draft</>
                     ) : (
-                        <>Previewing Published with Draft</>
+                        <>Previewing: Published with Draft</>
                     )}
                 </span>
             </div>


### PR DESCRIPTION
## Description

The Preview page tags were missing a colon.

## Tickets

* [CNFT2-1605](https://cdc-nbs.atlassian.net/browse/CNFT2-1605)
* [CNFT2-1937](https://cdc-nbs.atlassian.net/browse/CNFT2-1937)
* [CNFT2-1938](https://cdc-nbs.atlassian.net/browse/CNFT2-1938)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
