### PR TITLE
Bug/fix error messag display for business rules

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
@@ -33,7 +33,6 @@ const AddBusinessRule = () => {
                 authorization: authorization(),
                 ruleId: Number(ruleId)
             }).then((resp: Rule) => {
-                console.log('response', resp);
                 const sourceQuestion = resp.sourceQuestion?.label || '';
 
                 setSourceValues(resp.sourceValues || []);

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
@@ -24,13 +24,16 @@ const AddBusinessRule = () => {
     const { pageId, ruleId } = useParams();
     const deleteWarningModal = useRef<ModalRef>(null);
     const { showAlert } = useAlert();
+    const [loading, setIsLoading] = useState(false);
 
     useEffect(() => {
         if (ruleId) {
+            setIsLoading(true);
             PageRuleControllerService.viewRuleResponseUsingGet({
                 authorization: authorization(),
                 ruleId: Number(ruleId)
             }).then((resp: Rule) => {
+                console.log('response', resp);
                 const sourceQuestion = resp.sourceQuestion?.label || '';
 
                 setSourceValues(resp.sourceValues || []);
@@ -51,6 +54,7 @@ const AddBusinessRule = () => {
 
                 setSelectedFieldType(resp.ruleFunction);
                 setTargets(resp.targets || []);
+                setIsLoading(false);
             });
         }
     }, [ruleId]);
@@ -136,10 +140,6 @@ const AddBusinessRule = () => {
     const title = !ruleId ? 'Add new' : 'Edit';
     const ruleFunction = form.watch('ruleFunction');
 
-    useEffect(() => {
-        form.reset({ ruleFunction: ruleFunction, targetType: Rule.targetType.QUESTION });
-    }, [ruleFunction]);
-
     return (
         <>
             <ConfirmationModal
@@ -200,7 +200,10 @@ const AddBusinessRule = () => {
                                                         outline={field.value !== selectedFieldType}
                                                         onClick={() => {
                                                             setSelectedFieldType(field.value);
-                                                            form.setValue('ruleFunction', field.value);
+                                                            form.reset({
+                                                                ruleFunction: ruleFunction,
+                                                                targetType: Rule.targetType.QUESTION
+                                                            });
                                                         }}>
                                                         {field.display}
                                                     </Button>
@@ -209,7 +212,7 @@ const AddBusinessRule = () => {
                                         )}
                                     </Grid>
                                 </Grid>
-                                {selectedFieldType == '' ? null : (
+                                {selectedFieldType == '' && !loading ? null : (
                                     <FormProvider {...form}>
                                         <BusinessRulesForm
                                             targets={targets}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
@@ -175,11 +175,11 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
 
     useEffect(() => {
         if (anySourceValueToggle) {
-            // form.reset({
-            //     ...form.getValues(),
-            //     comparator: Rule.comparator.EQUAL_TO,
-            //     sourceValues: undefined
-            // });
+            form.reset({
+                ...form.getValues(),
+                comparator: Rule.comparator.EQUAL_TO,
+                sourceValues: undefined
+            });
         }
     }, [anySourceValueToggle]);
 

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
@@ -285,7 +285,6 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
                                     <MultiSelectInput
                                         value={form?.getValues('sourceValues')?.map((val) => val?.id || '')}
                                         onChange={(value) => {
-                                            console.log('e', value);
                                             handleSourceValueChange(value);
                                         }}
                                         options={sourceValueList}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
@@ -36,6 +36,7 @@ interface Props {
     targets?: Target[];
     question?: SourceQuestion;
     sourceValues?: string[];
+    isEditing: boolean;
 }
 
 const BusinessRulesForm = ({ question, sourceValues }: Props) => {
@@ -47,7 +48,7 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
     const [selectedSource, setSelectedSource] = useState<QuestionProps[]>([]);
     const [anySourceValueToggle, setAnySource] = useState<boolean>(false);
 
-    const { pageId } = useParams();
+    const { pageId, ruleId } = useParams();
     const [sourceDescription, setSourceDescription] = useState<string>(
         form.watch('sourceText') && form.watch('sourceIdentifier')
             ? `${form.watch('sourceText')} (${form.watch('sourceIdentifier')})`
@@ -399,7 +400,7 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
                     </Grid>
                 )}
             />
-            {ruleFunction != Rule.ruleFunction.DATE_COMPARE ? (
+            {ruleFunction == Rule.ruleFunction.DATE_COMPARE && ruleId ? (
                 <Grid row className="inline-field">
                     <Grid col={3}>
                         <Label className="input-label" htmlFor="ruleFunction" requiredMarker>

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
@@ -36,7 +36,6 @@ interface Props {
     targets?: Target[];
     question?: SourceQuestion;
     sourceValues?: string[];
-    isEditing: boolean;
 }
 
 const BusinessRulesForm = ({ question, sourceValues }: Props) => {
@@ -135,11 +134,11 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
             value: Rule.comparator.LESS_THAN
         },
         {
-            name: 'Less or equal to',
+            name: 'Less than or equal to',
             value: Rule.comparator.LESS_THAN_OR_EQUAL_TO
         },
         {
-            name: 'Greater or equal to',
+            name: 'Greater than or equal to',
             value: Rule.comparator.GREATER_THAN_OR_EQUAL_TO
         },
         {
@@ -176,11 +175,11 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
 
     useEffect(() => {
         if (anySourceValueToggle) {
-            form.reset({
-                ...form.getValues(),
-                comparator: Rule.comparator.EQUAL_TO,
-                sourceValues: undefined
-            });
+            // form.reset({
+            //     ...form.getValues(),
+            //     comparator: Rule.comparator.EQUAL_TO,
+            //     sourceValues: undefined
+            // });
         }
     }, [anySourceValueToggle]);
 
@@ -409,12 +408,12 @@ const BusinessRulesForm = ({ question, sourceValues }: Props) => {
                     </Grid>
                     <Grid col={9}>
                         <Input
-                            readOnly
+                            readOnly={true}
                             type="text"
                             multiline
-                            value={`'${sourceDescription}' must be ${mapLogicForDateCompare(
-                                form.getValues('comparator')
-                            )} ${targetQuestions.map((val) => `${val.name} (${val.question})`).join(', ')}`}
+                            defaultValue={`'${form.watch('sourceText')}' must be ${mapLogicForDateCompare(
+                                form.watch('comparator')
+                            )} '${form.watch('targetValueText')?.[0]} (${form.watch('targetIdentifiers')?.[0]})'`}
                             name={'errorMessage'}
                             id={'errorMessage'}
                         />

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/helpers/mapLogicForDateCompare.ts
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/helpers/mapLogicForDateCompare.ts
@@ -1,7 +1,6 @@
 import { Rule } from 'apps/page-builder/generated';
 
 export const mapLogicForDateCompare = (logic: Rule.comparator) => {
-    console.log('logic', logic);
     switch (logic) {
         case Rule.comparator.EQUAL_TO:
             return '=';

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/helpers/mapLogicForDateCompare.ts
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/helpers/mapLogicForDateCompare.ts
@@ -1,6 +1,7 @@
 import { Rule } from 'apps/page-builder/generated';
 
 export const mapLogicForDateCompare = (logic: Rule.comparator) => {
+    console.log('logic', logic);
     switch (logic) {
         case Rule.comparator.EQUAL_TO:
             return '=';


### PR DESCRIPTION
## Description

There was a bug caught when testing the error message display for date rules.  There was some form fields automatically being reset, so i moved that logic into a change handler instead of in useEffect.
## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-2120)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
