### PR TITLE
CNFT2-2064 Previewing label

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/GroupQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/GroupQuestion.tsx
@@ -3,7 +3,7 @@ import styles from './group-question.module.scss';
 import { useForm, FormProvider } from 'react-hook-form';
 import { Form, ModalRef } from '@trussworks/react-uswds';
 import { RefObject, useState } from 'react';
-import { ModalToggleButton } from '@trussworks/react-uswds';
+import { Button, ModalToggleButton } from '@trussworks/react-uswds';
 import { RepeatingBlock } from './RepeatingBlock';
 import { SubsectionDetails } from './SubsectionDetails';
 import { SubSectionControllerService } from 'apps/page-builder/generated';
@@ -58,6 +58,7 @@ export const GroupQuestion = ({ subsection, questions, modalRef }: Props) => {
                     id: data.id
                 }
             }).then(() => {
+                modalRef.current?.toggleModal();
                 showAlert({
                     type: 'success',
                     header: 'Grouped',
@@ -66,6 +67,7 @@ export const GroupQuestion = ({ subsection, questions, modalRef }: Props) => {
                 refresh();
             });
         } catch (error) {
+            modalRef.current?.toggleModal();
             if (error instanceof Error) {
                 console.error(error);
                 showAlert({
@@ -131,14 +133,9 @@ export const GroupQuestion = ({ subsection, questions, modalRef }: Props) => {
                         <ModalToggleButton modalRef={modalRef} onClick={() => reset()} type="button" outline closer>
                             Cancel
                         </ModalToggleButton>
-                        <ModalToggleButton
-                            modalRef={modalRef}
-                            onClick={onSubmit}
-                            type="button"
-                            disabled={!valid}
-                            closer>
+                        <Button onClick={onSubmit} type="button" disabled={!valid}>
                             Submit
-                        </ModalToggleButton>
+                        </Button>
                     </div>
                 </Form>
             </FormProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/layout/PageManagementLayout.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/layout/PageManagementLayout.tsx
@@ -20,20 +20,7 @@ const PageManagementLayout = ({ name, mode, children }: PageBuilderLayoutProps) 
                 <Breadcrumb start="/page-builder/pages" currentPage={name}>
                     Page library
                 </Breadcrumb>
-                <span
-                    className={classNames(styles.mode, {
-                        [styles.draft]: mode === 'Draft',
-                        [styles.edit]: mode === 'Edit',
-                        [styles.published]: mode === 'Published'
-                    })}>
-                    {mode === 'Published' ? (
-                        <>Previewing: Published</>
-                    ) : mode === 'Draft' ? (
-                        <>Previewing: Initial Draft</>
-                    ) : (
-                        <>Previewing: Published with Draft</>
-                    )}
-                </span>
+                <span className={classNames(styles.mode)}>PREVIEWING: {mode}</span>
             </div>
             <div className={styles.content}>{children}</div>
         </section>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/layout/page-management-layout.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/layout/page-management-layout.module.scss
@@ -32,18 +32,6 @@
             border-radius: 0.125rem;
             text-transform: uppercase;
             background: colors.$info;
-
-            &.draft {
-                background: colors.$info;
-            }
-
-            &.edit {
-                background: colors.$warning;
-            }
-
-            &.published {
-                background: colors.$info;
-            }
         }
     }
 }


### PR DESCRIPTION
## Description

To accomodate the backend change of Page status, we now display the status directly in the Page Preview label.
Also snuck in a small change to the GroupQuestion form.

## Tickets

* [CNFT2-2064](https://cdc-nbs.atlassian.net/browse/CNFT2-2064)
* [CNFT2-1769](https://cdc-nbs.atlassian.net/browse/CNFT2-1769)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2064]: https://cdc-nbs.atlassian.net/browse/CNFT2-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT2-1769]: https://cdc-nbs.atlassian.net/browse/CNFT2-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ