### PR TITLE
Fix issue with deleting Initial Draft pages.

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageDeletor.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageDeletor.java
@@ -15,13 +15,10 @@ import gov.cdc.nbs.questionbank.page.util.PageConstants;
 public class PageDeletor {
 
   private final EntityManager entityManager;
-  private final PageUidFinder pageUidFinder;
 
   public PageDeletor(
-      final EntityManager entityManager,
-      final PageUidFinder pageUidFinder) {
+      final EntityManager entityManager) {
     this.entityManager = entityManager;
-    this.pageUidFinder = pageUidFinder;
   }
 
   @Transactional
@@ -33,18 +30,7 @@ public class PageDeletor {
     }
 
     if (page.getTemplateType().equals(PageConstants.DRAFT)) {
-
-      Long publishedWithDraft = pageUidFinder.findTemplateByType(page.getFormCd(), PageConstants.PUBLISHED_WITH_DRAFT);
-
-      WaTemplate publishedWithDraftPage = entityManager.find(WaTemplate.class, publishedWithDraft);
-
-      if (publishedWithDraftPage == null) {
-        throw new PageNotFoundException();
-      }
-      publishedWithDraftPage.setTemplateType(PageConstants.PUBLISHED);
-
       entityManager.remove(page);
-
     } else {
       throw new PageUpdateException(PageConstants.DELETE_DRAFT_FAIL);
     }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageDeletor.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageDeletor.java
@@ -14,11 +14,15 @@ import gov.cdc.nbs.questionbank.page.util.PageConstants;
 @Service
 public class PageDeletor {
 
+
   private final EntityManager entityManager;
+  private final PageUidFinder pageUidFinder;
 
   public PageDeletor(
-      final EntityManager entityManager) {
+      final EntityManager entityManager,
+      final PageUidFinder pageUidFinder) {
     this.entityManager = entityManager;
+    this.pageUidFinder = pageUidFinder;
   }
 
   @Transactional
@@ -30,11 +34,20 @@ public class PageDeletor {
     }
 
     if (page.getTemplateType().equals(PageConstants.DRAFT)) {
+
+      Long publishedWithDraft = pageUidFinder.findTemplateByType(page.getFormCd(), PageConstants.PUBLISHED_WITH_DRAFT);
+
+      if (publishedWithDraft != null) {
+        WaTemplate publishedWithDraftPage = entityManager.find(WaTemplate.class, publishedWithDraft);
+        publishedWithDraftPage.setTemplateType(PageConstants.PUBLISHED);
+      }
       entityManager.remove(page);
+
     } else {
       throw new PageUpdateException(PageConstants.DELETE_DRAFT_FAIL);
     }
     return new PageDeleteResponse(page.getId(), PageConstants.DRAFT_DELETE_SUCCESS);
   }
+
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageUidFinder.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageUidFinder.java
@@ -4,6 +4,8 @@ package gov.cdc.nbs.questionbank.page;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class PageUidFinder {
   private static final String FIND_BY_FORM_CD_AND_TYPE_QUERY = """
@@ -24,12 +26,18 @@ public class PageUidFinder {
   }
 
   public Long findTemplateByType(String formCode, String pageType) {
-    return this.template.query(
+    List<Long> result = this.template.query(
         FIND_BY_FORM_CD_AND_TYPE_QUERY,
         setter -> {
           setter.setString(LOCAL_TEMPLATE_TYPE, pageType);
           setter.setString(LOCAL_FORM_CD, formCode);
         },
-        (rs, row) -> rs.getLong(COLUMN_INDEX)).get(0);
+        (rs, row) -> rs.getLong(COLUMN_INDEX));
+
+    if (!result.isEmpty()) {
+      return result.get(0);
+    } else {
+      return null;
+    }
   }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorSteps.java
@@ -56,10 +56,8 @@ public class PageDeletorSteps {
     }
 
 
-    @Then("the draft is deleted and the page changed to published")
-    public void the_page_deleted_and_changed_to_published() {
-        Optional<WaTemplate> temp = waTemplateRepository.findById(currPage.active().getId());
-        assertEquals(PageConstants.PUBLISHED, temp.get().getTemplateType());
+    @Then("the draft is deleted")
+    public void the_page_is_deleted() {
         assertEquals(Optional.empty(), waTemplateRepository.findById(draftPage.active().getId()));
     }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorSteps.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.questionbank.page;
 
 import java.util.Optional;
 
+import org.junit.Assert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import gov.cdc.nbs.questionbank.entity.repository.WaTemplateRepository;
 import gov.cdc.nbs.questionbank.page.util.PageConstants;
 import gov.cdc.nbs.questionbank.support.ExceptionHolder;
@@ -35,14 +37,21 @@ public class PageDeletorSteps {
     private final Active<WaTemplate> currPage = new Active<>();
     private final Active<WaTemplate> draftPage = new Active<>();
 
-    @Given("I create a delete page request with draft page")
-    public void i_create_a_delete_page_request_with_draft_page() {
+    @Given("I create a delete page request with published with draft page")
+    public void i_create_a_delete_page_request_with_published_with_draft_page() {
         WaTemplate temp = pageMother.one();
         temp.setTemplateType(PageConstants.DRAFT);
         temp.setFormCd("PG_testing");
         WaTemplate publishWithDraft = pageMother.createPagePublishedWithDraft(temp);
         currPage.active(publishWithDraft);
         this.draftPage.active(temp);
+    }
+
+    @Given("I create a delete page request with single draft page")
+    public void i_create_a_delete_page_request_with_single_draft_page() {
+        WaTemplate temp = pageMother.one();
+        temp.setTemplateType(PageConstants.DRAFT);
+        draftPage.active(temp);
     }
 
     @When("I send a delete page request")
@@ -56,8 +65,16 @@ public class PageDeletorSteps {
     }
 
 
+    @Then("the draft is deleted and the page changed to published")
+    public void the_page_deleted_and_changed_to_published() {
+        Optional<WaTemplate> temp = waTemplateRepository.findById(currPage.active().getId());
+        Assert.assertEquals(PageConstants.PUBLISHED, temp.get().getTemplateType());
+        Assert.assertEquals(Optional.empty(), waTemplateRepository.findById(draftPage.active().getId()));
+    }
+
     @Then("the draft is deleted")
     public void the_page_is_deleted() {
         assertEquals(Optional.empty(), waTemplateRepository.findById(draftPage.active().getId()));
     }
+
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorTest.java
@@ -22,9 +22,6 @@ class PageDeletorTest {
     @Mock
     private EntityManager entityManager;
 
-    @Mock
-    private PageUidFinder pageUidFinder;
-
     @InjectMocks
     PageDeletor pageDeletor;
 
@@ -44,11 +41,6 @@ class PageDeletorTest {
         publishedWithDraft.setTemplateType("Published With Draft");
 
         when(entityManager.find(WaTemplate.class, requestId)).thenReturn(page);
-
-        when(pageUidFinder.findTemplateByType(page.getFormCd(), PageConstants.PUBLISHED_WITH_DRAFT)).thenReturn(
-            publishedWithDraft.getId());
-
-        when(entityManager.find(WaTemplate.class, publishedWithDraft.getId())).thenReturn(publishedWithDraft);
 
         PageDeleteResponse response = pageDeletor.deletePageDraft(requestId);
         assertEquals(requestId, response.templateId());
@@ -83,15 +75,7 @@ class PageDeletorTest {
         WaTemplate page = new WaTemplate();
         page.setId(requestId);
         page.setTemplateType(PageConstants.DRAFT);
-        when(entityManager.find(WaTemplate.class, page.getId())).thenReturn(page);
-
-        Long publishWithDraftId = 2L;
-
-        when(pageUidFinder.findTemplateByType(page.getFormCd(), PageConstants.PUBLISHED_WITH_DRAFT)).thenReturn(
-            publishWithDraftId);
-
-        when(entityManager.find(WaTemplate.class, publishWithDraftId)).thenReturn(null);
-
+        when(entityManager.find(WaTemplate.class, page.getId())).thenReturn(null);
         assertThrows(PageNotFoundException.class, () -> pageDeletor.deletePageDraft(requestId));
     }
 }

--- a/apps/question-bank/src/test/resources/features/page/PageDeletor.feature
+++ b/apps/question-bank/src/test/resources/features/page/PageDeletor.feature
@@ -9,5 +9,5 @@ Feature: Delete Draft Page
     Scenario: I can delete draft page
         Given I create a delete page request with draft page
         When I send a delete page request
-        Then the draft is deleted and the page changed to published
+        Then the draft is deleted
 

--- a/apps/question-bank/src/test/resources/features/page/PageDeletor.feature
+++ b/apps/question-bank/src/test/resources/features/page/PageDeletor.feature
@@ -6,8 +6,12 @@ Feature: Delete Draft Page
         And I am logged in
         And I can "LDFAdministration" any "System"
 
-    Scenario: I can delete draft page
-        Given I create a delete page request with draft page
+    Scenario: I can delete single draft page
+        Given I create a delete page request with single draft page
         When I send a delete page request
         Then the draft is deleted
 
+    Scenario: I can delete draft page when published with draft
+        Given I create a delete page request with published with draft page
+        When I send a delete page request
+        Then the draft is deleted and the page changed to published


### PR DESCRIPTION
## Description

After creating a new page, the page is in INITIAL DRAFT state. Currently, the ability to delete the Initial Draft is inoperable.

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT2-2258
