### PR TITLE
CNFT1-2084 prefix, quick code search in autocomplete for provider/facility

### DIFF
--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/facilities/autocomplete/FacilityOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/facilities/autocomplete/FacilityOptionResolver.java
@@ -19,7 +19,7 @@ public class FacilityOptionResolver extends SQLBasedOptionResolver {
                 [name],
                 row_number() over( order by [name])
             from [facility]
-            where [name] like :criteria
+            where [name] like :criteria OR [name] like :prefixCriteria
 
             order by
                 [name]

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/facilities/autocomplete/FacilityOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/facilities/autocomplete/FacilityOptionResolver.java
@@ -8,18 +8,20 @@ import org.springframework.stereotype.Component;
 public class FacilityOptionResolver extends SQLBasedOptionResolver {
 
     private static final String QUERY = """
-            with [facility]([value], [name]) as (
+            with [facility]([value], [name], [quickCode]) as (
                 select
                     organization_uid,
-                    display_nm
+                    display_nm,
+                    root_extension_txt
                 from Organization
+                left join Entity_id on entity_uid=organization_uid and type_cd='QEC'
             )
             select
                 [value],
                 [name],
                 row_number() over( order by [name])
             from [facility]
-            where [name] like :criteria OR [name] like :prefixCriteria
+            where [quickCode]=:quickCode or [name] like :criteria or [name] like :prefixCriteria
 
             order by
                 [name]

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
@@ -13,6 +13,7 @@ public class SQLBasedOptionResolver {
 
 
   private static final String CRITERIA_PARAMETER = "criteria";
+  private static final String PREFIX_CRITERIA_PARAMETER = "prefixCriteria";
   private static final String LIMIT_PARAMETER = "limit";
   private static final String SQL_WILDCARD = "%";
 
@@ -30,16 +31,19 @@ public class SQLBasedOptionResolver {
   public Collection<Option> resolve(final String keyword, final int limit) {
     Map<String, Object> parameters = Map.of(
         CRITERIA_PARAMETER, withWildcard(keyword),
-        LIMIT_PARAMETER, limit
-    );
+        PREFIX_CRITERIA_PARAMETER, withPrefixWildcard(keyword),
+        LIMIT_PARAMETER, limit);
     return this.template.query(
         this.query,
         new MapSqlParameterSource(parameters),
-        this.mapper
-    );
+        this.mapper);
   }
 
   private String withWildcard(final String value) {
     return value + SQL_WILDCARD;
+  }
+
+  private String withPrefixWildcard(final String value) {
+    return SQL_WILDCARD + ' ' + value + SQL_WILDCARD;
   }
 }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
@@ -16,6 +16,7 @@ public class SQLBasedOptionResolver {
   private static final String PREFIX_CRITERIA_PARAMETER = "prefixCriteria";
   private static final String LIMIT_PARAMETER = "limit";
   private static final String SQL_WILDCARD = "%";
+  private static final String QUICK_CODE = "quickCode";
 
   private final String query;
   private final NamedParameterJdbcTemplate template;
@@ -32,6 +33,7 @@ public class SQLBasedOptionResolver {
     Map<String, Object> parameters = Map.of(
         CRITERIA_PARAMETER, withWildcard(keyword),
         PREFIX_CRITERIA_PARAMETER, withPrefixWildcard(keyword),
+        QUICK_CODE, keyword,
         LIMIT_PARAMETER, limit);
     return this.template.query(
         this.query,

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
@@ -21,7 +21,7 @@ public class ProviderOptionResolver extends SQLBasedOptionResolver {
                 [name],
                 row_number() over( order by [name])
             from [user]
-            where [name] like :criteria
+            where [name] like :criteria OR [name] like :prefixCriteria
 
             order by
                 [name]

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
@@ -8,11 +8,13 @@ import org.springframework.stereotype.Component;
 public class ProviderOptionResolver extends SQLBasedOptionResolver {
 
     private static final String QUERY = """
-            with [user]([value], [name]) as (
+            with [user]([value], [name], [quickCode]) AS (
                 select
                     person_uid,
-                    ISNULL(first_nm + ' ', '') + ISNULL(last_nm, '')
+                    ISNULL(first_nm + ' ', '') + ISNULL(last_nm, ''),
+                    root_extension_txt
                 from Person
+                left join Entity_id on entity_uid=person_uid and type_cd='QEC'
                 where
                     cd='PRV'
             )
@@ -21,7 +23,7 @@ public class ProviderOptionResolver extends SQLBasedOptionResolver {
                 [name],
                 row_number() over( order by [name])
             from [user]
-            where [name] like :criteria OR [name] like :prefixCriteria
+            where [quickCode]=:quickCode or [name] like :criteria or [name] like :prefixCriteria
 
             order by
                 [name]

--- a/libs/options-api/src/test/resources/features/facilities/FacilityOptions.feature
+++ b/libs/options-api/src/test/resources/features/facilities/FacilityOptions.feature
@@ -4,6 +4,7 @@ Feature: Facility Options REST API
   Background:
     Given there is a facility for "afacility"
     And there is a facility for "abfacility"
+    And there is a facility for "the abfacility"
     And there is a facility for "bfacility"
     And there is a facility for "cfacility"
     And there is a facility for "tafacility"
@@ -16,6 +17,7 @@ Feature: Facility Options REST API
     Then there are options available
     And the option named "afacility" is included
     And the option named "abfacility" is included
+    And the option named "the abfacility" is included
     And the option named "bfacility" is not included
 
   Scenario: I can find a specific number of facilities

--- a/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
+++ b/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
@@ -3,6 +3,8 @@ Feature: Provider Options REST API
 
   Background:
     Given there is a provider for "Tommy" "Oliver"
+    And there is a provider for "Tyler" "Tomkins"
+    And there is a provider for "Atom" "Moon"
     And there is a provider for "Tyler" "Durden"
     And there is a provider for "Tywin" "Lanister"
     And there is a provider for "Howard" "Moon"
@@ -15,6 +17,8 @@ Feature: Provider Options REST API
     When I am trying to find providers that start with "tom"
     Then there are options available
     And the option named "Tommy Oliver" is included
+    And the option named "Tyler Tomkins" is included
+    And the option named "Atom Moon" is not included
     And the option named "Tommy Callahan III" is included
     And the option named "Tommy Pickles" is not included
 


### PR DESCRIPTION
## Description

When searching by autocomplete for `A` return `Anne Jones`, `Joe Adams`, but not `Tammy Tate`.  Add the ability to autocomplete (on exact match) of quick code.

## Tickets

* [CNFT1-2084](https://cdc-nbs.atlassian.net/browse/CNFT1-2084)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2084]: https://cdc-nbs.atlassian.net/browse/CNFT1-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ