### PR TITLE
CNFT2-2143 Reorder modal: Static elements

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderQuestion/ReorderQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderQuestion/ReorderQuestion.tsx
@@ -22,7 +22,15 @@ export const ReorderQuestion = ({ question, index, visible }: Props) => {
                             <Icon name={'drag'} size={'m'} />
                         </div>
                         <Icon name={'question'} size={'m'} />
-                        <p>{question.name}</p>
+                        {question.displayComponent === 1003 ? (
+                            <p> &#60; Hyperlink &#62;</p>
+                        ) : question.displayComponent === 1012 ? (
+                            <p> &#60; Line separator &#62;</p>
+                        ) : question.displayComponent === 1014 ? (
+                            <p> &#60; Comment &#62;</p>
+                        ) : (
+                            <p>{question.name}</p>
+                        )}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Description
Here we distinguish static elements in the Reorder Modal. They maintain the Question icon but have their own distinctive styling.
<img width="807" alt="image" src="https://github.com/CDCgov/NEDSS-Modernization/assets/124739504/9ede8808-a5ff-471a-b5f4-e83f32ede50b">

## Tickets

* [CNFT2-2143](https://cdc-nbs.atlassian.net/browse/CNFT2-2143)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2143]: https://cdc-nbs.atlassian.net/browse/CNFT2-2143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ