### PR TITLE
[CNFT1-2078] Initialize Investigation index

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/SearchableInvestigationConfiguration.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/SearchableInvestigationConfiguration.java
@@ -1,0 +1,20 @@
+package gov.cdc.nbs.event.search.investigation;
+
+import gov.cdc.nbs.search.SimpleIndex;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class SearchableInvestigationConfiguration {
+
+  @Bean
+  SimpleIndex investigationIndex(
+      @Value("${nbs.search.investigation.index.name}") final String index,
+      @Value("${nbs.search.investigation.index.mapping}") final String location
+  ) {
+    return new SimpleIndex(index, location);
+  }
+
+
+}

--- a/apps/modernization-api/src/main/resources/application.yml
+++ b/apps/modernization-api/src/main/resources/application.yml
@@ -31,9 +31,11 @@ nbs:
     lab-report:
       index:
         name: lab_report
-        mapping: classpath:search/lab-report/lab-report.index.json
-      results:
-        max: ${nbs.max-page-size}
+        mapping: /search/lab-report/lab-report.index.json
+    investigation:
+      index:
+        name: investigation
+        mapping: /search/investigation/investigation.index.json
   authentication:
     paths:
       ignored:

--- a/apps/modernization-api/src/main/resources/search/investigation/investigation.index.json
+++ b/apps/modernization-api/src/main/resources/search/investigation/investigation.index.json
@@ -1,0 +1,256 @@
+{
+  "mappings" : {
+    "properties" : {
+      "_class" : {
+        "type" : "keyword",
+        "index" : false,
+        "doc_values" : false
+      },
+      "act_ids" : {
+        "type" : "nested",
+        "properties" : {
+          "_class" : {
+            "type" : "keyword",
+            "index" : false,
+            "doc_values" : false
+          },
+          "act_id_seq" : {
+            "type" : "integer"
+          },
+          "id" : {
+            "type" : "long"
+          },
+          "last_change_time" : {
+            "type" : "date",
+            "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+          },
+          "record_status" : {
+            "type" : "keyword"
+          },
+          "root_extension_txt" : {
+            "type" : "keyword"
+          },
+          "type_cd" : {
+            "type" : "keyword"
+          },
+          "type_desc_txt" : {
+            "type" : "text"
+          }
+        }
+      },
+      "activity_from_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "activity_to_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "add_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "add_user_id" : {
+        "type" : "long"
+      },
+      "case_class_cd" : {
+        "type" : "keyword"
+      },
+      "case_type_cd" : {
+        "type" : "keyword"
+      },
+      "cd_desc_txt" : {
+        "type" : "keyword"
+      },
+      "condition" : {
+        "type" : "keyword"
+      },
+      "curr_process_state_cd" : {
+        "type" : "keyword"
+      },
+      "investigation_status_cd" : {
+        "type" : "keyword"
+      },
+      "jurisdiction_cd" : {
+        "type" : "long"
+      },
+      "jurisdiction_code_desc_txt" : {
+        "type" : "text"
+      },
+      "last_change_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "last_chg_user_id" : {
+        "type" : "long"
+      },
+      "local_id" : {
+        "type" : "keyword"
+      },
+      "mood_cd" : {
+        "type" : "keyword"
+      },
+      "notification_add_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "notification_last_chg_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "notification_local_id" : {
+        "type" : "keyword"
+      },
+      "notification_record_status_cd" : {
+        "type" : "keyword"
+      },
+      "organization_participations" : {
+        "type" : "nested",
+        "properties" : {
+          "_class" : {
+            "type" : "keyword",
+            "index" : false,
+            "doc_values" : false
+          },
+          "act_uid" : {
+            "type" : "long"
+          },
+          "entity_id" : {
+            "type" : "long"
+          },
+          "name" : {
+            "type" : "text"
+          },
+          "org_last_change_time" : {
+            "type" : "date"
+          },
+          "organization_last_change_time" : {
+            "type" : "date",
+            "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+          },
+          "participation_last_change_time" : {
+            "type" : "date",
+            "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+          },
+          "participation_record_status" : {
+            "type" : "keyword"
+          },
+          "record_status" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "subject_class_cd" : {
+            "type" : "keyword"
+          },
+          "type_cd" : {
+            "type" : "keyword"
+          },
+          "type_desc_txt" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "outbreak_name" : {
+        "type" : "keyword"
+      },
+      "person_participations" : {
+        "type" : "nested",
+        "properties" : {
+          "_class" : {
+            "type" : "keyword",
+            "index" : false,
+            "doc_values" : false
+          },
+          "act_uid" : {
+            "type" : "long"
+          },
+          "birth_time" : {
+            "type" : "date",
+            "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+          },
+          "curr_sex_cd" : {
+            "type" : "keyword"
+          },
+          "entity_id" : {
+            "type" : "long"
+          },
+          "first_name" : {
+            "type" : "text"
+          },
+          "last_name" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase"
+              }
+            }
+          },
+          "local_id" : {
+            "type" : "keyword"
+          },
+          "participation_last_change_time" : {
+            "type" : "date",
+            "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+          },
+          "participation_record_status" : {
+            "type" : "keyword"
+          },
+          "person_cd" : {
+            "type" : "keyword"
+          },
+          "person_last_change_time" : {
+            "type" : "date",
+            "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+          },
+          "person_last_chg_time" : {
+            "type" : "date"
+          },
+          "person_parent_uid" : {
+            "type" : "long"
+          },
+          "person_record_status" : {
+            "type" : "keyword"
+          },
+          "subject_class_cd" : {
+            "type" : "keyword"
+          },
+          "type_cd" : {
+            "type" : "keyword"
+          },
+          "type_desc_txt" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "pregnant_ind_cd" : {
+        "type" : "keyword"
+      },
+      "prog_area_cd" : {
+        "type" : "keyword"
+      },
+      "program_jurisdiction_oid" : {
+        "type" : "long"
+      },
+      "public_health_case_last_chg_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      },
+      "public_health_case_uid" : {
+        "type" : "long"
+      },
+      "record_status_cd" : {
+        "type" : "keyword"
+      },
+      "rpt_form_cmplt_time" : {
+        "type" : "date",
+        "format" : "uuuu-MM-dd'T'HH:mm:ss||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss.SS||uuuu-MM-dd HH:mm:ss.SSS||uuuu-MM-dd HH:mm:ss.S||uuuu-MM-dd HH:mm:ss.SS"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Auto-initializes the 'investigation' Elasticsearch index on application start up if the index does not already exist. A file has been added that contains the current mappings for the index.

## Tickets

* [CNFT1-2078](https://cdc-nbs.atlassian.net/browse/CNFT1-2078)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2078]: https://cdc-nbs.atlassian.net/browse/CNFT1-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ