### PR TITLE
CNFT1-798 Search Update- Update API for SoundEx for Search 1.1

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -59,6 +59,7 @@ public class PatientFilter {
   private List<RecordStatus> recordStatus;
   private String treatmentId;
   private String vaccinationId;
+  private boolean disableSoundex;
   @JsonIgnore
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaQueryResolver.java
@@ -98,7 +98,13 @@ class PatientSearchCriteriaQueryResolver {
     String name = criteria.getFirstName();
 
     if (name != null && !name.isBlank()) {
-      String encoded = soundex.encode(name.trim());
+
+      String encoded;
+      if (criteria.isDisableSoundex()) {
+        encoded = "";
+      } else {
+        encoded = soundex.encode(name.trim());
+      }
 
       return Optional.of(
           BoolQuery.of(
@@ -147,7 +153,12 @@ class PatientSearchCriteriaQueryResolver {
     String name = AdjustStrings.withoutHyphens(criteria.getLastName());
 
     if (name != null && !name.isBlank()) {
-      String encoded = soundex.encode(name.trim());
+      String encoded;
+      if (criteria.isDisableSoundex()) {
+        encoded = "";
+      } else {
+        encoded = soundex.encode(name.trim());
+      }
 
       return Optional.of(
           BoolQuery.of(

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -1,101 +1,101 @@
-
 input IdentificationCriteria {
-    identificationNumber: String
-    identificationType: String
-    assigningAuthority: String
+  identificationNumber: String
+  identificationType: String
+  assigningAuthority: String
 }
 
 input PersonFilter {
-    id: ID
-    lastName: String
-    firstName: String
-    race: String
-    identification: IdentificationCriteria
-    phoneNumber: String
-    email: String
-    dateOfBirth: Date
-    dateOfBirthOperator: Operator
-    gender: String
-    deceased: Deceased
-    address: String
-    city: String
-    state: String
-    country: String
-    zip: String
-    mortalityStatus: String
-    ethnicity: String
-    vaccinationId: String
-    treatmentId: String
-    recordStatus: [RecordStatus!]!
+  id: ID
+  lastName: String
+  firstName: String
+  race: String
+  identification: IdentificationCriteria
+  phoneNumber: String
+  email: String
+  dateOfBirth: Date
+  dateOfBirthOperator: Operator
+  gender: String
+  deceased: Deceased
+  address: String
+  city: String
+  state: String
+  country: String
+  zip: String
+  mortalityStatus: String
+  ethnicity: String
+  vaccinationId: String
+  treatmentId: String
+  disableSoundex: Boolean
+  recordStatus: [RecordStatus!]!
 }
 
 enum Gender {
-    M
-    F
-    U
+  M
+  F
+  U
 }
 
 enum Deceased {
-    Y
-    N
-    UNK
+  Y
+  N
+  UNK
 }
 
 enum Operator {
-    EQUAL
-    BEFORE
-    AFTER
+  EQUAL
+  BEFORE
+  AFTER
 }
 
 enum SortDirection {
-    ASC
-    DESC
+  ASC
+  DESC
 }
 
 type PatientSearchResultIdentification {
-    type: String!
-    value: String!
+  type: String!
+  value: String!
 }
 
 type PatientSearchResultName {
-    first: String
-    middle: String
-    last: String
-    suffix: String
+  first: String
+  middle: String
+  last: String
+  suffix: String
 }
 
 type PatientSearchResultAddress {
-    use: String!
-    address: String
-    address2: String
-    city: String
-    state: String
-    zipcode: String
+  use: String!
+  address: String
+  address2: String
+  city: String
+  state: String
+  zipcode: String
 }
 
 type PatientSearchResult {
-    patient: Int!
-    birthday: Date
-    age: Int
-    gender: String
-    status: String!
-    shortId: Int!
-    legalName: PatientSearchResultName
-    names: [PatientSearchResultName!]!
-    identification: [PatientSearchResultIdentification!]!
-    addresses: [PatientSearchResultAddress!]!
-    phones: [String!]!
-    emails: [String!]!
+  patient: Int!
+  birthday: Date
+  age: Int
+  gender: String
+  status: String!
+  shortId: Int!
+  legalName: PatientSearchResultName
+  names: [PatientSearchResultName!]!
+  identification: [PatientSearchResultIdentification!]!
+  addresses: [PatientSearchResultAddress!]!
+  phones: [String!]!
+  emails: [String!]!
 }
 
 type PatientSearchResults {
-    content: [PatientSearchResult!]!
-    total: Int!
+  content: [PatientSearchResult!]!
+  total: Int!
 }
 
 type Query {
-    findPatientsByFilter(
-        filter: PersonFilter!
-        page: SortablePage
-    ): PatientSearchResults!
+  findPatientsByFilter(
+    filter: PersonFilter!
+    page: SortablePage
+  ): PatientSearchResults!
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -13,8 +13,7 @@ public class PatientSearchCriteriaSteps {
 
   PatientSearchCriteriaSteps(
       final Active<PatientIdentifier> patient,
-      final Active<PatientFilter> criteria
-  ) {
+      final Active<PatientFilter> criteria) {
     this.patient = patient;
     this.criteria = criteria;
   }
@@ -22,8 +21,7 @@ public class PatientSearchCriteriaSteps {
   @Given("I add the patient criteria for a(n) {string} equal to {string}")
   public void i_add_the_patient_criteria_for_a_field_that_is_value(
       final String field,
-      final String value
-  ) {
+      final String value) {
 
     if (field == null || field.isEmpty()) {
       return;
@@ -36,11 +34,11 @@ public class PatientSearchCriteriaSteps {
   private PatientFilter applyCriteria(
       final String field,
       final String value,
-      final PatientFilter criteria
-  ) {
+      final PatientFilter criteria) {
     switch (field.toLowerCase()) {
       case "first name" -> criteria.setFirstName(value);
       case "last name" -> criteria.setLastName(value);
+      case "disable soundex" -> criteria.setDisableSoundex(value.equals("true"));
       case "phone number" -> criteria.setPhoneNumber(value);
       case "email", "email address" -> criteria.setEmail(value);
       case "city" -> criteria.setCity(value);
@@ -69,15 +67,13 @@ public class PatientSearchCriteriaSteps {
   public void i_would_like_to_search_for_a_patient_using_a_short_ID() {
 
     this.patient.maybeActive().ifPresent(
-        found -> this.criteria.active(criteria -> criteria.withId(String.valueOf(found.shortId())))
-    );
+        found -> this.criteria.active(criteria -> criteria.withId(String.valueOf(found.shortId()))));
 
   }
 
   @Given("I would like to search for a patient using a local ID")
   public void i_would_like_to_search_for_a_patient_using_a_local_ID() {
     this.patient.maybeActive().ifPresent(
-        found -> this.criteria.active(criteria -> criteria.withId(found.local()))
-    );
+        found -> this.criteria.active(criteria -> criteria.withId(found.local())));
   }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -85,6 +85,20 @@ Feature: Patient Search
     And search result 2 has a "first name" of "Jon"
     And search result 2 has a "last name" of "Snow"
 
+  Scenario: I can find the most relevant patient when searching by first name with soundex disabled
+    Given the patient has the "legal" name "Something" "Other"
+    And I have another patient
+    And the patient has the "legal" name "Jon" "Snow"
+    And I have another patient
+    And the patient has the "legal" name "John" "Little"
+    And patients are available for search
+    And I add the patient criteria for a "first name" equal to "John"
+    And I add the patient criteria for a "disable soundex" equal to "true"
+    When I search for patients
+    Then search result 1 has a "first name" of "John"
+    And search result 1 has a "last name" of "Little"
+    And there are 1 patient search results
+
   Scenario: I can find the most relevant patient when searching by last name
     Given the patient has the "legal" name "Something" "Other"
     And I have another patient
@@ -98,6 +112,20 @@ Feature: Patient Search
     And search result 1 has a "last name" of "Smith"
     And search result 2 has a "first name" of "Albert"
     And search result 2 has a "last name" of "Smyth"
+
+  Scenario: I can find the most relevant patient when searching by last name with soundex disabled
+    Given the patient has the "legal" name "Something" "Other"
+    And I have another patient
+    And the patient has the "legal" name "Albert" "Smyth"
+    And I have another patient
+    And the patient has the "legal" name "Fatima" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a "last name" equal to "Smith"
+    And I add the patient criteria for a "disable soundex" equal to "true"
+    When I search for patients
+    Then search result 1 has a "first name" of "Fatima"
+    And search result 1 has a "last name" of "Smith"
+    And there are 1 patient search results
 
   Scenario: I can find the patient when searching for a hyphenated last name using a hyphen
     Given the patient has the "legal" name "Something" "Other-than"

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -227,7 +227,7 @@ export type IdentificationTypeId = {
 
 export type Investigation = {
   __typename?: 'Investigation';
-  addTime?: Maybe<Scalars['DateTime']['output']>;
+  addTime?: Maybe<Scalars['Date']['output']>;
   cdDescTxt?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['ID']['output']>;
   investigationStatusCd?: Maybe<Scalars['String']['output']>;
@@ -281,7 +281,7 @@ export type InvestigationFilter = {
 
 export type InvestigationPersonParticipation = {
   __typename?: 'InvestigationPersonParticipation';
-  birthTime?: Maybe<Scalars['DateTime']['output']>;
+  birthTime?: Maybe<Scalars['Date']['output']>;
   currSexCd?: Maybe<Scalars['String']['output']>;
   firstName?: Maybe<Scalars['String']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
@@ -1596,6 +1596,7 @@ export type PersonFilter = {
   dateOfBirth?: InputMaybe<Scalars['Date']['input']>;
   dateOfBirthOperator?: InputMaybe<Operator>;
   deceased?: InputMaybe<Deceased>;
+  disableSoundex?: InputMaybe<Scalars['Boolean']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   ethnicity?: InputMaybe<Scalars['String']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -97,7 +97,7 @@ type InvestigationResults {
 }
 
 type InvestigationPersonParticipation {
-    birthTime: DateTime
+    birthTime: Date
     currSexCd: String
     typeCd: String!
     firstName: String
@@ -112,7 +112,7 @@ type Investigation {
     cdDescTxt: String
     jurisdictionCodeDescTxt: String
     localId: String
-    addTime: DateTime
+    addTime: Date
     investigationStatusCd: String
     notificationRecordStatusCd: String
     personParticipations: [InvestigationPersonParticipation!]!
@@ -1058,106 +1058,106 @@ type PatientProfile {
 extend type Query {
     findPatientProfile(patient: ID, shortId: Int): PatientProfile
 }
-
 input IdentificationCriteria {
-    identificationNumber: String
-    identificationType: String
-    assigningAuthority: String
+  identificationNumber: String
+  identificationType: String
+  assigningAuthority: String
 }
 
 input PersonFilter {
-    id: ID
-    lastName: String
-    firstName: String
-    race: String
-    identification: IdentificationCriteria
-    phoneNumber: String
-    email: String
-    dateOfBirth: Date
-    dateOfBirthOperator: Operator
-    gender: String
-    deceased: Deceased
-    address: String
-    city: String
-    state: String
-    country: String
-    zip: String
-    mortalityStatus: String
-    ethnicity: String
-    vaccinationId: String
-    treatmentId: String
-    recordStatus: [RecordStatus!]!
+  id: ID
+  lastName: String
+  firstName: String
+  race: String
+  identification: IdentificationCriteria
+  phoneNumber: String
+  email: String
+  dateOfBirth: Date
+  dateOfBirthOperator: Operator
+  gender: String
+  deceased: Deceased
+  address: String
+  city: String
+  state: String
+  country: String
+  zip: String
+  mortalityStatus: String
+  ethnicity: String
+  vaccinationId: String
+  treatmentId: String
+  disableSoundex: Boolean
+  recordStatus: [RecordStatus!]!
 }
 
 enum Gender {
-    M
-    F
-    U
+  M
+  F
+  U
 }
 
 enum Deceased {
-    Y
-    N
-    UNK
+  Y
+  N
+  UNK
 }
 
 enum Operator {
-    EQUAL
-    BEFORE
-    AFTER
+  EQUAL
+  BEFORE
+  AFTER
 }
 
 enum SortDirection {
-    ASC
-    DESC
+  ASC
+  DESC
 }
 
 type PatientSearchResultIdentification {
-    type: String!
-    value: String!
+  type: String!
+  value: String!
 }
 
 type PatientSearchResultName {
-    first: String
-    middle: String
-    last: String
-    suffix: String
+  first: String
+  middle: String
+  last: String
+  suffix: String
 }
 
 type PatientSearchResultAddress {
-    use: String!
-    address: String
-    address2: String
-    city: String
-    state: String
-    zipcode: String
+  use: String!
+  address: String
+  address2: String
+  city: String
+  state: String
+  zipcode: String
 }
 
 type PatientSearchResult {
-    patient: Int!
-    birthday: Date
-    age: Int
-    gender: String
-    status: String!
-    shortId: Int!
-    legalName: PatientSearchResultName
-    names: [PatientSearchResultName!]!
-    identification: [PatientSearchResultIdentification!]!
-    addresses: [PatientSearchResultAddress!]!
-    phones: [String!]!
-    emails: [String!]!
+  patient: Int!
+  birthday: Date
+  age: Int
+  gender: String
+  status: String!
+  shortId: Int!
+  legalName: PatientSearchResultName
+  names: [PatientSearchResultName!]!
+  identification: [PatientSearchResultIdentification!]!
+  addresses: [PatientSearchResultAddress!]!
+  phones: [String!]!
+  emails: [String!]!
 }
 
 type PatientSearchResults {
-    content: [PatientSearchResult!]!
-    total: Int!
+  content: [PatientSearchResult!]!
+  total: Int!
 }
 
 type Query {
-    findPatientsByFilter(
-        filter: PersonFilter!
-        page: SortablePage
-    ): PatientSearchResults!
+  findPatientsByFilter(
+    filter: PersonFilter!
+    page: SortablePage
+  ): PatientSearchResults!
 }
 type PatientTreatment {
   treatment: ID!


### PR DESCRIPTION
## Description

Add option to backend API to disable soundex upon searching.  Add `disableSoundex` to `PatientFilter`.  For backwards compatibility it defaults to false and behaves as before and is optional.   The front end api can now use this option to disable soundex results from searches.

## Tickets

* [CNFT1-798](https://cdc-nbs.atlassian.net/browse/CNFT1-798)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


# disableSoundex: false (the default)
<img width="1022" alt="Screenshot 2024-03-26 at 9 51 35 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/34244063/67504dc6-2bc0-4e1a-8b42-b6b9ae107a1e">


# disableSoundex: true

<img width="1249" alt="Screenshot 2024-03-26 at 9 52 59 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/34244063/036f76c5-b167-4fb5-adfd-6d622ecf01ae">


[CNFT1-798]: https://cdc-nbs.atlassian.net/browse/CNFT1-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ