### PR TITLE
Filter electronic Providers and Facilities

### DIFF
--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/facilities/autocomplete/FacilityOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/facilities/autocomplete/FacilityOptionResolver.java
@@ -11,11 +11,20 @@ public class FacilityOptionResolver extends SQLBasedOptionResolver {
       """
           with [facility]([value], [name], [quickCode]) as (
               select
-                  organization_uid,
-                  display_nm + IIF(root_extension_txt is null or root_extension_txt='', '', ' [' + root_extension_txt + ']'),
+                  [organization].organization_uid,
+                  [organization].display_nm + IIF(
+                        [quick_code].root_extension_txt is null
+                    or  [quick_code].root_extension_txt='',
+                    '',
+                    ' [' + [quick_code].root_extension_txt + ']'),
                   root_extension_txt
-              from Organization
-              left join Entity_id on entity_uid=organization_uid and type_cd='QEC'
+              from Organization [organization]
+                left join Entity_id [quick_code] on
+                  [quick_code].entity_uid = [organization].organization_uid
+                  and [quick_code].type_cd ='QEC'
+              where [organization].electronic_ind is null
+                or [organization].electronic_ind <> 'Y'
+              
           )
           select
               [value],

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/facility/autocomplete/FacilityOptionSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/facility/autocomplete/FacilityOptionSteps.java
@@ -1,7 +1,5 @@
 package gov.cdc.nbs.option.facility.autocomplete;
 
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 
 public class FacilityOptionSteps {
@@ -12,14 +10,13 @@ public class FacilityOptionSteps {
     this.mother = mother;
   }
 
-  @Before("@facilities")
-  @After("@facilities")
-  public void clean() {
-    mother.reset();
-  }
-
   @Given("there is a facility for {string}")
   public void there_is_a_facility_for(final String name) {
     mother.create(name);
+  }
+
+  @Given("there is a facility for {string} that was added electronically")
+  public void there_is_an_electronic_facility(final String name) {
+    mother.electronic(name);
   }
 }

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/provider/autocomplete/ProviderOptionSteps.java
@@ -1,7 +1,5 @@
 package gov.cdc.nbs.option.provider.autocomplete;
 
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 
 public class ProviderOptionSteps {
@@ -12,15 +10,14 @@ public class ProviderOptionSteps {
     this.mother = mother;
   }
 
-  @After("@providers")
-  @Before("@providers")
-  public void clean() {
-    mother.reset();
+  @Given("there is a provider for {string} {string}")
+  public void there_is_a_provider(final String first, final String last) {
+    mother.create(first, last);
   }
 
-  @Given("there is a provider for {string} {string}")
-  public void there_is_a_condition(final String first, final String last) {
-    mother.create(first, last);
+  @Given("there is a provider for {string} {string} that was added electronically")
+  public void there_is_an_electronic_provider(final String first, final String last) {
+    mother.electronic(first, last);
   }
 
 }

--- a/libs/options-api/src/test/resources/features/facilities/FacilityOptions.feature
+++ b/libs/options-api/src/test/resources/features/facilities/FacilityOptions.feature
@@ -27,3 +27,8 @@ Feature: Facility Options REST API
   Scenario: I cannot find specific facilities that do not exist
     When I am trying to find facilities that start with "zzzzzzzzz"
     Then there aren't any options available
+
+  Scenario: Electronic facilities are not available for search
+    Given there is a facility for "Cyberdyne Systems" that was added electronically
+    When I am trying to find facilities that start with "cyber"
+    Then there aren't any options available

--- a/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
+++ b/libs/options-api/src/test/resources/features/providers/ProviderOptions.feature
@@ -29,3 +29,8 @@ Feature: Provider Options REST API
   Scenario: I cannot find specific providers that do not exist
     When I am trying to find providers that start with "zzzzzzzzz"
     Then there aren't any options available
+
+  Scenario: Electronic providers are not available for search
+    Given there is a provider for "Miles" "Dyson" that was added electronically
+    When I am trying to find providers that start with "mile"
+    Then there aren't any options available


### PR DESCRIPTION
## Description

Restricts the Providers and Facilities returned by the autocomplete API to only return manually entered items only.  This is required due to new Organizations and Facilities being added during data ingestion.  

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
