### PR TITLE
CNFT2-2106 Preview page header: Business rules - published

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/PageBuilderRouting.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/PageBuilderRouting.tsx
@@ -9,6 +9,7 @@ import { AddNewPage } from './pages/AddNewPage/AddNewPage';
 import { BusinessRulesLibrary } from './pages/BusinessRulesLibrary/BusinessRulesLibrary';
 import AddBusinessRule from './pages/BusinessRulesLibrary/Add/AddBusinessRule';
 import { PageProvider } from 'page';
+import { ViewBusinessRule } from './pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule';
 
 const routing: RouteObject[] = [
     {
@@ -70,6 +71,10 @@ const routing: RouteObject[] = [
                                                 <BusinessRulesLibrary />
                                             </PageProvider>
                                         )
+                                    },
+                                    {
+                                        path: ':ruleId',
+                                        element: <ViewBusinessRule />
                                     },
                                     {
                                         path: 'add',

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { ModalRef, ModalToggleButton } from '@trussworks/react-uswds';
+import { Button, ModalRef, ModalToggleButton } from '@trussworks/react-uswds';
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { RefObject, useEffect, useState } from 'react';
 import { Direction } from 'sorting';
@@ -113,7 +113,69 @@ export const BusinessRulesLibraryTable = ({
         ]
     });
 
-    const asTableRows = (rules: Rule[] | undefined): TableBody[] => rules?.map(asTableRow) || [];
+    const asTableViewRow = (rule: Rule): TableBody => ({
+        key: rule.id,
+        id: rule.template.toString(),
+        tableDetails: [
+            {
+                id: 1,
+                title: (
+                    <Link to={`/page-builder/pages/${page?.id}/business-rules/${rule.id}`}>
+                        {rule.sourceQuestion.label} ({rule.sourceQuestion.questionIdentifier})
+                    </Link>
+                )
+            },
+            { id: 2, title: <div className="event-text">{mapComparatorToString(rule.comparator)}</div> },
+            {
+                id: 3,
+                title: (
+                    <div>
+                        {!rule.anySourceValue ? (
+                            rule?.sourceValues?.map((value, index) => (
+                                <React.Fragment key={index}>
+                                    <span>{value}</span>
+                                    <br />
+                                </React.Fragment>
+                            ))
+                        ) : (
+                            <div>Any source value</div>
+                        )}
+                    </div>
+                )
+            },
+            {
+                id: 4,
+                title: <div>{mapRuleFunctionToString(rule.ruleFunction)}</div>
+            },
+            {
+                id: 5,
+                title: (
+                    <div>
+                        {rule.targets?.map((target, index) => (
+                            <React.Fragment key={index}>
+                                <span>
+                                    {target.label} ({target.targetIdentifier})
+                                </span>
+                                <br />
+                            </React.Fragment>
+                        ))}
+                    </div>
+                )
+            },
+            {
+                id: 6,
+                title: <div>{rule.id}</div>
+            }
+        ]
+    });
+
+    const asTableRows = (rules: Rule[] | undefined): TableBody[] => {
+        if (page?.status === 'Published') {
+            return rules?.map(asTableViewRow) || [];
+        } else {
+            return rules?.map(asTableRow) || [];
+        }
+    };
 
     useEffect(() => {
         setTableRows(asTableRows(summaries));
@@ -193,9 +255,15 @@ export const BusinessRulesLibraryTable = ({
                 <div className="business-rules-header">
                     <h3> {page?.name} | Business rules </h3>
                 </div>
-                <NavLinkButton className="test-btn" to={`${redirectRuleURL}/add`}>
-                    Add new business rule
-                </NavLinkButton>
+                {page?.status === 'Published' ? (
+                    <Button type="button" disabled>
+                        Add new business rule
+                    </Button>
+                ) : (
+                    <NavLinkButton className="test-btn" to={`${redirectRuleURL}/add`}>
+                        Add new business rule
+                    </NavLinkButton>
+                )}
             </div>
             <div>
                 <SearchBar onChange={onQueryChange} />

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.spec.tsx
@@ -1,0 +1,43 @@
+import { screen, render } from '@testing-library/react';
+import { ViewBusinessRule } from './ViewBusinessRule';
+import { BrowserRouter } from 'react-router-dom';
+import { Rule } from 'apps/page-builder/generated';
+import { PageProvider } from 'page';
+
+    describe('when ViewBusinessRule rendered', () => {
+        it('should display heading', () => {
+            const { container } = render(
+                <BrowserRouter>
+                    <PageProvider>
+                        <ViewBusinessRule />
+                    </PageProvider>
+                </BrowserRouter>
+            );
+            const heading = container.querySelector('h2');
+            expect(heading).toHaveTextContent('View business rule');
+        });
+        it('should display table headers', async () => {
+            const { findAllByRole } = render(
+                <BrowserRouter>
+                    <PageProvider>
+                        <ViewBusinessRule />
+                    </PageProvider>
+                </BrowserRouter>
+            );
+
+            const tableHeads = await findAllByRole('columnheader');
+            expect(tableHeads).toHaveLength(2);
+        });
+        it('should rule fields', async () => {
+            const { findAllByRole } = render(
+                <BrowserRouter>
+                    <PageProvider>
+                        <ViewBusinessRule />
+                    </PageProvider>
+                </BrowserRouter>
+            );
+
+            const tableData = await findAllByRole('cell');
+            expect(tableData).toHaveLength(12);
+        });
+    });

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { PageRuleControllerService } from 'apps/page-builder/generated';
+import { Rule } from 'apps/page-builder/generated';
+import { authorization } from 'authorization';
+import { Breadcrumb } from 'breadcrumb';
+import styles from './view-business-rule.module.scss';
+
+export const ViewBusinessRule = () => {
+    const { ruleId } = useParams();
+    const [rule, setRule] = useState<Rule | undefined>(undefined);
+
+    useEffect(() => {
+        if (ruleId) {
+            PageRuleControllerService.viewRuleResponseUsingGet({
+                authorization: authorization(),
+                ruleId: Number(ruleId)
+            }).then((response: Rule) => {
+                setRule(response);
+            });
+        }
+    }, [ruleId]);
+
+    return (
+        <div className={styles.view}>
+            <Breadcrumb start="../">Business rules</Breadcrumb>
+            <div className={styles.container}>
+                <h2>View business rule</h2>
+                <div className={styles.body}>
+                    <table cellSpacing={0}>
+                        <thead>
+                            <th>Function</th>
+                            <th>Require if</th>
+                        </thead>
+                        <tr>
+                            <td>Source</td>
+                            <td>
+                                {rule?.sourceQuestion.label} ({rule?.sourceQuestion.questionIdentifier})
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Any source value</td>
+                            <td>{rule?.anySourceValue ? 'True' : 'False'}</td>
+                        </tr>
+                        <tr>
+                            <td>Logic</td>
+                            <td>
+                                {rule?.comparator
+                                    ? rule.comparator.charAt(0).toUpperCase() +
+                                      rule.comparator.slice(1).replaceAll('_', ' ').toLowerCase()
+                                    : ''}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Source value(s)</td>
+                            <td>
+                                {rule?.sourceValues?.map((value, key) => (
+                                    <span key={key}>{value}</span>
+                                ))}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Target(s)</td>
+                            <td>
+                                {rule?.targets.map((target, key) => (
+                                    <span key={key}>
+                                        {target.label} ({target.targetIdentifier})
+                                    </span>
+                                ))}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Rule description</td>
+                            <td>{rule?.description}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/view-business-rule.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/view-business-rule.module.scss
@@ -1,0 +1,48 @@
+@use 'styles/colors';
+
+.view {
+    padding: 1rem;
+    .container {
+        background-color: colors.$base-white;
+        max-width: 55rem;
+        min-height: 40rem;
+        margin: 1.5rem auto;
+        padding: 1.5rem 0;
+        h2 {
+            text-align: center;
+            margin: 1.25rem 0 0 0;
+        }
+        .body {
+            max-width: 45rem;
+            margin: 4rem auto auto;
+            table {
+                width: 100%;
+                thead {
+                    th {
+                        border-bottom: 1px solid colors.$base-lighter;
+                        text-align: left;
+                        font-size: 1rem;
+                        padding-bottom: 1.5rem;
+                        &:first-of-type {
+                            width: 8.75rem;
+                        }
+                    }
+                }
+                tr td {
+                    font-weight: 400;
+                    padding: 1.75rem 1.5rem 0.75rem 0;
+                    vertical-align: top;
+                    &:first-of-type {
+                        width: 8.75rem;
+                    }
+                    span {
+                        display: inline-block;
+                        width: 50%;
+                        margin-bottom: 0.75rem;
+                        vertical-align: top;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

When a Page is 'Published', when you select "Business rules", the "Add business rule" button is disabled.
From the table, when you select a Business rule, it takes you to a read-only display of the Rule.
<img width="1493" alt="image" src="https://github.com/CDCgov/NEDSS-Modernization/assets/124739504/2b9199a0-cbc9-45aa-b938-6476cc93cd13">
<img width="927" alt="image" src="https://github.com/CDCgov/NEDSS-Modernization/assets/124739504/295c5d97-c6da-4913-93b2-4d11464df307">


## Tickets

* [CNFT2-2106](https://cdc-nbs.atlassian.net/browse/CNFT2-2106)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2106]: https://cdc-nbs.atlassian.net/browse/CNFT2-2106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ