### PR TITLE
[CNFT2-2285] - Add Display Type validation

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/UserInterfaceFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/UserInterfaceFields.tsx
@@ -150,13 +150,16 @@ export const UserInterfaceFields = ({ published = false }: Props) => {
                 control={form.control}
                 name="displayControl"
                 rules={{ required: { value: !published, message: 'Display Type required' } }}
-                render={({ field: { onChange, value }, fieldState: { error } }) => (
+                render={({ field: { onBlur, onChange, value }, fieldState: { error } }) => (
                     <SelectInput
                         label="Display Type"
                         data-testid="displayType"
                         required={!published}
                         defaultValue={value}
-                        onChange={onChange}
+                        onChange={(e) => {
+                            onChange(e);
+                            onBlur();
+                        }}
                         error={error?.message}
                         options={getDisplayTypeOptions()}
                         disabled={published}


### PR DESCRIPTION
## Description

Added Display Type validation
<img width="1264" alt="Screenshot 2024-04-04 at 7 06 43 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/cd2c417c-8d12-47ad-bbac-475a5f5c443c">

<img width="1259" alt="Screenshot 2024-04-04 at 7 00 55 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/0793fdff-fa4e-4b94-9094-0e79dc4ac084">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNFT2-2285

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
