### PR TITLE
[CNFT1-2091] upgrades nbs-gateway to Spring Boot 3.2.2

### DIFF
--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/filter/RequestParameterToCookieGatewayFilterFactoryTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/filter/RequestParameterToCookieGatewayFilterFactoryTest.java
@@ -45,7 +45,7 @@ class RequestParameterToCookieGatewayFilterFactoryTest {
                         HttpHeaders.SET_COOKIE,
                         actual -> assertThat(actual)
                                 .contains("Secure")
-                                .contains("HttpOnly")
+                                .containsIgnoringCase("HTTPOnly")
                                 .contains("Cookie=parameter-value")
                 );
 


### PR DESCRIPTION
## Description

Upgrades the `nbs-gateway` to Spring Boot 3.2.2 to resolve [CVE-2024-22233](https://spring.io/security/cve-2024-22233).  A unit test had to be changed to reflect a case change in how the WebTestClient is parsing the Set-Cookie header.

## Tickets

* [CNFT1-2091](https://cdc-nbs.atlassian.net/browse/CNFT1-2091)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
