### PR TITLE
business rules UI bugs

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/TargetQuestion/TargetQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/TargetQuestion/TargetQuestion.tsx
@@ -67,7 +67,7 @@ const TargetQuestion = ({
 
     const visible = true;
     const selectedRecord = sourceList.filter((list) => list.selected);
-    const isSelectedAll = selectedRecord?.length === sourceList.length;
+    const isSelectedAll = sourceList.length !== 0 && selectedRecord?.length === sourceList.length;
 
     const handleSelectAll = (e: any) => {
         setSourceList((prevState: any) => prevState.map((list: any) => ({ ...list, selected: e.target.checked })));

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRule.scss
@@ -198,3 +198,9 @@
 .bold-text {
     font-weight: bold;
 }
+
+.multi-select__control {
+    &.multi-select__control--is-disabled {
+        background-color: colors.$disabled;
+    }
+}


### PR DESCRIPTION
## Description

Two small UI bugs within the add business rules page. One that matches the greys of disabled input fields, and to change the default of the select all checkbox within the target question modal

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
