### PR TITLE
Fix the page size selection for question search.

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/QuestionSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/QuestionSearch.tsx
@@ -47,8 +47,8 @@ export const QuestionSearch = ({ pageId, onCreateNew, onCancel, onAccept }: Prop
 
     useEffect(() => {
         if (response) {
-            const currentPage = response?.number ? response?.number + 1 : 1;
-            ready(response?.totalElements ?? 0, currentPage);
+            const currentPage = response.number ? response.number + 1 : 1;
+            ready(response.totalElements ?? 0, currentPage);
         } else if (error) {
             alertError({ message: 'Failed to retrieve questions' });
         }


### PR DESCRIPTION
## Description

The page size was resetting back to 10 due to a de-rendering of the RangeToggle component. This was cause by a duplicate usePage `ready` trigger with undefined.

## Tickets

* [CNFT2-2103](https://cdc-nbs.atlassian.net/browse/CNFT2-2103)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2103]: https://cdc-nbs.atlassian.net/browse/CNFT2-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ