### PR TITLE
Add validation to data mart repeat number to restrict to 0-5

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/SubsectionDetails.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/SubsectionDetails.tsx
@@ -107,15 +107,20 @@ export const SubsectionDetails = () => {
                         control={control}
                         name="repeatingNbr"
                         rules={{
-                            required: { value: true, message: 'Repeat number required.' }
+                            required: { value: true, message: 'Repeat number required.' },
+                            max: { value: 5, message: 'Must be between 0 and 5' },
+                            min: { value: 0, message: 'Must be between 0 and 5' }
                         }}
-                        render={({ field: { onChange, value, name }, fieldState: { error } }) => (
+                        render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                             <Input
                                 type="number"
                                 name={name}
                                 defaultValue={value?.toString()}
                                 onChange={onChange}
+                                onBlur={onBlur}
                                 required
+                                min={0}
+                                max={5}
                                 error={error?.message}
                             />
                         )}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/section.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/section.module.scss
@@ -5,6 +5,7 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 1.5rem;
+    padding-bottom: 8rem;
 
     .section {
         width: 100%;


### PR DESCRIPTION
## Description

Limits the Data mart repeat number to 0-5 as indicated by the help text.

## Tickets
NA

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
