### PR TITLE
CNFT1-2094 fix hyphenated name search

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/AdjustStrings.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/AdjustStrings.java
@@ -8,6 +8,12 @@ public class AdjustStrings {
         : null;
   }
 
+  public static String withoutHyphens(final String value) {
+    return value != null
+        ? value.replace("-", " ")
+        : null;
+  }
+
   private AdjustStrings() {
 
   }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -99,6 +99,20 @@ Feature: Patient Search
     And search result 2 has a "first name" of "Albert"
     And search result 2 has a "last name" of "Smyth"
 
+  Scenario: I can find the patient when searching for a hyphenated last name using a hyphen
+    Given the patient has the "legal" name "Something" "Other-than"
+    And patients are available for search
+    And I add the patient criteria for a "last name" equal to "Other-than"
+    When I search for patients
+    Then search result 1 has a "last name" of "Other-than"
+
+  Scenario: I can find the patient when searching for a hyphenated last name without using a hyphen
+    Given the patient has the "legal" name "Something" "Other-than"
+    And patients are available for search
+    And I add the patient criteria for a "last name" equal to "Other than"
+    When I search for patients
+    Then search result 1 has a "last name" of "Other-than"
+
   Scenario: I can search for a Patient and find them by their legal name
     Given the patient has the "legal" name "Something" "Other" as of "2022-01-01"
     And the patient has the "legal" name "This" "One" "Here", "Junior" as of "2022-11-13"


### PR DESCRIPTION
## Description

Last names are stored in the index without a hyphen.  Strip the hyphen from the search criteria and replace with a space.

## Tickets

* [CNFT1-2094](https://cdc-nbs.atlassian.net/browse/CNFT1-2094)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2094]: https://cdc-nbs.atlassian.net/browse/CNFT1-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ