### PR TITLE
CNFT2-2277-group-again-with-published

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/Update/UpdateGroupedQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/GroupQuestion/Update/UpdateGroupedQuestion.tsx
@@ -70,6 +70,12 @@ export const UpdateGroupedQuestion = ({ page, subsection, onSuccess, onCancel }:
             });
             form.reset();
             onSuccess();
+        } else if (error && !subsection.questions.every((question) => question.isPublished === false)) {
+            showAlert({
+                type: 'error',
+                header: 'error',
+                message: 'Subsection includes a question(s) that has already been published”'
+            });
         } else if (error) {
             showAlert({
                 type: 'error',


### PR DESCRIPTION
## Description

When editing a grouped Subsection with published questions, we want to show an alert that specifically states that there are published Questions when attempting to group again.

## Tickets

* [CNFT2-2277](https://cdc-nbs.atlassian.net/browse/CNFT2-2277)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2277]: https://cdc-nbs.atlassian.net/browse/CNFT2-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ