### PR TITLE
CNFT2-2271 Appearing in table

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/RepeatingBlock.tsx
@@ -22,7 +22,9 @@ export const RepeatingBlock = ({ questions, valid, setValid }: Props) => {
 
     const batches = useWatch({ control: control, name: 'batches' });
     const calcTotal = (batches: Batch[]): number => {
-        return batches.reduce((n, { width }) => n + parseInt(String(width ?? 0)), 0);
+        return batches
+            .filter((batch) => batch.appearsInTable)
+            .reduce((n, { width }) => n + parseInt(String(width ?? 0)), 0);
     };
 
     useEffect(() => {
@@ -38,7 +40,7 @@ export const RepeatingBlock = ({ questions, valid, setValid }: Props) => {
     const validateWidths = () => {
         const calculated = calcTotal(batches);
         setTotal(isNaN(calculated) ? undefined : calculated);
-        setValid(calcTotal(batches) === 100);
+        setValid(calculated === 100);
     };
 
     return (


### PR DESCRIPTION
## Description

Here we fix in Group questions: Repeating block, if "No" is selected in "Appears in table", it's width is not factored into the total width nor is it required to have a width.

## Tickets

* [CNFT2-2271](https://cdc-nbs.atlassian.net/browse/CNFT2-2271)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2271]: https://cdc-nbs.atlassian.net/browse/CNFT2-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ