### PR TITLE
CNFT2-2241 Business rules: target subsection max 10

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRules.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Add/AddBusinessRules.tsx
@@ -67,6 +67,7 @@ export const AddBusinessRule = () => {
         if (
             watch.sourceIdentifier &&
             (watch.targetIdentifiers?.length ?? 0 > 0) &&
+            (watch.targetIdentifiers?.length ?? 0) < 11 &&
             watch.targetType &&
             watch.ruleFunction &&
             (watch.anySourceValue || (watch.comparator && watch.sourceValues))

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/RuleSearchBar.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/RuleSearchBar.tsx
@@ -52,7 +52,7 @@ export const RuleSearchBar = ({ onChange, onDownloadCsv, onDownloadPdf }: Props)
                     </Button>
                 </div>
                 <Button
-                    aria-label="Print page"
+                    aria-label="Print this page"
                     type="button"
                     onClick={onDownloadPdf}
                     className={styles.downloadButton}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
@@ -38,7 +38,7 @@ const SubSectionsDropdown = ({ onSelect }: Props) => {
     }, [JSON.stringify(page)]);
 
     useEffect(() => {
-        if (selectedSubsections.length > 9) {
+        if (selectedSubsections.length > 10) {
             setErrorMessage('You can not select more than 10 target fields.');
         } else {
             setErrorMessage('');

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/SubSectionDropdown.tsx
@@ -11,6 +11,7 @@ interface Props {
 const SubSectionsDropdown = ({ onSelect }: Props) => {
     const [subSections, setSubSections] = useState<PagesSubSection[]>([]);
     const [selectedSubsections, setSelectedSubsections] = useState<string[]>([]);
+    const [errorMessage, setErrorMessage] = useState<string>('');
 
     const form = useFormContext<RuleRequest>();
 
@@ -37,6 +38,14 @@ const SubSectionsDropdown = ({ onSelect }: Props) => {
     }, [JSON.stringify(page)]);
 
     useEffect(() => {
+        if (selectedSubsections.length > 9) {
+            setErrorMessage('You can not select more than 10 target fields.');
+        } else {
+            setErrorMessage('');
+        }
+    }, [selectedSubsections]);
+
+    useEffect(() => {
         if (form.watch('targetIdentifiers').length) {
             // use the selectedSubsectionIdentifiers to search the subsections array and find the matching subsections
             const selected: PagesSubSection[] = subSections.filter((section) =>
@@ -49,7 +58,14 @@ const SubSectionsDropdown = ({ onSelect }: Props) => {
 
     const options = subSections.map((subSection) => ({ name: subSection.name, value: subSection.questionIdentifier }));
 
-    return <MultiSelectInput onChange={handleSelectSubsection} value={selectedSubsections} options={options} />;
+    return (
+        <MultiSelectInput
+            onChange={handleSelectSubsection}
+            value={selectedSubsections}
+            options={options}
+            error={errorMessage}
+        />
+    );
 };
 
 export default SubSectionsDropdown;


### PR DESCRIPTION
## Description

Here we limit target subsections in Add Business Rule to 10.
Also fixed a small tooltip typo
<img width="959" alt="image" src="https://github.com/CDCgov/NEDSS-Modernization/assets/124739504/c564d5a1-b2e0-4404-84e5-fac9bccf0fe7">


## Tickets

* [CNFT2-2241](https://cdc-nbs.atlassian.net/browse/CNFT2-2241)
* [CNFT2-2268](https://cdc-nbs.atlassian.net/browse/CNFT2-2268)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2241]: https://cdc-nbs.atlassian.net/browse/CNFT2-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT2-2268]: https://cdc-nbs.atlassian.net/browse/CNFT2-2268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ