### PR TITLE
Fix: View Business rule

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
@@ -242,9 +242,15 @@ export const BusinessRulesLibraryTable = ({
             <div className="no-data-info">
                 <span className="no-items">No items to display</span>
                 <p>Click 'Add new business rule' to add new rule</p>
-                <NavLinkButton className="submit-btn" to={`${redirectRuleURL}/add`}>
-                    Add new business rule
-                </NavLinkButton>
+                {page?.status === 'Published' ? (
+                    <Button type="button" disabled>
+                        Add new business rule
+                    </Button>
+                ) : (
+                    <NavLinkButton className="submit-btn" to={`${redirectRuleURL}/add`}>
+                        Add new business rule
+                    </NavLinkButton>
+                )}
             </div>
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.spec.tsx
@@ -38,6 +38,6 @@ import { PageProvider } from 'page';
             );
 
             const tableData = await findAllByRole('cell');
-            expect(tableData).toHaveLength(12);
+            expect(tableData).toHaveLength(16);
         });
     });

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.tsx
@@ -5,6 +5,7 @@ import { Rule } from 'apps/page-builder/generated';
 import { authorization } from 'authorization';
 import { Breadcrumb } from 'breadcrumb';
 import styles from './view-business-rule.module.scss';
+import { mapLogicForDateCompare } from '../helpers/mapLogicForDateCompare';
 
 export const ViewBusinessRule = () => {
     const { ruleId } = useParams();
@@ -16,6 +17,7 @@ export const ViewBusinessRule = () => {
                 authorization: authorization(),
                 ruleId: Number(ruleId)
             }).then((response: Rule) => {
+                console.log(response);
                 setRule(response);
             });
         }
@@ -30,18 +32,31 @@ export const ViewBusinessRule = () => {
                     <table cellSpacing={0}>
                         <thead>
                             <th>Function</th>
-                            <th>Require if</th>
+                            <th>
+                                {rule?.ruleFunction === 'DATE_COMPARE'
+                                    ? 'Date validation'
+                                    : rule?.ruleFunction
+                                    ? rule.ruleFunction.charAt(0).toUpperCase() +
+                                      rule.ruleFunction.slice(1).replaceAll('_', ' ').toLowerCase()
+                                    : ''}
+                            </th>
                         </thead>
                         <tr>
-                            <td>Source</td>
+                            <td>Rule Id</td>
+                            <td>{rule?.id}</td>
+                        </tr>
+                        <tr>
+                            <td>Source question</td>
                             <td>
                                 {rule?.sourceQuestion.label} ({rule?.sourceQuestion.questionIdentifier})
                             </td>
                         </tr>
-                        <tr>
-                            <td>Any source value</td>
-                            <td>{rule?.anySourceValue ? 'True' : 'False'}</td>
-                        </tr>
+                        {rule?.ruleFunction !== 'DATE_COMPARE' ? (
+                            <tr>
+                                <td>Any source value</td>
+                                <td>{rule?.anySourceValue ? 'True' : 'False'}</td>
+                            </tr>
+                        ) : null}
                         <tr>
                             <td>Logic</td>
                             <td>
@@ -51,14 +66,22 @@ export const ViewBusinessRule = () => {
                                     : ''}
                             </td>
                         </tr>
-                        <tr>
-                            <td>Source value(s)</td>
-                            <td>
-                                {rule?.sourceValues?.map((value, key) => (
-                                    <span key={key}>{value}</span>
-                                ))}
-                            </td>
-                        </tr>
+                        {rule?.ruleFunction !== 'DATE_COMPARE' ? (
+                            <tr>
+                                <td>Source value(s)</td>
+                                <td>
+                                    {rule?.sourceValues?.map((value, key) => (
+                                        <span key={key}>{value}</span>
+                                    ))}
+                                </td>
+                            </tr>
+                        ) : null}
+                        {rule?.targetType ? (
+                            <tr>
+                                <td>Target type</td>
+                                <td>{rule?.targetType}</td>
+                            </tr>
+                        ) : null}
                         <tr>
                             <td>Target(s)</td>
                             <td>
@@ -72,6 +95,18 @@ export const ViewBusinessRule = () => {
                         <tr>
                             <td>Rule description</td>
                             <td>{rule?.description}</td>
+                        </tr>
+                        <tr>
+                            <td>Error message</td>
+                            <td>
+                                {rule?.targets.map((target, i) => (
+                                    <span key={i} className={styles.full}>
+                                        ${rule?.sourceQuestion.label} (${rule?.sourceQuestion.questionIdentifier})' must
+                                        be ${mapLogicForDateCompare(rule!.comparator)} '${target.label} ($
+                                        {target.targetIdentifier})
+                                    </span>
+                                ))}
+                            </td>
                         </tr>
                     </table>
                 </div>

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/view-business-rule.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/view-business-rule.module.scss
@@ -7,7 +7,7 @@
         max-width: 55rem;
         min-height: 40rem;
         margin: 1.5rem auto;
-        padding: 1.5rem 0;
+        padding: 1.5rem 0 4rem;
         h2 {
             text-align: center;
             margin: 1.25rem 0 0 0;
@@ -40,6 +40,9 @@
                         width: 50%;
                         margin-bottom: 0.75rem;
                         vertical-align: top;
+                        &.full {
+                            width: 100%;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description

There needed to be different Business rule views based on type. 
Error messages were added and some fields that were missing from initial designs.
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/124739504/58a10183-e287-4de1-afbe-a5c263e5cc96)


## Tickets

* [CNFT2-2192](https://cdc-nbs.atlassian.net/browse/CNFT2-2192)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2192]: https://cdc-nbs.atlassian.net/browse/CNFT2-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ