### PR TITLE
display subsection names for business rules

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
@@ -12,6 +12,7 @@ import {
     ConceptControllerService,
     CreateRuleRequest,
     PagesQuestion,
+    PagesSubSection,
     Rule,
     SourceQuestion,
     Target
@@ -72,7 +73,7 @@ const BusinessRulesForm = ({ question, sourceValues, selectedFieldType, targets 
         }
     };
 
-    const handleChangeTargetQuestion = (data: QuestionProps[] | PagesQuestion[]) => {
+    const handleChangeTargetQuestion = (data: QuestionProps[]) => {
         setTargetQuestions({
             ...targetQuestions,
             [selectedFieldType]: data
@@ -82,6 +83,20 @@ const BusinessRulesForm = ({ question, sourceValues, selectedFieldType, targets 
         const text = data.map((val) => val.name);
         form.setValue('targetIdentifiers', values);
         form.setValue('targetValueText', text);
+    };
+
+    const handleChangeTargetSubsections = (data: PagesSubSection[]) => {
+        setTargetQuestions({
+            ...targetQuestions,
+            [selectedFieldType]: data
+        });
+
+        const values = data.map((val) => val.id.toString());
+        form.setValue('targetIdentifiers', values);
+        form.setValue(
+            'targetValueText',
+            data.map((val) => val.name)
+        );
     };
 
     const handleChangeSource = (data: QuestionProps[]) => {
@@ -123,7 +138,10 @@ const BusinessRulesForm = ({ question, sourceValues, selectedFieldType, targets 
             sourceValues?.length && !anySourceValueToggle
                 ? sourceValues?.map((value) => value.text).join(', ')
                 : 'any source value';
-        const targetValues = targetQuestions[selectedFieldType]?.map((val) => `${val.name} (${val.question})`);
+        const targetValues =
+            form.watch('targetType') == Rule.targetType.QUESTION
+                ? targetQuestions[selectedFieldType]?.map((val) => `${val.name} (${val.question})`)
+                : targetQuestions[selectedFieldType]?.map((val) => val.name);
 
         if (selectedSource && targetQuestions[selectedFieldType]?.length && logic && sourceText) {
             if (ruleFunction != Rule.ruleFunction.DATE_COMPARE) {
@@ -225,6 +243,8 @@ const BusinessRulesForm = ({ question, sourceValues, selectedFieldType, targets 
         });
         return errors;
     };
+
+    console.log('form', form.getValues());
 
     return (
         <>
@@ -392,8 +412,8 @@ const BusinessRulesForm = ({ question, sourceValues, selectedFieldType, targets 
                     {form.watch('targetType') === Rule.targetType.SUBSECTION && pageId ? (
                         <SubSectionsDropdown
                             pageId={pageId}
-                            selectedQuestionIdentifiers={targetValueIdentifiers}
-                            onSelect={handleChangeTargetQuestion}
+                            selectedSubsectionIdentifiers={targetValueIdentifiers}
+                            onSelect={handleChangeTargetSubsections}
                         />
                     ) : null}
                     {isTargetQuestionSelected && form.watch('targetType') != Rule.targetType.SUBSECTION ? (

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesForm.tsx
@@ -244,8 +244,6 @@ const BusinessRulesForm = ({ question, sourceValues, selectedFieldType, targets 
         return errors;
     };
 
-    console.log('form', form.getValues());
-
     return (
         <>
             <Grid row className="inline-field">

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
@@ -55,6 +55,13 @@ export const BusinessRulesLibraryTable = ({
     const { page } = useGetPageDetails();
     const { page: curPage, request } = usePage();
 
+    const getSubsections = () => {
+        if (page) {
+            const sections = page.tabs?.map((tab) => tab.sections).flat();
+            return sections?.map((section) => section.subSections).flat();
+        }
+    };
+
     const redirectRuleURL = `/page-builder/pages/${page?.id}/business-rules`;
 
     const asTableRow = (rule: Rule): TableBody => ({
@@ -95,14 +102,29 @@ export const BusinessRulesLibraryTable = ({
                 id: 5,
                 title: (
                     <div>
-                        {rule.targets?.map((target, index) => (
-                            <React.Fragment key={index}>
-                                <span>
-                                    {target.label} ({target.targetIdentifier})
-                                </span>
-                                <br />
-                            </React.Fragment>
-                        ))}
+                        {rule.targets?.map((target, index) => {
+                            if (rule.targetType == Rule.targetType.SUBSECTION) {
+                                const subsections = getSubsections();
+                                const subsection = subsections?.find(
+                                    (sub) => sub.id == Number(target?.targetIdentifier)
+                                );
+                                return (
+                                    <React.Fragment key={index}>
+                                        <span>{subsection?.name}</span>
+                                        <br />
+                                    </React.Fragment>
+                                );
+                            } else {
+                                return (
+                                    <React.Fragment key={index}>
+                                        <span>
+                                            {target.label} ({target.targetIdentifier})
+                                        </span>
+                                        <br />
+                                    </React.Fragment>
+                                );
+                            }
+                        })}
                     </div>
                 )
             },
@@ -151,14 +173,29 @@ export const BusinessRulesLibraryTable = ({
                 id: 5,
                 title: (
                     <div>
-                        {rule.targets?.map((target, index) => (
-                            <React.Fragment key={index}>
-                                <span>
-                                    {target.label} ({target.targetIdentifier})
-                                </span>
-                                <br />
-                            </React.Fragment>
-                        ))}
+                        {rule.targets?.map((target, index) => {
+                            if (rule.targetType == Rule.targetType.SUBSECTION) {
+                                const subsections = getSubsections();
+                                const subsection = subsections?.find(
+                                    (sub) => sub.id == Number(target?.targetIdentifier)
+                                );
+                                return (
+                                    <React.Fragment key={index}>
+                                        <span>{subsection?.name}</span>
+                                        <br />
+                                    </React.Fragment>
+                                );
+                            } else {
+                                return (
+                                    <React.Fragment key={index}>
+                                        <span>
+                                            {target.label} ({target.targetIdentifier})
+                                        </span>
+                                        <br />
+                                    </React.Fragment>
+                                );
+                            }
+                        })}
                     </div>
                 )
             },

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
@@ -14,14 +14,11 @@ const SubSectionsDropdown = ({ pageId, selectedSubsectionIdentifiers, onSelect }
     const [subSections, setSubSections] = useState<PagesSubSection[]>([]);
     const [selectedSubsections, setSelectedSubsections] = useState<string[]>([]);
 
-    console.log('selectedQuestionidentifiers', selectedSubsectionIdentifiers);
     const handleSelectSubsection = (subSectionIds: string[]) => {
-        console.log('subsectionIds on change', subSectionIds);
         const selected: PagesSubSection[] = subSections.filter((section) =>
             subSectionIds.includes(section.id.toString())
         );
 
-        console.log('test', selected);
         setSelectedSubsections(selected.map((section) => section.id.toString()));
         onSelect(selected);
     };
@@ -29,7 +26,6 @@ const SubSectionsDropdown = ({ pageId, selectedSubsectionIdentifiers, onSelect }
     useEffect(() => {
         if (pageId) {
             fetchPageDetails(authorization(), Number(pageId)).then((data) => {
-                console.log('data', data);
                 const sections = data.tabs?.map((tab) => tab.sections).flat();
                 const subs = sections
                     ?.map((section) => section.subSections)

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
@@ -1,4 +1,4 @@
-import { PagesQuestion, PagesSubSection } from 'apps/page-builder/generated';
+import { PagesSubSection } from 'apps/page-builder/generated';
 import { fetchPageDetails } from 'apps/page-builder/services/pagesAPI';
 import { authorization } from 'authorization';
 import { MultiSelectInput } from 'components/selection/multi';
@@ -6,25 +6,30 @@ import { useEffect, useState } from 'react';
 
 interface Props {
     pageId: string;
-    selectedQuestionIdentifiers: string[];
-    onSelect: (questions: PagesQuestion[]) => void;
+    selectedSubsectionIdentifiers: string[];
+    onSelect: (subSections: PagesSubSection[]) => void;
 }
 
-const SubSectionsDropdown = ({ pageId, selectedQuestionIdentifiers, onSelect }: Props) => {
+const SubSectionsDropdown = ({ pageId, selectedSubsectionIdentifiers, onSelect }: Props) => {
     const [subSections, setSubSections] = useState<PagesSubSection[]>([]);
     const [selectedSubsections, setSelectedSubsections] = useState<string[]>([]);
 
+    console.log('selectedQuestionidentifiers', selectedSubsectionIdentifiers);
     const handleSelectSubsection = (subSectionIds: string[]) => {
-        const selected = subSections.filter((section) => subSectionIds.includes(section.id.toString()));
-        const questions = selected.map((section) => section.questions).flat();
+        console.log('subsectionIds on change', subSectionIds);
+        const selected: PagesSubSection[] = subSections.filter((section) =>
+            subSectionIds.includes(section.id.toString())
+        );
 
+        console.log('test', selected);
         setSelectedSubsections(selected.map((section) => section.id.toString()));
-        onSelect(questions);
+        onSelect(selected);
     };
 
     useEffect(() => {
         if (pageId) {
             fetchPageDetails(authorization(), Number(pageId)).then((data) => {
+                console.log('data', data);
                 const sections = data.tabs?.map((tab) => tab.sections).flat();
                 const subs = sections
                     ?.map((section) => section.subSections)
@@ -37,15 +42,15 @@ const SubSectionsDropdown = ({ pageId, selectedQuestionIdentifiers, onSelect }: 
     }, [pageId]);
 
     useEffect(() => {
-        if (selectedQuestionIdentifiers.length) {
-            // search subsections and return all that have a question with an identifier in the selectedQuestionIdentifiers array
-            const selectedSubs = subSections.filter((section) =>
-                section.questions.find((question) => selectedQuestionIdentifiers.includes(question?.question ?? ''))
+        if (selectedSubsectionIdentifiers.length) {
+            // use the selectedSubsectionIdentifiers to search the subsections array and find the matching subsections
+            const selected: PagesSubSection[] = subSections.filter((section) =>
+                selectedSubsectionIdentifiers.includes(section.id.toString())
             );
 
-            setSelectedSubsections(selectedSubs.map((section) => section.id.toString()));
+            setSelectedSubsections(selected.map((section) => section.id.toString()));
         }
-    }, [selectedQuestionIdentifiers, subSections]);
+    }, [selectedSubsectionIdentifiers, subSections]);
 
     const options = subSections.map((section) => ({ name: section.name, value: section.id.toString() }));
 


### PR DESCRIPTION
## Description

Originally had the logic wrong for selecting a subsection, we now are only selecting a subsection and displaying it - not all of its questions.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT2/boards/99?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT2-2148)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
