### PR TITLE
fix undefined pageId when canceling rule edit form

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useFetchPageRules.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useFetchPageRules.ts
@@ -72,7 +72,7 @@ export const useFetchPageRules = () => {
     const { pageId } = useParams();
 
     useEffect(() => {
-        if (state.status === 'searching') {
+        if (state.status === 'searching' && pageId) {
             const sortString = state.search.sort
                 ? `${state.search.sort.field},${state.search.sort.direction}`
                 : undefined;

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.tsx
@@ -106,7 +106,11 @@ const AddBusinessRule = () => {
     });
 
     const handleCancel = () => {
-        navigate(`/page-builder/pages/${pageId}/business-rules`);
+        if (pageId) {
+            navigate(`/page-builder/pages/${pageId}/business-rules`);
+        } else {
+            navigate(`../`);
+        }
     };
 
     const handleDeleteRule = () => {

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.tsx
@@ -18,19 +18,19 @@ export const BusinessRulesLibrary = ({ modalRef }: any) => {
 
     useEffect(() => {
         search({ sort: undefined, page: 0, pageSize: 10 });
-    }, []);
+    }, [page?.id]);
 
     useEffect(() => {
-        if (curPage.status === Status.Requested) {
+        if (curPage.status === Status.Requested && page?.id) {
             search({
-                pageId: page?.id,
+                pageId: page.id,
                 page: curPage.current - 1,
                 pageSize: curPage.pageSize,
                 sort: sort,
                 query: query
             });
         }
-    }, [curPage.status]);
+    }, [curPage.status, page?.id]);
 
     useEffect(() => {
         if (curPage.current === 1) {


### PR DESCRIPTION
## Description

We've been having the issue where canceling a business rule edit would navigate back to the table with an undefined pageId.  I have not been able to reproduce this issue locally, but QA consistently has the issue.  I've added a few pageId checks that i'm hoping will fix but I won't know for sure until we merge and test on INT
## Tickets


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
