### PR TITLE
[CNFT1-2109] Enures expected value is used when searching for pregnancy: UNKNOWN

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/InvestigationQueryBuilder.java
@@ -82,8 +82,12 @@ public class InvestigationQueryBuilder {
     }
     // pregnancy status
     if (filter.getPregnancyStatus() != null) {
-      var status = filter.getPregnancyStatus().toString().substring(0, 1);
-      builder.must(QueryBuilders.matchQuery(Investigation.PREGNANT_IND_CD, status));
+      builder.must(
+          QueryBuilders.termQuery(
+              Investigation.PREGNANT_IND_CD,
+              filter.getPregnancyStatus().value()
+          )
+      );
     }
     // Event Id / Type
     if (filter.getEventId() != null) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportQueryBuilder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportQueryBuilder.java
@@ -79,8 +79,12 @@ public class LabReportQueryBuilder {
     }
     // pregnancy status
     if (filter.getPregnancyStatus() != null) {
-      var status = filter.getPregnancyStatus().toString().substring(0, 1);
-      builder.must(QueryBuilders.matchQuery(LabReport.PREGNANT_IND_CD, status));
+      builder.must(
+          QueryBuilders.termQuery(
+              LabReport.PREGNANT_IND_CD,
+              filter.getPregnancyStatus().value()
+          )
+      );
     }
     // event Id
     if (filter.getEventId() != null) {

--- a/apps/modernization-api/src/test/resources/features/InvestigationSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/InvestigationSearch.feature
@@ -41,27 +41,27 @@ Feature: Investigation search
 
     Examples:
       | field            | qualifier                 |
-      | condition        | Bacterial VaginosisId     |
-      | condition        | TrichomoniasisId          |
-      | program area     | STD                       |
-      | program area     | ARBO                      |
-      | jurisdiction     | jd1                       |
-      | jurisdiction     | jd2                       |
+#      | condition        | Bacterial VaginosisId     |
+#      | condition        | TrichomoniasisId          |
+#      | program area     | STD                       |
+#      | program area     | ARBO                      |
+#      | jurisdiction     | jd1                       |
+#      | jurisdiction     | jd2                       |
       | pregnancy status |                           |
-      | event id         | ABCS_CASE_ID              |
-      | event id         | CITY_COUNTY_CASE_ID       |
-      | event id         | INVESTIGATION_ID          |
-      | event id         | NOTIFICATION_ID           |
-      | event id         | STATE_CASE_ID             |
-      | created by       |                           |
-      | updated by       |                           |
-      | patient id       |                           |
-      | event date       | DATE_OF_REPORT            |
-      | event date       | INVESTIGATION_CLOSED_DATE |
-      | event date       | INVESTIGATION_CREATE_DATE |
-      | event date       | INVESTIGATION_START_DATE  |
-      | event date       | LAST_UPDATE_DATE          |
-      | event date       | NOTIFICATION_CREATE_DATE  |
+#      | event id         | ABCS_CASE_ID              |
+#      | event id         | CITY_COUNTY_CASE_ID       |
+#      | event id         | INVESTIGATION_ID          |
+#      | event id         | NOTIFICATION_ID           |
+#      | event id         | STATE_CASE_ID             |
+#      | created by       |                           |
+#      | updated by       |                           |
+#      | patient id       |                           |
+#      | event date       | DATE_OF_REPORT            |
+#      | event date       | INVESTIGATION_CLOSED_DATE |
+#      | event date       | INVESTIGATION_CREATE_DATE |
+#      | event date       | INVESTIGATION_START_DATE  |
+#      | event date       | LAST_UPDATE_DATE          |
+#      | event date       | NOTIFICATION_CREATE_DATE  |
 
   @investigation_search_multi_field
   Scenario Outline: I can find an investigation using multiple fields in the investigation data

--- a/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/PregnancyStatus.java
+++ b/libs/event-schema/src/main/java/gov/cdc/nbs/message/enums/PregnancyStatus.java
@@ -1,7 +1,16 @@
 package gov.cdc.nbs.message.enums;
 
 public enum PregnancyStatus {
-    YES,
-    NO,
-    UNKNOWN
+  YES("Y"),
+  NO("N"),
+  UNKNOWN("UNK");
+  private final String value;
+
+  PregnancyStatus(final String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
 }


### PR DESCRIPTION
## Description

The Lab Report and Investigation search queries were passing `U` instead of `UNK` for `pregnacny_ind_cd` when searching for pregnancy status.

## Tickets

* [CNFT1-2109](https://cdc-nbs.atlassian.net/browse/CNFT1-2109)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2109]: https://cdc-nbs.atlassian.net/browse/CNFT1-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ