### PR TITLE
bug fix for displaying >= in business rules table

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/helpers/mapComparatorToString.ts
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/helpers/mapComparatorToString.ts
@@ -8,6 +8,8 @@ export const mapComparatorToString = (comparator: Rule.comparator) => {
             return 'Less than or equal to';
         case Rule.comparator.GREATER_THAN:
             return 'Greater than';
+        case Rule.comparator.GREATER_THAN_OR_EQUAL_TO:
+            return 'Greater than or equal to';
         case Rule.comparator.EQUAL_TO:
             return 'Equal to';
         case Rule.comparator.NOT_EQUAL_TO:


### PR DESCRIPTION
## Description

We were missing the value from a switch statement.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
