### PR TITLE
Fix issue where Business rule misses part of the question If when Question contains a comma. 

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleFinder.java
@@ -31,7 +31,7 @@ class PageRuleFinder {
             [rule].target_question_identifier  as [targetQuestions],
             [question1].question_label          as [sourceQuestionLabel],
             [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-            STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ',') WITHIN GROUP
+            STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), '##') WITHIN GROUP 
              (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ',')) as [targetQuestionLabels],
                 0                                  as [TotalCount]
           from WA_rule_metadata [rule]
@@ -71,7 +71,7 @@ class PageRuleFinder {
              [rule].target_question_identifier  as [targetQuestions],
              [question1].question_label          as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-             STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ', ') WITHIN GROUP
+             STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), '##') WITHIN GROUP
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
              as [targetQuestionLabels],
              (SELECT COUNT(DISTINCT [rule].wa_rule_metadata_uid)
@@ -119,7 +119,7 @@ class PageRuleFinder {
              [rule].target_question_identifier  as [targetQuestions],
              [question1].question_label         as [sourceQuestionLabel],
              [CodeSet].code_set_nm              as [sourceQuestionCodeSet],
-             STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), ', ') WITHIN GROUP
+             STRING_AGG(CONVERT(NVARCHAR(max),[question2].question_label), '##') WITHIN GROUP 
             (ORDER BY CHARINDEX(',' + [question2].question_identifier + ',', ',' + [rule].target_question_identifier + ','))
              as [targetQuestionLabels],
              (SELECT COUNT(DISTINCT [rule].wa_rule_metadata_uid)

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapper.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapper.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 @Component
 class PageRuleMapper implements RowMapper<Rule> {
   record Column(int ruleId, int template, int ruleFunction, int description, int sourceQuestion, int ruleExpression,
-      int sourceValues, int comparator, int targetType, int targetQuestions, int sourceQuestionLabel,
-      int sourceQuestionCodeSet, int targetQuestionsLabels, int totalCount) {
+                int sourceValues, int comparator, int targetType, int targetQuestions, int sourceQuestionLabel,
+                int sourceQuestionCodeSet, int targetQuestionsLabels, int totalCount) {
 
   }
 
@@ -66,7 +66,7 @@ class PageRuleMapper implements RowMapper<Rule> {
   private List<Rule.Target> getTargets(String identifiers, String labels) {
     List<String> targetQuestions = identifiers != null ? Arrays.stream(identifiers.split(",")).toList() : null;
 
-    List<String> targetQuestionsLabels = labels != null ? Arrays.stream(labels.split(",")).toList() : null;
+    List<String> targetQuestionsLabels = labels != null ? Arrays.stream(labels.split("##")).toList() : null;
 
     List<Rule.Target> targets = new ArrayList<>();
     if (targetQuestions != null) {

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapperTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleMapperTest.java
@@ -34,7 +34,7 @@ class PageRuleMapperTest {
     when(resultSet.getString(10)).thenReturn("test456,test789,test123");
     when(resultSet.getString(11)).thenReturn("label123");
     when(resultSet.getString(12)).thenReturn("codeSetName");
-    when(resultSet.getString(13)).thenReturn("test456_label,test789_label");
+    when(resultSet.getString(13)).thenReturn("test456_label##test789_label");
     when(resultSet.getLong(14)).thenReturn(10l);
     Rule actualResponse = pageRuleMapper.mapRow(resultSet, 1);
     validate(actualResponse);


### PR DESCRIPTION
## Description

When Target Question has a comma, Business rule library is missing part of the question.

Please include a summary of the changes and any key information a reviewer may need.

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-2193