### PR TITLE
Adds pageview tracker that uses the router

### DIFF
--- a/apps/modernization-ui/src/analytics/AnalyticsProvider.tsx
+++ b/apps/modernization-ui/src/analytics/AnalyticsProvider.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { AnalyticsSettings, useAnalyticsSettings } from './useAnalytics';
 import { PostHogProvider } from 'posthog-js/react';
+import { PageviewTracker } from './PageviewTracker';
 
 type AnalyticsProviderProps = {
     children: ReactNode;
@@ -13,6 +14,7 @@ const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => {
 
 const withAnalytics = (settings: AnalyticsSettings, children: ReactNode) => (
     <PostHogProvider apiKey={settings.key} options={settings.options}>
+        <PageviewTracker />
         {children}
     </PostHogProvider>
 );

--- a/apps/modernization-ui/src/analytics/PageviewTracker.tsx
+++ b/apps/modernization-ui/src/analytics/PageviewTracker.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { usePostHog } from 'posthog-js/react';
+
+const PageviewTracker = () => {
+    const { pathname, search } = useLocation();
+    const posthog = usePostHog();
+
+    useEffect(() => {
+        if (posthog) {
+            posthog.capture('$pageview');
+        }
+    }, [pathname, search, posthog]);
+
+    return null;
+};
+
+export { PageviewTracker };

--- a/apps/modernization-ui/src/analytics/useAnalytics.ts
+++ b/apps/modernization-ui/src/analytics/useAnalytics.ts
@@ -19,7 +19,8 @@ const useAnalyticsSettings = (): AnalyticsSettings => {
             const host = settings.analytics?.host;
 
             const options = {
-                api_host: host
+                api_host: host,
+                capture_pageview: false
             };
 
             setAnalyticsSettings({


### PR DESCRIPTION
## Description

By default the `$pageview` event is triggered by pageLoad with SPAs pageLoad generally happens only once.  A `PageviewTracker` component was added to manually trigger a `$pageview` event when the router changes location.


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
