### PR TITLE
Cnft2 1992 value missing

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
@@ -123,17 +123,16 @@ class PageRuleFinder {
              [rule].target_question_identifier  as [targetQuestions],
              [question1].question_label          as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-             [question1].wa_question_uid         as [sourceQuestionId],
              STRING_AGG([question2].question_label, ', ') WITHIN GROUP
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
              as [targetQuestionLabels],
              (SELECT COUNT(DISTINCT [rule].wa_rule_metadata_uid)
               from WA_rule_metadata [rule]
-                left join WA_question [question1] on [rule].source_question_identifier = [question1].question_identifier
+                left join WA_UI_metadata [question1] on [rule].source_question_identifier = [question1].question_identifier
                 left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
-                left join WA_question [question2]
+                left join WA_UI_metadata [question2]
                     on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-              where [rule].wa_template_uid =:pageId
+              where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId
                 and
                 (
                 UPPER([rule].source_question_identifier) LIKE CONCAT('%', UPPER(:searchValue), '%')
@@ -144,9 +143,9 @@ class PageRuleFinder {
                 )
              ) as [totalCount]
           from WA_rule_metadata [rule]
-            left join WA_question [question1] on [rule].source_question_identifier = [question1].question_identifier
+            left join WA_UI_metadata [question1] on [rule].source_question_identifier = [question1].question_identifier
             left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
-            left join WA_question [question2]
+            left join WA_UI_metadata [question2]
                 on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
           where [rule].wa_template_uid =:pageId
             and
@@ -170,7 +169,6 @@ class PageRuleFinder {
              [rule].target_question_identifier,
              [question1].question_label,
              [CodeSet].code_set_nm,
-             [question1].wa_question_uid,
              [rule].add_time
              order by sortReplace
              offset :offset rows

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
@@ -31,15 +31,15 @@ class PageRuleFinder {
             [rule].target_question_identifier  as [targetQuestions],
             [question1].question_label          as [sourceQuestionLabel],
             [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-            STRING_AGG([question2].question_label, ',') WITHIN GROUP
+            STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ',') WITHIN GROUP
              (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',')) as [targetQuestionLabels],
                 0                                  as [TotalCount]
           from WA_rule_metadata [rule]
-           left join WA_question [question1] on [rule].source_question_identifier = [question1].question_identifier
+           left join WA_UI_Metadata [question1] on [rule].source_question_identifier = [question1].question_identifier
            left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
-           left join WA_question [question2]
+           left join WA_UI_Metadata [question2]
              on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-          where  [rule].wa_rule_metadata_uid =:ruleId
+          where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId and [question2].wa_template_uid = :pageId
 
           group by
             [rule].wa_rule_metadata_uid,
@@ -54,7 +54,6 @@ class PageRuleFinder {
             [rule].target_question_identifier,
             [question1].question_label,
             [CodeSet].code_set_nm,
-            [question1].wa_question_uid,
             [rule].add_time
             """;
   private String findByPageId =
@@ -72,23 +71,23 @@ class PageRuleFinder {
              [rule].target_question_identifier  as [targetQuestions],
              [question1].question_label          as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-             STRING_AGG([question2].question_label, ', ') WITHIN GROUP
+             STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ', ') WITHIN GROUP
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
              as [targetQuestionLabels],
              (SELECT COUNT(DISTINCT [rule].wa_rule_metadata_uid)
               from WA_rule_metadata [rule]
-                left join WA_question [question1] on [rule].source_question_identifier = [question1].question_identifier
+                left join WA_UI_Metadata [question1] on [rule].source_question_identifier = [question1].question_identifier
                 left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
-                left join WA_question [question2]
+                left join WA_UI_Metadata [question2]
                     on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-              where [rule].wa_template_uid =:pageId
+                    where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId and [question2].wa_template_uid = :pageId
              ) as [totalCount]
           from WA_rule_metadata [rule]
-            left join WA_question [question1] on [rule].source_question_identifier = [question1].question_identifier
+            left join WA_UI_Metadata [question1] on [rule].source_question_identifier = [question1].question_identifier
             left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
-            left join WA_question [question2]
+            left join WA_UI_Metadata [question2]
                 on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-          where [rule].wa_template_uid =:pageId
+                where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId and [question2].wa_template_uid = :pageId
           group by
              [rule].wa_rule_metadata_uid,
              [rule].wa_template_uid,
@@ -102,7 +101,6 @@ class PageRuleFinder {
              [rule].target_question_identifier,
              [question1].question_label,
              [CodeSet].code_set_nm,
-             [question1].wa_question_uid,
              [rule].add_time
                """;
 
@@ -119,7 +117,7 @@ class PageRuleFinder {
              [rule].logic                       as [comparator],
              [rule].target_type                 as [targetType],
              [rule].target_question_identifier  as [targetQuestions],
-             [question1].question_label          as [sourceQuestionLabel],
+             [question1].question_label         as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
              STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ', ') WITHIN GROUP
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
@@ -130,7 +128,7 @@ class PageRuleFinder {
                 left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
                 left join WA_UI_metadata [question2]
                     on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-              where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId
+              where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId and [question2].wa_template_uid = :pageId
                 and
                 (
                 UPPER([rule].source_question_identifier) LIKE CONCAT('%', UPPER(:searchValue), '%')
@@ -145,7 +143,7 @@ class PageRuleFinder {
             left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
             left join WA_UI_metadata [question2]
                 on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-          where [rule].wa_template_uid =:pageId
+          where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId and [question2].wa_template_uid = :pageId
             and
             (
                UPPER([rule].source_question_identifier) LIKE CONCAT('%', UPPER(:searchValue), '%')

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
@@ -39,7 +39,7 @@ class PageRuleFinder {
            left join [NBS_SRTE]..Codeset [CodeSet] on  [question1].code_set_group_id = [CodeSet].code_set_group_id
            left join WA_UI_Metadata [question2]
              on CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',') > 0
-          where [rule].wa_template_uid =:pageId and [question1].wa_template_uid = :pageId and [question2].wa_template_uid = :pageId
+          where [rule].wa_rule_metadata_uid = :ruleId
 
           group by
             [rule].wa_rule_metadata_uid,

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
@@ -31,7 +31,6 @@ class PageRuleFinder {
             [rule].target_question_identifier  as [targetQuestions],
             [question1].question_label          as [sourceQuestionLabel],
             [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-            [question1].wa_question_uid         as [sourceQuestionId],
             STRING_AGG([question2].question_label, ',') WITHIN GROUP
              (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',')) as [targetQuestionLabels],
                 0                                  as [TotalCount]
@@ -73,7 +72,6 @@ class PageRuleFinder {
              [rule].target_question_identifier  as [targetQuestions],
              [question1].question_label          as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-             [question1].wa_question_uid         as [sourceQuestionId],
              STRING_AGG([question2].question_label, ', ') WITHIN GROUP
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
              as [targetQuestionLabels],

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
@@ -123,7 +123,7 @@ class PageRuleFinder {
              [rule].target_question_identifier  as [targetQuestions],
              [question1].question_label          as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-             STRING_AGG([question2].question_label, ', ') WITHIN GROUP
+             STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ', ') WITHIN GROUP
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
              as [targetQuestionLabels],
              (SELECT COUNT(DISTINCT [rule].wa_rule_metadata_uid)

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapper.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 @Component
 class PageRuleMapper implements RowMapper<Rule> {
   record Column(int ruleId, int template, int ruleFunction, int description, int sourceQuestion, int ruleExpression,
-                int sourceValues, int comparator, int targetType, int targetQuestions, int sourceQuestionLabel,
-                int sourceQuestionCodeSet, int sourceQuestionId, int targetQuestionsLabels, int totalCount) {
+      int sourceValues, int comparator, int targetType, int targetQuestions, int sourceQuestionLabel,
+      int sourceQuestionCodeSet, int targetQuestionsLabels, int totalCount) {
 
   }
 
@@ -27,7 +27,7 @@ class PageRuleMapper implements RowMapper<Rule> {
   PageRuleMapper() {
     this.columns = new PageRuleMapper.Column(1, 2, 3, 4,
         5, 6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15);
+        11, 12, 13, 14);
   }
 
   private Long totalRowsCount = 0l;
@@ -45,13 +45,12 @@ class PageRuleMapper implements RowMapper<Rule> {
     String targetType = rs.getString(columns.targetType());
     String sourceQuestionLabel = rs.getString(columns.sourceQuestionLabel());
     String sourceQuestionCodeSet = rs.getString(columns.sourceQuestionCodeSet());
-    long sourceQuestionId = rs.getLong(columns.sourceQuestionId());
     totalRowsCount = rs.getLong(columns.totalCount());
     Rule.RuleFunction functionEnum = getFunctionEnum(function);
     Rule.Comparator comparatorEnum = getComparatorEnum(comparator);
     Rule.TargetType targetTypeEnum = getTargetTypeEnum(targetType);
     Rule.SourceQuestion sourceQuestionInfo =
-        new Rule.SourceQuestion(sourceQuestionId, sourceQuestionIdentifier, sourceQuestionLabel, sourceQuestionCodeSet);
+        new Rule.SourceQuestion(sourceQuestionIdentifier, sourceQuestionLabel, sourceQuestionCodeSet);
     boolean anySource = ruleExpression.contains("( )");
     List<String> sourceValuesList = null;
     if (sourceValues != null)
@@ -65,11 +64,9 @@ class PageRuleMapper implements RowMapper<Rule> {
   }
 
   private List<Rule.Target> getTargets(String identifiers, String labels) {
-    List<String> targetQuestions = identifiers != null ?
-        Arrays.stream(identifiers.split(",")).toList() : null;
+    List<String> targetQuestions = identifiers != null ? Arrays.stream(identifiers.split(",")).toList() : null;
 
-    List<String> targetQuestionsLabels = labels != null ?
-        Arrays.stream(labels.split(",")).toList() : null;
+    List<String> targetQuestionsLabels = labels != null ? Arrays.stream(labels.split(",")).toList() : null;
 
     List<Rule.Target> targets = new ArrayList<>();
     if (targetQuestions != null) {

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/Rule.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/Rule.java
@@ -14,8 +14,7 @@ public record Rule(
     List<String> sourceValues,
     @ApiModelProperty(required = true) Comparator comparator,
     @ApiModelProperty(required = true) TargetType targetType,
-    @ApiModelProperty(required = true) List<Target> targets
-) {
+    @ApiModelProperty(required = true) List<Target> targets) {
 
   public record CreateRuleRequest(
       @ApiModelProperty(required = true) RuleFunction ruleFunction,
@@ -35,7 +34,7 @@ public record Rule(
   }
 
 
-  public record SourceQuestion(long questionId, String questionIdentifier, String label, String codeSetName) {
+  public record SourceQuestion(String questionIdentifier, String label, String codeSetName) {
   }
 
 
@@ -50,6 +49,7 @@ public record Rule(
     HIDE("Hide"),
     REQUIRE_IF("Require If"),
     UNHIDE("Unhide");
+
     private final String value;
 
     RuleFunction(String value) {
@@ -69,6 +69,7 @@ public record Rule(
     GREATER_THAN_OR_EQUAL_TO(">="),
     LESS_THAN("<"),
     LESS_THAN_OR_EQUAL_TO("<=");
+
     private final String value;
 
     Comparator(String value) {
@@ -88,6 +89,5 @@ public record Rule(
 
 
 }
-
 
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleControllerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleControllerTest.java
@@ -114,7 +114,7 @@ class PageRuleControllerTest {
     List<String> sourceValues = new ArrayList<>();
     List<Rule.Target> targetQuestions = new ArrayList<>();
     List<Rule> content = new ArrayList<>();
-    Rule.SourceQuestion sourceQuestion = new Rule.SourceQuestion(1000l, "identifier", "label", "codeSet");
+    Rule.SourceQuestion sourceQuestion = new Rule.SourceQuestion("identifier", "label", "codeSet");
     content.add(new Rule(100l, 123l, Rule.RuleFunction.ENABLE, "testDesc", sourceQuestion,
         false, sourceValues, Rule.Comparator.EQUAL_TO, Rule.TargetType.QUESTION, targetQuestions));
     return content;

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapperTest.java
@@ -34,9 +34,8 @@ class PageRuleMapperTest {
     when(resultSet.getString(10)).thenReturn("test456,test789,test123");
     when(resultSet.getString(11)).thenReturn("label123");
     when(resultSet.getString(12)).thenReturn("codeSetName");
-    when(resultSet.getLong(13)).thenReturn(1000l);
-    when(resultSet.getString(14)).thenReturn("test456_label,test789_label");
-    when(resultSet.getLong(15)).thenReturn(10l);
+    when(resultSet.getString(13)).thenReturn("test456_label,test789_label");
+    when(resultSet.getLong(14)).thenReturn(10l);
     Rule actualResponse = pageRuleMapper.mapRow(resultSet, 1);
     validate(actualResponse);
     long rowsCount = pageRuleMapper.getTotalRowsCount();
@@ -75,8 +74,8 @@ class PageRuleMapperTest {
     when(resultSet.getString(10)).thenReturn(null);
     when(resultSet.getString(11)).thenReturn("label123");
     when(resultSet.getString(12)).thenReturn("codeSetName");
-    when(resultSet.getString(14)).thenReturn(null);
-    when(resultSet.getLong(15)).thenReturn(10l);
+    when(resultSet.getString(13)).thenReturn(null);
+    when(resultSet.getLong(14)).thenReturn(10l);
     Rule actualResponse = pageRuleMapper.mapRow(resultSet, 1);
 
     assertNull(actualResponse.sourceValues());

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapperTest.java
@@ -55,7 +55,6 @@ class PageRuleMapperTest {
     assertEquals(3, response.sourceValues().size());
     assertEquals("EQUAL_TO", response.comparator().toString());
     assertEquals("QUESTION", response.targetType().toString());
-    assertEquals(1000l, response.sourceQuestion().questionId());
     assertEquals("test456", response.targets().get(0).targetIdentifier());
     assertEquals("test456_label", response.targets().get(0).label());
   }
@@ -76,7 +75,6 @@ class PageRuleMapperTest {
     when(resultSet.getString(10)).thenReturn(null);
     when(resultSet.getString(11)).thenReturn("label123");
     when(resultSet.getString(12)).thenReturn("codeSetName");
-    when(resultSet.getLong(13)).thenReturn(1000l);
     when(resultSet.getString(14)).thenReturn(null);
     when(resultSet.getLong(15)).thenReturn(10l);
     Rule actualResponse = pageRuleMapper.mapRow(resultSet, 1);

--- a/apps/question-bank/src/test/resources/features/pagerules/CreatePageRule.feature
+++ b/apps/question-bank/src/test/resources/features/pagerules/CreatePageRule.feature
@@ -73,7 +73,7 @@ Feature: Create Business Rule
         And the business rule should have "target type" of "QUESTION"
         And the business rule should have target questions list of:
          | id           | label         |
-         | INV143       | Age at Onset  |
+         | INV143       | Age at Illness Onset: |
 
         And the business rule should have "source values" of:
             | Male   |
@@ -106,7 +106,7 @@ Feature: Create Business Rule
         And the business rule should have "target type" of "QUESTION"
         And the business rule should have target questions list of:
             | id           | label         |
-            | INV143       | Age at Onset  |
+            | INV143       | Age at Illness Onset:  |
         And the business rule should have "source values" of:
             | Male   |
             | Female |
@@ -138,7 +138,7 @@ Feature: Create Business Rule
         And the business rule should have "target type" of "QUESTION"
         And the business rule should have target questions list of:
             | id           | label         |
-            | INV143       | Age at Onset  |
+            | INV143       | Age at Illness Onset:  |
         And the business rule should have "source values" of:
             | Male   |
             | Female |
@@ -170,7 +170,7 @@ Feature: Create Business Rule
         And the business rule should have "target type" of "QUESTION"
         And the business rule should have target questions list of:
             | id           | label         |
-            | INV143       | Age at Onset  |
+            | INV143       | Age at Illness Onset:  |
         And the business rule should have "source values" of:
             | Male   |
             | Female |


### PR DESCRIPTION
## Description

When creating the below Business Rule, the target question, ‘Total duration of stay in the hospital (in days)’ does NOT appear in the Target Fields column with the rest of the other questions. Possibly, due to the length of the question. 

## Tickets

* [CNFT2-1992](https://cdc-nbs.atlassian.net/browse/CNFT2-1992)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1992]: https://cdc-nbs.atlassian.net/browse/CNFT2-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ