### PR TITLE
[CNFT1-1909] DRR Patient Profile Routing

### DIFF
--- a/apps/nbs-gateway/README.md
+++ b/apps/nbs-gateway/README.md
@@ -1,6 +1,6 @@
-# National Electronic Disease Surveillance System (NEDSS) Modernization NBS Gateway
+# National Electronic Disease Surveillance System (NEDSS) Base System Modernization Gateway
 
-An entry point for the Classic NBS Application that allows a Strangler Fig approach to piecemeal modernization.
+An entry point for an NBS 6.X Application that allows a Strangler Fig approach to piecemeal modernization.
 
 ## Running
 
@@ -47,18 +47,20 @@ Environment
 Variable,and [other useful means](https://docs.spring.io/spring-boot/docs/2.7.5/reference/html/features.html#features.external-config).
 The default profile contains the following properties configuration most likely to change.
 
-| Name                                            | Default                 | Description                                                                         |
-| ----------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------- |
-| nbs.gateway.defaults.protocol                   | `http`                  | The default protocol used to connect to services. Intra-pod communication is `http` |
-| nbs.gateway.classic                             | `http://localhost:7001` | The URI location of the classic NBS Application                                     |
-| nbs.gateway.patient.search.enabled              | `true`                  | Enables the Patient Search routing                                                  |
-| nbs.gateway.patient.search.service              | `localhost:8080`        | The host name of the Patient Search service                                         |
-| nbs.gateway.patient.profile.enabled             | `true`                  | Enables the Patient Profile routing                                                 |
-| nbs.gateway.patient.profile.service             | `localhost:8080`        | The host name of the Patient Profile service                                        |
-| nbs.gateway.pagebuilder.enabled                 | `false`                 | Enables Page Builder routing                                                        |
-| nbs.gateway.pagebuilder.page.management.enabled | `false`                 | Enables the Page Builder Page Management routing                                    |
-| nbs.gateway.pagebuilder.page.library.enabled    | `false`                 | Enables the Page Builder Page Library routing                                       |
-| nbs.gateway.pagebuilder.service                 | `localhost:8080`        | The host name of the service                                                        |
+| Name                                                   | Default                 | Description                                                                                                                                                                                              |
+|--------------------------------------------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| nbs.gateway.defaults.protocol                          | `http`                  | The default protocol used to connect to services. Intra-pod communication is `http`                                                                                                                      |
+| nbs.gateway.classic                                    | `http://localhost:7001` | The URI location of the classic NBS Application                                                                                                                                                          |
+| nbs.gateway.log.level                                  | `INFO`                  | A shortcut to configuring the `RoutePredicateHandlerMapping` logging level.  Equivalent to specifying the property `logging.levelorg.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping` |
+| nbs.gateway.patient.search.enabled                     | `true`                  | Enables the Patient Search routing                                                                                                                                                                       |
+| nbs.gateway.patient.search.service                     | `localhost:8080`        | The host name of the Patient Search service                                                                                                                                                              |
+| nbs.gateway.patient.profile.enabled                    | `true`                  | Enables the Patient Profile routing                                                                                                                                                                      |
+| nbs.gateway.patient.profile.service                    | `localhost:8080`        | The host name of the Patient Profile service                                                                                                                                                             |
+| nbs.gateway.pagebuilder.enabled                        | `false`                 | Enables Page Builder routing                                                                                                                                                                             |
+| nbs.gateway.pagebuilder.service                        | `localhost:8080`        | The host name of the service                                                                                                                                                                             |
+| nbs.gateway.pagebuilder.page.library.enabled           | `false`                 | Enables the Page Builder Page Library routing                                                                                                                                                            |
+| nbs.gateway.pagebuilder.page.management.create.enabled | `false`                 | Enables the Page Builder Page creation routing                                                                                                                                                           |
+| nbs.gateway.pagebuilder.page.management.edit.enabled   | `false`                 | Enables the Page Builder Page preview/edit routing                                                                                                                                                       |
 
 ### Configuring the Reverse Proxy to use local nbs-gateway
 
@@ -67,4 +69,14 @@ folder.
 
 ```shell
 NBS_GATEWAY_SERVER=host.docker.internal docker compose up -d reverse-proxy
+```
+
+### Logging
+
+The logging level for `RoutePredicateHandlerMapping` is set to `DEBUG` when running the `nbs-gateway` from the
+command-line using gradle. When running the container the logging level can be changed using the `NBS_GATEWAY_LOG_LEVEL`
+environment variable.
+
+```shell
+NBS_GATEWAY_LOG_LEVEL=DEBUG docker compose up -d nbs-gateway
 ```

--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -1,10 +1,8 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id 'org.springframework.boot' version '3.2.2'
+    id 'org.springframework.boot' version '3.2.3'
 }
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'gov.cdc.nbs.gateway'
 version = '0.0.1-SNAPSHOT'
@@ -30,7 +28,7 @@ testing {
 
             dependencies {
                 implementation 'org.springframework.boot:spring-boot-starter-test'
-                implementation "org.wiremock:wiremock-standalone:3.2.0"
+                implementation "org.wiremock:wiremock-standalone:3.4.2"
             }
         }
     }
@@ -40,7 +38,7 @@ dependencies {
 
     implementation platform(SpringBootPlugin.BOM_COORDINATES)
 
-    implementation libs.snake.yaml
+//    implementation libs.snake.yaml
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway:4.1.1'
 }
 

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/RouteOrdering.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/RouteOrdering.java
@@ -1,0 +1,25 @@
+package gov.cdc.nbs.gateway;
+
+public enum RouteOrdering {
+
+  PATIENT_PROFILE(0),
+  NBS_6(1000);
+
+  private final int order;
+
+  RouteOrdering(int order) {
+    this.order = order;
+  }
+
+  public int order() {
+    return order;
+  }
+
+  public int before() {
+    return order - 1;
+  }
+
+  public int after() {
+    return order + 1;
+  }
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/PatientProfileRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/PatientProfileRouteLocatorConfiguration.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.gateway.patient.profile;
 
+import gov.cdc.nbs.gateway.RouteOrdering;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -22,22 +23,24 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = "nbs.gateway.patient.profile", name = "enabled", havingValue = "true")
 class PatientProfileRouteLocatorConfiguration {
 
-    @Bean
-    RouteLocator patientProfileLocator(
-        final RouteLocatorBuilder builder,
-        @Qualifier("default") final GatewayFilter globalFilter,
-        final PatientProfileService parameters
-    ) {
-        return builder.routes()
-            .route(
-                "patient-profile",
-                route -> route.query("ContextAction", "ViewFile|FileSummary")
-                    .filters(
-                        filter -> filter.setPath("/nbs/redirect/patientProfile")
-                            .filter(globalFilter)
-                    )
-                    .uri(parameters.uri())
-            )
-            .build();
-    }
+  @Bean
+  RouteLocator patientProfileLocator(
+      final RouteLocatorBuilder builder,
+      @Qualifier("default") final GatewayFilter globalFilter,
+      final PatientProfileService parameters
+  ) {
+    return builder.routes()
+        .route(
+            "patient-profile",
+            route -> route
+                .order(RouteOrdering.PATIENT_PROFILE.order())
+                .query("ContextAction", "ViewFile|FileSummary")
+                .filters(
+                    filter -> filter.setPath("/nbs/redirect/patientProfile")
+                        .filter(globalFilter)
+                )
+                .uri(parameters.uri())
+        )
+        .build();
+  }
 }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfiguration.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.gateway.patient.profile.events.observation;
 
+import gov.cdc.nbs.gateway.RouteOrdering;
 import gov.cdc.nbs.gateway.classic.NBSClassicService;
 import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory;
 import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory.Config;
@@ -12,8 +13,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Adds the {@code Patient-Action} cookie to the response when the {@code routes.patient.profile.enabled} property is {@code true}
- * and any of the following criteria is satisfied;
+ * Adds the {@code Patient-Action} cookie to the response when the {@code routes.patient.profile.enabled} property is
+ * {@code true} and any of the following criteria is satisfied;
  *
  * <ul>
  *     <li>Path equal to {@code /nbs/NewLabReview1.do.do}</li>*
@@ -24,38 +25,40 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = "nbs.gateway.patient.profile", name = "enabled", havingValue = "true")
 class ViewObservationRouteLocatorConfiguration {
 
-    private static final String IDENTIFIER_PARAMETER = "observationUID";
+  private static final String IDENTIFIER_PARAMETER = "observationUID";
 
-    @Bean
-    RouteLocator viewObservationActionCookie(
-            final RouteLocatorBuilder builder,
-            @Qualifier("default") final GatewayFilter defaultFilter,
-            @Qualifier("classic") final GatewayFilter classicFilter,
-            final NBSClassicService service
-    ) {
-        return builder
-                .routes()
-                .route(
-                        "view-observation-apply-patient-action-cookie",
-                        route -> route.path("/nbs/NewLabReview1.do")
-                                .and()
-                                .query(IDENTIFIER_PARAMETER)
-                                .filters(
-                                        filter -> filter.filter(
-                                                        new RequestParameterToCookieGatewayFilterFactory()
-                                                                .apply(
-                                                                        new Config(
-                                                                            IDENTIFIER_PARAMETER,
-                                                                                "Patient-Action"
-                                                                        )
-                                                                )
-                                                )
-                                                .filter(defaultFilter)
-                                                .filter(classicFilter)
+  @Bean
+  RouteLocator viewObservationActionCookie(
+      final RouteLocatorBuilder builder,
+      @Qualifier("default") final GatewayFilter defaultFilter,
+      @Qualifier("classic") final GatewayFilter classicFilter,
+      final NBSClassicService service
+  ) {
+    return builder
+        .routes()
+        .route(
+            "view-observation-apply-patient-action-cookie",
+            route -> route
+                .order(RouteOrdering.PATIENT_PROFILE.after())
+                .path("/nbs/NewLabReview1.do")
+                .and()
+                .query(IDENTIFIER_PARAMETER)
+                .filters(
+                    filter -> filter.filter(
+                            new RequestParameterToCookieGatewayFilterFactory()
+                                .apply(
+                                    new Config(
+                                        IDENTIFIER_PARAMETER,
+                                        "Patient-Action"
+                                    )
                                 )
-                                .uri(service.uri())
+                        )
+                        .filter(defaultFilter)
+                        .filter(classicFilter)
                 )
-                .build();
-    }
+                .uri(service.uri())
+        )
+        .build();
+  }
 
 }

--- a/apps/nbs-gateway/src/main/resources/application.yml
+++ b/apps/nbs-gateway/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
       routes:
         - id: classic
           uri: ${nbs.gateway.classic}
+          order: 1000
           predicates:
             - Path=/nbs/**
           filters:
@@ -24,7 +25,7 @@ spring:
 nbs:
   gateway:
     log:
-      level: INFO
+      level: DEBUG
     defaults:
       protocol: 'http'
     classic: '${nbs.gateway.defaults.protocol}://localhost:7001'

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/RouteOrderingTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/RouteOrderingTest.java
@@ -1,0 +1,22 @@
+package gov.cdc.nbs.gateway;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RouteOrderingTest {
+
+  @Test
+  void should_return_ordering_to_apply_after_the_order() {
+    RouteOrdering ordering = RouteOrdering.NBS_6;
+
+    assertThat(ordering.after()).isGreaterThan(ordering.order());
+  }
+
+  @Test
+  void should_return_ordering_to_apply_before_the_order() {
+    RouteOrdering ordering = RouteOrdering.NBS_6;
+
+    assertThat(ordering.before()).isLessThan(ordering.order());
+  }
+}


### PR DESCRIPTION
## Description

The `view-observation-apply-patient-action-cookie` route was resolving before the `patient-profile` route when clicking the patient name in the Documents Requiring Review queue.  Ordering was introduced to ensure that the `view-observation-apply-patient-action-cookie` route is checked after the `patient-profile` route.

## Tickets

* [CNFT1-1909](https://cdc-nbs.atlassian.net/browse/CNFT1-1909)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-1909]: https://cdc-nbs.atlassian.net/browse/CNFT1-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ