### PR TITLE
[CNFT2-2145] - Subsection is still visible when user chooses Non visible

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
@@ -9,6 +9,7 @@ type Props = {
 };
 
 export const PreviewSubsection = ({ subsection }: Props) => {
+    const { visible } = subsection;
     const [isExpanded, setIsExpanded] = useState(true);
 
     const handleExpandedChange = (expanded: boolean) => {
@@ -16,16 +17,20 @@ export const PreviewSubsection = ({ subsection }: Props) => {
     };
 
     return (
-        <div className={styles.subsection}>
-            <PreviewSubsectionHeader
-                subsection={subsection}
-                isExpanded={isExpanded}
-                onExpandedChange={handleExpandedChange}
-            />
-            <div className={styles.questionWrapper}>
-                {isExpanded &&
-                    subsection.questions.map((question, k) => <PreviewQuestion question={question} key={k} />)}
-            </div>
-        </div>
+        <>
+            {visible && (
+                <div className={styles.subsection}>
+                    <PreviewSubsectionHeader
+                        subsection={subsection}
+                        isExpanded={isExpanded}
+                        onExpandedChange={handleExpandedChange}
+                    />
+                    <div className={styles.questionWrapper}>
+                        {isExpanded &&
+                            subsection.questions.map((question, k) => <PreviewQuestion question={question} key={k} />)}
+                    </div>
+                </div>
+            )}
+        </>
     );
 };


### PR DESCRIPTION
## Description

Fixed Subsection visibility when user chooses Non visible

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNFT2-2145

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
