### PR TITLE
changing the color for the no data indicator to pass color contrast

### DIFF
--- a/apps/modernization-ui/src/components/NoData/NoData.scss
+++ b/apps/modernization-ui/src/components/NoData/NoData.scss
@@ -1,5 +1,5 @@
 .no-data {
-    $no-data-color: #adadad;
+    $no-data-color: #757575;
 
     color: $no-data-color;
     margin: 0;


### PR DESCRIPTION
## Description

Changing the color for the no data indicator to meet color contrast requirements addressing a 508 compliance issue.

## Tickets

* [CNFT1-771](https://cdc-nbs.atlassian.net/browse/CNFT1-771)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-771]: https://cdc-nbs.atlassian.net/browse/CNFT1-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ