### PR TITLE
Change the page variable name to match the path variable name.

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleController.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleController.java
@@ -68,9 +68,9 @@ public class PageRuleController {
 
   @PutMapping("/{ruleId}")
   public CreateRuleResponse updatePageRule(@PathVariable Long ruleId,
-      @RequestBody Rule.CreateRuleRequest request, @PathVariable Long page) throws RuleException {
+      @RequestBody Rule.CreateRuleRequest request, @PathVariable Long id) throws RuleException {
     Long userId = userDetailsProvider.getCurrentUserDetails().getId();
-    return pageRuleService.updatePageRule(ruleId, request, userId, page);
+    return pageRuleService.updatePageRule(ruleId, request, userId, id);
   }
 
   @GetMapping("/{ruleId}")


### PR DESCRIPTION
## Description

When calling Update Page Rule API, it is not Working, as there is difference in the path variable name.  

## Tickets
