### PR TITLE
Fix metadata url

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
+++ b/apps/modernization-ui/src/apps/page-builder/hooks/api/useDownloadPageMetadata.ts
@@ -1,5 +1,4 @@
 import { OpenAPI } from 'apps/page-builder/generated/core/OpenAPI';
-import { authorization } from 'authorization';
 import { useEffect, useReducer } from 'react';
 
 type State =
@@ -29,12 +28,11 @@ export const useDownloadPageMetadata = () => {
     useEffect(() => {
         if (state.status === 'downloading') {
             // auto generated methods dont allow direct conversion to blob
-            fetch(`${OpenAPI.BASE}/nbs/page-builder/api/v1/pages/${state.page}/metadata`, {
+            fetch(`${OpenAPI.BASE}/api/v1/pages/${state.page}/metadata`, {
                 method: 'GET',
                 headers: {
-                    Accept: 'application/pdf',
-                    'Content-Type': 'application/json',
-                    Authorization: authorization()
+                    Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    'Content-Type': 'application/json'
                 }
             })
                 .then((response) => response.blob())


### PR DESCRIPTION
## Description

Fixes url for metadata download. Previously `/nbs/page-builder` was not included in the `OpenAPI.BASE`.

## Tickets

* [CNFT2-2263(https://cdc-nbs.atlassian.net/browse/CNFT2-2263)

### Demo
![downloadMetadata](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/46996cf4-540a-49ba-b757-3afac3c3fc65)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
