### PR TITLE
Fix watch for messaging fields

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/MessagingFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/MessagingFields.tsx
@@ -16,10 +16,10 @@ export const MessagingFields = ({ editing = false }: Props) => {
     const { options: codeSystems } = useOptions('CODE_SYSTEM');
     const { options: hl7Options } = useOptions('NBS_HL7_DATA_TYPE');
     const form = useFormContext<CreateQuestionForm>();
-    const messagingInfo = useWatch({ control: form.control, name: 'messagingInfo', exact: true });
+    const includedInMessage = useWatch({ control: form.control, name: 'messagingInfo.includedInMessage', exact: true });
 
     useEffect(() => {
-        if (!messagingInfo?.includedInMessage) {
+        if (!includedInMessage) {
             form.reset({
                 ...form.getValues(),
                 messagingInfo: {
@@ -30,7 +30,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 }
             });
         }
-    }, [messagingInfo?.includedInMessage]);
+    }, [includedInMessage]);
 
     return (
         <>
@@ -57,7 +57,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.messageVariableId"
                 rules={{
                     required: {
-                        value: messagingInfo?.includedInMessage ?? false,
+                        value: includedInMessage ?? false,
                         message: 'Message ID is required'
                     },
                     ...maxLengthRule(50)
@@ -72,8 +72,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        disabled={!messagingInfo?.includedInMessage}
-                        required={messagingInfo?.includedInMessage}
+                        disabled={!includedInMessage}
+                        required={includedInMessage}
                         error={error?.message}
                     />
                 )}
@@ -83,7 +83,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.labelInMessage"
                 rules={{
                     required: {
-                        value: messagingInfo?.includedInMessage ?? false,
+                        value: includedInMessage ?? false,
                         message: 'Message label is required'
                     },
                     ...maxLengthRule(100)
@@ -98,8 +98,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        required={messagingInfo?.includedInMessage}
-                        disabled={!messagingInfo?.includedInMessage}
+                        required={includedInMessage}
+                        disabled={!includedInMessage}
                         error={error?.message}
                     />
                 )}
@@ -109,7 +109,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.codeSystem"
                 rules={{
                     required: {
-                        value: messagingInfo?.includedInMessage ?? false,
+                        value: includedInMessage ?? false,
                         message: 'Code system name is required'
                     }
                 }}
@@ -123,12 +123,11 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         id={name}
                         htmlFor={name}
                         options={codeSystems}
-                        disabled={!messagingInfo?.includedInMessage}
-                        required={messagingInfo?.includedInMessage}
+                        disabled={!includedInMessage}
+                        required={includedInMessage}
                     />
                 )}
             />
-
             <Controller
                 control={form.control}
                 name="messagingInfo.requiredInMessage"
@@ -143,7 +142,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                                 className="requiredInMessage"
                                 checked={value}
                                 name="includedInMessage"
-                                disabled={!messagingInfo?.includedInMessage}
+                                disabled={!includedInMessage}
                                 onChange={onChange}
                             />
                             <div>Required</div>
@@ -156,7 +155,7 @@ export const MessagingFields = ({ editing = false }: Props) => {
                 name="messagingInfo.hl7DataType"
                 rules={{
                     required: {
-                        value: messagingInfo?.includedInMessage ?? false,
+                        value: includedInMessage ?? false,
                         message: 'HL7 data type required'
                     }
                 }}
@@ -170,8 +169,8 @@ export const MessagingFields = ({ editing = false }: Props) => {
                         name={name}
                         id={name}
                         htmlFor={name}
-                        disabled={!messagingInfo?.includedInMessage}
-                        required={messagingInfo?.includedInMessage}
+                        disabled={!includedInMessage}
+                        required={includedInMessage}
                         options={hl7Options}
                     />
                 )}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/modal/AddQuestionModal.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/modal/AddQuestionModal.tsx
@@ -22,6 +22,7 @@ export const AddQuestionModal = ({ modal, onAddQuestion }: Props) => {
 
     const handleAccept = (questions: number[]) => {
         onAddQuestion(questions);
+        setState('search');
         modal.current?.toggleModal(undefined, false);
     };
     return (

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/content/PageSideMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/content/PageSideMenu.tsx
@@ -1,6 +1,5 @@
-import styles from './page-content.module.scss';
 import { Icon } from '@trussworks/react-uswds';
-import { Icon as EQIcon } from 'components/Icon/Icon';
+import styles from './page-content.module.scss';
 
 type PageSideMenuProps = {
     onAddSection: () => void;
@@ -24,10 +23,6 @@ export const PageSideMenu = ({ onAddSection, onManageSection }: PageSideMenuProp
                     }}>
                     <Icon.Add size={3} />
                     Add section
-                </li>
-                <li>
-                    <EQIcon name="reorder" />
-                    Reorder
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Description

While prepping for the GDIT demo I noticed that the messaging fields sometimes failed to enable when toggling the radio button. This was due to the watch failing to initialize properly.

Krishna also asked to temporarily remove the reorder button until it is re-implemented.

The create question form also needs to reset its state upon successful creation of a question.

## Tickets

NA

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
