### PR TITLE
[CVE-2024-22257] Resolution

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 springBoot = '2.7.18'
-spring-security = '5.8.9'
+spring-security = '5.8.11'
 jackson = '2.13.5'
 queryDSL = '5.0.0'
 graphql = '20.7'


### PR DESCRIPTION
## Description

Updates Spring Security to 5.8.11 to resolve [CVE-2024-22257](https://spring.io/security/cve-2024-22257) and address https://github.com/CDCgov/NEDSS-Modernization/security/code-scanning/433 

