### PR TITLE
[CNFT1-2095] Lab Report Search returns to the modernized Patient Profile

### DIFF
--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationResults.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationResults.spec.tsx
@@ -75,10 +75,10 @@ describe('InvestigationResults component tests', () => {
         expect(getByText('Doe, John')).toBeInTheDocument();
         expect(getByText('2019 Novel Coronavirus')).toBeInTheDocument();
         expect(getByText('CAS10003001GA99')).toBeInTheDocument();
-        expect(getByText('1/1/1990')).toBeInTheDocument();
+        expect(getByText('01/01/1990')).toBeInTheDocument();
         expect(getByText(`(${age} years)`)).toBeInTheDocument();
         expect(getByText('63000')).toBeInTheDocument();
-        expect(getByText('7/21/2023')).toBeInTheDocument();
+        expect(getByText('07/21/2023')).toBeInTheDocument();
         expect(getByText('OPEN')).toBeInTheDocument();
         expect(getByText('Clayton County')).toBeInTheDocument();
         expect(getByText('2019 Novel Coronavirus').closest('a')).toHaveAttribute('href', '#');

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationSearchResult.spec.tsx
@@ -67,10 +67,10 @@ describe('when an investigation is found', () => {
         expect(getByText('Doe, John')).toBeInTheDocument();
         expect(getByText('2019 Novel Coronavirus')).toBeInTheDocument();
         expect(getByText('CAS10003001GA99')).toBeInTheDocument();
-        expect(getByText('1/1/1990')).toBeInTheDocument();
+        expect(getByText('01/01/1990')).toBeInTheDocument();
         expect(getByText(`(${age} years)`)).toBeInTheDocument();
         expect(getByText('63000')).toBeInTheDocument();
-        expect(getByText('7/21/2023')).toBeInTheDocument();
+        expect(getByText('07/21/2023')).toBeInTheDocument();
         expect(getByText('OPEN')).toBeInTheDocument();
         expect(getByText('Clayton County')).toBeInTheDocument();
         expect(getByText('2019 Novel Coronavirus').closest('a')).toHaveAttribute('href', '#');

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationSearchResult.tsx
@@ -1,16 +1,9 @@
-import { useNavigate } from 'react-router';
 import { Grid } from '@trussworks/react-uswds';
 import { Investigation, PersonParticipation } from 'generated/graphql/schema';
 import { NoData } from 'components/NoData';
 import { ClassicLink } from 'classic';
-import { calculateAge } from 'utils/util';
-import { formattedName } from 'utils';
-
-const formatDate = (date: Date) => {
-    return new Date(date).toLocaleDateString('en-US', {
-        timeZone: 'UTC'
-    });
-};
+import { PatientDetails } from 'apps/search/event/components/PatientDetails';
+import { internalizeDate } from 'date';
 
 const getPatient = (investigation: Investigation): PersonParticipation | undefined | null => {
     return investigation.personParticipations?.find((p) => p?.typeCd === 'SubjOfPHC');
@@ -67,7 +60,7 @@ const InvestigationSearchResult = ({ investigation }: InvestigationSearchResultP
                                 START DATE
                             </p>
                             <p className="margin-0 font-sans-1xs text-normal">
-                                {formatDate(investigation.addTime) || <NoData />}
+                                {internalizeDate(investigation.addTime) || <NoData />}
                             </p>
                         </Grid>
                     </Grid>
@@ -120,70 +113,6 @@ const InvestigationSearchResult = ({ investigation }: InvestigationSearchResultP
                 </Grid>
             </Grid>
         </div>
-    );
-};
-
-type PatientDetailsType = {
-    patient: PersonParticipation | null | undefined;
-};
-
-const PatientDetails = ({ patient }: PatientDetailsType) => {
-    const navigate = useNavigate();
-    let name = '';
-    let birthDate: string | undefined;
-    let age: string | undefined;
-    let sex: string | undefined;
-    if (patient) {
-        name =
-            !patient.lastName && !patient.firstName
-                ? `No Data`
-                : formattedName(patient?.lastName ?? '', patient?.firstName ?? '');
-        if (patient.birthTime) {
-            birthDate = formatDate(patient.birthTime);
-            age = calculateAge(new Date(patient.birthTime));
-        }
-        sex = patient.currSexCd === 'M' ? 'Male' : patient.currSexCd === 'F' ? 'Female' : 'Unknown';
-    }
-
-    const redirectPatientProfile = () => {
-        navigate(`/patient-profile/${patient?.shortId}`);
-    };
-
-    return (
-        <Grid row gap={3}>
-            <Grid col={12} className="margin-bottom-2">
-                <p className="margin-0 text-normal text-gray-50 search-result-item-label">LEGAL NAME</p>
-                <a
-                    onClick={redirectPatientProfile}
-                    className="margin-0 font-sans-md margin-top-05 text-bold text-primary word-break"
-                    style={{ wordBreak: 'break-word', cursor: 'pointer' }}>
-                    {name}
-                </a>
-            </Grid>
-            <Grid col={12} className="margin-bottom-2">
-                <div className="grid-row flex-align-center">
-                    <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                        DATE OF BIRTH
-                    </p>
-                    <p className="margin-0 font-sans-2xs text-normal">
-                        <>
-                            {birthDate ? birthDate : <NoData />}
-                            <span className="font-sans-2xs"> {age ? `(${age})` : ''}</span>
-                        </>
-                    </p>
-                </div>
-                <div className="grid-row flex-align-center">
-                    <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">SEX</p>
-                    <p className="margin-0 font-sans-2xs text-normal">{sex ? sex : <NoData />}</p>
-                </div>
-                <div className="grid-row flex-align-center">
-                    <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                        PATIENT ID
-                    </p>
-                    <p className="margin-0 font-sans-2xs text-normal">{patient?.shortId || <NoData />}</p>
-                </div>
-            </Grid>
-        </Grid>
     );
 };
 

--- a/apps/modernization-ui/src/apps/search/event/components/LabReportSearch/LabReportResults.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/LabReportSearch/LabReportResults.spec.tsx
@@ -92,10 +92,10 @@ describe('LabReportResults component tests', () => {
         expect(getByText('Doe, John')).toBeInTheDocument();
         expect(getByText('Acid-Fast Stain = abnormal')).toBeInTheDocument();
         expect(getByText('OBS10001008GA01')).toBeInTheDocument();
-        expect(getByText('1/1/1990')).toBeInTheDocument();
+        expect(getByText('01/01/1990')).toBeInTheDocument();
         expect(getByText(`(${age} years)`)).toBeInTheDocument();
         expect(getByText('63000')).toBeInTheDocument();
-        expect(getByText('7/27/2023')).toBeInTheDocument();
+        expect(getByText('07/27/2023')).toBeInTheDocument();
         expect(getByText('Piedmont Hospital')).toBeInTheDocument();
         expect(getByText('Lab Report').closest('a')).toHaveAttribute('href', '#');
     });

--- a/apps/modernization-ui/src/apps/search/event/components/LabReportSearch/LabReportResults.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/LabReportSearch/LabReportResults.tsx
@@ -1,13 +1,11 @@
 import { Grid, Pagination } from '@trussworks/react-uswds';
-import { useEffect, useRef } from 'react';
 import { LabReport, OrganizationParticipation, PersonParticipation } from 'generated/graphql/schema';
-import { calculateAge } from 'utils/util';
 import 'apps/search/advancedSearch/AdvancedSearch.scss';
-import { useNavigate } from 'react-router';
 import { ClassicLink } from 'classic';
 import { NoData } from 'components/NoData';
-import { formattedName } from 'utils';
 import { SearchCriteriaContext } from 'providers/SearchCriteriaContext';
+import { PatientDetails } from 'apps/search/event/components/PatientDetails';
+import { internalizeDate } from 'date';
 
 type LabReportResultsProps = {
     data: [LabReport];
@@ -17,246 +15,16 @@ type LabReportResultsProps = {
 };
 
 export const LabReportResults = ({ data, totalResults, handlePagination, currentPage }: LabReportResultsProps) => {
-    const searchItemsRef: any = useRef();
-    const navigate = useNavigate();
-
-    // Update 'width' and 'height' when the window resizes
-    useEffect(() => {
-        window.addEventListener('resize', getListSize);
-    }, []);
-
-    useEffect(() => {
-        getListSize();
-    }, [data]);
-
-    const getListSize = () => {
-        return searchItemsRef.current?.clientHeight;
-    };
-
     const handleNext = (page: number) => {
         handlePagination(page);
     };
 
-    const formatDate = (date: Date) => {
-        return new Date(date).toLocaleDateString('en-US', {
-            timeZone: 'UTC'
-        });
-    };
-
-    const getPatient = (labReport: LabReport): PersonParticipation | undefined | null => {
-        return labReport.personParticipations?.find(
-            (p) => p?.typeDescTxt === 'Patient subject' || p?.typeCd === 'PATSBJ'
-        );
-    };
-
-    const getOrderingProvidorName = (labReport: LabReport): string | undefined => {
-        const provider = labReport.personParticipations?.find((p) => p?.typeCd === 'ORD' && p?.personCd === 'PRV');
-        if (provider) {
-            return `${provider.firstName} ${provider.lastName}`;
-        } else {
-            return undefined;
-        }
-    };
-
-    const getReportingFacility = (labReport: LabReport): OrganizationParticipation | undefined | null => {
-        return labReport.organizationParticipations?.find((o) => o?.typeCd === 'AUT');
-    };
-
-    const getDescription = (labReport: LabReport): string => {
-        // TODO - there could be multiple tests associated with one lab report. How to display them in UI
-        const observation = labReport.observations?.find((o) => o?.altCd && o?.displayName && o?.cdDescTxt);
-        if (observation) {
-            return `${observation.cdDescTxt} = ${observation.displayName}`;
-        } else {
-            return 'No Data';
-        }
-    };
-
-    const buildPatientDetails = (labReport: LabReport) => {
-        const patient = getPatient(labReport);
-        let name = '';
-        let birthDate: string | undefined;
-        let age: string | undefined;
-        let sex: string | undefined;
-        if (patient) {
-            name =
-                !patient.lastName && !patient.firstName
-                    ? `No Data`
-                    : formattedName(patient?.lastName ?? '', patient?.firstName ?? '');
-            if (patient.birthTime) {
-                birthDate = formatDate(patient.birthTime);
-                age = calculateAge(new Date(patient.birthTime));
-            }
-            sex = patient.currSexCd === 'M' ? 'Male' : patient.currSexCd === 'F' ? 'Female' : 'Unknown';
-        }
-
-        const redirectPatientProfile = async () => {
-            navigate(`/patient-profile/${patient?.shortId}`);
-        };
-
-        return (
-            <Grid row gap={3}>
-                <Grid col={12} className="margin-bottom-2">
-                    <p className="margin-0 text-normal text-gray-50 search-result-item-label">LEGAL NAME</p>
-                    {name ? (
-                        <a
-                            onClick={redirectPatientProfile}
-                            className="margin-0 font-sans-md margin-top-05 text-bold text-primary word-break"
-                            style={{ wordBreak: 'break-word', cursor: 'pointer' }}>
-                            {name}
-                        </a>
-                    ) : (
-                        <NoData />
-                    )}
-                </Grid>
-                <Grid col={12} className="margin-bottom-2">
-                    <div className="grid-row flex-align-center">
-                        <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                            DATE OF BIRTH
-                        </p>
-                        <p className="margin-0 font-sans-1xs text-normal">
-                            <>
-                                {birthDate ? birthDate : <NoData />}
-                                <span className="font-sans-2xs"> {age ? `(${age})` : ''}</span>
-                            </>
-                        </p>
-                    </div>
-                    <div className="grid-row flex-align-center">
-                        <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">SEX</p>
-                        <p className="margin-0 font-sans-1xs text-normal">{sex ? sex : <NoData />}</p>
-                    </div>
-                    <div className="grid-row flex-align-center">
-                        <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                            PATIENT ID
-                        </p>
-                        <p className="margin-0 font-sans-1xs text-normal">{patient?.shortId}</p>
-                    </div>
-                </Grid>
-            </Grid>
-        );
-    };
-
     return (
         <div className="margin-x-4">
-            <div ref={searchItemsRef}>
+            <div>
                 {data &&
                     data?.length > 0 &&
-                    data?.map((item, index: number) => (
-                        <div
-                            key={index}
-                            className="padding-x-3 padding-top-3 padding-bottom-2 margin-bottom-3 bg-white border border-base-light radius-md">
-                            <Grid row gap={3}>
-                                <Grid col={4}>{buildPatientDetails(item)}</Grid>
-                                <Grid col={3}>
-                                    <Grid row gap={3}>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50">
-                                                DOCUMENT TYPE
-                                            </p>
-                                            <ClassicLink
-                                                className="margin-0 font-sans-md margin-top-05 text-bold text-primary word-break"
-                                                url={`/nbs/api/profile/${getPatient(item)?.shortId}/report/lab/${
-                                                    item.id
-                                                }`}>
-                                                Lab Report
-                                            </ClassicLink>
-                                        </Grid>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                                                DATE RECEIVED
-                                            </p>
-                                            <p className="margin-0 font-sans-1xs text-normal">
-                                                {formatDate(item.addTime) || 'No Data'}
-                                            </p>
-                                        </Grid>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                                                DESCRIPTION
-                                            </p>
-                                            {getDescription(item) === 'No Data' ? (
-                                                <NoData />
-                                            ) : (
-                                                <p className="margin-0 font-sans-1xs text-normal">
-                                                    {getDescription(item)}
-                                                </p>
-                                            )}
-                                        </Grid>
-                                    </Grid>
-                                </Grid>
-                                <Grid col={3}>
-                                    <Grid row gap={3}>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                                                REPORTING FACILITY
-                                            </p>
-                                            <p className="margin-0 font-sans-1xs text-normal">
-                                                {getReportingFacility(item)?.name ?? <NoData />}
-                                            </p>
-                                        </Grid>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                                                ORDERING PROVIDOR
-                                            </p>
-                                            <p className="margin-0 font-sans-1xs text-normal">
-                                                {getOrderingProvidorName(item) ?? <NoData />}
-                                            </p>
-                                        </Grid>
-                                        <SearchCriteriaContext.Consumer>
-                                            {({ searchCriteria }) => (
-                                                <Grid col={12} className="margin-bottom-2">
-                                                    <p className="margin-0 text-normal search-result-item-label text-gray-50">
-                                                        JURISDICTION
-                                                    </p>
-                                                    <p className="margin-0 font-sans-1xs text-normal">
-                                                        {item.jurisdictionCd ? (
-                                                            searchCriteria.jurisdictions.find(
-                                                                (j) => j.id === item.jurisdictionCd?.toString()
-                                                            )?.codeDescTxt
-                                                        ) : (
-                                                            <NoData />
-                                                        )}
-                                                    </p>
-                                                </Grid>
-                                            )}
-                                        </SearchCriteriaContext.Consumer>
-                                    </Grid>
-                                </Grid>
-                                <Grid col={2}>
-                                    <Grid row gap={3}>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                                                ASSOCIATED WITH
-                                            </p>
-                                            <div className="margin-0 font-sans-1xs text-normal">
-                                                {(!item.associatedInvestigations ||
-                                                    item.associatedInvestigations.length == 0) && <NoData />}
-                                                {item.associatedInvestigations &&
-                                                    item.associatedInvestigations?.length > 0 &&
-                                                    item.associatedInvestigations?.map((i, index) => (
-                                                        <div key={index}>
-                                                            <p
-                                                                className="margin-0 text-primary text-bold"
-                                                                style={{ wordBreak: 'break-word' }}>
-                                                                {i?.localId}
-                                                            </p>
-                                                            <p className="margin-0">{i?.cdDescTxt}</p>
-                                                        </div>
-                                                    ))}
-                                            </div>
-                                        </Grid>
-                                        <Grid col={12} className="margin-bottom-2">
-                                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
-                                                LOCAL ID
-                                            </p>
-                                            <p className="margin-0 font-sans-1xs text-normal">
-                                                {item.localId || <NoData />}
-                                            </p>
-                                        </Grid>
-                                    </Grid>
-                                </Grid>
-                            </Grid>
-                        </div>
-                    ))}
+                    data?.map((item, index: number) => <LabReportSearchResult item={item} key={index} />)}
             </div>
             {Boolean(totalResults && data?.length > 0) && (
                 <Pagination
@@ -269,6 +37,150 @@ export const LabReportResults = ({ data, totalResults, handlePagination, current
                     onClickPageNumber={(_, page) => handleNext(page)}
                 />
             )}
+        </div>
+    );
+};
+
+const getPatient = (labReport: LabReport): PersonParticipation | undefined | null => {
+    return labReport.personParticipations?.find((p) => p?.typeDescTxt === 'Patient subject' || p?.typeCd === 'PATSBJ');
+};
+
+const getOrderingProvidorName = (labReport: LabReport): string | undefined => {
+    const provider = labReport.personParticipations?.find((p) => p?.typeCd === 'ORD' && p?.personCd === 'PRV');
+    if (provider) {
+        return `${provider.firstName} ${provider.lastName}`;
+    } else {
+        return undefined;
+    }
+};
+
+const getReportingFacility = (labReport: LabReport): OrganizationParticipation | undefined | null => {
+    return labReport.organizationParticipations?.find((o) => o?.typeCd === 'AUT');
+};
+
+const getDescription = (labReport: LabReport): string => {
+    // TODO - there could be multiple tests associated with one lab report. How to display them in UI
+    const observation = labReport.observations?.find((o) => o?.altCd && o?.displayName && o?.cdDescTxt);
+    if (observation) {
+        return `${observation.cdDescTxt} = ${observation.displayName}`;
+    } else {
+        return 'No Data';
+    }
+};
+
+type LabReportSearchResultProps = {
+    item: LabReport;
+};
+
+const LabReportSearchResult = ({ item }: LabReportSearchResultProps) => {
+    const patient = getPatient(item);
+    return (
+        <div className="padding-x-3 padding-top-3 padding-bottom-2 margin-bottom-3 bg-white border border-base-light radius-md">
+            <Grid row gap={3}>
+                <Grid col={4}>
+                    <PatientDetails patient={patient} />
+                </Grid>
+                <Grid col={3}>
+                    <Grid row gap={3}>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50">DOCUMENT TYPE</p>
+                            <ClassicLink
+                                className="margin-0 font-sans-md margin-top-05 text-bold text-primary word-break"
+                                url={`/nbs/api/profile/${getPatient(item)?.personParentUid}/report/lab/${item.id}`}>
+                                Lab Report
+                            </ClassicLink>
+                        </Grid>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                                DATE RECEIVED
+                            </p>
+                            <p className="margin-0 font-sans-1xs text-normal">
+                                {internalizeDate(item.addTime) || 'No Data'}
+                            </p>
+                        </Grid>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                                DESCRIPTION
+                            </p>
+                            {getDescription(item) === 'No Data' ? (
+                                <NoData />
+                            ) : (
+                                <p className="margin-0 font-sans-1xs text-normal">{getDescription(item)}</p>
+                            )}
+                        </Grid>
+                    </Grid>
+                </Grid>
+                <Grid col={3}>
+                    <Grid row gap={3}>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                                REPORTING FACILITY
+                            </p>
+                            <p className="margin-0 font-sans-1xs text-normal">
+                                {getReportingFacility(item)?.name ?? <NoData />}
+                            </p>
+                        </Grid>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                                ORDERING PROVIDOR
+                            </p>
+                            <p className="margin-0 font-sans-1xs text-normal">
+                                {getOrderingProvidorName(item) ?? <NoData />}
+                            </p>
+                        </Grid>
+                        <SearchCriteriaContext.Consumer>
+                            {({ searchCriteria }) => (
+                                <Grid col={12} className="margin-bottom-2">
+                                    <p className="margin-0 text-normal search-result-item-label text-gray-50">
+                                        JURISDICTION
+                                    </p>
+                                    <p className="margin-0 font-sans-1xs text-normal">
+                                        {item.jurisdictionCd ? (
+                                            searchCriteria.jurisdictions.find(
+                                                (j) => j.id === item.jurisdictionCd?.toString()
+                                            )?.codeDescTxt
+                                        ) : (
+                                            <NoData />
+                                        )}
+                                    </p>
+                                </Grid>
+                            )}
+                        </SearchCriteriaContext.Consumer>
+                    </Grid>
+                </Grid>
+                <Grid col={2}>
+                    <Grid row gap={3}>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                                ASSOCIATED WITH
+                            </p>
+                            <div className="margin-0 font-sans-1xs text-normal">
+                                {(!item.associatedInvestigations || item.associatedInvestigations.length == 0) && (
+                                    <NoData />
+                                )}
+                                {item.associatedInvestigations &&
+                                    item.associatedInvestigations?.length > 0 &&
+                                    item.associatedInvestigations?.map((i, index) => (
+                                        <div key={index}>
+                                            <p
+                                                className="margin-0 text-primary text-bold"
+                                                style={{ wordBreak: 'break-word' }}>
+                                                {i?.localId}
+                                            </p>
+                                            <p className="margin-0">{i?.cdDescTxt}</p>
+                                        </div>
+                                    ))}
+                            </div>
+                        </Grid>
+                        <Grid col={12} className="margin-bottom-2">
+                            <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                                LOCAL ID
+                            </p>
+                            <p className="margin-0 font-sans-1xs text-normal">{item.localId || <NoData />}</p>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/search/event/components/PatientDetails/PatientDetails.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/PatientDetails/PatientDetails.tsx
@@ -1,0 +1,74 @@
+import { useNavigate } from 'react-router';
+import { Grid } from '@trussworks/react-uswds';
+import { PersonParticipation } from 'generated/graphql/schema';
+import { NoData } from 'components/NoData';
+
+import { calculateAge } from 'utils/util';
+import { formattedName } from 'utils';
+import { internalizeDate } from 'date';
+
+type PatientDetailsProps = {
+    patient: PersonParticipation | null | undefined;
+};
+
+const PatientDetails = ({ patient }: PatientDetailsProps) => {
+    const navigate = useNavigate();
+    let name = '';
+    let birthDate: string | undefined;
+    let age: string | undefined;
+    let sex: string | undefined;
+    if (patient) {
+        name =
+            !patient.lastName && !patient.firstName
+                ? `No Data`
+                : formattedName(patient?.lastName ?? '', patient?.firstName ?? '');
+        if (patient.birthTime) {
+            birthDate = internalizeDate(patient.birthTime);
+            age = calculateAge(new Date(patient.birthTime));
+        }
+        sex = patient.currSexCd === 'M' ? 'Male' : patient.currSexCd === 'F' ? 'Female' : 'Unknown';
+    }
+
+    const redirectPatientProfile = () => {
+        navigate(`/patient-profile/${patient?.shortId}`);
+    };
+
+    return (
+        <Grid row gap={3}>
+            <Grid col={12} className="margin-bottom-2">
+                <p className="margin-0 text-normal text-gray-50 search-result-item-label">LEGAL NAME</p>
+                <a
+                    onClick={redirectPatientProfile}
+                    className="margin-0 font-sans-md margin-top-05 text-bold text-primary word-break"
+                    style={{ wordBreak: 'break-word', cursor: 'pointer' }}>
+                    {name}
+                </a>
+            </Grid>
+            <Grid col={12} className="margin-bottom-2">
+                <div className="grid-row flex-align-center">
+                    <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                        DATE OF BIRTH
+                    </p>
+                    <p className="margin-0 font-sans-2xs text-normal">
+                        <>
+                            {birthDate ? birthDate : <NoData />}
+                            <span className="font-sans-2xs"> {age ? `(${age})` : ''}</span>
+                        </>
+                    </p>
+                </div>
+                <div className="grid-row flex-align-center">
+                    <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">SEX</p>
+                    <p className="margin-0 font-sans-2xs text-normal">{sex ? sex : <NoData />}</p>
+                </div>
+                <div className="grid-row flex-align-center">
+                    <p className="margin-0 text-normal search-result-item-label text-gray-50 margin-right-1">
+                        PATIENT ID
+                    </p>
+                    <p className="margin-0 font-sans-2xs text-normal">{patient?.shortId || <NoData />}</p>
+                </div>
+            </Grid>
+        </Grid>
+    );
+};
+
+export { PatientDetails };

--- a/apps/modernization-ui/src/apps/search/event/components/PatientDetails/index.ts
+++ b/apps/modernization-ui/src/apps/search/event/components/PatientDetails/index.ts
@@ -1,0 +1,1 @@
+export * from './PatientDetails';

--- a/apps/modernization-ui/src/date/InternalizeDate.ts
+++ b/apps/modernization-ui/src/date/InternalizeDate.ts
@@ -1,19 +1,20 @@
 /* eslint-disable no-redeclare */
-import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
-import { INTERNAL_DATE_FORMAT } from './Dates';
 
 function internalizeDate(input: string): string;
 function internalizeDate(input: Date): string;
 function internalizeDate(input: string | null | undefined): null;
 function internalizeDate(input: Date | null | undefined): null;
 function internalizeDate(input: string | Date | null | undefined) {
-    if (input) {
-        if (typeof input === 'string') {
-            return format(parseISO(input), INTERNAL_DATE_FORMAT);
-        } else if (input instanceof Date) {
-            return format(input, INTERNAL_DATE_FORMAT);
-        }
+    if (typeof input === 'string') {
+        return internalizeDate(parseISO(input));
+    } else if (input instanceof Date) {
+        return input.toLocaleDateString('en-US', {
+            timeZone: 'UTC',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric'
+        });
     }
 
     return null;


### PR DESCRIPTION
## Description

The url used to link to the lab report was using the Patient short id instead of the actual identifier which prevented the Patient from being resolved when returning to the patient profile.

## Tickets

* [CNFT1-2095](https://cdc-nbs.atlassian.net/browse/CNFT1-2095)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2095]: https://cdc-nbs.atlassian.net/browse/CNFT1-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ