### PR TITLE
Edit coded question fix

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/CodedFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/CodedFields.tsx
@@ -8,10 +8,11 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import styles from '../question-form.module.scss';
 
 type Props = {
-    onFindValueSet: () => void;
+    onFindValueSet?: () => void;
     published?: boolean;
+    editing?: boolean;
 };
-export const CodedFields = ({ onFindValueSet, published = true }: Props) => {
+export const CodedFields = ({ onFindValueSet, editing = false, published = false }: Props) => {
     const form = useFormContext<CreateCodedQuestionRequest>();
     const valueSet = useWatch({ control: form.control, name: 'valueSet', exact: true });
     const [valueSets, setValueSets] = useState<ValueSetOption[]>([]);
@@ -56,7 +57,7 @@ export const CodedFields = ({ onFindValueSet, published = true }: Props) => {
                     />
                 )}
             />
-            {!published && (
+            {!published && !editing && (
                 <>
                     <Button className={styles.valuesetSearchButton} type="button" outline onClick={onFindValueSet}>
                         Search value set

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/NumericFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/NumericFields.tsx
@@ -23,7 +23,7 @@ export const NumericFields = ({ maskOptions, editing = false, published = false 
         exact: true
     });
     const [numericMaskOptions, setNumericMaskOptions] = useState<Option[]>([]);
-    const [relatedUnitsToggle, setRelatedUnitsToggle] = useState(unitType !== undefined || unitType !== '');
+    const [relatedUnitsToggle, setRelatedUnitsToggle] = useState(unitType !== undefined && unitType !== '');
     const [valueSets, setValueSets] = useState<Selectable[]>([]);
 
     useEffect(() => {

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/QuestionSpecificFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/QuestionSpecificFields.tsx
@@ -7,7 +7,7 @@ import { NumericFields } from './NumericFields';
 import { TextFields } from './TextFields';
 
 type Props = {
-    onFindValueSet: () => void;
+    onFindValueSet?: () => void;
     editing?: boolean;
     published?: boolean;
 };
@@ -18,7 +18,9 @@ export const QuestionSpecificFields = ({ onFindValueSet, editing = false, publis
 
     return (
         <>
-            {questionType === 'CODED' && <CodedFields published={published} onFindValueSet={onFindValueSet} />}
+            {questionType === 'CODED' && (
+                <CodedFields editing={editing} published={published} onFindValueSet={onFindValueSet} />
+            )}
             {questionType === 'NUMERIC' && (
                 <NumericFields editing={editing} published={published} maskOptions={maskOptions} />
             )}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/edit-question/EditQuestionModal.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/edit-question/EditQuestionModal.tsx
@@ -106,7 +106,7 @@ const EditQuestionContent = ({ onUpdated, onClose, question }: ContentProps) => 
             <div className={styles.content}>
                 <div className={styles.formWrapper}>
                     <FormProvider {...form}>
-                        <EditPageQuestion page={page.id} question={question} onFindValueSet={() => {}} />
+                        <EditPageQuestion page={page.id} question={question} />
                     </FormProvider>
                 </div>
             </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/edit-question/form/EditPageQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/edit-question/form/EditPageQuestion.tsx
@@ -18,14 +18,13 @@ export type EditPageQuestionForm = Omit<UpdatePageQuestionRequest & AdditionalQu
 type Props = {
     page: number;
     question?: PagesQuestion;
-    onFindValueSet: () => void;
 };
 
-export const EditPageQuestion = ({ page, question, onFindValueSet }: Props) => {
+export const EditPageQuestion = ({ page, question }: Props) => {
     return (
         <div className={styles.form}>
             <BasicInformationFields editing />
-            <QuestionSpecificFields editing published={question?.isPublished} onFindValueSet={onFindValueSet} />
+            <QuestionSpecificFields editing published={question?.isPublished} />
             <HorizontalRule />
             <UserInterfaceFields published={question?.isPublished} />
             <EditFields />


### PR DESCRIPTION
## Description

1. When editing a `CODED` question, hide the create new value set workflow.
2. Related units was default to `Yes` due to using `||` instead of `&&`

## Tickets

NA

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
