### PR TITLE
bug fix for edit business rules, target question

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Edit/EditBusinessRules.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Edit/EditBusinessRules.tsx
@@ -54,7 +54,7 @@ export const EditBusinessRule = () => {
                 sourceText: `${response.sourceQuestion.label} (${response.sourceQuestion.questionIdentifier})`,
                 targetIdentifiers: response.targets.map((target) => target.targetIdentifier),
                 targetValueText: response.targets.map((target) => target.label),
-                targetType: response.targetType
+                targetType: response.targetType ?? Rule.targetType.QUESTION
             });
         });
     }, [ruleId]);


### PR DESCRIPTION
## Description

In edit, when source question is cleared, the target question button was not showing up

![Screenshot 2024-04-03 at 11 20 46 AM](https://github.com/CDCgov/NEDSS-Modernization/assets/137817788/bd1f004f-cce8-4d98-aa79-9ee8364e2283)


## Tickets

* [CNFT2-2279](https://cdc-nbs.atlassian.net/browse/CNFT2-2279)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2279]: https://cdc-nbs.atlassian.net/browse/CNFT2-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ