### PR TITLE
CNFT2-2213 Ungroup Questions: close menu

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/MoreOptions/MoreOptions.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/MoreOptions/MoreOptions.tsx
@@ -1,9 +1,14 @@
 import './MoreOptions.scss';
 import useComponentVisible from '../../helpers/useComponentVisible';
+import { useEffect } from 'react';
 
-export const MoreOptions = ({ children, header }: any) => {
+export const MoreOptions = ({ children, header, close }: any) => {
     const { ref, isComponentVisible, setIsComponentVisible } = useComponentVisible(false);
-
+    useEffect(() => {
+        if (close === true) {
+            setIsComponentVisible(false);
+        }
+    }, [close]);
     return (
         <div className="more-options">
             <div

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -7,7 +7,7 @@ import { authorization } from 'authorization';
 import { Icon as IconComponent } from 'components/Icon/Icon';
 import { ModalComponent } from 'components/ModalComponent/ModalComponent';
 import { ConfirmationModal } from 'confirmation';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { usePageManagement } from '../../usePageManagement';
 import styles from './subsection.module.scss';
 
@@ -34,6 +34,7 @@ export const SubsectionHeader = ({
     const ungroupSubsectionModalRef = useRef<ModalRef>(null);
     const addStaticElementModalRef = useRef<ModalRef>(null);
     const { showAlert } = useAlert();
+    const [closeOptions, setCloseOptions] = useState(false);
 
     const handleUngroup = () => {
         try {
@@ -83,12 +84,17 @@ export const SubsectionHeader = ({
                 <Button type="button" className="add-btn" outline onClick={onAddQuestion}>
                     Add question
                 </Button>
-                <MoreOptions header={<Icon.MoreVert size={4} />}>
+                <MoreOptions
+                    header={<Icon.MoreVert size={4} onClick={() => setCloseOptions(false)} />}
+                    close={closeOptions}>
                     <Button type="button" onClick={onEditSubsection}>
                         <Icon.Edit size={3} /> Edit subsection
                     </Button>
                     {subsection.isGrouped ? (
-                        <ModalToggleButton type="button" modalRef={ungroupSubsectionModalRef}>
+                        <ModalToggleButton
+                            type="button"
+                            modalRef={ungroupSubsectionModalRef}
+                            onClick={() => setCloseOptions(true)}>
                             <IconComponent name={'group'} size={'s'} /> Ungroup questions
                         </ModalToggleButton>
                     ) : (


### PR DESCRIPTION
## Description

Because the Subsection menu doesn't close when Ungroup Questions is selected, user needs to click an extra time to change focus to the modal. Here I ensure the menu closes so focus is restored to the modal.

## Tickets

* [CNFT2-2213](https://cdc-nbs.atlassian.net/browse/CNFT2-2213)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2213]: https://cdc-nbs.atlassian.net/browse/CNFT2-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ