### PR TITLE
Download metadata fix

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
@@ -44,9 +44,9 @@ export const useDownloadPageMetadata = () => {
                     a.href = url;
                     a.download = 'PageMetadata.xlsx';
                     a.click();
-                });
-            // .catch((error) => dispatch({ type: 'error', error: error.message }))
-            // .then((response) => dispatch({ type: 'complete', concepts: response ?? [] }));
+                    dispatch({ type: 'complete' });
+                })
+                .catch((error) => dispatch({ type: 'error', error: error.message }));
         }
     }, [state.status]);
 

--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
@@ -1,0 +1,60 @@
+import { OpenAPI } from 'apps/page-builder/generated/core/OpenAPI';
+import { authorization } from 'authorization';
+import { useEffect, useReducer } from 'react';
+
+type State =
+    | { status: 'idle' }
+    | { status: 'downloading'; page: number }
+    | { status: 'complete' }
+    | { status: 'error'; error: string };
+
+type Action = { type: 'download'; page: number } | { type: 'complete' } | { type: 'error'; error: string };
+
+const reducer = (_state: State, action: Action): State => {
+    switch (action.type) {
+        case 'download':
+            return { status: 'downloading', page: action.page };
+        case 'complete':
+            return { status: 'complete' };
+        case 'error':
+            return { status: 'error', error: action.error };
+        default:
+            return { status: 'idle' };
+    }
+};
+
+export const useDownloadPageMetadata = () => {
+    const [state, dispatch] = useReducer(reducer, { status: 'idle' });
+
+    useEffect(() => {
+        if (state.status === 'downloading') {
+            // auto generated methods dont allow direct conversion to blob
+            fetch(`${OpenAPI.BASE}/nbs/page-builder/api/v1/pages/${state.page}/metadata`, {
+                method: 'GET',
+                headers: {
+                    Accept: 'application/pdf',
+                    'Content-Type': 'application/json',
+                    Authorization: authorization()
+                }
+            })
+                .then((response) => response.blob())
+                .then((blob) => {
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'PageMetadata.xlsx';
+                    a.click();
+                });
+            // .catch((error) => dispatch({ type: 'error', error: error.message }))
+            // .then((response) => dispatch({ type: 'complete', concepts: response ?? [] }));
+        }
+    }, [state.status]);
+
+    const value = {
+        error: state.status === 'error' ? state.error : undefined,
+        isLoading: state.status === 'downloading',
+        download: (page: number) => dispatch({ type: 'download', page })
+    };
+
+    return value;
+};

--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
@@ -53,7 +53,7 @@ export const useDownloadPageMetadata = () => {
     const value = {
         error: state.status === 'error' ? state.error : undefined,
         isLoading: state.status === 'downloading',
-        download: (page: number) => dispatch({ type: 'download', page })
+        downloadMetadata: (page: number) => dispatch({ type: 'download', page })
     };
 
     return value;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
@@ -1,18 +1,17 @@
 import { Button, Icon, Pagination } from '@trussworks/react-uswds';
-import { Heading } from 'components/heading';
-import { authorization } from 'authorization';
-import styles from './page-information.module.scss';
 import {
-    PageSummaryDownloadControllerService,
-    PageInformationService,
     PageInformation as InfoType,
     PageControllerService,
-    PageHistory
+    PageHistory,
+    PageInformationService
 } from 'apps/page-builder/generated';
+import { useDownloadPageMetadata } from 'apps/page-builder/hooks/api/useDownloadPageMetadata';
+import { authorization } from 'authorization';
+import { Heading } from 'components/heading';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { usePageManagement } from '../../usePageManagement';
+import styles from './page-information.module.scss';
 
 const PageInformation = () => {
     const [activeTab, setActiveTab] = useState('Details');
@@ -24,6 +23,7 @@ const PageInformation = () => {
     const pageSize = 10;
     const navigate = useNavigate();
     const { page } = usePageManagement();
+    const { download } = useDownloadPageMetadata();
     const fetchPageHistory = async () => {
         PageControllerService?.getPageHistoryUsingGet?.({
             authorization: authorization(),
@@ -55,19 +55,8 @@ const PageInformation = () => {
         setCurrentPage(page);
         fetchPageHistory();
     };
-    const handleDownloadCSV = async () => {
-        PageSummaryDownloadControllerService.downloadPageMetadataUsingGet({
-            authorization: authorization(),
-            id: Number(pageId)
-        }).then((data) => {
-            const dataIn = data as Blob;
-            const newBlob = new Blob([dataIn], { type: '.xlsx' });
-            const downloadURL = window.URL.createObjectURL(newBlob);
-            const link = document.createElement('a');
-            link.href = downloadURL;
-            link.download = 'PageMetadata' + '.xlsx';
-            link.click();
-        });
+    const handleDownloadMetadata = async () => {
+        download(page.id);
     };
 
     const handleViewPage = () => {
@@ -98,12 +87,10 @@ const PageInformation = () => {
         <section className={styles.information}>
             <header>
                 <Heading level={2}>Page information</Heading>
-                {false && (
-                    <Button type="button" outline onClick={handleDownloadCSV} className={styles.icon}>
-                        <Icon.FileDownload />
-                        Metadata
-                    </Button>
-                )}
+                <Button type="button" outline onClick={handleDownloadMetadata} className={styles.icon}>
+                    <Icon.FileDownload />
+                    Metadata
+                </Button>
             </header>
             <nav>
                 <div>{renderTabs}</div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
@@ -23,7 +23,7 @@ const PageInformation = () => {
     const pageSize = 10;
     const navigate = useNavigate();
     const { page } = usePageManagement();
-    const { download } = useDownloadPageMetadata();
+    const { downloadMetadata } = useDownloadPageMetadata();
     const fetchPageHistory = async () => {
         PageControllerService?.getPageHistoryUsingGet?.({
             authorization: authorization(),
@@ -56,7 +56,7 @@ const PageInformation = () => {
         fetchPageHistory();
     };
     const handleDownloadMetadata = async () => {
-        download(page.id);
+        downloadMetadata(page.id);
     };
 
     const handleViewPage = () => {


### PR DESCRIPTION
## Description

The page metadata download was corrupted when attempting to download through the auto generated API call.

## Tickets

* [CNFT-1934](https://cdc-nbs.atlassian.net/browse/CNFT2-1934)


### Demo
![downloadMetadata](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/5e2d1606-1fb7-4f2f-9d7c-1779d35f70f0)


### Excel file contents
|Tab | Modernized row count | Classic row count|
|---|---|---|
|Simple Question Metadata| 175 | 175 |
|Comprehensive Question Metadata| 233 | 233 |
|Vocabulary Metadata| 1003 | 1003 |
|Question With Vocabulary | 2401 | 2401|

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
