### PR TITLE
Externalize date on concept creation

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/EditValueset/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/EditValueset/CreateConcept.tsx
@@ -27,7 +27,8 @@ export const CreateConcept = ({ onCreated, onCancel, onClose, valuesetName }: Pr
             authorization: authorization(),
             request: {
                 ...form.getValues(),
-                effectiveToTime: externalizeDateTime(form.getValues('effectiveToTime')) ?? undefined
+                effectiveToTime: externalizeDateTime(form.getValues('effectiveToTime')) ?? undefined,
+                effectiveFromTime: externalizeDateTime(form.getValues('effectiveFromTime')) ?? undefined
             },
             codeSetNm: valuesetName
         })

--- a/apps/modernization-ui/src/apps/page-builder/components/EditValueset/CreateConcept.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/EditValueset/CreateConcept.tsx
@@ -28,7 +28,7 @@ export const CreateConcept = ({ onCreated, onCancel, onClose, valuesetName }: Pr
             request: {
                 ...form.getValues(),
                 effectiveToTime: externalizeDateTime(form.getValues('effectiveToTime')) ?? undefined,
-                effectiveFromTime: externalizeDateTime(form.getValues('effectiveFromTime')) ?? undefined
+                effectiveFromTime: externalizeDateTime(form.getValues('effectiveFromTime')) ?? new Date().toISOString()
             },
             codeSetNm: valuesetName
         })

--- a/apps/modernization-ui/src/apps/page-builder/components/EditValueset/concept/ConceptForm.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/EditValueset/concept/ConceptForm.tsx
@@ -4,9 +4,10 @@ import { useOptions } from 'apps/page-builder/hooks/api/useOptions';
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { Input } from 'components/FormInputs/Input';
 import { SelectInput } from 'components/FormInputs/SelectInput';
-import { ChangeEvent } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { ChangeEvent, useEffect } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
+import { isBefore } from 'validation/date';
 import styles from './concept-form.module.scss';
 
 type Props = {
@@ -15,6 +16,11 @@ type Props = {
 export const ConceptForm = ({ isEditing = false }: Props) => {
     const form = useFormContext<CreateConceptRequest>();
     const { options: codeSystems } = useOptions('CODE_SYSTEM');
+    const effectiveTo = useWatch({ control: form.control, name: 'effectiveToTime' });
+
+    useEffect(() => {
+        form.trigger('effectiveFromTime');
+    }, [effectiveTo]);
 
     return (
         <div className={styles.conceptForm}>
@@ -103,14 +109,18 @@ export const ConceptForm = ({ isEditing = false }: Props) => {
                     <Controller
                         control={form.control}
                         name="effectiveFromTime"
-                        rules={{ required: { value: true, message: 'Effective from time is required' } }}
-                        render={({ field: { onChange, onBlur, value } }) => (
+                        rules={{
+                            required: { value: true, message: 'Effective from time is required' },
+                            validate: isBefore(effectiveTo)
+                        }}
+                        render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
                             <DatePickerInput
                                 defaultValue={value}
                                 label="Effective from time"
                                 onChange={onChange}
                                 onBlur={onBlur}
                                 required
+                                errorMessage={error?.message}
                             />
                         )}
                     />

--- a/apps/modernization-ui/src/validation/date/isBefore.ts
+++ b/apps/modernization-ui/src/validation/date/isBefore.ts
@@ -1,8 +1,8 @@
 import { isAfter } from 'date-fns';
 
 const isBefore =
-    (max: string) =>
-    (current: string): string | undefined => {
+    (max?: string) =>
+    (current?: string): string | undefined => {
         if (max && current) {
             const maxDate = new Date(max);
             const currentDate = new Date(current);


### PR DESCRIPTION
## Description

`Effective from time` was not being externalized on concept creation. Added validation to prevent `from` time being after `to` time.

## Tickets

* [CNFT2-2189](https://cdc-nbs.atlassian.net/browse/CNFT2-2189)

### Create Concept
![createConcept](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/97310cb6-f293-4991-a9c6-ce083e112c2d)


### Date validation
![dateValidation](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/3bc91da5-5482-4169-bc9e-741e9f6b295d)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2189]: https://cdc-nbs.atlassian.net/browse/CNFT2-2189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ