### PR TITLE
CNFT2-2259 Page library: search functionality

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
@@ -49,7 +49,7 @@ const PageLibraryMenu = ({ properties, filters, onSearch, onFilter, onDownloadCs
                 id="page-search"
                 name="search"
                 ariaLabel="search page name and  by keyword"
-                placeholder="Search by page or condition name"
+                placeholder="Search by page name, condition name or condition code"
                 onSearch={onSearch}
             />
             <menu>

--- a/apps/modernization-ui/src/components/Search/Search.tsx
+++ b/apps/modernization-ui/src/components/Search/Search.tsx
@@ -38,6 +38,14 @@ const Search = (props: SearchProps) => {
             setResetInput(false);
         }
     }, [resetInput]);
+
+    useEffect(() => {
+        if (keyword === '') {
+            setResetInput(true);
+            handleSearch();
+        }
+    }, [keyword]);
+
     return (
         <search className={classNames(styles.search, props.className)}>
             <label className="usa-sr-only" htmlFor={props.id}>

--- a/apps/modernization-ui/src/components/SideNavigation/SideNavigation.tsx
+++ b/apps/modernization-ui/src/components/SideNavigation/SideNavigation.tsx
@@ -17,7 +17,11 @@ type NavigationEntryProps = EntryProps & {
     path: string;
 };
 const NavigationEntry = ({ children, path }: NavigationEntryProps) => {
-    return <Link to={path}>{children}</Link>;
+    return (
+        <Link to={path} reloadDocument>
+            {children}
+        </Link>
+    );
 };
 
 type Children = ReactElement<LinkEntryProps> | ReactElement<NavigationEntryProps>;


### PR DESCRIPTION
## Description

Here we fix the search bar in Page Library:
1. When you clear a search term, the library resets to default
2. When you make a search, the Page Library sidebar item will refresh the page
3. Search bar placeholder text updated

## Tickets

* [CNFT2-2259](https://cdc-nbs.atlassian.net/browse/CNFT2-2259)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
