### PR TITLE
Add questionIdentifier to subsection object

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/generated/models/PagesSubSection.ts
+++ b/apps/modernization-ui/src/apps/page-builder/generated/models/PagesSubSection.ts
@@ -10,6 +10,7 @@ export type PagesSubSection = {
     isGrouped: boolean;
     name: string;
     order: number;
+    questionIdentifier: string;
     questions: Array<PagesQuestion>;
     visible: boolean;
 };

--- a/apps/modernization-ui/src/apps/page-builder/helpers/moveObjectInArray.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/helpers/moveObjectInArray.spec.tsx
@@ -3,14 +3,86 @@ import { moveSubsectionInArray } from './moveObjectInArray';
 describe('Object manipulation in Array', () => {
     it('should place two after three', () => {
         const values = [
-            { name: 'one', isGrouped: false, id: 0, order: 0, visible: true, isGroupable: true, questions: [] },
-            { name: 'two', isGrouped: false, id: 1, order: 1, visible: true, isGroupable: true, questions: [] },
-            { name: 'three', isGrouped: false, id: 2, order: 2, visible: true, isGroupable: true, questions: [] },
-            { name: 'four', isGrouped: false, id: 3, order: 3, visible: true, isGroupable: true, questions: [] },
-            { name: 'five', isGrouped: false, id: 4, order: 4, visible: true, isGroupable: true, questions: [] },
-            { name: 'six', isGrouped: false, id: 5, order: 5, visible: true, isGroupable: true, questions: [] },
-            { name: 'seven', isGrouped: false, id: 6, order: 6, visible: true, isGroupable: true, questions: [] },
-            { name: 'eight', isGrouped: false, id: 7, order: 7, visible: true, isGroupable: true, questions: [] }
+            {
+                name: 'one',
+                isGrouped: false,
+                id: 0,
+                order: 0,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'two',
+                isGrouped: false,
+                id: 1,
+                order: 1,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'three',
+                isGrouped: false,
+                id: 2,
+                order: 2,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'four',
+                isGrouped: false,
+                id: 3,
+                order: 3,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'five',
+                isGrouped: false,
+                id: 4,
+                order: 4,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'six',
+                isGrouped: false,
+                id: 5,
+                order: 5,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'seven',
+                isGrouped: false,
+                id: 6,
+                order: 6,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'eight',
+                isGrouped: false,
+                id: 7,
+                order: 7,
+                visible: true,
+                isGroupable: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            }
         ];
 
         const actual = moveSubsectionInArray(values, 7, 3);
@@ -30,8 +102,26 @@ describe('Object manipulation in Array', () => {
     });
     it('should swap one and two', () => {
         const values = [
-            { name: 'one', isGrouped: false, isGroupable: true, id: 0, order: 0, visible: true, questions: [] },
-            { name: 'two', isGrouped: false, isGroupable: true, id: 1, order: 1, visible: true, questions: [] }
+            {
+                name: 'one',
+                isGrouped: false,
+                isGroupable: true,
+                id: 0,
+                order: 0,
+                visible: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            },
+            {
+                name: 'two',
+                isGrouped: false,
+                isGroupable: true,
+                id: 1,
+                order: 1,
+                visible: true,
+                questionIdentifier: 'identifier',
+                questions: []
+            }
         ];
         const actual = moveSubsectionInArray(values, 0, 1);
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/GroupQuestion.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/GroupQuestion.spec.tsx
@@ -40,6 +40,7 @@ const subSections: PagesSubSection = {
     order: 2,
     questions: [dateQuestion, dropDownQuestion],
     isGroupable: true,
+    questionIdentifier: 'identifier',
     visible: true
 };
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/RepeatingBlock.spec.tsx
@@ -27,6 +27,7 @@ const subSections: PagesSubSection = {
     order: 2,
     questions: [dateQuestion, dropDownQuestion],
     isGroupable: true,
+    questionIdentifier: 'identifier',
     visible: true
 };
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.spec.tsx
@@ -42,6 +42,7 @@ const subSections: PagesSubSection = {
     order: 2,
     questions: [dateQuestion, dropDownQuestion],
     isGroupable: true,
+    questionIdentifier: 'identifier',
     visible: true
 };
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderSection/ReorderSection.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderSection/ReorderSection.spec.tsx
@@ -29,6 +29,7 @@ describe('when ReorderSection renders', () => {
                                 visible: true,
                                 order: 1,
                                 isGroupable: true,
+                                questionIdentifier: 'identifier',
                                 questions: []
                             },
                             {
@@ -38,6 +39,7 @@ describe('when ReorderSection renders', () => {
                                 visible: true,
                                 order: 2,
                                 isGroupable: true,
+                                questionIdentifier: 'identifier',
                                 questions: []
                             }
                         ]
@@ -58,6 +60,7 @@ describe('when ReorderSection renders', () => {
                 visible: true,
                 order: 1,
                 isGroupable: true,
+                questionIdentifier: 'identifier',
                 questions: []
             },
             {
@@ -67,6 +70,7 @@ describe('when ReorderSection renders', () => {
                 visible: true,
                 order: 2,
                 isGroupable: true,
+                questionIdentifier: 'identifier',
                 questions: []
             }
         ],

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderSubsection/ReorderSubsection.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/reorder/ReorderSubsection/ReorderSubsection.spec.tsx
@@ -40,6 +40,7 @@ describe('when ReorderSubsection renders', () => {
         name: 'Test Section',
         order: 1,
         isGroupable: true,
+        questionIdentifier: 'identifier',
         questions: [
             {
                 allowFutureDates: true,

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSection.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSection.spec.tsx
@@ -28,6 +28,7 @@ describe('when ManageSection renders', () => {
                                 visible: true,
                                 order: 1,
                                 isGroupable: true,
+                                questionIdentifier: 'identifier',
                                 questions: []
                             },
                             {
@@ -37,6 +38,7 @@ describe('when ManageSection renders', () => {
                                 visible: true,
                                 order: 2,
                                 isGroupable: true,
+                                questionIdentifier: 'identifier',
                                 questions: []
                             }
                         ]

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSectionTile/ManageSectionTile.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSectionTile/ManageSectionTile.spec.tsx
@@ -29,6 +29,7 @@ describe('when ManageSectionTile renders', () => {
                                 visible: true,
                                 order: 1,
                                 isGroupable: true,
+                                questionIdentifier: 'identifier',
                                 questions: []
                             },
                             {
@@ -38,6 +39,7 @@ describe('when ManageSectionTile renders', () => {
                                 visible: true,
                                 order: 2,
                                 isGroupable: true,
+                                questionIdentifier: 'identifier',
                                 questions: []
                             }
                         ]
@@ -58,6 +60,7 @@ describe('when ManageSectionTile renders', () => {
                 visible: true,
                 order: 1,
                 isGroupable: true,
+                questionIdentifier: 'identifier',
                 questions: []
             },
             {
@@ -67,6 +70,7 @@ describe('when ManageSectionTile renders', () => {
                 visible: true,
                 order: 2,
                 isGroupable: true,
+                questionIdentifier: 'identifier',
                 questions: []
             }
         ],

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/ManageSubsectionTile/ManageSubsectionTile.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/ManageSubsectionTile/ManageSubsectionTile.spec.tsx
@@ -40,6 +40,7 @@ describe('when ReorderSubsection renders', () => {
         name: 'Test Subsection',
         order: 1,
         isGroupable: true,
+        questionIdentifier: 'identifier',
         questions: [
             {
                 allowFutureDates: true,

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/tabs/ManageTabs/ManageTabs.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/tabs/ManageTabs/ManageTabs.spec.tsx
@@ -27,7 +27,8 @@ const content: PagesResponse = {
                             visible: true,
                             order: 1,
                             questions: [],
-                            isGroupable: true
+                            isGroupable: true,
+                            questionIdentifier: 'identifier'
                         },
                         {
                             id: 456,
@@ -36,7 +37,8 @@ const content: PagesResponse = {
                             visible: true,
                             order: 2,
                             questions: [],
-                            isGroupable: true
+                            isGroupable: true,
+                            questionIdentifier: 'identifier'
                         }
                     ]
                 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/component/SubSectionNode.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/component/SubSectionNode.java
@@ -8,14 +8,24 @@ public final class SubSectionNode extends LayoutNode {
 
   private final Collection<ContentNode> children;
   private boolean isGrouped;
+  private String questionIdentifier;
 
   public boolean isGrouped() {
     return isGrouped;
   }
 
-  public SubSectionNode(final long identifier, final Definition definition,boolean isGrouped) {
+  public String questionIdentifier() {
+    return questionIdentifier;
+  }
+
+  public SubSectionNode(
+      final long identifier,
+      final Definition definition,
+      boolean isGrouped,
+      String questionIdentifier) {
     super(identifier, LayoutNode.Type.SUB_SECTION, definition);
-    this.isGrouped=isGrouped;
+    this.isGrouped = isGrouped;
+    this.questionIdentifier = questionIdentifier;
     this.children = new ArrayList<>();
   }
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/component/tree/LayoutComponentResolver.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/component/tree/LayoutComponentResolver.java
@@ -34,8 +34,7 @@ class LayoutComponentResolver {
     return new ComponentNode.Definition(
         component.name(),
         component.visible(),
-        component.order()
-    );
+        component.order());
   }
 
   private PageNode asPage(final FlattenedComponent component) {
@@ -49,22 +48,20 @@ class LayoutComponentResolver {
   private TabNode asTab(final FlattenedComponent component) {
     return new TabNode(
         component.identifier(),
-        asDefinition(component)
-    );
+        asDefinition(component));
   }
 
   private SectionNode asSection(final FlattenedComponent component) {
     return new SectionNode(
         component.identifier(),
-        asDefinition(component)
-    );
+        asDefinition(component));
   }
 
   private SubSectionNode asSubSection(final FlattenedComponent component) {
     return new SubSectionNode(
         component.identifier(),
         asDefinition(component),
-        component.isGrouped()
-    );
+        component.isGrouped(),
+        component.question());
   }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponse.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponse.java
@@ -56,6 +56,7 @@ public record PagesResponse(
       @ApiModelProperty(required = true) boolean visible,
       @ApiModelProperty(required = true) boolean isGrouped,
       @ApiModelProperty(required = true) boolean isGroupable,
+      @ApiModelProperty(required = true) String questionIdentifier,
       @ApiModelProperty(required = true) Collection<PagesQuestion> questions) {
   }
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapper.java
@@ -90,6 +90,7 @@ class PagesResponseMapper {
         subsection.definition().visible(),
         subsection.isGrouped(),
         isGroupable,
+        subsection.questionIdentifier(),
         mapAll(this::asQuestion, subsection.children()));
   }
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/detail/PagesResponseMapperTest.java
@@ -162,7 +162,8 @@ class PagesResponseMapperTest {
                                                 "sub-section-name-value",
                                                 true,
                                                 4),
-                                            false))));
+                                            false,
+                                            "identifier"))));
 
     PageDescription description = mock(PageDescription.class);
 
@@ -180,6 +181,7 @@ class PagesResponseMapperTest {
                             () -> assertThat(subSection.id()).isEqualTo(1693L),
                             () -> assertThat(subSection.name()).isEqualTo("sub-section-name-value"),
                             () -> assertThat(subSection.visible()).isTrue(),
+                            () -> assertThat(subSection.questionIdentifier()).isEqualTo("identifier"),
                             () -> assertThat(subSection.order()).isEqualTo(4)))));
 
   }
@@ -211,7 +213,8 @@ class PagesResponseMapperTest {
                                                 "sub-section-name-value",
                                                 true,
                                                 4),
-                                            false).add(
+                                            false,
+                                            "identifier").add(
                                                 new StaticNode(
                                                     1697L,
                                                     StaticNode.Type.HYPERLINK,


### PR DESCRIPTION
## Description

Adds the `questionIdentifier` field to the `PagesSubsection` object in support of business rules.

## Tickets


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
