### PR TITLE
Fix add question value set removal

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/CodedQuestionEntity.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/CodedQuestionEntity.java
@@ -15,9 +15,6 @@ import lombok.NoArgsConstructor;
 public class CodedQuestionEntity extends WaQuestion {
   static final String CODED_QUESTION_TYPE = "CODED";
 
-  @Column(name = "code_set_group_id")
-  private Long codeSetGroupId;
-
   @Column(name = "default_value", length = 300)
   private String defaultValue;
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/WaQuestion.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/WaQuestion.java
@@ -196,7 +196,7 @@ public abstract class WaQuestion {
     private Long lastChgUserId;
 
     @Column(name = "code_set_group_id")
-    private Long codeSetGroupId;
+    protected Long codeSetGroupId;
 
     public abstract String getDataType();
 


### PR DESCRIPTION
## Description

When adding a Coded question to a page, the valueset information is being lost after the Spring boot / java upgrade. This fixes an issue where a field was re-declared in the `CodedQuestionEntity`

## Tickets

* [CNFT2-2272](https://cdc-nbs.atlassian.net/browse/CNFT2-2272)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2272]: https://cdc-nbs.atlassian.net/browse/CNFT2-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ