### PR TITLE
Align checkbox to middle of row

### DIFF
--- a/apps/modernization-ui/src/components/Table/table.module.scss
+++ b/apps/modernization-ui/src/components/Table/table.module.scss
@@ -43,6 +43,12 @@
 
                 label {
                     margin: 0 !important;
+                    display: flex;
+                    align-items: center;
+
+                    ::before {
+                        margin-top: 0;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

The table row checkbox was appearing after the `label` element created by trussworks `Checkbox` component. This updates the styling to center the checkbox

### Before
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/e6f0fac0-a99b-434b-bdcf-db3e5c1f8927)


### After 
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/16ae0f6a-e9bd-45ae-99d7-4353d79d3f14)


## Tickets

NA

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
