### PR TITLE
update success banners for business rules

### DIFF
--- a/apps/modernization-ui/src/alert/useAlert.tsx
+++ b/apps/modernization-ui/src/alert/useAlert.tsx
@@ -4,7 +4,7 @@ import './alert.scss';
 
 type AlertType = 'success' | 'warning' | 'error' | 'info';
 
-type Message = { header?: string; message?: string };
+type Message = { header?: string; message?: string | ReactNode };
 
 type Alert = { type: AlertType } & Message;
 

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.scss
@@ -194,3 +194,7 @@
         }
     }
 }
+
+.bold-text {
+    font-weight: bold;
+}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
@@ -61,8 +61,16 @@ const AddBusinessRule = () => {
                 authorization: authorization(),
                 id: Number(pageId),
                 request: data
-            }).then((resp) => {
-                showAlert({ type: 'success', header: 'added', message: resp.message });
+            }).then(() => {
+                showAlert({
+                    type: 'success',
+                    message: (
+                        <>
+                            The business rule <span className="bold-text">'{data.sourceText}'</span> is successfully
+                            added. Please click the unique name to edit.
+                        </>
+                    )
+                });
             });
         } else {
             PageRuleControllerService.updatePageRuleUsingPut({
@@ -71,8 +79,16 @@ const AddBusinessRule = () => {
                 ruleId: Number(ruleId),
                 request: data
             })
-                .then((resp) => {
-                    showAlert({ type: 'success', header: 'updated', message: resp.message });
+                .then(() => {
+                    showAlert({
+                        type: 'success',
+                        message: (
+                            <>
+                                The business rule <span className="bold-text">'{data.sourceText}'</span> is successfully
+                                updated. Please click the unique name to edit.
+                            </>
+                        )
+                    });
                 })
                 .catch((err) => {
                     console.log('error', err);
@@ -90,9 +106,17 @@ const AddBusinessRule = () => {
             authorization: authorization(),
             id: Number(pageId),
             ruleId: Number(ruleId)
-        }).then((resp: any) => {
+        }).then(() => {
             handleCancel();
-            showAlert({ type: 'success', header: 'Deleted', message: resp });
+            showAlert({
+                type: 'success',
+                message: (
+                    <>
+                        The business rule <span className="bold-text">'{form.getValues('sourceText')}'</span> was
+                        successfully deleted.
+                    </>
+                )
+            });
         });
     };
 


### PR DESCRIPTION
## Description

Simple updating the copy message when successfully adding/editing/deleting a business rule.  Had to make a change to the Alert itself to allow a node so that I could style a span with bold font.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-2002)

## Checklist before requesting a review
- [x ] PR focuses on a single story
- [x ] Code has been fully tested to meet acceptance criteria
- [ x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ x] All new functions/classes/components reasonably small
- [ x] Functions/classes/components focused on one responsibility
- [x ] Code easy to understand and modify (clarity over concise/clever)
- [ x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ x] PR does not contain hardcoded values (Uses constants)
- [x ] All code is covered by unit or feature tests
