### PR TITLE
Display batch label for heading

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
@@ -36,7 +36,9 @@ export const PreviewSubsection = ({ subsection }: Props) => {
                                             <>
                                                 {question.appearsInBatch && (
                                                     <div className={styles.groupedQuestionName} key={k}>
-                                                        <Heading level={3}>{question.name}</Heading>
+                                                        <Heading level={3}>
+                                                            {question.batchLabel ?? question.name}
+                                                        </Heading>
                                                     </div>
                                                 )}
                                             </>


### PR DESCRIPTION
## Description

When showing the headers for a grouped subsection, the label specified by the grouping should be displayed instead of the question label.

## Tickets

### Repeating block settings
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/2d80d9fe-b030-40dc-a731-e99e52226112)

### Before
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/e9f16d82-513f-4be1-a515-f681c5d1dc2b)

### After
![image](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/3c347f12-147e-4315-a6ea-eca230ff76b8)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
