### PR TITLE
Cnft2 2251 published rule targets

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -36,35 +36,35 @@ export const SubsectionHeader = ({
     const [closeOptions, setCloseOptions] = useState(false);
 
     const handleUngroup = () => {
-        try {
-            SubSectionControllerService.unGroupSubSection({
-                page: page.id,
-                subSectionId: subsection.id
-            }).then(() => {
+        SubSectionControllerService.unGroupSubSection({
+            page: page.id,
+            subSectionId: subsection.id
+        })
+            .then(() => {
                 showAlert({
                     type: 'success',
                     header: 'Ungrouped',
                     message: `You've successfully ungrouped ${subsection.name}`
                 });
                 refresh();
+            })
+            .catch((error) => {
+                if (error instanceof Error) {
+                    console.error(error);
+                    showAlert({
+                        type: 'error',
+                        header: 'error',
+                        message: error.message
+                    });
+                } else {
+                    console.error(error);
+                    showAlert({
+                        type: 'error',
+                        header: 'error',
+                        message: 'An unknown error occurred'
+                    });
+                }
             });
-        } catch (error) {
-            if (error instanceof Error) {
-                console.error(error);
-                showAlert({
-                    type: 'error',
-                    header: 'error',
-                    message: error.message
-                });
-            } else {
-                console.error(error);
-                showAlert({
-                    type: 'error',
-                    header: 'error',
-                    message: 'An unknown error occurred'
-                });
-            }
-        }
     };
 
     const closeThenAct = (action: (subsection: PagesSubSection) => void) => {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/subsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/subsection.module.scss
@@ -8,10 +8,8 @@
         display: flex;
         padding: 1.5rem;
         justify-content: space-between;
-        align-items: center;
         flex: 1 0 0;
         align-self: stretch;
-
         background: colors.$cool-accent-lighter;
 
         .info {
@@ -19,13 +17,14 @@
             flex-direction: row;
             align-items: center;
             gap: 0.5rem;
+
             .name {
                 color: colors.$base-black;
-                text-align: center;
                 font-size: 1rem;
                 font-weight: 700;
                 margin-bottom: 0.5rem;
             }
+
             .count {
                 color: colors.$base-darkest;
                 font-size: 0.875rem;
@@ -61,6 +60,6 @@
         justify-content: flex-end;
     }
 }
-    #confirmation .usa-modal #confirmation-description {
-        font-weight: 300;
-    }
+#confirmation .usa-modal #confirmation-description {
+    font-weight: 300;
+}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.tsx
@@ -86,7 +86,7 @@ export const BusinessRulesLibrary = ({ modalRef }: any) => {
                 <div className="business-rules-library__container">
                     <div className="business-rules-library__table">
                         <BusinessRulesLibraryTable
-                            summaries={response?.content ?? []}
+                            rules={response?.content ?? []}
                             qtnModalRef={modalRef}
                             onSortChange={setSort}
                             onQueryChange={setQuery}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.spec.tsx
@@ -31,7 +31,7 @@ describe('BusinessRulesLibraryTable', () => {
                 <BrowserRouter>
                     <PageProvider>
                         <BusinessRulesLibraryTable
-                            summaries={summaries}
+                            rules={summaries}
                             qtnModalRef={modalRef}
                             onSortChange={jest.fn()}
                             onQueryChange={jest.fn()}
@@ -78,7 +78,7 @@ describe('BusinessRulesLibraryTable', () => {
                 <BrowserRouter>
                     <PageProvider>
                         <BusinessRulesLibraryTable
-                            summaries={summaries}
+                            rules={summaries}
                             qtnModalRef={modalRef}
                             onSortChange={jest.fn()}
                             onQueryChange={jest.fn()}

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
@@ -34,7 +34,7 @@ const tableColumns = [
 ];
 
 type Props = {
-    summaries: Rule[];
+    rules: Rule[];
     onSortChange: (sort: BusinessRuleSort | undefined) => void;
     onQueryChange: (query: string) => void;
     qtnModalRef: RefObject<ModalRef>;
@@ -44,7 +44,7 @@ type Props = {
 };
 
 export const BusinessRulesLibraryTable = ({
-    summaries,
+    rules,
     qtnModalRef,
     onSortChange,
     onQueryChange,
@@ -67,146 +67,88 @@ export const BusinessRulesLibraryTable = ({
 
     const redirectRuleURL = `/page-builder/pages/${page?.id}/business-rules`;
 
-    const asTableRow = (rule: Rule): TableBody => ({
-        key: rule.id,
-        id: rule.template.toString(),
-        tableDetails: [
-            {
-                id: 1,
-                title: (
-                    <Link to={`/page-builder/pages/${page?.id}/business-rules/edit/${rule.id}`}>
-                        {rule.sourceQuestion.label} ({rule.sourceQuestion.questionIdentifier})
-                    </Link>
-                )
-            },
-            { id: 2, title: <div className="event-text">{mapComparatorToString(rule.comparator)}</div> },
-            {
-                id: 3,
-                title: (
-                    <div>
-                        {!rule.anySourceValue ? (
-                            rule?.sourceValues?.map((value, index) => (
-                                <React.Fragment key={index}>
-                                    <span>{value}</span>
-                                    <br />
-                                </React.Fragment>
-                            ))
-                        ) : (
-                            <div>Any source value</div>
-                        )}
-                    </div>
-                )
-            },
-            {
-                id: 4,
-                title: <div>{mapRuleFunctionToString(rule.ruleFunction)}</div>
-            },
-            {
-                id: 5,
-                title: (
-                    <div>
-                        {rule.targets?.map((target, index) => {
-                            return (
-                                <React.Fragment key={index}>
-                                    <span>
-                                        {target.label} ({target.targetIdentifier})
-                                    </span>
-                                    <br />
-                                </React.Fragment>
-                            );
-                        })}
-                    </div>
-                )
-            },
-            {
-                id: 6,
-                title: <div>{rule.id}</div>
-            }
-        ]
-    });
-
-    const asTableViewRow = (rule: Rule): TableBody => ({
-        key: rule.id,
-        id: rule.template.toString(),
-        tableDetails: [
-            {
-                id: 1,
-                title: (
-                    <Link to={`/page-builder/pages/${page?.id}/business-rules/${rule.id}`}>
-                        {rule.sourceQuestion.label} ({rule.sourceQuestion.questionIdentifier})
-                    </Link>
-                )
-            },
-            { id: 2, title: <div className="event-text">{mapComparatorToString(rule.comparator)}</div> },
-            {
-                id: 3,
-                title: (
-                    <div>
-                        {!rule.anySourceValue ? (
-                            rule?.sourceValues?.map((value, index) => (
-                                <React.Fragment key={index}>
-                                    <span>{value}</span>
-                                    <br />
-                                </React.Fragment>
-                            ))
-                        ) : (
-                            <div>Any source value</div>
-                        )}
-                    </div>
-                )
-            },
-            {
-                id: 4,
-                title: <div>{mapRuleFunctionToString(rule.ruleFunction)}</div>
-            },
-            {
-                id: 5,
-                title: (
-                    <div>
-                        {rule.targets?.map((target, index) => {
-                            if (rule.targetType == Rule.targetType.SUBSECTION) {
-                                const subsections = getSubsections();
-                                const subsection = subsections?.find(
-                                    (sub) => sub.id == Number(target?.targetIdentifier)
-                                );
-                                return (
-                                    <React.Fragment key={index}>
-                                        <span>{subsection?.name}</span>
-                                        <br />
-                                    </React.Fragment>
-                                );
-                            } else {
-                                return (
-                                    <React.Fragment key={index}>
-                                        <span>
-                                            {target.label} ({target.targetIdentifier})
-                                        </span>
-                                        <br />
-                                    </React.Fragment>
-                                );
-                            }
-                        })}
-                    </div>
-                )
-            },
-            {
-                id: 6,
-                title: <div>{rule.id}</div>
-            }
-        ]
-    });
-
-    const asTableRows = (rules: Rule[] | undefined): TableBody[] => {
+    const asTableRow = (rule: Rule): TableBody => {
+        let url: string;
         if (page?.status === 'Published') {
-            return rules?.map(asTableViewRow) || [];
+            url = `/page-builder/pages/${page?.id}/business-rules/${rule.id}`;
         } else {
-            return rules?.map(asTableRow) || [];
+            url = `/page-builder/pages/${page?.id}/business-rules/edit/${rule.id}`;
         }
+        return {
+            key: rule.id,
+            id: rule.template.toString(),
+            tableDetails: [
+                {
+                    id: 1,
+                    title: (
+                        <Link to={url}>
+                            {rule.sourceQuestion.label} ({rule.sourceQuestion.questionIdentifier})
+                        </Link>
+                    )
+                },
+                { id: 2, title: <div className="event-text">{mapComparatorToString(rule.comparator)}</div> },
+                {
+                    id: 3,
+                    title: (
+                        <div>
+                            {!rule.anySourceValue ? (
+                                rule?.sourceValues?.map((value, index) => (
+                                    <React.Fragment key={index}>
+                                        <span>{value}</span>
+                                        <br />
+                                    </React.Fragment>
+                                ))
+                            ) : (
+                                <div>Any source value</div>
+                            )}
+                        </div>
+                    )
+                },
+                {
+                    id: 4,
+                    title: <div>{mapRuleFunctionToString(rule.ruleFunction)}</div>
+                },
+                {
+                    id: 5,
+                    title: (
+                        <div>
+                            {rule.targets?.map((target, index) => {
+                                if (rule.targetType == Rule.targetType.SUBSECTION) {
+                                    const subsections = getSubsections();
+                                    const subsection = subsections?.find(
+                                        (sub) => sub.questionIdentifier === target.targetIdentifier
+                                    );
+                                    return (
+                                        <React.Fragment key={index}>
+                                            <span>{subsection?.name}</span>
+                                            <br />
+                                        </React.Fragment>
+                                    );
+                                } else {
+                                    return (
+                                        <React.Fragment key={index}>
+                                            <span>
+                                                {target.label} ({target.targetIdentifier})
+                                            </span>
+                                            <br />
+                                        </React.Fragment>
+                                    );
+                                }
+                            })}
+                        </div>
+                    )
+                },
+                {
+                    id: 6,
+                    title: <div>{rule.id}</div>
+                }
+            ]
+        };
     };
 
     useEffect(() => {
-        setTableRows(asTableRows(summaries));
-    }, [summaries]);
+        setTableRows(rules.map(asTableRow) ?? []);
+    }, [rules]);
 
     const handleSort = (name: string, direction: Direction) => {
         if (direction === Direction.None) {
@@ -313,10 +255,10 @@ export const BusinessRulesLibraryTable = ({
                 currentPage={curPage.current}
                 handleNext={request}
                 sortData={handleSort}
-                rangeSelector={isLoading === true || summaries.length > 0}
+                rangeSelector={isLoading === true || rules.length > 0}
                 isLoading={isLoading}
             />
-            {summaries.length === 0 && !isLoading && dataNotAvailableElement}
+            {rules.length === 0 && !isLoading && dataNotAvailableElement}
             <div className="footer-action display-none">{footerActionBtn}</div>
         </div>
     );


### PR DESCRIPTION
## Description

There are two methods for rendering the table rows. One for a `Published` page and one for Draft. The only difference between the two was the inclusion of `edit` in the view rule url. 

## Tickets

* [CNFT2-2251](https://cdc-nbs.atlassian.net/browse/CNFT2-2251)

### Display `Target(s)` for both Published and Draft pages
![displayTargetPublished](https://github.com/CDCgov/NEDSS-Modernization/assets/109251240/3ac91517-0781-4798-b5e4-9f2c0767c245)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2251]: https://cdc-nbs.atlassian.net/browse/CNFT2-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ