### PR TITLE
Expose loading indicator for page refresh

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/Edit.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/Edit.tsx
@@ -16,7 +16,7 @@ import { ReorderModal } from './reorder/ReorderModal/ReorderModal';
 import DragDropProvider from 'apps/page-builder/context/DragDropProvider';
 
 export const Edit = () => {
-    const { page, fetch, refresh } = useGetPageDetails();
+    const { page, fetch, refresh, loading } = useGetPageDetails();
 
     const manageSectionModalRef = useRef<ModalRef>(null);
     const addSectionModalRef = useRef<ModalRef>(null);
@@ -32,7 +32,7 @@ export const Edit = () => {
     return (
         <>
             {page ? (
-                <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={loading}>
                     <ManageSectionModal addSecModalRef={addSectionModalRef} manageSecModalRef={manageSectionModalRef} />
                     <EditPageContent handleManageSection={handleManageSection} handleAddSection={handleAddSection} />
                 </PageManagementProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/GroupQuestion.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/GroupQuestion.spec.tsx
@@ -68,7 +68,7 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
     });
 
     return (
-        <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn}>
+        <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
             <AlertProvider>
                 <FormProvider {...methods}>{children}</FormProvider>
             </AlertProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.spec.tsx
@@ -66,7 +66,7 @@ describe('when page loads', () => {
         const { getByTestId } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <PageContent tab={tabs} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -80,7 +80,7 @@ describe('when page loads', () => {
         const { getByTestId } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <PageContent tab={tabs} />
                     </PageManagementProvider>
                 </AlertProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
@@ -9,6 +9,7 @@ import { Icon as NbsIcon } from 'components/Icon/Icon';
 import { RadioButtons } from 'apps/page-builder/components/RadioButton/RadioButton';
 import { Button, Icon } from '@trussworks/react-uswds';
 import { ConceptOptionsResponse, ConceptOptionsService } from 'generated';
+import { usePageManagement } from '../../usePageManagement';
 
 type Props = {
     defaultValue: string;
@@ -41,9 +42,10 @@ export const QuestionContent = ({
     onEditValueset
 }: Props) => {
     const [conceptState, setConceptState] = useState<Selectable[]>([]);
+    const { loading } = usePageManagement();
 
     useEffect(() => {
-        if (valueSet) {
+        if (valueSet && !loading) {
             ConceptOptionsService.allUsingGet({
                 authorization: authorization(),
                 name: valueSet
@@ -51,7 +53,7 @@ export const QuestionContent = ({
                 setConceptState(resp.options);
             });
         }
-    }, [valueSet]);
+    }, [valueSet, loading]);
 
     const renderLabelWithComponent = (
         <div className={styles.content}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderModal/ReorderModal.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderModal/ReorderModal.spec.tsx
@@ -37,7 +37,7 @@ describe('when ReorderModal renders', () => {
     const fetch = () => {
         jest.fn();
     };
-    
+
     const refresh = () => {
         jest.fn();
     };
@@ -47,7 +47,7 @@ describe('when ReorderModal renders', () => {
     };
     it('should display Tab', () => {
         const { getByText } = render(
-            <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+            <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                 <DragDropProvider pageData={page}>
                     <ReorderModal {...props} />
                 </DragDropProvider>
@@ -58,7 +58,7 @@ describe('when ReorderModal renders', () => {
 
     it('should display Sections', () => {
         const { getByText } = render(
-            <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+            <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                 <DragDropProvider pageData={page}>
                     <ReorderModal {...props} />
                 </DragDropProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/AddStaticElement.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/AddStaticElement.spec.tsx
@@ -25,7 +25,7 @@ describe('When page loads', () => {
         const { getByTestId } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -39,7 +39,7 @@ describe('When page loads', () => {
         const { getByText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -55,7 +55,7 @@ describe('When line separator is chosen', () => {
         const { getByTestId, findByText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -80,7 +80,7 @@ describe('When hyperlink is chosen', () => {
         const { getByTestId, findByText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -106,7 +106,7 @@ describe('When comments is chosen', () => {
         const { getByTestId, findByText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -132,7 +132,7 @@ describe('When participants is chosen', () => {
         const { getByTestId, findByText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -158,7 +158,7 @@ describe('When electronic doc list is chosen', () => {
         const { getByTestId, findByText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -183,7 +183,7 @@ describe('When all inputs are entered', () => {
         const { getByTestId, findByTestId, getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <AddStaticElement />
                     </PageManagementProvider>
                 </AlertProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/EditStaticElement.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/EditStaticElement.spec.tsx
@@ -49,7 +49,7 @@ describe('When modal loads with hyperlink element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={hyperlinkElement} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -63,7 +63,7 @@ describe('When modal loads with hyperlink element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={hyperlinkElement} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -79,7 +79,7 @@ describe('When modal loads with hyperlink element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={hyperlinkElement} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -95,7 +95,7 @@ describe('When modal loads with comments element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={commentsElement} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -109,7 +109,7 @@ describe('When modal loads with comments element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={commentsElement} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -126,7 +126,7 @@ describe('When modal loads with line separator element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={lineSeparatorElement} />
                     </PageManagementProvider>
                 </AlertProvider>
@@ -140,7 +140,7 @@ describe('When modal loads with line separator element', () => {
         const { getByLabelText } = render(
             <BrowserRouter>
                 <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
                         <EditStaticElement question={lineSeparatorElement} />
                     </PageManagementProvider>
                 </AlertProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/header/tabs/PageTabs.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/header/tabs/PageTabs.spec.tsx
@@ -38,7 +38,7 @@ describe('When PageTabs renders', () => {
     it('should display the Manage Tabs button when passed onAddSuccess', () => {
         const { container } = render(
             <DragDropProvider pageData={content}>
-                <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()}>
+                <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()} loading={false}>
                     <PageTabs pageId={999} tabs={content.tabs!} onAddSuccess={jest.fn()} />
                 </PageManagementProvider>
             </DragDropProvider>
@@ -49,7 +49,7 @@ describe('When PageTabs renders', () => {
     it('should not display the Manage Tabs button when not passed onAddSuccess', () => {
         const { container } = render(
             <DragDropProvider pageData={content}>
-                <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()}>
+                <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()} loading={false}>
                     <PageTabs pageId={999} tabs={content.tabs!} />
                 </PageManagementProvider>
             </DragDropProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
@@ -27,7 +27,7 @@ const PreviewPage = () => {
     const { page, fetch, refresh } = useGetPageDetails();
 
     return page ? (
-        <PageManagementProvider page={page} fetch={fetch} refresh={refresh}>
+        <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
             <PreviewPageContent />
         </PageManagementProvider>
     ) : (

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PublishPage/PublishPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PublishPage/PublishPage.spec.tsx
@@ -1,8 +1,8 @@
-import { AlertProvider } from "alert";
-import { PageManagementProvider } from "../../usePageManagement";
-import { PublishPage } from "./PublishPage";
-import { render } from "@testing-library/react";
-import { PagesResponse } from "apps/page-builder/generated";
+import { AlertProvider } from 'alert';
+import { PageManagementProvider } from '../../usePageManagement';
+import { PublishPage } from './PublishPage';
+import { render } from '@testing-library/react';
+import { PagesResponse } from 'apps/page-builder/generated';
 
 describe('When PublishPage renders', () => {
     const modalRef = { current: null };
@@ -37,7 +37,7 @@ describe('When PublishPage renders', () => {
     };
     it('should display textarea', () => {
         const { container } = render(
-            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()}>
+            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()} loading={false}>
                 <AlertProvider>
                     <PublishPage modalRef={modalRef} />
                 </AlertProvider>
@@ -48,7 +48,7 @@ describe('When PublishPage renders', () => {
     });
     it('should display label', () => {
         const { container } = render(
-            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()}>
+            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()} loading={false}>
                 <AlertProvider>
                     <PublishPage modalRef={modalRef} />
                 </AlertProvider>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/SaveTemplate/SaveTemplate.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/SaveTemplate/SaveTemplate.spec.tsx
@@ -1,8 +1,8 @@
-import { SaveTemplate } from "./SaveTemplate";
-import { render } from "@testing-library/react";
-import { PageManagementProvider } from "../../usePageManagement";
-import { PagesResponse } from "apps/page-builder/generated";
-import { AlertProvider } from "alert";
+import { SaveTemplate } from './SaveTemplate';
+import { render } from '@testing-library/react';
+import { PageManagementProvider } from '../../usePageManagement';
+import { PagesResponse } from 'apps/page-builder/generated';
+import { AlertProvider } from 'alert';
 
 describe('When SaveTemplate renders', () => {
     const modalRef = { current: null };
@@ -37,23 +37,23 @@ describe('When SaveTemplate renders', () => {
     };
     it('should display inputs', () => {
         const { container } = render(
-            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()}>
+            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()} loading={false}>
                 <AlertProvider>
                     <SaveTemplate modalRef={modalRef} />
                 </AlertProvider>
             </PageManagementProvider>
-        )
+        );
         const inputs = container.getElementsByTagName('input');
         expect(inputs).toHaveLength(2);
     });
     it('should display input labels', () => {
         const { container } = render(
-            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()}>
+            <PageManagementProvider page={content} fetch={jest.fn()} refresh={jest.fn()} loading={false}>
                 <AlertProvider>
                     <SaveTemplate modalRef={modalRef} />
                 </AlertProvider>
             </PageManagementProvider>
-        )
+        );
         const label = container.getElementsByTagName('label');
         expect(label).toHaveLength(2);
     });

--- a/apps/modernization-ui/src/apps/page-builder/page/management/useGetPageDetails.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/useGetPageDetails.ts
@@ -70,7 +70,7 @@ export const useGetPageDetails = (): Interaction => {
 
     const value = {
         error: state.status === 'error' ? state.error : undefined,
-        loading: state.status === 'fetching',
+        loading: state.status === 'fetching' || state.status === 'refreshing',
         page: state.status === 'complete' || state.status === 'refreshing' ? state.details : undefined,
         fetch: (page: number) => dispatch({ type: 'fetch', page }),
         refresh: () => (state.status === 'complete' ? dispatch({ type: 'refresh', details: state.details }) : undefined)

--- a/apps/modernization-ui/src/apps/page-builder/page/management/usePageManagement.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/usePageManagement.tsx
@@ -9,6 +9,7 @@ type Interactions = {
     fetch: (page: number) => void;
     refresh: () => void;
     select: (tab: PagesTab) => void;
+    loading: boolean;
 };
 
 export const PageManagementContext = createContext<Interactions | undefined>(undefined);
@@ -18,13 +19,14 @@ type PageManagementProviderProps = {
     fetch: (page: number) => void;
     refresh: () => void;
     children: ReactNode;
+    loading: boolean;
 };
 
-const PageManagementProvider = ({ page, children, fetch, refresh }: PageManagementProviderProps) => {
+const PageManagementProvider = ({ page, children, fetch, refresh, loading }: PageManagementProviderProps) => {
     const [selected, setSelected] = useState<number>(0);
 
     const select = (tab: PagesTab) => setSelected(page.tabs?.indexOf(tab) ?? 0);
-    const value = useMemo(() => {
+    const base = useMemo(() => {
         return {
             page,
             selected: page.tabs?.[selected],
@@ -33,6 +35,10 @@ const PageManagementProvider = ({ page, children, fetch, refresh }: PageManageme
             select
         };
     }, [JSON.stringify(page), selected]);
+
+    const value = useMemo(() => {
+        return { ...base, loading: loading };
+    }, [base, loading]);
 
     return <PageManagementContext.Provider value={value}>{children}</PageManagementContext.Provider>;
 };


### PR DESCRIPTION
## Description

After editing a value set, refresh the concepts for coded questions. 

After the value set is editing the `refresh` method is called to pull the latest changes for a page. This did not trigger the `loading` state or re-render the question components, leading to them still having the old value set concepts.

By exposing the loading state of a refresh, the components can monitor that and trigger a fetch of their concepts.

## Tickets

NA

![conceptrefresh](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/d6ba13e7-9cfd-4ed8-a0a0-9c8a7d58ef68)


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
