### PR TITLE
CNFT1-2160 Repopulate DB with anonymized data set

### DIFF
--- a/db/golden/01-pii-export-odse.sql
+++ b/db/golden/01-pii-export-odse.sql
@@ -1,51 +1,17 @@
 use NBS_ODSE
 GO
 
-IF (object_id('pii_Act_id') is not null)
-    DROP PROCEDURE [dbo].[pii_Act_id]
-GO
-
-CREATE PROCEDURE [dbo].[pii_Act_id]
-@fromTime Datetime = null
-
-AS
-BEGIN
-    SET NOCOUNT ON
-    SELECT act_uid, act_id_seq, root_extension_txt
-    FROM dbo.Act_id
-    WHERE @fromTime IS NULL OR (status_time IS NOT NULL AND status_time > @fromTime)
-END
-GO
-
-IF (object_id('pii_Act_id_hist') is not null)
-DROP PROCEDURE [dbo].[pii_Act_id_hist]
-GO
-
-CREATE PROCEDURE [dbo].[pii_Act_id_hist]
-    @fromTime Datetime = null
-
-AS
-BEGIN
-    SET NOCOUNT ON
-    SELECT act_uid, act_id_seq, version_ctrl_nbr, root_extension_txt
-    FROM dbo.Act_id_hist
-    WHERE @fromTime IS NULL OR (status_time IS NOT NULL AND status_time > @fromTime)
-END
-GO
-
 IF (object_id('pii_Activity_log') is not null)
     DROP PROCEDURE [dbo].[pii_Activity_log]
 GO
 
 CREATE PROCEDURE [dbo].[pii_Activity_log]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT activity_log_uid, doc_nm, message_txt
     FROM dbo.Activity_log
-    WHERE @fromTime IS NULL OR add_time > @fromTime
+    WHERE doc_nm IS NOT NULL OR message_txt IS NOT NULL
 END
 GO
 
@@ -54,14 +20,12 @@ IF (object_id('pii_Auth_user') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Auth_user]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT auth_user_uid, user_first_nm, user_last_nm
     FROM dbo.Auth_user
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE user_first_nm IS NOT NULL OR user_last_nm IS NOT NULL
 END
 GO
 
@@ -70,15 +34,15 @@ IF (object_id('pii_case_management') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_case_management]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT case_management_uid, fld_foll_up_dispo_date, fld_foll_up_exam_date, fld_foll_up_expected_date, init_foll_up_closed_date, ooj_due_date,
-           subj_complexion, subj_hair, subj_height, subj_oth_idntfyng_info, subj_size_build, surv_closed_date,
-           ooj_initg_agncy_outc_due_date, ooj_initg_agncy_outc_snt_date, ooj_initg_agncy_recd_date, surv_assigned_date, foll_up_assigned_date,
-           init_foll_up_assigned_date, interview_assigned_date, init_interview_assigned_date, case_closed_date, case_review_status_date
+    SELECT case_management_uid,
+           fld_foll_up_dispo_date, fld_foll_up_exam_date, fld_foll_up_expected_date, init_foll_up_closed_date,
+           ooj_agency, ooj_due_date, ooj_number, subj_oth_idntfyng_info, surv_closed_date,
+           ooj_initg_agncy_outc_due_date, ooj_initg_agncy_outc_snt_date, ooj_initg_agncy_recd_date,
+           surv_assigned_date, foll_up_assigned_date, init_foll_up_assigned_date, interview_assigned_date,
+           init_interview_assigned_date, case_closed_date, case_review_status_date
     FROM dbo.case_management
 END
 GO
@@ -88,15 +52,15 @@ IF (object_id('pii_case_management_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_case_management_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT case_management_hist_uid, fld_foll_up_dispo_date, fld_foll_up_exam_date, fld_foll_up_expected_date, init_foll_up_closed_date, ooj_due_date,
-           subj_complexion, subj_hair, subj_height, subj_oth_idntfyng_info, subj_size_build, surv_closed_date,
-           ooj_initg_agncy_outc_due_date, ooj_initg_agncy_outc_snt_date, ooj_initg_agncy_recd_date, surv_assigned_date, foll_up_assigned_date,
-           init_foll_up_assigned_date, interview_assigned_date, init_interview_assigned_date, case_closed_date, case_review_status_date
+    SELECT case_management_hist_uid,
+           fld_foll_up_dispo_date, fld_foll_up_exam_date, fld_foll_up_expected_date, init_foll_up_closed_date,
+           ooj_agency, ooj_due_date, ooj_number, subj_oth_idntfyng_info, surv_closed_date,
+           ooj_initg_agncy_outc_due_date, ooj_initg_agncy_outc_snt_date, ooj_initg_agncy_recd_date,
+           surv_assigned_date, foll_up_assigned_date, init_foll_up_assigned_date, interview_assigned_date,
+           init_interview_assigned_date, case_closed_date, case_review_status_date
     FROM dbo.case_management_hist
 END
 GO
@@ -106,30 +70,26 @@ IF (object_id('pii_CDF_subform_import_log') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CDF_subform_import_log]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT import_log_uid, admin_comment
     FROM dbo.CDF_subform_import_log
-    WHERE @fromTime IS NULL OR (import_time IS NOT NULL AND import_time > @fromTime)
+    WHERE admin_comment IS NOT NULL
 END
 GO
 
-IF (object_id('pii_Chart_report_metadata') is not null)
-    DROP PROCEDURE [dbo].[pii_Chart_report_metadata]
+IF (object_id('pii_CN_transportq_out') is not null)
+    DROP PROCEDURE [dbo].[pii_CN_transportq_out]
 GO
 
-CREATE PROCEDURE [dbo].[pii_Chart_report_metadata]
-@fromTime Datetime = null
-
+CREATE PROCEDURE [dbo].[pii_CN_transportq_out]
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT chart_report_metadata_uid, chart_report_desc_txt, chart_report_short_desc_txt
-    FROM dbo.Chart_report_metadata
-    WHERE @fromTime IS NULL OR (add_time IS NOT NULL AND add_time > @fromTime)
+    SELECT cn_transportq_out_uid
+    FROM dbo.CN_transportq_out
+    WHERE message_payload IS NOT NULL
 END
 GO
 
@@ -138,13 +98,13 @@ IF (object_id('pii_Confirmation_method') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Confirmation_method]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT public_health_case_uid, confirmation_method_cd, confirmation_method_time
+    SELECT public_health_case_uid, confirmation_method_cd,
+           confirmation_method_time
     FROM dbo.Confirmation_method
+    WHERE confirmation_method_time IS NOT NULL
 END
 GO
 
@@ -153,13 +113,13 @@ IF (object_id('pii_Confirmation_method_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Confirmation_method_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT public_health_case_uid, confirmation_method_cd, confirmation_method_time
+    SELECT public_health_case_uid, confirmation_method_cd, version_ctrl_nbr,
+           confirmation_method_time
     FROM dbo.Confirmation_method_hist
+    WHERE confirmation_method_time IS NOT NULL
 END
 GO
 
@@ -168,8 +128,6 @@ IF (object_id('pii_CT_contact') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CT_contact]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
@@ -177,7 +135,6 @@ BEGIN
            txt, symptom_onset_date, symptom_txt, evaluation_date, evaluation_txt,
            treatment_start_date, treatment_end_date, treatment_txt
     FROM dbo.CT_contact
-    WHERE @fromTime IS NULL OR add_time > @fromTime
 END
 GO
 
@@ -186,8 +143,6 @@ IF (object_id('pii_CT_contact_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CT_contact_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
@@ -195,7 +150,6 @@ BEGIN
            txt, symptom_onset_date, symptom_txt, evaluation_date, evaluation_txt,
            treatment_start_date, treatment_end_date, treatment_txt
     FROM dbo.CT_contact_hist
-    WHERE @fromTime IS NULL OR add_time > @fromTime
 END
 GO
 
@@ -204,14 +158,12 @@ IF (object_id('pii_CT_contact_answer') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CT_contact_answer]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT ct_contact_answer_uid, answer_txt, answer_large_txt
     FROM dbo.CT_contact_answer
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE answer_txt IS NOT NULL OR answer_large_txt IS NOT NULL
 END
 GO
 
@@ -220,14 +172,12 @@ IF (object_id('pii_CT_contact_answer_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CT_contact_answer_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT ct_contact_answer_hist_uid, answer_txt, answer_large_txt
     FROM dbo.CT_contact_answer_hist
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE answer_txt IS NOT NULL OR answer_large_txt IS NOT NULL
 END
 GO
 
@@ -236,14 +186,11 @@ IF (object_id('pii_CT_contact_attachment') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CT_contact_attachment]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT ct_contact_attachment_uid, desc_txt, file_nm_txt
     FROM dbo.CT_contact_attachment
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
 END
 GO
 
@@ -252,14 +199,11 @@ IF (object_id('pii_CT_contact_note') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_CT_contact_note]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT ct_contact_note_uid, note
     FROM dbo.CT_contact_note
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
 END
 GO
 
@@ -268,14 +212,11 @@ IF (object_id('pii_Custom_queues') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Custom_queues]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT queue_name, description
     FROM dbo.Custom_queues
-    WHERE @fromTime IS NULL OR (last_chg_time IS NOT NULL AND last_chg_time > @fromTime)
 END
 GO
 
@@ -284,13 +225,12 @@ IF (object_id('pii_Data_migration_record') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Data_migration_record]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT data_migration_record_uid, data_migration_batch_uid, sub_nm
     FROM dbo.Data_migration_record
+    WHERE sub_nm IS NOT NULL OR failed_record_txt IS NOT NULL
 END
 GO
 
@@ -299,14 +239,12 @@ IF (object_id('pii_dsm_algorithm') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_dsm_algorithm]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT dsm_algorithm_uid, algorithm_nm, admin_comment
+    SELECT dsm_algorithm_uid, admin_comment
     FROM dbo.dsm_algorithm
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE admin_comment IS NOT NULL
 END
 GO
 
@@ -315,14 +253,12 @@ IF (object_id('pii_dsm_algorithm_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_dsm_algorithm_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT dsm_algorithm_hist_uid, algorithm_nm, admin_comment
+    SELECT dsm_algorithm_hist_uid, admin_comment
     FROM dbo.dsm_algorithm_hist
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE admin_comment IS NOT NULL
 END
 GO
 
@@ -331,15 +267,13 @@ IF (object_id('pii_EDX_activity_detail_log') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_EDX_activity_detail_log]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT edx_activity_detail_log_uid, log_comment
     FROM dbo.EDX_activity_detail_log Eadl
     JOIN dbo.EDX_activity_log Eal ON Eal.edx_activity_log_uid = Eadl.edx_activity_log_uid
-    WHERE @fromTime IS NULL OR (record_status_time IS NOT NULL AND record_status_time > @fromTime)
+    WHERE log_comment IS NOT NULL
 END
 GO
 
@@ -348,14 +282,12 @@ IF (object_id('pii_EDX_activity_log') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_EDX_activity_log]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT edx_activity_log_uid, Entity_nm
     FROM dbo.EDX_activity_log
-    WHERE @fromTime IS NULL OR (record_status_time IS NOT NULL AND record_status_time > @fromTime)
+    WHERE Entity_nm IS NOT NULL
 END
 GO
 
@@ -364,14 +296,11 @@ IF (object_id('pii_EDX_Document') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_EDX_Document]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT EDX_Document_uid, original_payload
     FROM dbo.EDX_Document
-    WHERE @fromTime IS NULL OR add_time > @fromTime
 END
 GO
 
@@ -380,15 +309,12 @@ IF (object_id('pii_ELR_activity_log') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_ELR_activity_log]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT msg_observation_uid, elr_activity_log_seq,
-           process_time, subject_nm, report_fac_nm, detail_txt
+           subject_nm, report_fac_nm, detail_txt
     FROM dbo.ELR_activity_log
-    WHERE @fromTime IS NULL OR process_time > @fromTime
 END
 GO
 
@@ -397,51 +323,11 @@ IF (object_id('pii_ELRWorkerQueue') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_ELRWorkerQueue]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT recordId, payloadName, errorMessage
     FROM dbo.ELRWorkerQueue
-    WHERE @fromTime IS NULL OR (receivedTime IS NOT NULL AND receivedTime > @fromTime)
-END
-GO
-
-IF (object_id('pii_Entity_id') is not null)
-    DROP PROCEDURE [dbo].[pii_Entity_id]
-GO
-
-CREATE PROCEDURE [dbo].[pii_Entity_id]
-@fromTime Datetime = null
-
-AS
-BEGIN
-    SET NOCOUNT ON
-    SELECT entity_uid, entity_id_seq, root_extension_txt
-    FROM dbo.Entity_id
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
-END
-GO
-
-IF (object_id('pii_Entity_id_hist') is not null)
-    DROP PROCEDURE [dbo].[pii_Entity_id_hist]
-GO
-
-CREATE PROCEDURE [dbo].[pii_Entity_id_hist]
-@fromTime Datetime = null
-
-AS
-BEGIN
-    SET NOCOUNT ON
-    SELECT entity_uid, entity_id_seq, version_ctrl_nbr,
-           root_extension_txt
-    FROM dbo.Entity_id_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -450,14 +336,12 @@ IF (object_id('pii_Export_receiving_facility') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Export_receiving_facility]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT export_receiving_facility_uid, admin_comment
     FROM dbo.Export_receiving_facility
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE admin_comment IS NOT NULL
 END
 GO
 
@@ -466,17 +350,12 @@ IF (object_id('pii_Intervention') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Intervention]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT intervention_uid,
            txt, age_at_vacc, material_lot_nm, material_expiration_time
     FROM dbo.Intervention
-    WHERE @fromTime IS NULL OR
-           (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-           (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -485,17 +364,12 @@ IF (object_id('pii_Intervention_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Intervention_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT intervention_uid, version_ctrl_nbr,
            txt, age_at_vacc, material_lot_nm, material_expiration_time
     FROM dbo.Intervention_hist
-    WHERE @fromTime IS NULL OR
-           (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-           (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -504,14 +378,12 @@ IF (object_id('pii_Interview') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Interview]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT interview_uid, interview_date
     FROM dbo.Interview
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE interview_date IS NOT NULL
 END
 GO
 
@@ -520,14 +392,12 @@ IF (object_id('pii_Interview_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Interview_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT interview_hist_uid, interview_date
     FROM dbo.Interview_hist
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE interview_date IS NOT NULL
 END
 GO
 
@@ -536,15 +406,14 @@ IF (object_id('pii_lab_event') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_lab_event]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT lab_event_uid,
            result_rpt_dt, specimen_analyzed_dt, specimen_collection_dt,
-           suscep_specimen_collection_dt, suscep_result_rpt_dt,
-           lab_result_comments, suscep_lab_result_comments
+           lab_result_comments, suscep_lab_result_comments,
+           suscep_specimen_collection_dt, suscep_result_rpt_dt
+
     FROM dbo.lab_event
 END
 GO
@@ -554,15 +423,13 @@ IF (object_id('pii_lab_event_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_lab_event_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT lab_event_hist_uid,
            result_rpt_dt, specimen_analyzed_dt, specimen_collection_dt,
-           suscep_specimen_collection_dt, suscep_result_rpt_dt,
-           lab_result_comments, suscep_lab_result_comments
+           lab_result_comments, suscep_lab_result_comments,
+           suscep_specimen_collection_dt, suscep_result_rpt_dt
     FROM dbo.lab_event_hist
 END
 GO
@@ -572,15 +439,13 @@ IF (object_id('pii_Manufactured_material') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Manufactured_material]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT material_uid, manufactured_material_seq,
            expiration_time, lot_nm
     FROM dbo.Manufactured_material
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE expiration_time IS NOT NULL OR lot_nm IS NOT NULL
 END
 GO
 
@@ -589,15 +454,13 @@ IF (object_id('pii_Manufactured_material_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Manufactured_material_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT material_uid, manufactured_material_seq, version_ctrl_nbr,
            expiration_time, lot_nm
     FROM dbo.Manufactured_material_hist
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
+    WHERE expiration_time IS NOT NULL OR lot_nm IS NOT NULL
 END
 GO
 
@@ -606,17 +469,14 @@ IF (object_id('pii_nbs_answer') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_nbs_answer]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_answer_uid, answer_txt
     FROM dbo.nbs_answer
-    WHERE nbs_question_uid IN (
+    WHERE answer_txt IS NOT NULL AND nbs_question_uid IN (
         SELECT nbs_question_uid FROM dbo.NBS_ui_metadata
         WHERE nbs_ui_component_uid IN (1009, 1014, 1019, 1026, 1029))
-            AND @fromTime IS NULL OR last_chg_time > @fromTime
 END
 GO
 
@@ -625,17 +485,28 @@ IF (object_id('pii_nbs_answer_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_nbs_answer_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_answer_hist_uid, answer_txt
     FROM dbo.nbs_answer_hist ans
-    WHERE nbs_question_uid IN (
+    WHERE answer_txt IS NOT NULL AND nbs_question_uid IN (
         SELECT nbs_question_uid FROM dbo.NBS_ui_metadata
         WHERE nbs_ui_component_uid IN (1009, 1014, 1019, 1026, 1029))
-            AND @fromTime IS NULL OR last_chg_time > @fromTime
+END
+GO
+
+IF (object_id('pii_NBS_attachment') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_attachment]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_attachment]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT nbs_attachment_uid, desc_txt
+    FROM dbo.NBS_attachment
+    WHERE attachment IS NOT NULL OR desc_txt IS NOT NULL
 END
 GO
 
@@ -644,17 +515,14 @@ IF (object_id('pii_NBS_case_answer') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NBS_case_answer]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_case_answer_uid, answer_txt
     FROM dbo.NBS_case_answer ans
-    WHERE nbs_question_uid IN (
+    WHERE answer_txt IS NOT NULL AND nbs_question_uid IN (
         SELECT nbs_question_uid FROM dbo.NBS_ui_metadata
         WHERE nbs_ui_component_uid IN (1009, 1014, 1019, 1026, 1029))
-            AND @fromTime IS NULL OR last_chg_time > @fromTime
 END
 GO
 
@@ -663,17 +531,14 @@ IF (object_id('pii_NBS_case_answer_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NBS_case_answer_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_case_answer_hist_uid, answer_txt
     FROM dbo.NBS_case_answer_hist ans
-    WHERE nbs_question_uid IN (
+    WHERE answer_txt IS NOT NULL AND nbs_question_uid IN (
         SELECT nbs_question_uid FROM dbo.NBS_ui_metadata
         WHERE nbs_ui_component_uid IN (1009, 1014, 1019, 1026, 1029))
-            AND @fromTime IS NULL OR last_chg_time > @fromTime
 END
 GO
 
@@ -682,16 +547,11 @@ IF (object_id('pii_NBS_document') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NBS_document]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_document_uid, txt, sending_facility_nm
     FROM dbo.NBS_document
-    WHERE @fromTime IS NULL OR
-           (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-           (add_time > @fromTime)
 END
 GO
 
@@ -700,16 +560,11 @@ IF (object_id('pii_NBS_document_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NBS_document_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_document_hist_uid, txt, sending_facility_nm
     FROM dbo.NBS_document_hist
-    WHERE @fromTime IS NULL OR
-           (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-           (add_time > @fromTime)
 END
 GO
 
@@ -718,14 +573,11 @@ IF (object_id('pii_NBS_note') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NBS_note]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_note_uid, note
     FROM dbo.NBS_note
-    WHERE @fromTime IS NULL OR last_chg_time > @fromTime
 END
 GO
 
@@ -734,14 +586,12 @@ IF (object_id('pii_Notification') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Notification]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT notification_uid, txt
     FROM dbo.Notification
-    WHERE @fromTime IS NULL OR (last_chg_time IS NOT NULL AND last_chg_time > @fromTime)
+    WHERE message_txt IS NOT NULL OR txt IS NOT NULL
 END
 GO
 
@@ -750,14 +600,12 @@ IF (object_id('pii_Notification_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Notification_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT notification_uid, version_ctrl_nbr, txt
     FROM dbo.Notification_hist
-    WHERE @fromTime IS NULL OR (last_chg_time IS NOT NULL AND last_chg_time > @fromTime)
+    WHERE message_txt IS NOT NULL OR txt IS NOT NULL
 END
 GO
 
@@ -766,8 +614,6 @@ IF (object_id('pii_Obs_value_coded') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Obs_value_coded]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
@@ -782,46 +628,40 @@ IF (object_id('pii_Obs_value_coded_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Obs_value_coded_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT observation_uid, code,
+    SELECT observation_uid, code, version_ctrl_nbr,
            display_name, original_txt
     FROM dbo.Obs_value_coded_hist
 END
 GO
 
-IF (object_id('pii_Obs_value_numeric') is not null)
-    DROP PROCEDURE [dbo].[pii_Obs_value_numeric]
+IF (object_id('pii_Obs_value_date') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_date]
 GO
 
-CREATE PROCEDURE [dbo].[pii_Obs_value_numeric]
-@fromTime Datetime = null
-
+CREATE PROCEDURE [dbo].[pii_Obs_value_date]
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT observation_uid, obs_value_numeric_seq,
-           numeric_value_1, numeric_value_2
-    FROM dbo.Obs_value_numeric
+    SELECT observation_uid, obs_value_date_seq
+    FROM dbo.Obs_value_date
+    WHERE from_time IS NOT NULL OR to_time IS NOT NULL
 END
 GO
 
-IF (object_id('pii_Obs_value_numeric_hist') is not null)
-    DROP PROCEDURE [dbo].[pii_Obs_value_numeric_hist]
+IF (object_id('pii_Obs_value_date_hist') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_date_hist]
 GO
 
-CREATE PROCEDURE [dbo].[pii_Obs_value_numeric_hist]
-@fromTime Datetime = null
-
+CREATE PROCEDURE [dbo].[pii_Obs_value_date_hist]
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT observation_uid, obs_value_numeric_seq, version_ctrl_nbr,
-           numeric_value_1, numeric_value_2
-    FROM dbo.Obs_value_numeric_hist
+    SELECT observation_uid, obs_value_date_seq, version_ctrl_nbr
+    FROM dbo.Obs_value_date_hist
+    WHERE from_time IS NOT NULL OR to_time IS NOT NULL
 END
 GO
 
@@ -830,8 +670,6 @@ IF (object_id('pii_Obs_value_txt') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Obs_value_txt]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
@@ -846,8 +684,6 @@ IF (object_id('pii_Obs_value_txt_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Obs_value_txt_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
@@ -862,17 +698,12 @@ IF (object_id('pii_Observation') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Observation]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT observation_uid,
            txt, rpt_to_state_time
     FROM dbo.Observation
-    WHERE @fromTime IS NULL OR
-           (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-           (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -881,17 +712,12 @@ IF (object_id('pii_Observation_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Observation_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT observation_uid, version_ctrl_nbr,
            txt, rpt_to_state_time
     FROM dbo.Observation_hist
-    WHERE @fromTime IS NULL OR
-           (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-           (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -900,17 +726,12 @@ IF (object_id('pii_Organization') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Organization]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT organization_uid,
            description, display_nm, city_desc_txt, zip_cd
     FROM dbo.Organization
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -919,17 +740,12 @@ IF (object_id('pii_Organization_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Organization_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT organization_uid, version_ctrl_nbr,
            description, display_nm, city_desc_txt, zip_cd
     FROM dbo.Organization_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -938,8 +754,6 @@ IF (object_id('pii_Organization_name') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Organization_name]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
@@ -947,9 +761,7 @@ BEGIN
     FROM dbo.Organization_name nm
     INNER JOIN dbo.Organization org 
         ON org.organization_uid = nm.organization_uid
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
+    WHERE nm_txt IS NOT NULL
 END
 GO
 
@@ -958,18 +770,15 @@ IF (object_id('pii_Organization_name_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Organization_name_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT nm.organization_uid, organization_name_seq, nm_txt
+    SELECT nm.organization_uid, organization_name_seq, nm.version_ctrl_nbr,
+           nm_txt
     FROM dbo.Organization_name_hist nm
     INNER JOIN dbo.Organization_hist org
         ON org.organization_uid = nm.organization_uid
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
+    WHERE nm_txt IS NOT NULL
 END
 GO
 
@@ -978,26 +787,20 @@ IF (object_id('pii_Person') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Person]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT person_uid,
            age_calc, age_calc_time, age_reported, age_reported_time,
            birth_time, birth_time_calc, deceased_time, description,
-           mothers_maiden_nm, first_nm, last_nm, middle_nm, nm_prefix, nm_suffix, preferred_nm,
+           mothers_maiden_nm, first_nm, last_nm, middle_nm, preferred_nm,
            hm_street_addr1, hm_street_addr2, hm_city_desc_txt,
            hm_zip_cd, hm_phone_nbr, hm_email_addr, cell_phone_nbr,
            wk_street_addr1, wk_street_addr2, wk_city_desc_txt,
            wk_zip_cd, wk_phone_nbr, wk_email_addr,
            SSN, medicaid_num, dl_num, birth_city_desc_txt,
            as_of_date_admin, as_of_date_ethnicity, as_of_date_general, as_of_date_morbidity, as_of_date_sex
-
     FROM dbo.Person
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1006,26 +809,20 @@ IF (object_id('pii_Person_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Person_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT person_uid, version_ctrl_nbr,
            age_calc, age_calc_time, age_reported, age_reported_time,
            birth_time, birth_time_calc, deceased_time, description,
-           mothers_maiden_nm, first_nm, last_nm, middle_nm, nm_prefix, nm_suffix, preferred_nm,
+           mothers_maiden_nm, first_nm, last_nm, middle_nm, preferred_nm,
            hm_street_addr1, hm_street_addr2, hm_city_desc_txt,
            hm_zip_cd, hm_phone_nbr, hm_email_addr, cell_phone_nbr,
            wk_street_addr1, wk_street_addr2, wk_city_desc_txt,
            wk_zip_cd, wk_phone_nbr, wk_email_addr,
            SSN, medicaid_num, dl_num, birth_city_desc_txt,
            as_of_date_admin, as_of_date_ethnicity, as_of_date_general, as_of_date_morbidity, as_of_date_sex
-
     FROM dbo.Person_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1034,18 +831,14 @@ IF (object_id('pii_Person_name') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Person_name]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT person_uid, person_name_seq,
-           first_nm, first_nm_sndx, last_nm, last_nm_sndx, last_nm2, last_nm2_sndx,
-           middle_nm, middle_nm2, nm_degree, nm_prefix, nm_suffix, nm_use_cd
+           first_nm, first_nm_sndx, last_nm, last_nm_sndx,
+           last_nm2, last_nm2_sndx, middle_nm, middle_nm2,
+           as_of_date
     FROM dbo.Person_name
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1054,18 +847,14 @@ IF (object_id('pii_Person_name_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Person_name_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT person_uid, person_name_seq, version_ctrl_nbr,
-           first_nm, first_nm_sndx, last_nm, last_nm_sndx, last_nm2, last_nm2_sndx,
-           middle_nm, middle_nm2, nm_degree, nm_prefix, nm_suffix, nm_use_cd
+           first_nm, first_nm_sndx, last_nm, last_nm_sndx,
+           last_nm2, last_nm2_sndx, middle_nm, middle_nm2,
+           as_of_date
     FROM dbo.Person_name_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1074,17 +863,12 @@ IF (object_id('pii_Postal_locator') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Postal_locator]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT postal_locator_uid,
            city_desc_txt, cnty_desc_txt, street_addr1, street_addr2, zip_cd
     FROM dbo.Postal_locator
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1093,17 +877,12 @@ IF (object_id('pii_Postal_locator_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Postal_locator_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT postal_locator_uid, version_ctrl_nbr,
            city_desc_txt, cnty_desc_txt, street_addr1, street_addr2, zip_cd
     FROM dbo.Postal_locator_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1112,20 +891,15 @@ IF (object_id('pii_Public_health_case') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Public_health_case]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT public_health_case_uid,
-           diagnosis_time, outbreak_name, pat_age_at_onset,
-           rpt_form_cmplt_time, rpt_to_county_time, rpt_to_state_time, txt,
-           investigator_assigned_time, imported_city_desc_txt, deceased_time,
-           contact_inv_txt
+           diagnosis_time, pat_age_at_onset,
+           rpt_form_cmplt_time, rpt_to_county_time, rpt_to_state_time,
+           txt, investigator_assigned_time, imported_city_desc_txt,
+           deceased_time, contact_inv_txt
     FROM dbo.Public_health_case
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1134,20 +908,15 @@ IF (object_id('pii_Public_health_case_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Public_health_case_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT public_health_case_uid, version_ctrl_nbr,
-           diagnosis_time, outbreak_name, pat_age_at_onset,
-           rpt_form_cmplt_time, rpt_to_county_time, rpt_to_state_time, txt,
-           investigator_assigned_time, imported_city_desc_txt, deceased_time,
-           contact_inv_txt
+           diagnosis_time, pat_age_at_onset,
+           rpt_form_cmplt_time, rpt_to_county_time, rpt_to_state_time,
+           txt, investigator_assigned_time, imported_city_desc_txt,
+           deceased_time, contact_inv_txt
     FROM dbo.Public_health_case_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1156,26 +925,21 @@ IF (object_id('pii_PublicHealthCaseFact') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_PublicHealthCaseFact]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT public_health_case_uid,
-           ageInMonths, ageInYears, age_reported, birth_time, birth_time_calc,
+           ageInMonths, ageInYears, age_reported_time, age_reported, birth_time, birth_time_calc,
            cnty_code_desc_txt, city_desc_txt, confirmation_method_time, county,
            deceased_time, diagnosis_date, event_date,
            firstNotificationSenddate, firstNotificationdate, geoLatitude, geoLongitude,
            investigatorAssigneddate, investigatorName, lastNotificationdate, lastNotificationSenddate,
            mart_record_creation_date, mart_record_creation_time, notificationdate, onSetDate,
-           organizationName, outbreak_name, pat_age_at_onset, providerName, reporterName,
+           organizationName, pat_age_at_onset, providerName, reporterName,
            rpt_form_cmplt_time, rpt_to_county_time, rpt_to_state_time, zip_cd,
-           patientName, jurisdiction, investigationstartdate, report_date, state_case_id,
-           rpt_cnty_desc_txt, outbreak_name_desc, HSPTL_ADMISSION_DT, HSPTL_DISCHARGE_DT
+           patientName, jurisdiction, investigationstartdate, report_date, sub_addr_as_of_date,
+           rpt_cnty_desc_txt
     FROM dbo.PublicHealthCaseFact
-    WHERE @fromTime IS NULL OR
-        (LASTUPDATE IS NOT NULL AND LASTUPDATE > @fromTime) OR
-        (PHC_add_time IS NOT NULL AND PHC_add_time > @fromTime)
 END
 GO
 
@@ -1184,17 +948,12 @@ IF (object_id('pii_Referral') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Referral]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT referral_uid,
            reason_txt, referral_desc_txt, txt
     FROM dbo.Referral
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1203,17 +962,12 @@ IF (object_id('pii_Referral_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Referral_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT referral_uid, version_ctrl_nbr,
            reason_txt, referral_desc_txt, txt
     FROM dbo.Referral_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -1222,13 +976,12 @@ IF (object_id('pii_SUSPCT_MEAT_OBTND_DATA') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_SUSPCT_MEAT_OBTND_DATA]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT business_object_uid, ldf_uid, version_ctrl_nbr, ldf_value
     FROM dbo.SUSPCT_MEAT_OBTND_DATA
+    WHERE ldf_value IS NOT NULL
 END
 GO
 
@@ -1237,16 +990,12 @@ IF (object_id('pii_Tele_locator') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Tele_locator]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT tele_locator_uid, email_address, url_address
+    SELECT tele_locator_uid, email_address, phone_nbr_txt
     FROM dbo.Tele_locator
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
+    WHERE email_address IS NOT NULL OR phone_nbr_txt IS NOT NULL
 END
 GO
 
@@ -1255,17 +1004,13 @@ IF (object_id('pii_Tele_locator_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Tele_locator_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT tele_locator_uid, version_ctrl_nbr,
-           email_address, url_address
+           email_address, phone_nbr_txt
     FROM dbo.Tele_locator_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
+    WHERE email_address IS NOT NULL OR phone_nbr_txt IS NOT NULL
 END
 GO
 
@@ -1274,16 +1019,13 @@ IF (object_id('pii_Treatment') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Treatment]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT treatment_uid, txt
     FROM dbo.Treatment
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
+    WHERE txt IS NOT NULL OR
+          activity_from_time IS NOT NULL OR activity_to_time IS NOT NULL
 END
 GO
 
@@ -1292,16 +1034,69 @@ IF (object_id('pii_Treatment_hist') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_Treatment_hist]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT treatment_uid, version_ctrl_nbr, txt
     FROM dbo.Treatment_hist
-    WHERE @fromTime IS NULL OR
-        (last_chg_time IS NOT NULL AND last_chg_time > @fromTime) OR
-        (add_time IS NOT NULL AND add_time > @fromTime)
+    WHERE txt IS NOT NULL OR
+        activity_from_time IS NOT NULL OR activity_to_time IS NOT NULL
+END
+GO
+
+IF (object_id('pii_Treatment_administered') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_administered]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_administered]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT treatment_uid, treatment_administered_seq
+    FROM dbo.Treatment_administered
+    WHERE effective_from_time IS NOT NULL OR effective_to_time IS NOT NULL
+END
+GO
+
+IF (object_id('pii_Treatment_administered_hist') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_administered_hist]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_administered_hist]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT treatment_uid, treatment_administered_seq, version_ctrl_nbr
+    FROM dbo.Treatment_administered_hist
+    WHERE effective_from_time IS NOT NULL OR effective_to_time IS NOT NULL
+END
+GO
+
+IF (object_id('pii_Treatment_procedure') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_procedure]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_procedure]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT treatment_uid, treatment_procedure_seq
+    FROM dbo.Treatment_procedure
+    WHERE effective_from_time IS NOT NULL OR effective_to_time IS NOT NULL
+END
+GO
+
+IF (object_id('pii_Treatment_procedure_hist') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_procedure_hist]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_procedure_hist]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT treatment_uid, treatment_procedure_seq
+    FROM dbo.Treatment_procedure_hist
+    WHERE effective_from_time IS NOT NULL OR effective_to_time IS NOT NULL
 END
 GO
 
@@ -1310,33 +1105,11 @@ IF (object_id('pii_USER_PROFILE') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_USER_PROFILE]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT NEDSS_ENTRY_ID, FIRST_NM, LAST_NM
     FROM dbo.USER_PROFILE
-    WHERE @fromTime IS NULL OR (LAST_UPD_TIME IS NOT NULL AND LAST_UPD_TIME > @fromTime)
 END
 GO
-
-IF (object_id('pii_Jurisdiction_code') is not null)
-    DROP PROCEDURE [dbo].[pii_Jurisdiction_code]
-GO
-
-CREATE PROCEDURE [dbo].[pii_Jurisdiction_code]
-@fromTime Datetime = null
-
-AS
-BEGIN
-    SET NOCOUNT ON
-    SELECT code, code_desc_txt, code_short_desc_txt
-    FROM NBS_SRTE.dbo.Jurisdiction_code
-    WHERE @fromTime IS NULL OR
-        (status_time IS NOT NULL AND status_time > @fromTime)
-END
-GO
-
-
 

--- a/db/golden/02-pii-export-msgoute.sql
+++ b/db/golden/02-pii-export-msgoute.sql
@@ -6,15 +6,12 @@ IF (object_id('pii_MSG_ANSWER') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_ANSWER]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT MSG_CONTAINER_UID,
            ANS_DISPLAY_TXT, ANSWER_TXT
     FROM dbo.MSG_ANSWER
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -23,36 +20,16 @@ IF (object_id('pii_MSG_CASE_INVESTIGATION') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_CASE_INVESTIGATION]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
+    SELECT MSG_CONTAINER_UID, INV_LOCAL_ID, PAT_LOCAL_ID,
            INV_CLOSE_DT, INV_DIAGNOSIS_DT, INV_EFFECTIVE_TIME,
-           INV_HOSPITALIZED_ADMIT_DT, INV_HOSPITALIZED_DISCHARGE_DT,
-           INV_ILLNESS_ONSET_AGE, INV_INVESTIGATOR_ASSIGNED_DT, INV_PATIENT_DEATH_DT,
+           INV_ILLNESS_ONSET_AGE, INV_INVESTIGATOR_ASSIGNED_DT,
+           INV_IMPORT_CITY_TXT, INV_PATIENT_DEATH_DT,
            INV_REPORT_DT, INV_REPORT_TO_COUNTY_DT, INV_REPORT_TO_STATE_DT,
            INV_START_DT
     FROM dbo.MSG_CASE_INVESTIGATION
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
-END
-GO
-
-IF (object_id('pii_MSG_CONTAINER') is not null)
-    DROP PROCEDURE [dbo].[pii_MSG_CONTAINER]
-GO
-
-CREATE PROCEDURE [dbo].[pii_MSG_CONTAINER]
-@lastUid bigint = null
-
-AS
-BEGIN
-    SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
-           EFFECTIVE_TIME, RECORD_STATUS_TIME
-    FROM dbo.MSG_CONTAINER
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -61,15 +38,13 @@ IF (object_id('pii_MSG_INTERVIEW') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_INTERVIEW]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
+    SELECT MSG_CONTAINER_UID, IXS_LOCAL_ID, IXS_INTERVIEWEE_ID,
            IXS_EFFECTIVE_TIME, IXS_INTERVIEW_DT
     FROM dbo.MSG_INTERVIEW
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
+    WHERE IXS_EFFECTIVE_TIME IS NOT NULL OR IXS_INTERVIEW_DT IS NOT NULL
 END
 GO
 
@@ -78,18 +53,15 @@ IF (object_id('pii_MSG_ORGANIZATION') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_ORGANIZATION]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
-           ORG_EFFECTIVE_TIME, ORG_NAME_TXT, ORG_ADDR_CITY_TXT,
+    SELECT MSG_CONTAINER_UID, ORG_LOCAL_ID,
+           ORG_NAME_TXT, ORG_ADDR_CITY_TXT,
            ORG_ADDR_STREET_ADDR1_TXT, ORG_ADDR_STREET_ADDR2_TXT, ORG_ADDR_ZIP_CODE_TXT,
            ORG_EMAIL_ADDRESS_TXT, ORG_ID_CLIA_NBR_TXT, ORG_ID_FACILITY_IDENTIFIER_TXT,
-           ORG_PHONE_NBR_TXT, ORG_URL_ADDRESS_TXT
+           ORG_PHONE_NBR_TXT
     FROM dbo.MSG_ORGANIZATION
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -98,21 +70,17 @@ IF (object_id('pii_MSG_PATIENT') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_PATIENT]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
-           PAT_ADDR_CITY_TXT, PAT_ADDR_CENSUS_TRACT_TXT,
-           PAT_ADDR_STREET_ADDR1_TXT, PAT_ADDR_STREET_ADDR2_TXT, PAT_ADDR_ZIP_CODE_TXT,
+    SELECT MSG_CONTAINER_UID, PAT_LOCAL_ID,
+           PAT_ADDR_CITY_TXT, PAT_ADDR_STREET_ADDR1_TXT, PAT_ADDR_STREET_ADDR2_TXT, PAT_ADDR_ZIP_CODE_TXT,
            PAT_BIRTH_DT, PAT_CELL_PHONE_NBR_TXT, PAT_DECEASED_DT, PAT_EFFECTIVE_TIME,
            PAT_ID_MEDICAL_RECORD_NBR_TXT, PAT_ID_STATE_HIV_CASE_NBR_TXT, PAT_ID_SSN_TXT,
            PAT_EMAIL_ADDRESS_TXT, PAT_HOME_PHONE_NBR_TXT, PAT_NAME_ALIAS_TXT,
            PAT_NAME_FIRST_TXT, PAT_NAME_LAST_TXT, PAT_NAME_MIDDLE_TXT, PAT_PHONE_COMMENT_TXT,
-           PAT_REPORTED_AGE, PAT_URL_ADDRESS_TXT, PAT_WORK_PHONE_NBR_TXT, PAT_WORK_PHONE_EXTENSION_TXT
+           PAT_REPORTED_AGE, PAT_WORK_PHONE_NBR_TXT
     FROM dbo.MSG_PATIENT
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -121,17 +89,13 @@ IF (object_id('pii_MSG_PLACE') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_PLACE]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
-           PLA_EFFECTIVE_TIME, PLA_ADDR_CITY_TXT, PLA_ADDR_STREET_ADDR1_TXT, PLA_ADDR_STREET_ADDR2_TXT,
-           PLA_ADDR_ZIP_CODE_TXT, PLA_CENSUS_TRACT_TXT, PLA_EMAIL_ADDRESS_TXT, PLA_NAME_TXT,
-           PLA_PHONE_EXTENSION_TXT, PLA_PHONE_NBR_TXT, PLA_URL_ADDRESS_TXT
+    SELECT MSG_CONTAINER_UID, PLA_LOCAL_ID,
+           PLA_ADDR_CITY_TXT, PLA_ADDR_STREET_ADDR1_TXT, PLA_ADDR_STREET_ADDR2_TXT,
+           PLA_ADDR_ZIP_CODE_TXT, PLA_EMAIL_ADDRESS_TXT, PLA_NAME_TXT, PLA_PHONE_NBR_TXT
     FROM dbo.MSG_PLACE
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -140,18 +104,15 @@ IF (object_id('pii_MSG_PROVIDER') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_PROVIDER]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
+    SELECT MSG_CONTAINER_UID, PRV_LOCAL_ID,
            PRV_ADDR_CITY_TXT, PRV_ADDR_STREET_ADDR1_TXT, PRV_ADDR_STREET_ADDR2_TXT, PRV_ADDR_ZIP_CODE_TXT,
-           PRV_ID_ALT_ID_NBR_TXT, PRV_ID_QUICK_CODE_TXT, PRV_ID_NBR_TXT, PRV_ID_NPI_TXT, PRV_EFFECTIVE_TIME,
+           PRV_ID_ALT_ID_NBR_TXT, PRV_ID_QUICK_CODE_TXT, PRV_ID_NBR_TXT, PRV_ID_NPI_TXT,
            PRV_EMAIL_ADDRESS_TXT, PRV_NAME_FIRST_TXT, PRV_NAME_LAST_TXT, PRV_NAME_MIDDLE_TXT,
-           PRV_PHONE_EXTENSION_TXT, PRV_PHONE_NBR_TXT, PRV_URL_ADDRESS_TXT
+           PRV_PHONE_NBR_TXT
     FROM dbo.MSG_PROVIDER
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -160,15 +121,12 @@ IF (object_id('pii_MSG_TREATMENT') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MSG_TREATMENT]
-@lastUid bigint = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT MSG_CONTAINER_UID,
+    SELECT MSG_CONTAINER_UID, TRT_LOCAL_ID,
            TRT_CUSTOM_TREATMENT_TXT, TRT_EFFECTIVE_TIME, TRT_TREATMENT_DT
     FROM dbo.MSG_TREATMENT
-    WHERE @lastUid IS NULL OR (MSG_CONTAINER_UID > @lastUid)
 END
 GO
 
@@ -177,16 +135,12 @@ IF (object_id('pii_MsgOut_activity_log') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MsgOut_activity_log]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT activity_log_uid, doc_nm, action_txt
+    SELECT activity_log_uid, doc_nm
     FROM dbo.MsgOut_activity_log
-    WHERE @fromTime IS NULL OR
-        (add_time IS NOT NULL AND add_time > @fromTime) OR
-        (start_time IS NOT NULL AND start_time > @fromTime)
+    WHERE doc_nm IS NOT NULL OR message_txt IS NOT NULL
 END
 GO
 
@@ -195,14 +149,25 @@ IF (object_id('pii_MsgOut_activity_log_detail') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MsgOut_activity_log_detail]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT msgout_activity_detail_log_uid, log_comment
     FROM dbo.MsgOut_activity_log_detail
-    WHERE @fromTime IS NULL OR (start_time IS NOT NULL AND start_time > @fromTime)
+    WHERE log_comment IS NOT NULL
+END
+GO
+
+IF (object_id('pii_MsgOut_Message') is not null)
+    DROP PROCEDURE [dbo].[pii_MsgOut_Message]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MsgOut_Message]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT message_uid
+    FROM dbo.MsgOut_Message
 END
 GO
 
@@ -211,14 +176,12 @@ IF (object_id('pii_MsgOut_Receiving_facility') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MsgOut_Receiving_facility]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT receiving_facility_entity_uid, receiving_facility_nm
     FROM dbo.MsgOut_Receiving_facility
-    WHERE @fromTime IS NULL OR (status_time IS NOT NULL AND status_time > @fromTime)
+    WHERE receiving_facility_nm IS NOT NULL
 END
 GO
 
@@ -227,14 +190,12 @@ IF (object_id('pii_MsgOut_Sending_facility') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_MsgOut_Sending_facility]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT sending_facility_entity_uid, sending_facility_nm
     FROM dbo.MsgOut_Sending_facility
-    WHERE @fromTime IS NULL OR (status_time IS NOT NULL AND status_time > @fromTime)
+    WHERE sending_facility_nm IS NOT NULL
 END
 GO
 
@@ -243,14 +204,11 @@ IF (object_id('pii_NBS_interface') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NBS_interface]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT nbs_interface_uid, lab_clia, specimen_coll_date
     FROM dbo.NBS_interface
-    WHERE @fromTime IS NULL OR add_time > @fromTime
 END
 GO
 
@@ -259,14 +217,11 @@ IF (object_id('pii_NETSS_TransportQ_out') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_NETSS_TransportQ_out]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
     SELECT NETSS_TransportQ_out_uid, payload
     FROM dbo.NETSS_TransportQ_out
-    WHERE @fromTime IS NULL OR (add_time IS NOT NULL AND add_time > @fromTime)
 END
 GO
 
@@ -275,14 +230,12 @@ IF (object_id('pii_PSF_CLIENT') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_PSF_CLIENT]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT psfClientUid, clientFirstName, clientLastName, clientDOB, birthYear
+    SELECT psfClientUid,
+           clientFirstName, clientLastName, clientDOB, birthYear
     FROM dbo.PSF_CLIENT
-    WHERE @fromTime IS NULL OR (lastModifiedDate IS NOT NULL AND lastModifiedDate > @fromTime)
 END
 GO
 
@@ -291,15 +244,13 @@ IF (object_id('pii_PSF_INDEX') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_PSF_INDEX]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT psfIndexUid, clientFirstName, clientLastName, clientDOB,
-           caseOpenDate, caseCloseDate
+    SELECT psfIndexUid,
+           clientFirstName, clientLastName, clientDOB,
+           indexDateDemographicsCollected
     FROM dbo.PSF_INDEX
-    WHERE @fromTime IS NULL OR (indexLastChgDt IS NOT NULL AND indexLastChgDt > @fromTime)
 END
 GO
 
@@ -308,17 +259,13 @@ IF (object_id('pii_PSF_PARTNER') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_PSF_PARTNER]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT psfPartnerUid, clientFirstName, clientLastName, clientDOB,
+    SELECT psfPartnerUid,
+           clientFirstName, clientLastName, clientDOB,
            sampleDate, firstMedicalCareAppointmentDate
     FROM dbo.PSF_PARTNER
-    WHERE @fromTime IS NULL OR
-        (crAddTime IS NOT NULL AND crAddTime > @fromTime) OR
-        (crLastChgTime IS NOT NULL AND crLastChgTime > @fromTime)
 END
 GO
 
@@ -327,15 +274,13 @@ IF (object_id('pii_PSF_RISK') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_PSF_RISK]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT psfRiskUid, clientFirstName, clientLastName, clientDOB
+    SELECT psfRiskUid,
+           clientFirstName, clientLastName, clientDOB,
+           dateCollectedForRiskProfile
     FROM dbo.PSF_RISK
-    WHERE @fromTime IS NULL OR
-        (dateCollectedForRiskProfile IS NOT NULL AND dateCollectedForRiskProfile > @fromTime)
 END
 GO
 
@@ -344,13 +289,26 @@ IF (object_id('pii_PSF_SESSION') is not null)
 GO
 
 CREATE PROCEDURE [dbo].[pii_PSF_SESSION]
-@fromTime Datetime = null
-
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT psfSessionUid, clientFirstName, clientLastName, clientDOB
+    SELECT psfSessionUid,
+           clientFirstName, clientLastName, clientDOB,
+           sessionDate
     FROM dbo.PSF_SESSION
-    WHERE @fromTime IS NULL OR (sessionDate IS NOT NULL AND sessionDate > @fromTime)
+END
+GO
+
+IF (object_id('pii_TransportQ_out') is not null)
+    DROP PROCEDURE [dbo].[pii_TransportQ_out]
+GO
+
+CREATE PROCEDURE [dbo].[pii_TransportQ_out]
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT recordId
+    FROM dbo.TransportQ_out
+    WHERE payloadContent IS NOT NULL
 END
 GO

--- a/db/golden/03-pii-restore-odse.sql
+++ b/db/golden/03-pii-restore-odse.sql
@@ -1,0 +1,2345 @@
+use NBS_ODSE
+GO
+
+IF (object_id('sp_bulk_insert') is not null)
+    DROP PROCEDURE [dbo].[sp_bulk_insert]
+GO
+
+CREATE PROCEDURE [dbo].[sp_bulk_insert]
+@filePath varchar(max)
+
+AS
+BEGIN
+    DECLARE @SQL NVARCHAR(MAX) = ''
+    SET @SQL = N'
+    BULK INSERT #tmp FROM ''' + @filePath + '''
+    WITH (FIELDTERMINATOR = ''|'', ROWTERMINATOR = ''\n'', FIRSTROW = 3)'
+
+    EXEC sp_executesql @SQL
+END
+GO
+
+IF (object_id('pii_Activity_log_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Activity_log_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Activity_log_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        name varchar(250),
+        txt varchar(max)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Activity_log]
+    SET doc_nm = name,
+        message_txt = txt
+    FROM [Activity_log]
+    INNER JOIN #tmp ON activity_log_uid = uid
+END
+GO
+
+IF (object_id('pii_Auth_user_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Auth_user_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Auth_user_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        first_nm varchar(100),
+        last_nm varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Auth_user]
+    SET user_first_nm = first_nm,
+        user_last_nm = last_nm
+    FROM [dbo].[Auth_user]
+    INNER JOIN #tmp ON auth_user_uid = uid
+END
+GO
+
+IF (object_id('pii_case_management_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_case_management_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_case_management_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        ffu_disp_dt datetime, ffu_exam_dt datetime, ffu_exp_dt datetime, ifu_closed_dt datetime,
+        ooj_agncy varchar(20), ooj_due_dt datetime, ooj_num varchar(20),
+        oth_info varchar(2000), surv_closed_dt datetime,
+        agncy_due_dt datetime, agncy_snt_dt datetime, agncy_recd_dt datetime,
+        surv_assigned_dt datetime, fu_assigned_dt datetime,
+        ifu_assigned_dt datetime, iv_assigned_dt datetime, init_iv_assigned_dt datetime,
+        case_closed_dt datetime, case_review_status_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[case_management]
+    SET fld_foll_up_dispo_date = ffu_disp_dt, fld_foll_up_exam_date = ffu_exam_dt, fld_foll_up_expected_date = ffu_exp_dt,
+        init_foll_up_closed_date = ifu_closed_dt, ooj_agency = ooj_agncy, ooj_due_date = ooj_due_dt, ooj_number = ooj_num,
+        subj_oth_idntfyng_info = oth_info, surv_closed_date = surv_closed_dt,
+        ooj_initg_agncy_outc_due_date = agncy_due_dt, ooj_initg_agncy_outc_snt_date = agncy_snt_dt, ooj_initg_agncy_recd_date = agncy_recd_dt,
+        surv_assigned_date = surv_assigned_dt, foll_up_assigned_date = fu_assigned_dt,
+        init_foll_up_assigned_date = ifu_assigned_dt, interview_assigned_date = iv_assigned_dt, init_interview_assigned_date = init_iv_assigned_dt,
+        case_closed_date = case_closed_dt, case_review_status_date = case_review_status_dt
+    FROM [dbo].[case_management]
+    INNER JOIN #tmp ON case_management_uid = uid
+END
+GO
+
+IF (object_id('pii_case_management_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_case_management_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_case_management_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        ffu_disp_dt datetime, ffu_exam_dt datetime, ffu_exp_dt datetime, ifu_closed_dt datetime,
+        ooj_agncy varchar(20), ooj_due_dt datetime, ooj_num varchar(20),
+        oth_info varchar(2000), surv_closed_dt datetime,
+        agncy_due_dt datetime, agncy_snt_dt datetime, agncy_recd_dt datetime,
+        surv_assigned_dt datetime, fu_assigned_dt datetime,
+        ifu_assigned_dt datetime, iv_assigned_dt datetime, init_iv_assigned_dt datetime,
+        case_closed_dt datetime, case_review_status_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[case_management_hist]
+    SET fld_foll_up_dispo_date = ffu_disp_dt, fld_foll_up_exam_date = ffu_exam_dt, fld_foll_up_expected_date = ffu_exp_dt,
+        init_foll_up_closed_date = ifu_closed_dt, ooj_agency = ooj_agncy, ooj_due_date = ooj_due_dt, ooj_number = ooj_num,
+        subj_oth_idntfyng_info = oth_info, surv_closed_date = surv_closed_dt,
+        ooj_initg_agncy_outc_due_date = agncy_due_dt, ooj_initg_agncy_outc_snt_date = agncy_snt_dt, ooj_initg_agncy_recd_date = agncy_recd_dt,
+        surv_assigned_date = surv_assigned_dt, foll_up_assigned_date = fu_assigned_dt,
+        init_foll_up_assigned_date = ifu_assigned_dt, interview_assigned_date = iv_assigned_dt, init_interview_assigned_date = init_iv_assigned_dt,
+        case_closed_date = case_closed_dt, case_review_status_date = case_review_status_dt
+    FROM [dbo].[case_management_hist]
+    INNER JOIN #tmp ON case_management_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_CDF_subform_import_log_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CDF_subform_import_log_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CDF_subform_import_log_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        comment varchar(300)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CDF_subform_import_log]
+    SET admin_comment = comment
+    FROM [dbo].[CDF_subform_import_log]
+    INNER JOIN #tmp ON import_log_uid = uid
+END
+GO
+
+IF (object_id('pii_CN_transportq_out_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CN_transportq_out_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CN_transportq_out_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CN_transportq_out]
+    SET message_payload = NULL
+    FROM [dbo].[CN_transportq_out]
+    INNER JOIN #tmp ON cn_transportq_out_uid = uid
+END
+GO
+
+IF (object_id('pii_Confirmation_method_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Confirmation_method_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Confirmation_method_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        cd varchar(20),
+        dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Confirmation_method]
+    SET confirmation_method_time = dt
+    FROM [dbo].[Confirmation_method]
+    INNER JOIN #tmp ON public_health_case_uid = uid AND confirmation_method_cd = cd
+END
+GO
+
+IF (object_id('pii_Confirmation_method_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Confirmation_method_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Confirmation_method_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        cd varchar(20),
+        ver smallint,
+        dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Confirmation_method_hist]
+    SET confirmation_method_time = dt
+    FROM [dbo].[Confirmation_method_hist]
+    INNER JOIN #tmp ON public_health_case_uid = uid AND confirmation_method_cd = cd AND
+          version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_CT_contact_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CT_contact_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CT_contact_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        assigned_dt datetime,
+        disp_dt datetime,
+        named_on_dt datetime,
+        ct_txt varchar(2000),
+        smp_dt datetime, smp_txt varchar(2000),
+        eval_dt datetime, eval_txt varchar(2000),
+        treat_start_dt datetime, treat_end_dt datetime,
+        treat_txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CT_contact]
+    SET investigator_assigned_date = assigned_dt,
+        disposition_date = disp_dt,
+        named_on_date = named_on_dt,
+        txt = ct_txt,
+        symptom_onset_date = smp_dt,
+        symptom_txt = smp_txt,
+        evaluation_date = eval_dt,
+        evaluation_txt = eval_txt,
+        treatment_start_date = treat_start_dt,
+        treatment_end_date = treat_end_dt,
+        treatment_txt = treat_txt
+    FROM [dbo].[CT_contact]
+    INNER JOIN #tmp ON ct_contact_uid = uid
+END
+GO
+
+IF (object_id('pii_CT_contact_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CT_contact_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CT_contact_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        assigned_dt datetime,
+        disp_dt datetime,
+        named_on_dt datetime,
+        ct_txt varchar(2000),
+        smp_dt datetime, smp_txt varchar(2000),
+        eval_dt datetime, eval_txt varchar(2000),
+        treat_start_dt datetime, treat_end_dt datetime,
+        treat_txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CT_contact_hist]
+    SET investigator_assigned_date = assigned_dt,
+        disposition_date = disp_dt,
+        named_on_date = named_on_dt,
+        txt = ct_txt,
+        symptom_onset_date = smp_dt,
+        symptom_txt = smp_txt,
+        evaluation_date = eval_dt,
+        evaluation_txt = eval_txt,
+        treatment_start_date = treat_start_dt,
+        treatment_end_date = treat_end_dt,
+        treatment_txt = treat_txt
+    FROM [dbo].[CT_contact_hist]
+    INNER JOIN #tmp ON ct_contact_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_CT_contact_answer_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CT_contact_answer_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CT_contact_answer_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ans_txt varchar(2000),
+        large_txt varchar(max)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CT_contact_answer]
+    SET answer_txt = ans_txt,
+        answer_large_txt = large_txt
+    FROM [dbo].[CT_contact_answer]
+    INNER JOIN #tmp ON ct_contact_answer_uid = uid
+END
+GO
+
+IF (object_id('pii_CT_contact_answer_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CT_contact_answer_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CT_contact_answer_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ans_txt varchar(2000),
+        large_txt varchar(max)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CT_contact_answer_hist]
+    SET answer_txt = ans_txt,
+        answer_large_txt = large_txt
+    FROM [dbo].[CT_contact_answer_hist]
+    INNER JOIN #tmp ON ct_contact_answer_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_CT_contact_attachment_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CT_contact_attachment_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CT_contact_attachment_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        dsc_txt varchar(2000),
+        name varchar(250)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CT_contact_attachment]
+    SET desc_txt = dsc_txt,
+        attachment = NULL,
+        file_nm_txt = name
+    FROM [dbo].[CT_contact_attachment]
+    INNER JOIN #tmp ON ct_contact_attachment_uid = uid
+END
+GO
+
+IF (object_id('pii_CT_contact_note_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_CT_contact_note_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_CT_contact_note_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ct_note varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[CT_contact_note]
+    SET note = ct_note
+    FROM [dbo].[CT_contact_note]
+    INNER JOIN #tmp ON ct_contact_note_uid = uid
+END
+GO
+
+IF (object_id('pii_Custom_queues_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Custom_queues_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Custom_queues_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        name varchar(100),
+        descr varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Custom_queues]
+    SET description = descr
+    FROM [dbo].[Custom_queues]
+    INNER JOIN #tmp ON queue_name = name
+END
+GO
+
+IF (object_id('pii_Data_migration_record_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Data_migration_record_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Data_migration_record_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        batch_uid bigint,
+        name varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Data_migration_record]
+    SET failed_record_txt = NULL,
+        sub_nm = name
+    FROM [dbo].[Data_migration_record]
+    INNER JOIN #tmp ON data_migration_record_uid = uid AND data_migration_batch_uid = batch_uid
+END
+GO
+
+IF (object_id('pii_dsm_algorithm_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_dsm_algorithm_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_dsm_algorithm_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        comment varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[dsm_algorithm]
+    SET admin_comment = comment
+    FROM [dbo].[dsm_algorithm]
+    INNER JOIN #tmp ON dsm_algorithm_uid = uid
+END
+GO
+
+IF (object_id('pii_dsm_algorithm_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_dsm_algorithm_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_dsm_algorithm_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        comment varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[dsm_algorithm_hist]
+    SET admin_comment = comment
+    FROM [dbo].[dsm_algorithm_hist]
+    INNER JOIN #tmp ON dsm_algorithm_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_EDX_activity_detail_log_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_EDX_activity_detail_log_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_EDX_activity_detail_log_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        comment varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[EDX_activity_detail_log]
+    SET log_comment = comment
+    FROM [dbo].[EDX_activity_detail_log]
+    INNER JOIN #tmp ON edx_activity_detail_log_uid = uid
+END
+GO
+
+IF (object_id('pii_EDX_activity_log_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_EDX_activity_log_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_EDX_activity_log_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        name varchar(255)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[EDX_activity_log]
+    SET Entity_nm = name
+    FROM [dbo].[EDX_activity_log]
+    INNER JOIN #tmp ON edx_activity_log_uid = uid
+END
+GO
+
+IF (object_id('pii_EDX_Document_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_EDX_Document_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_EDX_Document_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        load varchar(max)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[EDX_Document]
+    SET payload = '',
+        original_payload = load
+    FROM [dbo].[EDX_Document]
+    INNER JOIN #tmp ON EDX_Document_uid = uid
+END
+GO
+
+IF (object_id('pii_ELR_activity_log_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_ELR_activity_log_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_ELR_activity_log_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        subj_nm varchar(100),
+        fac_nm varchar(100),
+        dtl_txt varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[ELR_activity_log]
+    SET subject_nm = subj_nm,
+        report_fac_nm = fac_nm,
+        detail_txt = dtl_txt
+    FROM [dbo].[ELR_activity_log]
+    INNER JOIN #tmp ON msg_observation_uid = uid AND elr_activity_log_seq = seq
+END
+GO
+
+IF (object_id('pii_ELRWorkerQueue_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_ELRWorkerQueue_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_ELRWorkerQueue_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        name varchar(255),
+        msg varchar(255)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[ELRWorkerQueue]
+    SET payloadBinaryContent = NULL,
+        payloadTextContent = NULL,
+        payloadName = name,
+        errorMessage = msg
+    FROM [dbo].[ELRWorkerQueue]
+    INNER JOIN #tmp ON recordId = uid
+END
+GO
+
+IF (object_id('pii_Export_receiving_facility_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Export_receiving_facility_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Export_receiving_facility_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        comment varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Export_receiving_facility]
+    SET admin_comment = comment
+    FROM [dbo].[Export_receiving_facility]
+    INNER JOIN #tmp ON export_receiving_facility_uid = uid
+END
+GO
+
+IF (object_id('pii_Intervention_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Intervention_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Intervention_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        itxt varchar(1000),
+        age smallint,
+        lot_nm varchar(50),
+        exp_time datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Intervention]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        txt = itxt,
+        age_at_vacc = age,
+        material_lot_nm = lot_nm,
+        material_expiration_time = exp_time
+    FROM [dbo].[Intervention]
+    INNER JOIN #tmp ON intervention_uid = uid
+END
+GO
+
+IF (object_id('pii_Intervention_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Intervention_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Intervention_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        itxt varchar(1000),
+        age smallint,
+        lot_nm varchar(50),
+        exp_time datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Intervention_hist]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        txt = itxt,
+        age_at_vacc = age,
+        material_lot_nm = lot_nm,
+        material_expiration_time = exp_time
+    FROM [dbo].[Intervention_hist]
+    INNER JOIN #tmp ON intervention_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Interview_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Interview_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Interview_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        date1 datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Interview]
+    SET interview_date = date1
+    FROM [dbo].[Interview]
+    INNER JOIN #tmp ON interview_uid = uid
+END
+GO
+
+IF (object_id('pii_Interview_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Interview_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Interview_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        date1 datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Interview_hist]
+    SET interview_date = date1
+    FROM [dbo].[Interview_hist]
+    INNER JOIN #tmp ON interview_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_lab_event_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_lab_event_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_lab_event_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        rpt_dt datetime,
+        analyzed_dt datetime,
+        collection_dt datetime,
+        lab_comments varchar(2000),
+        sus_lab_comments varchar(2000),
+        sus_collection_dt datetime,
+        sus_rpt_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[lab_event]
+    SET result_rpt_dt = rpt_dt,
+        specimen_analyzed_dt = analyzed_dt,
+        specimen_collection_dt = collection_dt,
+        lab_result_comments = lab_comments,
+        suscep_lab_result_comments = sus_lab_comments,
+        suscep_specimen_collection_dt = sus_collection_dt,
+        suscep_result_rpt_dt = sus_rpt_dt
+    FROM [dbo].[lab_event]
+    INNER JOIN #tmp ON lab_event_uid = uid
+END
+GO
+
+IF (object_id('pii_lab_event_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_lab_event_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_lab_event_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        rpt_dt datetime,
+        analyzed_dt datetime,
+        collection_dt datetime,
+        lab_comments varchar(2000),
+        sus_lab_comments varchar(2000),
+        sus_collection_dt datetime,
+        sus_rpt_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[lab_event_hist]
+    SET result_rpt_dt = rpt_dt,
+        specimen_analyzed_dt = analyzed_dt,
+        specimen_collection_dt = collection_dt,
+        lab_result_comments = lab_comments,
+        suscep_lab_result_comments = sus_lab_comments,
+        suscep_specimen_collection_dt = sus_collection_dt,
+        suscep_result_rpt_dt = sus_rpt_dt
+    FROM [dbo].[lab_event_hist]
+    INNER JOIN #tmp ON lab_event_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_Manufactured_material_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Manufactured_material_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Manufactured_material_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        exp_time datetime,
+        name varchar(50)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Manufactured_material]
+    SET expiration_time = exp_time,
+        lot_nm = name
+    FROM [dbo].[Manufactured_material]
+    INNER JOIN #tmp ON material_uid = uid AND manufactured_material_seq = seq
+END
+GO
+
+IF (object_id('pii_Manufactured_material_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Manufactured_material_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Manufactured_material_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint,
+        exp_time datetime,
+        name varchar(50)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Manufactured_material_hist]
+    SET expiration_time = exp_time,
+        lot_nm = name
+    FROM [dbo].[Manufactured_material_hist]
+    INNER JOIN #tmp ON material_uid = uid AND manufactured_material_seq = seq AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_nbs_answer_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_nbs_answer_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_nbs_answer_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[nbs_answer]
+    SET answer_txt = txt
+    FROM [dbo].[nbs_answer]
+    INNER JOIN #tmp ON nbs_answer_uid = uid
+END
+GO
+
+IF (object_id('pii_nbs_answer_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_nbs_answer_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_nbs_answer_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[nbs_answer_hist]
+    SET answer_txt = txt
+    FROM [dbo].[nbs_answer_hist]
+    INNER JOIN #tmp ON nbs_answer_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_attachment_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_attachment_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_attachment_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_attachment]
+    SET desc_txt = txt,
+        attachment = NULL
+    FROM [dbo].[NBS_attachment]
+    INNER JOIN #tmp ON nbs_attachment_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_case_answer_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_case_answer_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_case_answer_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_case_answer]
+    SET answer_txt = txt
+    FROM [dbo].[NBS_case_answer]
+    INNER JOIN #tmp ON nbs_case_answer_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_case_answer_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_case_answer_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_case_answer_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_case_answer_hist]
+    SET answer_txt = txt
+    FROM [dbo].[NBS_case_answer_hist]
+    INNER JOIN #tmp ON nbs_case_answer_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_document_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_document_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_document_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        doc_txt varchar(2000),
+        name varchar(250)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_document]
+    SET doc_payload = '',
+        txt = doc_txt,
+        sending_facility_nm = name,
+        phdc_doc_derived = NULL
+    FROM [dbo].[NBS_document]
+    INNER JOIN #tmp ON nbs_document_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_document_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_document_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_document_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        doc_txt varchar(2000),
+        name varchar(250)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_document_hist]
+    SET doc_payload = '',
+        txt = doc_txt,
+        sending_facility_nm = name,
+        phdc_doc_derived = NULL
+    FROM [dbo].[NBS_document_hist]
+    INNER JOIN #tmp ON nbs_document_hist_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_note_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_note_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_note_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_note]
+    SET note = txt
+    FROM [dbo].[NBS_note]
+    INNER JOIN #tmp ON nbs_note_uid = uid
+END
+GO
+
+IF (object_id('pii_Notification_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Notification_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Notification_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ntxt varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Notification]
+    SET message_txt = NULL,
+        txt = ntxt
+    FROM [dbo].[Notification]
+    INNER JOIN #tmp ON notification_uid = uid
+END
+GO
+
+IF (object_id('pii_Notification_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Notification_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Notification_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        ntxt varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Notification_hist]
+    SET message_txt = NULL,
+        txt = ntxt
+    FROM [dbo].[Notification_hist]
+    INNER JOIN #tmp ON notification_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Obs_value_coded_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_coded_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Obs_value_coded_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        cd varchar(20),
+        name varchar(300),
+        orig_txt varchar(300)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Obs_value_coded]
+    SET display_name = name,
+        original_txt = orig_txt
+    FROM [dbo].[Obs_value_coded]
+    INNER JOIN #tmp ON observation_uid = uid AND code = cd
+END
+GO
+
+IF (object_id('pii_Obs_value_coded_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_coded_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Obs_value_coded_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        cd varchar(20),
+        ver smallint,
+        name varchar(300),
+        orig_txt varchar(300)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Obs_value_coded_hist]
+    SET display_name = name,
+        original_txt = orig_txt
+    FROM [dbo].[Obs_value_coded_hist]
+    INNER JOIN #tmp ON observation_uid = uid AND code = cd AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Obs_value_date_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_date_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Obs_value_date_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Obs_value_date]
+    SET from_time = CASE WHEN from_time IS NOT NULL THEN DATEADD(day, @dw, from_time) END,
+        to_time = CASE WHEN to_time IS NOT NULL THEN DATEADD(day, @dw, to_time) END
+    FROM [dbo].[Obs_value_date]
+    INNER JOIN #tmp ON observation_uid = uid AND obs_value_date_seq = seq
+END
+GO
+
+IF (object_id('pii_Obs_value_date_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_date_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Obs_value_date_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Obs_value_date_hist]
+    SET from_time = CASE WHEN from_time IS NOT NULL THEN DATEADD(day, @dw, from_time) END,
+        to_time = CASE WHEN to_time IS NOT NULL THEN DATEADD(day, @dw, to_time) END
+    FROM [dbo].[Obs_value_date_hist]
+    INNER JOIN #tmp ON observation_uid = uid AND obs_value_date_seq = seq AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Obs_value_txt_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_txt_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Obs_value_txt_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Obs_value_txt]
+    SET value_image_txt = NULL,
+        value_txt = txt
+    FROM [dbo].[Obs_value_txt]
+    INNER JOIN #tmp ON observation_uid = uid AND obs_value_txt_seq = seq
+END
+GO
+
+IF (object_id('pii_Obs_value_txt_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Obs_value_txt_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Obs_value_txt_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint,
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Obs_value_txt_hist]
+    SET value_image_txt = NULL,
+        value_txt = txt
+    FROM [dbo].[Obs_value_txt_hist]
+    INNER JOIN #tmp ON observation_uid = uid AND obs_value_txt_seq = seq AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Observation_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Observation_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Observation_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        otxt varchar(1000),
+        rpt_time datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Observation]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        txt = otxt,
+        rpt_to_state_time = rpt_time
+    FROM [dbo].[Observation]
+    INNER JOIN #tmp ON observation_uid = uid
+END
+GO
+
+IF (object_id('pii_Observation_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Observation_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Observation_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        otxt varchar(1000),
+        rpt_time datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Observation_hist]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        txt = otxt,
+        rpt_to_state_time = rpt_time
+    FROM [dbo].[Observation_hist]
+    INNER JOIN #tmp ON observation_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Organization_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Organization_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Organization_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        dsc varchar(1000),
+        name varchar(100),
+        city varchar(100),
+        zip varchar(20)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Organization]
+    SET description = dsc,
+        display_nm = name,
+        city_desc_txt = city,
+        zip_cd = zip
+    FROM [dbo].[Organization]
+    INNER JOIN #tmp ON organization_uid = uid
+END
+GO
+
+IF (object_id('pii_Organization_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Organization_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Organization_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        dsc varchar(1000),
+        name varchar(100),
+        city varchar(100),
+        zip varchar(20)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Organization_hist]
+    SET description = dsc,
+        display_nm = name,
+        city_desc_txt = city,
+        zip_cd = zip
+    FROM [dbo].[Organization_hist]
+    INNER JOIN #tmp ON organization_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Organization_name_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Organization_name_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Organization_name_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        name varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Organization_name]
+    SET nm_txt = name
+    FROM [dbo].[Organization_name]
+    INNER JOIN #tmp ON organization_uid = uid AND organization_name_seq = seq
+END
+GO
+
+IF (object_id('pii_Organization_name_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Organization_name_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Organization_name_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint,
+        name varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Organization_name_hist]
+    SET nm_txt = name
+    FROM [dbo].[Organization_name_hist]
+    INNER JOIN #tmp ON organization_uid = uid AND organization_name_seq = seq AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Person_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Person_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Person_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        age_clc smallint,
+        age_clc_time datetime,
+        age_rep varchar(10),
+        age_rep_time datetime,
+        birt_time datetime,
+        birt_time_clc datetime,
+        dec_time datetime,
+        descr varchar(2000),
+        mothers_nm varchar(50),
+        fst_nm varchar(50),
+        lst_nm varchar(50),
+        mid_nm varchar(50),
+        pref_nm varchar(50),
+        hm_st_addr1 varchar(100),
+        hm_st_addr2 varchar(100),
+        hm_cty_desc varchar(100),
+        hm_zip varchar(20),
+        hm_phone varchar(20),
+        hm_email varchar(100),
+        cell_phone varchar(20),
+        wk_st_addr1 varchar(100),
+        wk_st_addr2 varchar(100),
+        wk_cty_desc varchar(100),
+        wk_zip varchar(20),
+        wk_phone varchar(20),
+        wk_email varchar(100),
+        ssn_cd varchar(100),
+        med_num varchar(100),
+        dr_lic varchar(100),
+        birt_cty_desc varchar(100),
+        dt_admin datetime,
+        dt_ethnic datetime,
+        dt_gen datetime,
+        dt_morb datetime,
+        dt_sex datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Person]
+    SET age_calc = age_clc, age_calc_time = age_clc_time, age_reported = age_rep, age_reported_time = age_rep_time,
+        birth_time = birt_time, birth_time_calc = birt_time_clc, deceased_time = dec_time, description = descr,
+        mothers_maiden_nm = mothers_nm, first_nm = fst_nm, last_nm = lst_nm, middle_nm = mid_nm, preferred_nm = pref_nm,
+        hm_street_addr1 = hm_st_addr1, hm_street_addr2 = hm_st_addr2, hm_city_desc_txt = hm_cty_desc, hm_zip_cd = hm_zip,
+        hm_phone_nbr = hm_phone, hm_email_addr = hm_email, cell_phone_nbr = cell_phone,
+        wk_street_addr1 = wk_st_addr1, wk_street_addr2 = wk_st_addr2, wk_city_desc_txt = wk_cty_desc,
+        wk_zip_cd = wk_zip, wk_phone_nbr = wk_phone, wk_email_addr = wk_email,
+        SSN = ssn_cd, medicaid_num = med_num, dl_num = dr_lic, birth_city_desc_txt = birt_cty_desc,
+        as_of_date_admin = dt_admin, as_of_date_ethnicity = dt_ethnic, as_of_date_general = dt_gen,
+        as_of_date_morbidity = dt_morb, as_of_date_sex = dt_sex
+    FROM [dbo].[Person]
+    INNER JOIN #tmp ON person_uid = uid
+END
+GO
+
+IF (object_id('pii_Person_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Person_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Person_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        age_clc smallint,
+        age_clc_time datetime,
+        age_rep varchar(10),
+        age_rep_time datetime,
+        birt_time datetime,
+        birt_time_clc datetime,
+        dec_time datetime,
+        descr varchar(2000),
+        mothers_nm varchar(50),
+        fst_nm varchar(50),
+        lst_nm varchar(50),
+        mid_nm varchar(50),
+        pref_nm varchar(50),
+        hm_st_addr1 varchar(100),
+        hm_st_addr2 varchar(100),
+        hm_cty_desc varchar(100),
+        hm_zip varchar(20),
+        hm_phone varchar(20),
+        hm_email varchar(100),
+        cell_phone varchar(20),
+        wk_st_addr1 varchar(100),
+        wk_st_addr2 varchar(100),
+        wk_cty_desc varchar(100),
+        wk_zip varchar(20),
+        wk_phone varchar(20),
+        wk_email varchar(100),
+        ssn_cd varchar(100),
+        med_num varchar(100),
+        dr_lic varchar(100),
+        birt_cty_desc varchar(100),
+        dt_admin datetime,
+        dt_ethnic datetime,
+        dt_gen datetime,
+        dt_morb datetime,
+        dt_sex datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Person_hist]
+    SET age_calc = age_clc, age_calc_time = age_clc_time, age_reported = age_rep, age_reported_time = age_rep_time,
+        birth_time = birt_time, birth_time_calc = birt_time_clc, deceased_time = dec_time, description = descr,
+        mothers_maiden_nm = mothers_nm, first_nm = fst_nm, last_nm = lst_nm, middle_nm = mid_nm, preferred_nm = pref_nm,
+        hm_street_addr1 = hm_st_addr1, hm_street_addr2 = hm_st_addr2, hm_city_desc_txt = hm_cty_desc, hm_zip_cd = hm_zip,
+        hm_phone_nbr = hm_phone, hm_email_addr = hm_email, cell_phone_nbr = cell_phone,
+        wk_street_addr1 = wk_st_addr1, wk_street_addr2 = wk_st_addr2, wk_city_desc_txt = wk_cty_desc,
+        wk_zip_cd = wk_zip, wk_phone_nbr = wk_phone, wk_email_addr = wk_email,
+        SSN = ssn_cd, medicaid_num = med_num, dl_num = dr_lic, birth_city_desc_txt = birt_cty_desc,
+        as_of_date_admin = dt_admin, as_of_date_ethnicity = dt_ethnic, as_of_date_general = dt_gen,
+        as_of_date_morbidity = dt_morb, as_of_date_sex = dt_sex
+    FROM [dbo].[Person_hist]
+    INNER JOIN #tmp ON person_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Person_name_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Person_name_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Person_name_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        fst_nm varchar(50),
+        fst_nm_sndx varchar(50),
+        lst_nm varchar(50),
+        lst_nm_sndx varchar(50),
+        lst_nm2 varchar(50),
+        lst_nm2_sndx varchar(50),
+        mid_nm varchar(50),
+        mid_nm2 varchar(50),
+        as_of_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Person_name]
+    SET first_nm = fst_nm, first_nm_sndx = fst_nm_sndx,
+        last_nm = lst_nm, last_nm_sndx = lst_nm_sndx,
+        last_nm2 = lst_nm2, last_nm2_sndx = lst_nm2_sndx,
+        middle_nm = mid_nm, middle_nm2 = mid_nm2,
+        as_of_date = as_of_dt
+    FROM [dbo].[Person_name]
+    INNER JOIN #tmp ON person_uid = uid AND person_name_seq = seq
+END
+GO
+
+IF (object_id('pii_Person_name_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Person_name_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Person_name_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint,
+        fst_nm varchar(50),
+        fst_nm_sndx varchar(50),
+        lst_nm varchar(50),
+        lst_nm_sndx varchar(50),
+        lst_nm2 varchar(50),
+        lst_nm2_sndx varchar(50),
+        mid_nm varchar(50),
+        mid_nm2 varchar(50),
+        as_of_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Person_name_hist]
+    SET first_nm = fst_nm, first_nm_sndx = fst_nm_sndx,
+        last_nm = lst_nm, last_nm_sndx = lst_nm_sndx,
+        last_nm2 = lst_nm2, last_nm2_sndx = lst_nm2_sndx,
+        middle_nm = mid_nm, middle_nm2 = mid_nm2,
+        as_of_date = as_of_dt
+    FROM [dbo].[Person_name_hist]
+    INNER JOIN #tmp ON person_uid = uid AND person_name_seq = seq AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Postal_locator_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Postal_locator_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Postal_locator_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        cty_dsc_txt varchar(100),
+        cnt_dsc_txt varchar(100),
+        st_addr1 varchar(100),
+        st_addr2 varchar(100),
+        zip varchar(20)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Postal_locator]
+    SET city_desc_txt = cty_dsc_txt, cnty_desc_txt = cnt_dsc_txt,
+        street_addr1 = st_addr1, street_addr2 = st_addr2, zip_cd = zip
+    FROM [dbo].[Postal_locator]
+    INNER JOIN #tmp ON postal_locator_uid = uid
+END
+GO
+
+IF (object_id('pii_Postal_locator_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Postal_locator_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Postal_locator_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        cty_dsc_txt varchar(100),
+        cnt_dsc_txt varchar(100),
+        st_addr1 varchar(100),
+        st_addr2 varchar(100),
+        zip varchar(20)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Postal_locator_hist]
+    SET city_desc_txt = cty_dsc_txt, cnty_desc_txt = cnt_dsc_txt,
+        street_addr1 = st_addr1, street_addr2 = st_addr2, zip_cd = zip
+    FROM [dbo].[Postal_locator_hist]
+    INNER JOIN #tmp ON postal_locator_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Public_health_case_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Public_health_case_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Public_health_case_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        diag_time datetime,
+        pat_age varchar(20),
+        rpt_cmplt_time datetime,
+        rpt_to_cnty_time datetime,
+        rpt_to_ste_time datetime,
+        txt1 varchar(2000),
+        assigned_time datetime,
+        import_cty_desc varchar(250),
+        dec_time datetime,
+        cont_inv_txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Public_health_case]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        diagnosis_time = diag_time,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        outbreak_from_time = CASE WHEN outbreak_from_time IS NOT NULL THEN DATEADD(day, @dw, outbreak_from_time) END,
+        outbreak_to_time = CASE WHEN outbreak_to_time IS NOT NULL THEN DATEADD(day, @dw, outbreak_to_time) END,
+        pat_age_at_onset = pat_age,
+        rpt_form_cmplt_time = rpt_cmplt_time,
+        rpt_to_county_time = rpt_cnty_cd,
+        rpt_to_state_time = rpt_to_ste_time,
+        txt = txt1,
+        investigator_assigned_time = assigned_time,
+        hospitalized_admin_time = CASE WHEN hospitalized_admin_time IS NOT NULL THEN DATEADD(day, @dw, hospitalized_admin_time) END,
+        hospitalized_discharge_time = CASE WHEN hospitalized_discharge_time IS NOT NULL THEN DATEADD(day, @dw, hospitalized_discharge_time) END,
+        imported_city_desc_txt = import_cty_desc,
+        deceased_time = dec_time,
+        contact_inv_txt = cont_inv_txt,
+        infectious_from_date = CASE WHEN infectious_from_date IS NOT NULL THEN DATEADD(day, @dw, infectious_from_date) END,
+        infectious_to_date = CASE WHEN infectious_to_date IS NOT NULL THEN DATEADD(day, @dw, infectious_to_date) END
+    FROM [dbo].[Public_health_case]
+    INNER JOIN #tmp ON public_health_case_uid = uid
+END
+GO
+
+IF (object_id('pii_Public_health_case_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Public_health_case_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Public_health_case_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        diag_time datetime,
+        pat_age varchar(20),
+        rpt_cmplt_time datetime,
+        rpt_to_cnty_time datetime,
+        rpt_to_ste_time datetime,
+        txt1 varchar(2000),
+        assigned_time datetime,
+        import_cty_desc varchar(250),
+        dec_time datetime,
+        cont_inv_txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Public_health_case_hist]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        diagnosis_time = diag_time,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        outbreak_from_time = CASE WHEN outbreak_from_time IS NOT NULL THEN DATEADD(day, @dw, outbreak_from_time) END,
+        outbreak_to_time = CASE WHEN outbreak_to_time IS NOT NULL THEN DATEADD(day, @dw, outbreak_to_time) END,
+        pat_age_at_onset = pat_age,
+        rpt_form_cmplt_time = rpt_cmplt_time,
+        rpt_to_county_time = rpt_cnty_cd,
+        rpt_to_state_time = rpt_to_ste_time,
+        txt = txt1,
+        investigator_assigned_time = assigned_time,
+        hospitalized_admin_time = CASE WHEN hospitalized_admin_time IS NOT NULL THEN DATEADD(day, @dw, hospitalized_admin_time) END,
+        hospitalized_discharge_time = CASE WHEN hospitalized_discharge_time IS NOT NULL THEN DATEADD(day, @dw, hospitalized_discharge_time) END,
+        imported_city_desc_txt = import_cty_desc,
+        deceased_time = dec_time,
+        contact_inv_txt = cont_inv_txt,
+        infectious_from_date = CASE WHEN infectious_from_date IS NOT NULL THEN DATEADD(day, @dw, infectious_from_date) END,
+        infectious_to_date = CASE WHEN infectious_to_date IS NOT NULL THEN DATEADD(day, @dw, infectious_to_date) END
+    FROM [dbo].[Public_health_case_hist]
+    INNER JOIN #tmp ON public_health_case_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_PublicHealthCaseFact_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_PublicHealthCaseFact_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_PublicHealthCaseFact_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ageInM smallint,
+        ageInY smallint,
+        age_rpt_time datetime,
+        age_rpt numeric(8),
+        birt_time datetime,
+        birt_time_calc datetime,
+        cnty_code_dsc varchar(200),
+        city_dsc varchar(100),
+        confirm_method_time datetime,
+        cnty varchar(255),
+        decs_time datetime,
+        diag_dt datetime,
+        event_dt datetime,
+        first_notif_send_dt datetime,
+        first_notif_dt datetime,
+        geoLat real,
+        geoLong real,
+        inv_assign_dt datetime,
+        inv_nm varchar(102),
+        last_notif_dt datetime,
+        last_notif_send_dt datetime,
+        mart_rec_crt_dt datetime,
+        mart_rec_crt_time datetime,
+        notif_dt datetime,
+        onset_dt datetime,
+        org_nm varchar(100),
+        pat_age_onset numeric(8),
+        provider_nm varchar(102),
+        reporter_nm varchar(102),
+        rpt_form_time datetime,
+        rpt_to_cnty_time datetime,
+        rpt_to_ste_time datetime,
+        zip varchar(20),
+        pat_nm varchar(102),
+        jur varchar(50),
+        inv_start_dt datetime,
+        rpt_dt datetime,
+        sub_addr_as_of_dt datetime,
+        rpt_cnty_desc varchar(300)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[PublicHealthCaseFact]
+    SET ageInMonths = ageInM, ageInYears = ageInY,
+        age_reported_time = age_rpt_time, age_reported = age_rpt,
+        birth_time = birt_time, birth_time_calc = birt_time_calc,
+        cnty_code_desc_txt = cnty_code_dsc, city_desc_txt = cnty_code_dsc,
+        confirmation_method_time = confirm_method_time, county = cnty,
+        deceased_time = decs_time, diagnosis_date = diag_dt, event_date = event_dt,
+        firstNotificationSenddate = first_notif_send_dt, firstNotificationdate = first_notif_dt,
+        geoLatitude = geoLat, geoLongitude = geoLong,
+        investigatorAssigneddate = inv_assign_dt, investigatorName = inv_nm,
+        lastNotificationdate = last_notif_dt, lastNotificationSenddate = last_notif_send_dt,
+        mart_record_creation_date = mart_rec_crt_dt, mart_record_creation_time = mart_rec_crt_time,
+        notificationdate = notif_dt, onSetDate = onset_dt, organizationName = org_nm,
+        outbreak_from_time = CASE WHEN outbreak_from_time IS NOT NULL THEN DATEADD(day, @dw, outbreak_from_time) END,
+        outbreak_to_time = CASE WHEN outbreak_to_time IS NOT NULL THEN DATEADD(day, @dw, outbreak_to_time) END,
+        pat_age_at_onset = pat_age_onset,
+        providerName = provider_nm, reporterName = reporter_nm,
+        rpt_form_cmplt_time = rpt_form_time, rpt_to_county_time = rpt_to_cnty_time, rpt_to_state_time = rpt_to_ste_time,
+        zip_cd = zip, patientName = pat_nm, jurisdiction = jur,
+        investigationstartdate = inv_start_dt, report_date = rpt_dt,
+        sub_addr_as_of_date = sub_addr_as_of_dt, rpt_cnty_desc_txt = rpt_cnty_desc,
+        HSPTL_ADMISSION_DT = CASE WHEN HSPTL_ADMISSION_DT IS NOT NULL THEN DATEADD(day, @dw, HSPTL_ADMISSION_DT) END,
+        HSPTL_DISCHARGE_DT = CASE WHEN HSPTL_DISCHARGE_DT IS NOT NULL THEN DATEADD(day, @dw, HSPTL_DISCHARGE_DT) END
+    FROM [dbo].[PublicHealthCaseFact]
+    INNER JOIN #tmp ON public_health_case_uid = uid
+END
+GO
+
+IF (object_id('pii_Referral_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Referral_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Referral_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        rsn_txt varchar(100),
+        ref_desc varchar(100),
+        txt1  varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Referral]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        reason_txt = rsn_txt,
+        referral_desc_txt = ref_desc,
+        txt = txt1
+    FROM [dbo].[Referral]
+    INNER JOIN #tmp ON referral_uid = uid
+END
+GO
+
+IF (object_id('pii_Referral_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Referral_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Referral_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        rsn_txt varchar(100),
+        ref_desc varchar(100),
+        txt1  varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Referral_hist]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END,
+        reason_txt = rsn_txt,
+        referral_desc_txt = ref_desc,
+        txt = txt1
+    FROM [dbo].[Referral_hist]
+    INNER JOIN #tmp ON referral_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_SUSPCT_MEAT_OBTND_DATA_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_SUSPCT_MEAT_OBTND_DATA_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_SUSPCT_MEAT_OBTND_DATA_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid1 bigint,
+        uid2 bigint,
+        ver smallint,
+        ldf_val varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[SUSPCT_MEAT_OBTND_DATA]
+    SET ldf_value = ldf_val
+    FROM [dbo].[SUSPCT_MEAT_OBTND_DATA]
+    INNER JOIN #tmp ON business_object_uid = uid1 AND ldf_uid = uid2 AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Tele_locator_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Tele_locator_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Tele_locator_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        email varchar(100),
+        phone_nbr varchar(20)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Tele_locator]
+    SET email_address = email,
+        phone_nbr_txt = phone_nbr
+    FROM [dbo].[Tele_locator]
+    INNER JOIN #tmp ON tele_locator_uid = uid
+END
+GO
+
+IF (object_id('pii_Tele_locator_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Tele_locator_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Tele_locator_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        email varchar(100),
+        phone_nbr varchar(20)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[Tele_locator_hist]
+    SET email_address = email,
+        phone_nbr_txt = phone_nbr
+    FROM [dbo].[Tele_locator_hist]
+    INNER JOIN #tmp ON tele_locator_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Treatment_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ttxt varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Treatment]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        txt = ttxt
+    FROM [dbo].[Treatment]
+    INNER JOIN #tmp ON treatment_uid = uid
+END
+GO
+
+IF (object_id('pii_Treatment_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        ver smallint,
+        ttxt varchar(1000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Treatment_hist]
+    SET activity_from_time = CASE WHEN activity_from_time IS NOT NULL THEN DATEADD(day, @dw, activity_from_time) END,
+        activity_to_time = CASE WHEN activity_to_time IS NOT NULL THEN DATEADD(day, @dw, activity_to_time) END,
+        txt = ttxt
+    FROM [dbo].[Treatment_hist]
+    INNER JOIN #tmp ON treatment_uid = uid AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Treatment_administered_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_administered_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_administered_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Treatment_administered]
+    SET effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END
+    FROM [dbo].[Treatment_administered]
+    INNER JOIN #tmp ON treatment_uid = uid and treatment_administered_seq = seq
+END
+GO
+
+IF (object_id('pii_Treatment_administered_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_administered_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_administered_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Treatment_administered_hist]
+    SET effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END
+    FROM [dbo].[Treatment_administered_hist]
+    INNER JOIN #tmp ON treatment_uid = uid and treatment_administered_seq = seq AND version_ctrl_nbr = ver
+END
+GO
+
+IF (object_id('pii_Treatment_procedure_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_procedure_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_procedure_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Treatment_procedure]
+    SET effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END
+    FROM [dbo].[Treatment_procedure]
+    INNER JOIN #tmp ON treatment_uid = uid and treatment_procedure_seq = seq
+END
+GO
+
+IF (object_id('pii_Treatment_procedure_hist_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_Treatment_procedure_hist_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_Treatment_procedure_hist_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        seq smallint,
+        ver smallint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[Treatment_procedure_hist]
+    SET effective_from_time = CASE WHEN effective_from_time IS NOT NULL THEN DATEADD(day, @dw, effective_from_time) END,
+        effective_to_time = CASE WHEN effective_to_time IS NOT NULL THEN DATEADD(day, @dw, effective_to_time) END
+    FROM [dbo].[Treatment_procedure_hist]
+    INNER JOIN #tmp ON treatment_uid = uid and treatment_procedure_seq = seq AND version_ctlr_nbr = ver
+END
+GO
+
+IF (object_id('pii_USER_PROFILE_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_USER_PROFILE_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_USER_PROFILE_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+    CREATE TABLE #tmp (
+        uid bigint,
+        fst_nm varchar(100),
+        lst_nm varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[USER_PROFILE]
+    SET FIRST_NM = fst_nm, LAST_NM = lst_nm
+    FROM [dbo].[USER_PROFILE]
+    INNER JOIN #tmp ON NEDSS_ENTRY_ID = uid
+END
+GO

--- a/db/golden/04-pii-restore-msgoute.sql
+++ b/db/golden/04-pii-restore-msgoute.sql
@@ -1,0 +1,738 @@
+use NBS_MSGOUTE
+GO
+
+IF (object_id('sp_bulk_insert') is not null)
+    DROP PROCEDURE [dbo].[sp_bulk_insert]
+GO
+
+CREATE PROCEDURE [dbo].[sp_bulk_insert]
+@filePath varchar(max)
+
+AS
+BEGIN
+    DECLARE @SQL NVARCHAR(MAX) = ''
+    SET @SQL = N'
+    BULK INSERT #tmp FROM ''' + @filePath + '''
+    WITH (FIELDTERMINATOR = ''|'', ROWTERMINATOR = ''\n'', FIRSTROW = 3)'
+
+    EXEC sp_executesql @SQL
+END
+GO
+
+IF (object_id('pii_MSG_ANSWER_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_ANSWER_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_ANSWER_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        disp_txt varchar(250),
+        txt varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_ANSWER]
+    SET ANS_DISPLAY_TXT = disp_txt,
+        ANSWER_TXT = txt,
+        ANSWER_LARGE_TXT = NULL,
+        ANSWER_XML_TXT = NULL
+    FROM [dbo].[MSG_ANSWER]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid
+END
+GO
+
+IF (object_id('pii_MSG_CASE_INVESTIGATION_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_CASE_INVESTIGATION_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_CASE_INVESTIGATION_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        iid varchar(100),
+        pid varchar(100),
+        close_dt datetime,
+        diag_dt datetime,
+        effect_time datetime,
+        age int,
+        inv_assign_dt datetime,
+        import_cty varchar(100),
+        pat_death_dt datetime,
+        report_dt datetime,
+        rpt_cnty_dt datetime,
+        rpt_ste_dt datetime,
+        start_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[MSG_CASE_INVESTIGATION]
+    SET INV_CLOSE_DT = close_dt,
+        INV_COMMENT_TXT = NULL,
+        INV_CONTACT_INV_COMMENT_TXT = NULL,
+        INV_DIAGNOSIS_DT = diag_dt,
+        INV_EFFECTIVE_TIME = effect_time,
+        INV_HOSPITALIZED_ADMIT_DT = CASE WHEN INV_HOSPITALIZED_ADMIT_DT IS NOT NULL THEN DATEADD(day, @dw, INV_HOSPITALIZED_ADMIT_DT) END,
+        INV_HOSPITALIZED_DISCHARGE_DT = CASE WHEN INV_HOSPITALIZED_DISCHARGE_DT IS NOT NULL THEN DATEADD(day, @dw, INV_HOSPITALIZED_DISCHARGE_DT) END,
+        INV_ILLNESS_START_DT = CASE WHEN INV_ILLNESS_START_DT IS NOT NULL THEN DATEADD(day, @dw, INV_ILLNESS_START_DT) END,
+        INV_ILLNESS_END_DT = CASE WHEN INV_ILLNESS_END_DT IS NOT NULL THEN DATEADD(day, @dw, INV_ILLNESS_END_DT) END,
+        INV_ILLNESS_ONSET_AGE = age,
+        INV_INVESTIGATOR_ASSIGNED_DT = inv_assign_dt,
+        INV_IMPORT_CITY_TXT = import_cty,
+        INV_INFECTIOUS_FROM_DT = CASE WHEN INV_INFECTIOUS_FROM_DT IS NOT NULL THEN DATEADD(day, @dw, INV_INFECTIOUS_FROM_DT) END,
+        INV_INFECTIOUS_TO_DT = CASE WHEN INV_INFECTIOUS_TO_DT IS NOT NULL THEN DATEADD(day, @dw, INV_INFECTIOUS_TO_DT) END,
+        INV_PATIENT_DEATH_DT = pat_death_dt,
+        INV_REPORT_DT = report_dt,
+        INV_REPORT_TO_COUNTY_DT = rpt_cnty_dt,
+        INV_REPORT_TO_STATE_DT = rpt_ste_dt,
+        INV_START_DT = start_dt
+    FROM [dbo].[MSG_CASE_INVESTIGATION]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND INV_LOCAL_ID = iid AND PAT_LOCAL_ID = pid
+END
+GO
+
+IF (object_id('pii_MSG_INTERVIEW_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_INTERVIEW_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_INTERVIEW_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        lid varchar(100),
+        iid varchar(100),
+        effect_time datetime,
+        int_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_INTERVIEW]
+    SET IXS_EFFECTIVE_TIME = effect_time,
+        IXS_INTERVIEW_DT = int_dt
+    FROM [dbo].[MSG_INTERVIEW]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND IXS_LOCAL_ID = lid AND IXS_INTERVIEWEE_ID = iid
+END
+GO
+
+IF (object_id('pii_MSG_ORGANIZATION_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_ORGANIZATION_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_ORGANIZATION_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        lid varchar(100),
+        name varchar(100),
+        addr_city varchar(100),
+        addr_st1 varchar(100),
+        addr_st2 varchar(100),
+        addr_zip varchar(10),
+        email varchar(100),
+        clia_nbr varchar(100),
+        id_txt varchar(100),
+        phone varchar(50)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_ORGANIZATION]
+    SET ORG_NAME_TXT = name,
+        ORG_ADDR_CITY_TXT = addr_city,
+        ORG_ADDR_COMMENT_TXT = NULL,
+        ORG_COMMENT_TXT = NULL,
+        ORG_ADDR_STREET_ADDR1_TXT = addr_st1,
+        ORG_ADDR_STREET_ADDR2_TXT = addr_st2,
+        ORG_ADDR_ZIP_CODE_TXT = addr_zip,
+        ORG_EMAIL_ADDRESS_TXT = email,
+        ORG_ID_CLIA_NBR_TXT = clia_nbr,
+        ORG_ID_FACILITY_IDENTIFIER_TXT = id_txt,
+        ORG_PHONE_COMMENT_TXT = NULL,
+        ORG_PHONE_NBR_TXT = phone
+    FROM [dbo].[MSG_ORGANIZATION]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND ORG_LOCAL_ID = lid
+END
+GO
+
+IF (object_id('pii_MSG_PATIENT_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_PATIENT_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_PATIENT_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        lid varchar(100),
+        addr_city varchar(100),
+        addr_st1 varchar(100),
+        addr_st2 varchar(100),
+        addr_zip varchar(10),
+        birth_dt datetime,
+        cell_phone varchar(50),
+        dec_dt datetime,
+        effect_time datetime,
+        med_rec varchar(100),
+        hiv_case_nbr varchar(100),
+        id_ssn varchar(11),
+        email varchar(100),
+        home_phone varchar(50),
+        name_alias varchar(100),
+        name_first varchar(100),
+        name_last varchar(100),
+        name_mid varchar(100),
+        phone_comment varchar(100),
+        rpt_age int,
+        work_phone varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_PATIENT]
+    SET PAT_ADDR_CITY_TXT = addr_city,
+        PAT_ADDR_COMMENT_TXT = NULL,
+        PAT_ADDR_STREET_ADDR1_TXT = addr_st1,
+        PAT_ADDR_STREET_ADDR2_TXT = addr_st2,
+        PAT_ADDR_ZIP_CODE_TXT = addr_zip,
+        PAT_BIRTH_DT = birth_dt,
+        PAT_CELL_PHONE_NBR_TXT = cell_phone,
+        PAT_COMMENT_TXT = NULL,
+        PAT_DECEASED_DT = dec_dt,
+        PAT_EFFECTIVE_TIME = effect_time,
+        PAT_ID_MEDICAL_RECORD_NBR_TXT = med_rec,
+        PAT_ID_STATE_HIV_CASE_NBR_TXT = hiv_case_nbr,
+        PAT_ID_SSN_TXT = id_ssn,
+        PAT_EMAIL_ADDRESS_TXT = email,
+        PAT_HOME_PHONE_NBR_TXT = home_phone,
+        PAT_NAME_ALIAS_TXT = name_alias,
+        PAT_NAME_FIRST_TXT = name_first,
+        PAT_NAME_LAST_TXT = name_last,
+        PAT_NAME_MIDDLE_TXT = name_mid,
+        PAT_PHONE_COMMENT_TXT = phone_comment,
+        PAT_REPORTED_AGE = rpt_age,
+        PAT_WORK_PHONE_NBR_TXT = work_phone
+    FROM [dbo].[MSG_PATIENT]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND PAT_LOCAL_ID = lid
+END
+GO
+
+IF (object_id('pii_MSG_PLACE_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_PLACE_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_PLACE_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        lid varchar(100),
+        addr_city varchar(100),
+        addr_st1 varchar(100),
+        addr_st2 varchar(100),
+        addr_zip varchar(10),
+        email varchar(100),
+        name varchar(100),
+        phone varchar(50)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_PLACE]
+    SET PLA_ADDR_CITY_TXT = addr_city,
+        PLA_ADDR_STREET_ADDR1_TXT = addr_st1,
+        PLA_ADDR_STREET_ADDR2_TXT = addr_st2,
+        PLA_ADDR_ZIP_CODE_TXT = addr_zip,
+        PLA_ADDR_COMMENT_TXT = NULL,
+        PLA_COMMENT_TXT = NULL,
+        PLA_EMAIL_ADDRESS_TXT = email,
+        PLA_NAME_TXT = name,
+        PLA_PHONE_NBR_TXT = phone,
+        PLA_PHONE_COMMENT_TXT = NULL
+    FROM [dbo].[MSG_PLACE]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND PLA_LOCAL_ID = lid
+END
+GO
+
+IF (object_id('pii_MSG_PROVIDER_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_PROVIDER_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_PROVIDER_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        lid varchar(100),
+        addr_city varchar(100),
+        addr_st1 varchar(100),
+        addr_st2 varchar(100),
+        addr_zip varchar(10),
+        alt_id_nbr varchar(100),
+        quick_code varchar(100),
+        id_nbr varchar(100),
+        id_npi varchar(100),
+        email varchar(100),
+        name_first varchar(100),
+        name_last varchar(100),
+        name_mid varchar(100),
+        phone varchar(50)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_PROVIDER]
+    SET PRV_ADDR_CITY_TXT = addr_city,
+        PRV_ADDR_COMMENT_TXT = NULL,
+        PRV_ADDR_STREET_ADDR1_TXT = addr_st1,
+        PRV_ADDR_STREET_ADDR2_TXT = addr_st2,
+        PRV_ADDR_ZIP_CODE_TXT = addr_zip,
+        PRV_COMMENT_TXT = NULL,
+        PRV_ID_ALT_ID_NBR_TXT = alt_id_nbr,
+        PRV_ID_QUICK_CODE_TXT = quick_code,
+        PRV_ID_NBR_TXT = id_nbr,
+        PRV_ID_NPI_TXT = id_npi,
+        PRV_EMAIL_ADDRESS_TXT = email,
+        PRV_NAME_FIRST_TXT = name_first,
+        PRV_NAME_LAST_TXT = name_last,
+        PRV_NAME_MIDDLE_TXT = name_mid,
+        PRV_PHONE_COMMENT_TXT = NULL,
+        PRV_PHONE_NBR_TXT = phone
+    FROM [dbo].[MSG_PROVIDER]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND PRV_LOCAL_ID = lid
+END
+GO
+
+IF (object_id('pii_MSG_TREATMENT_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MSG_TREATMENT_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MSG_TREATMENT_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        lid varchar(100),
+        custom_txt varchar(255),
+        effect_time datetime,
+        treat_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MSG_TREATMENT]
+    SET TRT_COMMENT_TXT = NULL,
+        TRT_CUSTOM_TREATMENT_TXT = custom_txt,
+        TRT_EFFECTIVE_TIME = effect_time,
+        TRT_TREATMENT_DT = treat_dt
+    FROM [dbo].[MSG_TREATMENT]
+    INNER JOIN #tmp ON MSG_CONTAINER_UID = uid AND TRT_LOCAL_ID = lid
+END
+GO
+
+IF (object_id('pii_MsgOut_activity_log_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MsgOut_activity_log_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MsgOut_activity_log_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        name varchar(250)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MsgOut_activity_log]
+    SET doc_nm = name,
+        message_txt = NULL
+    FROM [dbo].[MsgOut_activity_log]
+    INNER JOIN #tmp ON activity_log_uid = uid
+END
+GO
+
+IF (object_id('pii_MsgOut_activity_log_detail_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MsgOut_activity_log_detail_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MsgOut_activity_log_detail_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        comment varchar(2000)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MsgOut_activity_log_detail]
+    SET log_comment = comment
+    FROM [dbo].[MsgOut_activity_log_detail]
+    INNER JOIN #tmp ON msgout_activity_detail_log_uid = uid
+END
+GO
+
+IF (object_id('pii_MsgOut_Message_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MsgOut_Message_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MsgOut_Message_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MsgOut_Message]
+    SET attachment_txt = ''
+    FROM [dbo].[MsgOut_Message]
+    INNER JOIN #tmp ON message_uid = uid
+END
+GO
+
+IF (object_id('pii_MsgOut_Receiving_facility_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MsgOut_Receiving_facility_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MsgOut_Receiving_facility_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        name varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MsgOut_Receiving_facility]
+    SET receiving_facility_nm = name
+    FROM [dbo].[MsgOut_Receiving_facility]
+    INNER JOIN #tmp ON receiving_facility_entity_uid = uid
+END
+GO
+
+IF (object_id('pii_MsgOut_Sending_facility_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_MsgOut_Sending_facility_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_MsgOut_Sending_facility_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        name varchar(100)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[MsgOut_Sending_facility]
+    SET sending_facility_nm = name
+    FROM [dbo].[MsgOut_Sending_facility]
+    INNER JOIN #tmp ON sending_facility_entity_uid = uid
+END
+GO
+
+IF (object_id('pii_NBS_interface_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NBS_interface_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NBS_interface_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        info varchar(250),
+        coll_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NBS_interface]
+    SET payload = NULL,
+        original_payload = NULL,
+        lab_clia = info,
+        specimen_coll_date = coll_dt,
+        original_payload_RR = NULL
+    FROM [dbo].[NBS_interface]
+    INNER JOIN #tmp ON nbs_interface_uid = uid
+END
+GO
+
+IF (object_id('pii_NETSS_TransportQ_out_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_NETSS_TransportQ_out_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_NETSS_TransportQ_out_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        txt varchar(250)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[NETSS_TransportQ_out]
+    SET payload = txt
+    FROM [dbo].[NETSS_TransportQ_out]
+    INNER JOIN #tmp ON NETSS_TransportQ_out_uid = uid
+END
+GO
+
+IF (object_id('pii_PSF_CLIENT_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_PSF_CLIENT_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_PSF_CLIENT_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        fst_name varchar(50),
+        lst_name varchar(50),
+        dob_dt datetime,
+        birth_year varchar(4)
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[PSF_CLIENT]
+    SET clientFirstName = fst_name,
+        clientLastName = lst_name,
+        clientDOB = dob_dt,
+        birthYear = birth_year
+    FROM [dbo].[PSF_CLIENT]
+    INNER JOIN #tmp ON psfClientUid = uid
+END
+GO
+
+IF (object_id('pii_PSF_INDEX_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_PSF_INDEX_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_PSF_INDEX_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        fst_name varchar(50),
+        lst_name varchar(50),
+        dob_dt datetime,
+        index_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    DECLARE @dw smallint
+    SET @dw = DATEPART(dw, GETDATE())
+
+    UPDATE [dbo].[PSF_INDEX]
+    SET clientFirstName = fst_name,
+        clientLastName = lst_name,
+        clientDOB = dob_dt,
+        indexDateDemographicsCollected = index_dt,
+        caseOpenDate = CASE WHEN caseOpenDate IS NOT NULL THEN DATEADD(day, @dw, caseOpenDate) END,
+        caseCloseDate = CASE WHEN caseCloseDate IS NOT NULL THEN DATEADD(day, @dw, caseCloseDate) END
+    FROM [dbo].[PSF_INDEX]
+    INNER JOIN #tmp ON psfIndexUid = uid
+END
+GO
+
+IF (object_id('pii_PSF_PARTNER_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_PSF_PARTNER_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_PSF_PARTNER_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        fst_name varchar(50),
+        lst_name varchar(50),
+        dob_dt datetime,
+        smp_dt datetime,
+        fst_app_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[PSF_PARTNER]
+    SET clientFirstName = fst_name,
+        clientLastName = lst_name,
+        clientDOB = dob_dt,
+        sampleDate = smp_dt,
+        firstMedicalCareAppointmentDate = fst_app_dt
+    FROM [dbo].[PSF_PARTNER]
+    INNER JOIN #tmp ON psfPartnerUid = uid
+END
+GO
+
+IF (object_id('pii_PSF_RISK_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_PSF_RISK_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_PSF_RISK_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        fst_name varchar(50),
+        lst_name varchar(50),
+        dob_dt datetime,
+        coll_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[PSF_RISK]
+    SET clientFirstName = fst_name,
+        clientLastName = lst_name,
+        clientDOB = dob_dt,
+        dateCollectedForRiskProfile = coll_dt
+    FROM [dbo].[PSF_RISK]
+    INNER JOIN #tmp ON psfRiskUid = uid
+END
+GO
+
+IF (object_id('pii_PSF_SESSION_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_PSF_SESSION_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_PSF_SESSION_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint,
+        fst_name varchar(50),
+        lst_name varchar(50),
+        dob_dt datetime,
+        sess_dt datetime
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[PSF_SESSION]
+    SET clientFirstName = fst_name,
+        clientLastName = lst_name,
+        clientDOB = dob_dt,
+        sessionDate = sess_dt
+    FROM [dbo].[PSF_SESSION]
+    INNER JOIN #tmp ON psfSessionUid = uid
+END
+GO
+
+IF (object_id('pii_TransportQ_out_Restore') is not null)
+    DROP PROCEDURE [dbo].[pii_TransportQ_out_Restore]
+GO
+
+CREATE PROCEDURE [dbo].[pii_TransportQ_out_Restore]
+@filePath varchar(max)
+
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #tmp (
+        uid bigint
+    )
+
+    EXEC sp_bulk_insert @filePath
+
+    UPDATE [dbo].[TransportQ_out]
+    SET payloadContent = NULL
+    FROM [dbo].[TransportQ_out]
+    INNER JOIN #tmp ON recordId = uid
+END
+GO

--- a/db/golden/restore-data.sh
+++ b/db/golden/restore-data.sh
@@ -33,12 +33,10 @@ GOLDEN_DB_DATA="$GOLDEN_DB_HOME/data"
 # Read table names from the file and export each to a CSV file
 while read -r table; do
   if [ ! -z "$table" ]; then  # Skip empty lines
-    echo "Exporting $table to CSV..."
+    echo "Restoring $table data to CSV..."
     sqlcmd -S "$SERVER_NAME" -d "$DATABASE_NAME" -U "$USERNAME" -P "$PASSWORD" \
-           -Q "EXEC dbo.pii_${table};" \
-           -o "$GOLDEN_DB_DATA/${table}.txt" -s"|" -W -k2
-    sed -i 's/NULL//ig' "$GOLDEN_DB_DATA/${table}.txt"
+           -Q "EXEC dbo.pii_${table}_Restore '$GOLDEN_DB_DATA/out/${table}.deid.resynthesis.txt';"
   fi
 done < "$TABLE_LIST_FILE"
 
-echo "Export completed."
+echo "Import completed."

--- a/db/golden/runCliniDeID.sh
+++ b/db/golden/runCliniDeID.sh
@@ -1,7 +1,9 @@
+#!/bin/bash
+
 arguments="$*"
 
 if [ -z "$CLINIDEID_HOME" ]; then
-  echo "The $CLINIDEID_HOME environment variable is not set."
+  echo "The CLINIDEID_HOME environment variable is not set."
   exit 1
 fi
 
@@ -10,8 +12,9 @@ if [ -z "$GOLDEN_DB_HOME" ]; then
   exit 1
 fi
 
+GOLDEN_DB_DATA="$GOLDEN_DB_HOME/data"
 
 cd $CLINIDEID_HOME
 java -Xmx28g -cp CliniDeIDComplete.jar com.clinacuity.deid.mains.DeidPipeline \
-    -l beyond -pii OtherIDNumber-false,Zip-2 -t resynthesis,detectedPII,map \
-    -txt -if -id $GOLDEN_DB_HOME -of -od $GOLDEN_DB_HOME/out $arguments
+    -l beyond -pii OtherIDNumber-false,Date-2,Zip-2 -t resynthesis,detectedPII,map \
+    -txt -if -id $GOLDEN_DB_DATA -of -od $GOLDEN_DB_DATA/out $arguments

--- a/db/golden/tabs-msgoute.txt
+++ b/db/golden/tabs-msgoute.txt
@@ -1,6 +1,5 @@
 MSG_ANSWER
 MSG_CASE_INVESTIGATION
-MSG_CONTAINER
 MSG_INTERVIEW
 MSG_ORGANIZATION
 MSG_PATIENT
@@ -9,6 +8,7 @@ MSG_PROVIDER
 MSG_TREATMENT
 MsgOut_activity_log
 MsgOut_activity_log_detail
+MsgOut_Message
 MsgOut_Receiving_facility
 MsgOut_Sending_facility
 NBS_interface
@@ -18,3 +18,4 @@ PSF_INDEX
 PSF_PARTNER
 PSF_RISK
 PSF_SESSION
+TransportQ_out

--- a/db/golden/tabs-odse.txt
+++ b/db/golden/tabs-odse.txt
@@ -1,11 +1,9 @@
-Act_id
-Act_id_hist
 Activity_log
 Auth_user
 case_management
 case_management_hist
 CDF_subform_import_log
-Chart_report_metadata
+CN_transportq_out
 Confirmation_method
 Confirmation_method_hist
 CT_contact
@@ -23,8 +21,6 @@ EDX_activity_log
 EDX_Document
 ELR_activity_log
 ELRWorkerQueue
-Entity_id
-Entity_id_hist
 Export_receiving_facility
 Intervention
 Intervention_hist
@@ -36,6 +32,7 @@ Manufactured_material
 Manufactured_material_hist
 nbs_answer
 nbs_answer_hist
+NBS_attachment
 NBS_case_answer
 NBS_case_answer_hist
 NBS_document
@@ -45,8 +42,8 @@ Notification
 Notification_hist
 Obs_value_coded
 Obs_value_coded_hist
-Obs_value_numeric
-Obs_value_numeric_hist
+Obs_value_date
+Obs_value_date_hist
 Obs_value_txt
 Obs_value_txt_hist
 Observation
@@ -71,5 +68,8 @@ Tele_locator
 Tele_locator_hist
 Treatment
 Treatment_hist
+Treatment_administered
+Treatment_administered_hist
+Treatment_procedure
+Treatment_procedure_hist
 USER_PROFILE
-Jurisdiction_code


### PR DESCRIPTION
## Description

Completed set of scripts to DB restore using de-identified sensitive data. Also includes some important corrections for sensitive data exporting scripts.

- **03-pii-restore-odse.sql**: sp creation for restore NBS_ODSE db with anonymized sensitive data
- **04-pii-restore-msgoute.sql**: sp creation for restore NBS_ODSE db with anonymized sensitive data
- **restore-data.sh**: shell script to run restoring procedures and bulk insert data from processed CSV files


## Tickets

* [CNFT1-2160 Golden DB - Repopulate DB with anonymized data set](https://cdc-nbs.atlassian.net/browse/CNFT1-2160)