### PR TITLE
Prevent duplicate wa_nnd_metadata

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaNndMetadatum.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaNndMetadatum.java
@@ -161,10 +161,10 @@ public class WaNndMetadatum {
   }
 
 
-  public static WaNndMetadatum clone(WaNndMetadatum original) {
+  public static WaNndMetadatum clone(WaNndMetadatum original, WaTemplate template) {
     return new WaNndMetadatum(
         null,
-        null,
+        template,
         original.questionIdentifierNnd,
         original.questionLabelNnd,
         original.questionRequiredNnd,
@@ -188,10 +188,7 @@ public class WaNndMetadatum {
         original.localId,
         original.waUiMetadataUid,
         original.questionMap,
-        original.indicatorCd
-    );
+        original.indicatorCd);
   }
-
-
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaRdbMetadata.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaRdbMetadata.java
@@ -143,10 +143,11 @@ public class WaRdbMetadata {
     this.lastChgUserId = user;
   }
 
-  public static WaRdbMetadata clone(WaRdbMetadata original) {
+
+  public static WaRdbMetadata clone(WaRdbMetadata original, WaTemplate template, WaUiMetadata metadata) {
     return new WaRdbMetadata(
         null,
-        null,
+        template,
         original.userDefinedColumnNm,
         original.recordStatusCd,
         original.recordStatusTime,
@@ -155,12 +156,13 @@ public class WaRdbMetadata {
         original.lastChgTime,
         original.lastChgUserId,
         original.localId,
-        null,
+        metadata,
         original.rdbTableNm,
         original.rptAdminColumnNm,
         original.rdbColumnNm,
         original.questionIdentifier,
         original.blockPivotNbr);
   }
+
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaUiMetadata.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaUiMetadata.java
@@ -697,10 +697,15 @@ public class WaUiMetadata {
     this.lastChgUserId = command.userId();
   }
 
-  public static WaUiMetadata clone(WaUiMetadata original) {
-    return new WaUiMetadata(
+  public static WaUiMetadata clone(WaUiMetadata original, WaTemplate page) {
+    WaNndMetadatum nndMetadata = null;
+    if (original.getWaNndMetadatum() != null) {
+      nndMetadata = WaNndMetadatum.clone(original.getWaNndMetadatum(), page);
+    }
+
+    WaUiMetadata cloned = new WaUiMetadata(
         null,
-        null,
+        page,
         original.getNbsUiComponentUid(),
         original.getParentUid(),
         original.getQuestionLabel(),
@@ -756,9 +761,16 @@ public class WaUiMetadata {
         original.getBatchTableColumnWidth(),
         original.getCoinfectionIndCd(),
         original.getBlockNm(),
-        original.waRdbMetadatum,
-        original.waNndMetadatum);
+        null,
+        nndMetadata);
 
+
+    WaRdbMetadata rdbMetadata = null;
+    if (original.getWaRdbMetadatum() != null) {
+      rdbMetadata = WaRdbMetadata.clone(original.getWaRdbMetadatum(), page, cloned);
+      cloned.setWaRdbMetadatum(rdbMetadata);
+    }
+    return cloned;
   }
 
   private void setVisible(boolean visible) {

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandler.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandler.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.questionbank.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -13,21 +14,27 @@ public class PageBuilderExceptionHandler {
     return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.BAD_REQUEST);
   }
 
-  @ExceptionHandler({
-      NotFoundException.class})
+  @ExceptionHandler({NotFoundException.class})
   public ResponseEntity<ExceptionMessage> handleNotFound(Exception e) {
     return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.NOT_FOUND);
   }
 
-  @ExceptionHandler({
-      InternalServerException.class})
+  @ExceptionHandler({InternalServerException.class})
   public ResponseEntity<ExceptionMessage> handleInternalException(Exception e) {
     return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
+  @ExceptionHandler({AccessDeniedException.class})
+  public ResponseEntity<ExceptionMessage> handleAccessDenied(Exception e) {
+    return new ResponseEntity<>(
+        new ExceptionMessage("Access denied"),
+        HttpStatus.FORBIDDEN);
+  }
+
   @ExceptionHandler({RuntimeException.class})
   public ResponseEntity<ExceptionMessage> handleRuntimeException(Exception e) {
-    return new ResponseEntity<>(new ExceptionMessage("An unexpected error has occurred"),
+    return new ResponseEntity<>(
+        new ExceptionMessage("An unexpected error has occurred"),
         HttpStatus.INTERNAL_SERVER_ERROR);
   }
 

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandler.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandler.java
@@ -8,23 +8,29 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class PageBuilderExceptionHandler {
 
-    @ExceptionHandler({BadRequestException.class})
-    public ResponseEntity<ExceptionMessage> handleBadRequestExceptions(Exception e) {
-        return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.BAD_REQUEST);
-    }
+  @ExceptionHandler({BadRequestException.class})
+  public ResponseEntity<ExceptionMessage> handleBadRequestExceptions(Exception e) {
+    return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.BAD_REQUEST);
+  }
 
-    @ExceptionHandler({
-            NotFoundException.class})
-    public ResponseEntity<ExceptionMessage> handleNotFound(Exception e) {
-        return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.NOT_FOUND);
-    }
+  @ExceptionHandler({
+      NotFoundException.class})
+  public ResponseEntity<ExceptionMessage> handleNotFound(Exception e) {
+    return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.NOT_FOUND);
+  }
 
-    @ExceptionHandler({
-            InternalServerException.class})
-    public ResponseEntity<ExceptionMessage> handleInternalException(Exception e) {
-        return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+  @ExceptionHandler({
+      InternalServerException.class})
+  public ResponseEntity<ExceptionMessage> handleInternalException(Exception e) {
+    return new ResponseEntity<>(new ExceptionMessage(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 
-    record ExceptionMessage(String message) {
-    }
+  @ExceptionHandler({RuntimeException.class})
+  public ResponseEntity<ExceptionMessage> handleRuntimeException(Exception e) {
+    return new ResponseEntity<>(new ExceptionMessage("An unexpected error has occurred"),
+        HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  record ExceptionMessage(String message) {
+  }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageCreator.java
@@ -88,8 +88,7 @@ public class PageCreator {
     List<WaUiMetadata> initialPageMappings = new ArrayList<>();
     List<WaUiMetadata> pages = waUiMetadataRepository.findAllByWaTemplateUid(template);
     for (WaUiMetadata original : pages) {
-      WaUiMetadata clone = WaUiMetadata.clone(original);
-      clone.setWaTemplateUid(newPage);
+      WaUiMetadata clone = WaUiMetadata.clone(original, newPage);
       initialPageMappings.add(clone);
     }
     return initialPageMappings;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageStateChanger.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageStateChanger.java
@@ -4,39 +4,38 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import gov.cdc.nbs.questionbank.entity.*;
-import gov.cdc.nbs.questionbank.entity.repository.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import gov.cdc.nbs.questionbank.entity.PageCondMapping;
+import gov.cdc.nbs.questionbank.entity.WaTemplate;
+import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
 import gov.cdc.nbs.questionbank.entity.pagerule.WaRuleMetadata;
+import gov.cdc.nbs.questionbank.entity.repository.PageCondMappingRepository;
+import gov.cdc.nbs.questionbank.entity.repository.WaTemplateRepository;
+import gov.cdc.nbs.questionbank.entity.repository.WaUiMetadataRepository;
 import gov.cdc.nbs.questionbank.page.exception.PageUpdateException;
 import gov.cdc.nbs.questionbank.page.response.PageStateResponse;
 import gov.cdc.nbs.questionbank.page.util.PageConstants;
 import gov.cdc.nbs.questionbank.pagerules.repository.WaRuleMetaDataRepository;
 
 @Service
+@Transactional
 public class PageStateChanger {
 
   private final WaTemplateRepository templateRepository;
   private final WaUiMetadataRepository waUiMetadataRepository;
   private final PageCondMappingRepository pageConMappingRepository;
   private final WaRuleMetaDataRepository waRuleMetaDataRepository;
-  private final WARDBMetadataRepository waRdbMetadataRepository;
-  private final WANNDMetadataRepository waNndMetadataRepository;
 
   public PageStateChanger(
       final WaTemplateRepository templateRepository,
       final WaUiMetadataRepository waUiMetadataRepository,
       final PageCondMappingRepository pageConMappingRepository,
-      final WaRuleMetaDataRepository waRuleMetaDataRepository,
-      final WARDBMetadataRepository waRdbMetadataRepository,
-      final WANNDMetadataRepository waNndMetadataRepository) {
+      final WaRuleMetaDataRepository waRuleMetaDataRepository) {
     this.templateRepository = templateRepository;
     this.waUiMetadataRepository = waUiMetadataRepository;
     this.pageConMappingRepository = pageConMappingRepository;
     this.waRuleMetaDataRepository = waRuleMetaDataRepository;
-    this.waRdbMetadataRepository = waRdbMetadataRepository;
-    this.waNndMetadataRepository = waNndMetadataRepository;
   }
 
   public PageStateResponse savePageAsDraft(Long id) {
@@ -49,19 +48,12 @@ public class PageStateChanger {
       }
       WaTemplate draftPage = createDraftCopy(page);
       page.setTemplateType(PageConstants.PUBLISHED_WITH_DRAFT);
-
       page = templateRepository.save(page);
       draftPage = templateRepository.save(draftPage);
       pageConMappingRepository.saveAll(draftPage.getConditionMappings());
 
       List<WaUiMetadata> draftMappings = copyWaTemplateUIMetaData(page, draftPage);
       waUiMetadataRepository.saveAll(draftMappings);
-
-      List<WaRdbMetadata> rdbMetadata = copyWaTemplateUIMetaDataRdb(page, draftPage);
-      waRdbMetadataRepository.saveAll(rdbMetadata);
-
-      List<WaNndMetadatum> nndMetadata = copyNndMetaData(page, draftPage);
-      waNndMetadataRepository.saveAll(nndMetadata);
 
       List<WaRuleMetadata> rules = copyRules(id, draftPage.getId());
       waRuleMetaDataRepository.saveAll(rules);
@@ -92,48 +84,11 @@ public class PageStateChanger {
     List<WaUiMetadata> draftMappings = new ArrayList<>();
     List<WaUiMetadata> pages = waUiMetadataRepository.findAllByWaTemplateUid(page);
     for (WaUiMetadata original : pages) {
-      WaUiMetadata clone = WaUiMetadata.clone(original);
-      clone.setWaTemplateUid(clonePage);
+      WaUiMetadata clone = WaUiMetadata.clone(original, clonePage);
       draftMappings.add(clone);
     }
     return draftMappings;
   }
-
-
-  public List<WaRdbMetadata> copyWaTemplateUIMetaDataRdb(WaTemplate page, WaTemplate clonePage) {
-    List<WaRdbMetadata> draftMappings = new ArrayList<>();
-    List<WaRdbMetadata> rdbMetadata = waRdbMetadataRepository.findAllByWaTemplateUid(page);
-    List<WaUiMetadata> newUiMetadata = waUiMetadataRepository.findAllByWaTemplateUid(clonePage);
-    for (WaRdbMetadata original : rdbMetadata) {
-      WaRdbMetadata clone = WaRdbMetadata.clone(original);
-      clone.setWaTemplateUid(clonePage);
-      clone.setWaUiMetadataUid(getWaUiMetadataUid(newUiMetadata, original.getQuestionIdentifier()));
-      draftMappings.add(clone);
-    }
-    return draftMappings;
-  }
-
-  public List<WaNndMetadatum> copyNndMetaData(WaTemplate page, WaTemplate clonePage) {
-    List<WaNndMetadatum> draftMappings = new ArrayList<>();
-    List<WaNndMetadatum> nndMetaData = waNndMetadataRepository.findAllByWaTemplateUid(page);
-    List<WaUiMetadata> newUiMetadata = waUiMetadataRepository.findAllByWaTemplateUid(clonePage);
-    for (WaNndMetadatum original : nndMetaData) {
-      WaNndMetadatum clone = WaNndMetadatum.clone(original);
-      clone.setWaTemplateUid(clonePage);
-      clone.setWaUiMetadataUid(getWaUiMetadataUid(newUiMetadata, original.getQuestionIdentifier()));
-      draftMappings.add(clone);
-    }
-    return draftMappings;
-  }
-
-  private WaUiMetadata getWaUiMetadataUid(List<WaUiMetadata> newUiMetadata, String questionIdentifier) {
-    for (WaUiMetadata waUiMetadata : newUiMetadata)
-      if (waUiMetadata.getQuestionIdentifier().equals(questionIdentifier))
-        return waUiMetadata;
-    return null;
-  }
-
-
 
   public WaTemplate createDraftCopy(WaTemplate oldPage) {
     if (oldPage.getTemplateType().equals("Draft")) {

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entity/WaUiMetadataTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entity/WaUiMetadataTest.java
@@ -642,6 +642,18 @@ class WaUiMetadataTest {
     assertThat(metadata.getBatchTableColumnWidth()).isNull();
   }
 
+  @Test
+  void should_clone_nnd() {
+    WaTemplate newPage = new WaTemplate();
+    WaUiMetadata metadata = new WaUiMetadata();
+    WaNndMetadatum nnd = new WaNndMetadatum();
+    metadata.setWaNndMetadatum(nnd);
+
+    WaUiMetadata cloned = WaUiMetadata.clone(metadata, newPage);
+
+    assertThat(cloned.getWaTemplateUid()).isEqualTo(newPage);
+  }
+
   private void validateMessaging(WaUiMetadata question, QuestionUpdate command) {
     assertThat(question.getWaNndMetadatum().getQuestionIdentifierNnd()).isEqualTo(command.messageVariableId());
     assertThat(question.getWaNndMetadatum().getQuestionRequiredNnd())

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entity/WaUiMetadataTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entity/WaUiMetadataTest.java
@@ -654,6 +654,18 @@ class WaUiMetadataTest {
     assertThat(cloned.getWaTemplateUid()).isEqualTo(newPage);
   }
 
+  @Test
+  void should_clone_rdb() {
+    WaTemplate newPage = new WaTemplate();
+    WaUiMetadata metadata = new WaUiMetadata();
+    WaRdbMetadata nnd = new WaRdbMetadata();
+    metadata.setWaRdbMetadatum(nnd);
+
+    WaUiMetadata cloned = WaUiMetadata.clone(metadata, newPage);
+
+    assertThat(cloned.getWaTemplateUid()).isEqualTo(newPage);
+  }
+
   private void validateMessaging(WaUiMetadata question, QuestionUpdate command) {
     assertThat(question.getWaNndMetadatum().getQuestionIdentifierNnd()).isEqualTo(command.messageVariableId());
     assertThat(question.getWaNndMetadatum().getQuestionRequiredNnd())

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandlerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.questionbank.exception;
 
 import gov.cdc.nbs.questionbank.exception.PageBuilderExceptionHandler.ExceptionMessage;
 import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
+import gov.cdc.nbs.questionbank.page.summary.download.exceptions.CsvCreationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,5 +62,39 @@ class PageBuilderExceptionHandlerTest {
         .isEqualTo("Access denied");
 
     assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  void should_internal_server() {
+    // given a questionCreateException
+    CsvCreationException exception = new CsvCreationException("failed");
+
+    // when the exception handler returns a response
+    ResponseEntity<ExceptionMessage> responseEntity = handler.handleInternalException(exception);
+
+    // then the message should be present
+    assertThat(responseEntity.getBody())
+        .extracting(ExceptionMessage::message)
+        .asString()
+        .isEqualTo("failed");
+
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void should_internal_server_runtime() {
+    // given a questionCreateException
+    RuntimeException exception = new RuntimeException("Failed");
+
+    // when the exception handler returns a response
+    ResponseEntity<ExceptionMessage> responseEntity = handler.handleRuntimeException(exception);
+
+    // then the message should be present
+    assertThat(responseEntity.getBody())
+        .extracting(ExceptionMessage::message)
+        .asString()
+        .isEqualTo("An unexpected error has occurred");
+
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandlerTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/exception/PageBuilderExceptionHandlerTest.java
@@ -5,7 +5,7 @@ import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
+import org.springframework.security.access.AccessDeniedException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -44,5 +44,22 @@ class PageBuilderExceptionHandlerTest {
 
     assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
+  }
+
+  @Test
+  void should_set_403() {
+    // given a questionCreateException
+    AccessDeniedException exception = new AccessDeniedException("Failed");
+
+    // when the exception handler returns a response
+    ResponseEntity<ExceptionMessage> responseEntity = handler.handleAccessDenied(exception);
+
+    // then the message should be present
+    assertThat(responseEntity.getBody())
+        .extracting(ExceptionMessage::message)
+        .asString()
+        .isEqualTo("Access denied");
+
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/state/PageStateChangeTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/state/PageStateChangeTest.java
@@ -29,173 +29,129 @@ import gov.cdc.nbs.questionbank.pagerules.repository.WaRuleMetaDataRepository;
 
 class PageStateChangeTest {
 
-    @Mock
-    private WaTemplateRepository templateRepository;
+  @Mock
+  private WaTemplateRepository templateRepository;
 
-    @Mock
-    private WaUiMetadataRepository waUiMetadataRepository;
+  @Mock
+  private WaUiMetadataRepository waUiMetadataRepository;
 
-    @Mock
-    private WANNDMetadataRepository wanndMetadataRepository;
+  @Mock
+  private WANNDMetadataRepository wanndMetadataRepository;
 
-    @Mock
-    private WARDBMetadataRepository wARDBMetadataRepository;
+  @Mock
+  private WARDBMetadataRepository wARDBMetadataRepository;
 
-    @Mock
-    private WaRuleMetaDataRepository waRuleMetaDataRepository;
+  @Mock
+  private WaRuleMetaDataRepository waRuleMetaDataRepository;
 
-    @Mock
-    private PageCondMappingRepository pageConMappingRepository;
-
-
-
-    @InjectMocks
-    PageStateChanger pageStateChanger;
+  @Mock
+  private PageCondMappingRepository pageConMappingRepository;
 
 
-    public PageStateChangeTest() {
-        MockitoAnnotations.openMocks(this);
-    }
+
+  @InjectMocks
+  PageStateChanger pageStateChanger;
 
 
-    @Test
-    void pageStateUpdateTest() {
-        Long requestId = 1l;
-        WaTemplate before = getTemplate(requestId, "TestPage", "Pblished");
-        when(templateRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(before));
-        when(templateRepository.save(Mockito.any())).thenReturn(before);
-        PageStateResponse response = pageStateChanger.savePageAsDraft(requestId);
-        assertEquals(requestId, response.getTemplateId());
-        assertEquals(PageConstants.SAVE_DRAFT_SUCCESS, response.getMessage());
-    }
-
-    @Test
-    void pageStateExceptionTest() {
-        Long requestId = 1l;
-        when(templateRepository.findById(Mockito.anyLong())).thenThrow(new IllegalArgumentException());
-        var exception = assertThrows(PageUpdateException.class, () -> pageStateChanger.savePageAsDraft(requestId));
-        assertEquals(PageConstants.SAVE_DRAFT_FAIL, exception.getMessage());
-    }
-
-    @Test
-    void pageStateNotFoundTest() {
-        Long requestId = 1l;
-        when(templateRepository.findById(Mockito.anyLong())).thenReturn(Optional.empty());
-        var exception = assertThrows(PageUpdateException.class, () -> pageStateChanger.savePageAsDraft(requestId));
-        assertEquals(PageConstants.SAVE_DRAFT_FAIL, exception.getMessage());
-    }
+  public PageStateChangeTest() {
+    MockitoAnnotations.openMocks(this);
+  }
 
 
-    @Test
-    void testCreateDraftCopy() {
-        WaTemplate oldPage = getTemplate(10l, "testName", "Published");
-        WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
-        assertEquals(newPage.getTemplateNm(), newPage.getTemplateNm());
-        assertEquals("Draft", newPage.getTemplateType());
-        assertEquals(0, newPage.getPublishVersionNbr().intValue());
-        assertEquals('F', newPage.getPublishIndCd().charValue());
-    }
+  @Test
+  void pageStateUpdateTest() {
+    Long requestId = 1l;
+    WaTemplate before = getTemplate(requestId, "TestPage", "Pblished");
+    when(templateRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(before));
+    when(templateRepository.save(Mockito.any())).thenReturn(before);
+    PageStateResponse response = pageStateChanger.savePageAsDraft(requestId);
+    assertEquals(requestId, response.getTemplateId());
+    assertEquals(PageConstants.SAVE_DRAFT_SUCCESS, response.getMessage());
+  }
 
-    @Test
-    void testCopyWaTemplateUIMetaData() {
-        WaTemplate oldPage = getTemplate(10l, "testName", "Published");
-        when(waUiMetadataRepository.findAllByWaTemplateUid(Mockito.any()))
-            .thenReturn(List.of(getwaUiMetaDtum(oldPage)));
-        WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
-        List<WaUiMetadata> result = pageStateChanger.copyWaTemplateUIMetaData(oldPage, newPage);
-        assertNotNull(result);
-        assertEquals(newPage.getId(), result.get(0).getWaTemplateUid().getId());
+  @Test
+  void pageStateExceptionTest() {
+    Long requestId = 1l;
+    when(templateRepository.findById(Mockito.anyLong())).thenThrow(new IllegalArgumentException());
+    var exception = assertThrows(PageUpdateException.class, () -> pageStateChanger.savePageAsDraft(requestId));
+    assertEquals(PageConstants.SAVE_DRAFT_FAIL, exception.getMessage());
+  }
 
-    }
-
-    @Test
-    void testCopyWaTemplateUIMetaDataRdb() {
-        WaTemplate oldPage = getTemplate(10l, "testName", "Published");
-
-        when(wARDBMetadataRepository.findAllByWaTemplateUid(Mockito.any()))
-            .thenReturn(List.of(getWaRdbMetadata(oldPage)));
-
-        when(waUiMetadataRepository.findAllByWaTemplateUid(Mockito.any()))
-            .thenReturn(List.of(getwaUiMetaDtum(oldPage)));
-
-        WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
-        List<WaRdbMetadata> result = pageStateChanger.copyWaTemplateUIMetaDataRdb(oldPage, newPage);
-        assertNotNull(result);
-        assertEquals(newPage.getId(), result.get(0).getWaTemplateUid().getId());
-    }
-
-    @Test
-    void testCopyNndMetaData() {
-        WaTemplate oldPage = getTemplate(10l, "testName", "Published");
-
-        when(wanndMetadataRepository.findAllByWaTemplateUid(Mockito.any()))
-            .thenReturn(List.of(getWaNndMetadatum(oldPage)));
-        WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
-        List<WaNndMetadatum> result = pageStateChanger.copyNndMetaData(oldPage, newPage);
-        assertNotNull(result);
-        assertEquals(newPage.getId(), result.get(0).getWaTemplateUid().getId());
-    }
-
-    @Test
-    void testCopyRules() {
-        WaTemplate oldPage = getTemplate(10l, "testName", "Published");
-
-        when(waRuleMetaDataRepository.findByWaTemplateUid(Mockito.any()))
-            .thenReturn(List.of(getWaRuleMetadata(oldPage)));
-
-        WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
-        List<WaRuleMetadata> result = pageStateChanger.copyRules(oldPage.getId(), 11l);
-        assertNotNull(result);
-    }
+  @Test
+  void pageStateNotFoundTest() {
+    Long requestId = 1l;
+    when(templateRepository.findById(Mockito.anyLong())).thenReturn(Optional.empty());
+    var exception = assertThrows(PageUpdateException.class, () -> pageStateChanger.savePageAsDraft(requestId));
+    assertEquals(PageConstants.SAVE_DRAFT_FAIL, exception.getMessage());
+  }
 
 
-    private WaUiMetadata getwaUiMetaDtum(WaTemplate aPage) {
-        WaUiMetadata record = new WaUiMetadata();
-        record.setWaTemplateUid(aPage);
-        record.setQuestionIdentifier("identifier");
-        return record;
-    }
+  @Test
+  void testCreateDraftCopy() {
+    WaTemplate oldPage = getTemplate(10l, "testName", "Published");
+    WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
+    assertEquals(newPage.getTemplateNm(), newPage.getTemplateNm());
+    assertEquals("Draft", newPage.getTemplateType());
+    assertEquals(0, newPage.getPublishVersionNbr().intValue());
+    assertEquals('F', newPage.getPublishIndCd().charValue());
+  }
 
-    private WaRdbMetadata getWaRdbMetadata(WaTemplate aPage) {
-        WaRdbMetadata record = new WaRdbMetadata();
-        record.setQuestionIdentifier("identifier");
-        record.setWaTemplateUid(aPage);
-        return record;
-    }
+  @Test
+  void testCopyWaTemplateUIMetaData() {
+    WaTemplate oldPage = getTemplate(10l, "testName", "Published");
+    when(waUiMetadataRepository.findAllByWaTemplateUid(Mockito.any()))
+        .thenReturn(List.of(getwaUiMetaDtum(oldPage)));
+    WaTemplate newPage = pageStateChanger.createDraftCopy(oldPage);
+    List<WaUiMetadata> result = pageStateChanger.copyWaTemplateUIMetaData(oldPage, newPage);
+    assertNotNull(result);
+    assertEquals(newPage.getId(), result.get(0).getWaTemplateUid().getId());
 
-    private WaRuleMetadata getWaRuleMetadata(WaTemplate aPage) {
-        WaRuleMetadata record = new WaRuleMetadata();
-        record.setWaTemplateUid(aPage.getId());
-        return record;
-    }
+  }
 
-    private WaNndMetadatum getWaNndMetadatum(WaTemplate aPage) {
-        WaNndMetadatum record = new WaNndMetadatum();
-        record.setQuestionIdentifier("identifier");
-        record.setWaTemplateUid(aPage);
-        return record;
-    }
+  @Test
+  void testCopyRules() {
+    WaTemplate oldPage = getTemplate(10l, "testName", "Published");
+
+    when(waRuleMetaDataRepository.findByWaTemplateUid(Mockito.any()))
+        .thenReturn(List.of(getWaRuleMetadata(oldPage)));
+
+    List<WaRuleMetadata> result = pageStateChanger.copyRules(oldPage.getId(), 11l);
+    assertNotNull(result);
+  }
 
 
-    private WaTemplate getTemplate(Long id, String templateName, String templateType) {
-        PageCondMapping one = new PageCondMapping();
+  private WaUiMetadata getwaUiMetaDtum(WaTemplate aPage) {
+    WaUiMetadata record = new WaUiMetadata();
+    record.setWaTemplateUid(aPage);
+    record.setQuestionIdentifier("identifier");
+    return record;
+  }
 
-        WaTemplate template = new WaTemplate();
-        template.setId(id);
-        template.setTemplateNm(templateName);
-        template.setTemplateType(templateType);
-        template.setPublishVersionNbr(1);
-        template.setPublishIndCd('T');
+  private WaRuleMetadata getWaRuleMetadata(WaTemplate aPage) {
+    WaRuleMetadata record = new WaRuleMetadata();
+    record.setWaTemplateUid(aPage.getId());
+    return record;
+  }
 
-        one.setAddTime(Instant.now());
-        one.setAddUserId(2l);
-        one.setLastChgTime(Instant.now());
-        one.setLastChgUserId(2l);
-        one.setWaTemplateUid(template);
+  private WaTemplate getTemplate(Long id, String templateName, String templateType) {
+    PageCondMapping one = new PageCondMapping();
 
-        template.setConditionMappings(Set.of(one));
+    WaTemplate template = new WaTemplate();
+    template.setId(id);
+    template.setTemplateNm(templateName);
+    template.setTemplateType(templateType);
+    template.setPublishVersionNbr(1);
+    template.setPublishIndCd('T');
 
-        return template;
-    }
+    one.setAddTime(Instant.now());
+    one.setAddUserId(2l);
+    one.setLastChgTime(Instant.now());
+    one.setLastChgUserId(2l);
+    one.setWaTemplateUid(template);
+
+    template.setConditionMappings(Set.of(one));
+
+    return template;
+  }
 
 }


### PR DESCRIPTION
## Description

When creating a draft, duplicate `wa_nnd_metadata` entries were being created. This changes how the clone works to not produce duplicates.


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
