### PR TITLE
Hide reporting / messaging for readonly

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/edit-question/form/EditPageQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/edit-question/form/EditPageQuestion.tsx
@@ -10,6 +10,7 @@ import { PagesQuestion } from 'apps/page-builder/generated';
 import { UpdatePageQuestionRequest } from 'apps/page-builder/hooks/api/useUpdatePageQuestion';
 import { EditFields } from './EditFields';
 import styles from './edit-question-form.module.scss';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 export type EditPageQuestionForm = Omit<UpdatePageQuestionRequest & AdditionalQuestionFields, 'codeSet'> & {
     codeSet: 'LOCAL' | 'PHIN';
@@ -21,6 +22,9 @@ type Props = {
 };
 
 export const EditPageQuestion = ({ page, question }: Props) => {
+    const form = useFormContext<EditPageQuestionForm>();
+    const displayControl = useWatch({ control: form.control, name: 'displayControl', exact: true });
+
     return (
         <div className={styles.form}>
             <BasicInformationFields editing />
@@ -28,10 +32,14 @@ export const EditPageQuestion = ({ page, question }: Props) => {
             <HorizontalRule />
             <UserInterfaceFields published={question?.isPublished} />
             <EditFields />
-            <HorizontalRule />
-            <DataMartFields editing page={page} questionId={question?.id} />
-            <HorizontalRule />
-            <MessagingFields />
+            {displayControl?.toString() !== '1026' && (
+                <>
+                    <HorizontalRule />
+                    <DataMartFields editing page={page} questionId={question?.id} />
+                    <HorizontalRule />
+                    <MessagingFields />
+                </>
+            )}
             <HorizontalRule />
             <AdministrativeFields />
         </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/AddStaticElement.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/AddStaticElement.spec.tsx
@@ -127,57 +127,6 @@ describe('When comments is chosen', () => {
     });
 });
 
-describe('When participants is chosen', () => {
-    it('only displays admin comments', async () => {
-        const { getByTestId, findByText } = render(
-            <BrowserRouter>
-                <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
-                        <AddStaticElement />
-                    </PageManagementProvider>
-                </AlertProvider>
-            </BrowserRouter>
-        );
-
-        const staticTypeInput = getByTestId('staticType');
-
-        act(() => {
-            userEvent.selectOptions(staticTypeInput, 'Participant list (read-only)');
-        });
-
-        act(() => {
-            fireEvent.blur(staticTypeInput);
-        });
-
-        expect(await findByText('Administrative Comments')).toBeInTheDocument();
-    });
-});
-
-describe('When electronic doc list is chosen', () => {
-    it('only displays admin comments', async () => {
-        const { getByTestId, findByText } = render(
-            <BrowserRouter>
-                <AlertProvider>
-                    <PageManagementProvider page={page} fetch={fetch} refresh={refresh} loading={false}>
-                        <AddStaticElement />
-                    </PageManagementProvider>
-                </AlertProvider>
-            </BrowserRouter>
-        );
-
-        const staticTypeInput = getByTestId('staticType');
-        act(() => {
-            userEvent.selectOptions(staticTypeInput, 'Electronic document list (read-only)');
-        });
-
-        act(() => {
-            fireEvent.blur(staticTypeInput);
-        });
-
-        expect(await findByText('Administrative Comments')).toBeInTheDocument();
-    });
-});
-
 describe('When all inputs are entered', () => {
     it('button enables once all inputs are selected', async () => {
         const { getByTestId, findByTestId, getByLabelText } = render(

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/AddStaticElement.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/AddStaticElement.tsx
@@ -20,9 +20,7 @@ import { useAlert } from 'alert';
 const staticType = [
     { value: 'LIN', name: 'Line separator' },
     { value: 'HYP', name: 'Hyperlink' },
-    { value: 'COM', name: 'Comments (read-only)' },
-    { value: 'PAR', name: 'Participant list (read-only)' },
-    { value: 'ELE', name: 'Electronic document list (read-only)' }
+    { value: 'COM', name: 'Comments (read-only)' }
 ];
 
 type AddStaticElementModalProps = {


### PR DESCRIPTION
## Description

If editing a question that has display control of `Readonly user entered text, number or date`, hide reporting / messaging fields.

## Tickets
NA

### Readonly
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/3e19f331-c400-4b4d-929c-3bd08777948d)

### Non-readonly
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/8f0932ed-205f-4f12-8bc5-1d86eab0e61f)



## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
