### PR TITLE
CNFT2-2219 Group: No toggle

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/SubsectionDetails.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/SubsectionDetails.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from 'react-hook-form';
 import { Input } from 'components/FormInputs/Input';
-import { Label } from '@trussworks/react-uswds';
+import { Radio } from '@trussworks/react-uswds';
 import styles from './subsection-details.module.scss';
 import { GroupRequest } from 'apps/page-builder/hooks/api/useGroupSubsection';
 import { useEffect, useState } from 'react';
@@ -52,23 +52,21 @@ export const SubsectionDetails = () => {
                         name="visible"
                         render={({ field: { name } }) => (
                             <div className={styles.radio}>
-                                <Label htmlFor="visibleYes">Yes</Label>
-                                <input
-                                    type="radio"
+                                <Radio
                                     name={name}
                                     value="true"
                                     id="visible"
                                     checked={control._formValues.visible}
                                     onChange={() => setVisibleToggle('true')}
+                                    label="Yes"
                                 />
-                                <Label htmlFor="visibleNo">No</Label>
-                                <input
-                                    type="radio"
+                                <Radio
                                     id="notvisible"
                                     name={name}
                                     value={false.toString()}
                                     checked={!control._formValues.visible}
                                     onChange={() => setVisibleToggle('false')}
+                                    label="No"
                                 />
                             </div>
                         )}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/SubsectionDetails.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/SubsectionDetails.tsx
@@ -1,11 +1,17 @@
 import { Controller, useFormContext } from 'react-hook-form';
 import { Input } from 'components/FormInputs/Input';
-import { Radio } from '@trussworks/react-uswds';
+import { Label } from '@trussworks/react-uswds';
 import styles from './subsection-details.module.scss';
 import { GroupRequest } from 'apps/page-builder/hooks/api/useGroupSubsection';
+import { useEffect, useState } from 'react';
 
 export const SubsectionDetails = () => {
-    const { control } = useFormContext<GroupRequest>();
+    const { control, setValue } = useFormContext<GroupRequest>();
+    const [visibleToggle, setVisibleToggle] = useState(control._formValues.visible ? 'true' : 'false');
+
+    useEffect(() => {
+        setValue('visible', visibleToggle === 'true' ? true : false);
+    }, [visibleToggle]);
 
     return (
         <div className={styles.details}>
@@ -44,23 +50,25 @@ export const SubsectionDetails = () => {
                     <Controller
                         control={control}
                         name="visible"
-                        render={({ field: { onChange, value, name } }) => (
+                        render={({ field: { name } }) => (
                             <div className={styles.radio}>
-                                <Radio
+                                <Label htmlFor="visibleYes">Yes</Label>
+                                <input
+                                    type="radio"
                                     name={name}
-                                    value="Y"
+                                    value="true"
                                     id="visible"
-                                    checked={value}
-                                    onChange={(e) => onChange(e.target.value)}
-                                    label="Yes"
+                                    checked={control._formValues.visible}
+                                    onChange={() => setVisibleToggle('true')}
                                 />
-                                <Radio
+                                <Label htmlFor="visibleNo">No</Label>
+                                <input
+                                    type="radio"
                                     id="notvisible"
                                     name={name}
-                                    value="N"
-                                    checked={!value}
-                                    onChange={(e) => onChange(e.target.value)}
-                                    label="No"
+                                    value={false.toString()}
+                                    checked={!control._formValues.visible}
+                                    onChange={() => setVisibleToggle('false')}
                                 />
                             </div>
                         )}


### PR DESCRIPTION
## Description

The "Visible" Yes/No toggle was not working on Group Questions--here we fix it.

## Tickets

* [CNFT2-2219](https://cdc-nbs.atlassian.net/browse/CNFT2-2219)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2219]: https://cdc-nbs.atlassian.net/browse/CNFT2-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ