### PR TITLE
Trigger change to required toggle when question is edited

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -19,12 +19,20 @@ const lineSeparatorId = 1012;
 const originalElecDocId = 1036;
 const readOnlyPartId = 1030;
 
-export const QuestionHeader = ({ question, onRequiredChange, onEditQuestion, onDeleteQuestion }: Props) => {
+export const QuestionHeader = ({ question, onEditQuestion, onRequiredChange, onDeleteQuestion }: Props) => {
     const [required, setRequired] = useState<boolean>(question.required === true);
 
     useEffect(() => {
-        setRequired(question.required === true);
+        if (question.required !== undefined) {
+            setRequired(question.required);
+        }
     }, [question.required]);
+
+    useEffect(() => {
+        if (required !== question.required) {
+            onRequiredChange(required);
+        }
+    }, [required]);
 
     const getHeadingText = (displayComponent: number | undefined) => {
         switch (displayComponent) {
@@ -59,8 +67,7 @@ export const QuestionHeader = ({ question, onRequiredChange, onEditQuestion, onD
                 <ToggleButton
                     checked={required}
                     onChange={() => {
-                        setRequired(!question.required);
-                        onRequiredChange(!question.required);
+                        setRequired(!required);
                     }}
                 />
                 <div className={styles.requiredToggle}>Required</div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -3,6 +3,7 @@ import DeleteQuestion from 'apps/page-builder/components/DeleteQuestion/DeleteQu
 import { ToggleButton } from 'apps/page-builder/components/ToggleButton';
 import { PagesQuestion } from 'apps/page-builder/generated';
 import { Heading } from 'components/heading';
+import { useEffect, useState } from 'react';
 import styles from './question-header.module.scss';
 
 type Props = {
@@ -19,6 +20,12 @@ const originalElecDocId = 1036;
 const readOnlyPartId = 1030;
 
 export const QuestionHeader = ({ question, onRequiredChange, onEditQuestion, onDeleteQuestion }: Props) => {
+    const [required, setRequired] = useState<boolean>(question.required === true);
+
+    useEffect(() => {
+        setRequired(question.required === true);
+    }, [question.required]);
+
     const getHeadingText = (displayComponent: number | undefined) => {
         switch (displayComponent) {
             case hyperlinkId:
@@ -50,8 +57,11 @@ export const QuestionHeader = ({ question, onRequiredChange, onEditQuestion, onD
                 <div className={styles.divider}>|</div>
                 <div className={styles.requiredToggle}>Not required</div>
                 <ToggleButton
-                    defaultChecked={question.required}
-                    onChange={() => onRequiredChange(!question.required)}
+                    checked={required}
+                    onChange={() => {
+                        setRequired(!question.required);
+                        onRequiredChange(!question.required);
+                    }}
                 />
                 <div className={styles.requiredToggle}>Required</div>
             </div>


### PR DESCRIPTION
## Description

The `Required` toggle in the question header does not update when the `Required` value changes through the edit modal.

## Tickets

* [CNFT2-2164](https://cdc-nbs.atlassian.net/browse/CNFT2-2164)

### 
![toggleRequired](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/542f02fc-ae95-499a-8a2b-7ac25dab3dca)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
