### PR TITLE
Validate identifiers are provided

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/staticelement/PageStaticCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/staticelement/PageStaticCreator.java
@@ -38,8 +38,7 @@ public class PageStaticCreator {
       final WaUiMetadataRepository uiMetadatumRepository,
       final EntityManager entityManager,
       final NbsConfigurationRepository configRepository,
-      final IdGeneratorService idGenerator
-  ) {
+      final IdGeneratorService idGenerator) {
     this.entityManager = entityManager;
     this.uiMetadatumRepository = uiMetadatumRepository;
     this.configRepository = configRepository;
@@ -65,8 +64,11 @@ public class PageStaticCreator {
     uiMetadatumRepository.incrementOrderNbrGreaterThanOrEqualTo(pageId, orderNum);
 
     WaUiMetadata staticElementEntry = new WaUiMetadata(
-        asAddLineSeparator(template, orderNum, user, request.adminComments()));
-
+        asAddLineSeparator(
+            template,
+            orderNum,
+            user,
+            request.adminComments()));
     staticElementEntry.setQuestionIdentifier(getLocalId());
 
     return uiMetadatumRepository.save(staticElementEntry).getId();

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreator.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreator.java
@@ -47,6 +47,15 @@ public class PageRuleCreator {
   }
 
   public Rule createPageRule(RuleRequest request, long page, Long userId) {
+    if (request == null) {
+      throw new RuleException("Invalid request");
+    }
+    if (request.targetIdentifiers() == null || request.targetIdentifiers().isEmpty()) {
+      throw new RuleException("At least 1 target identifier is required");
+    }
+    if (!request.targetIdentifiers().stream().allMatch(t -> t != null && t.trim().length() > 0)) {
+      throw new RuleException("A target is missing it's identifier");
+    }
 
     WaTemplate template = entityManager.find(WaTemplate.class, page);
     if (template == null) {

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/PageDeletorTest.java
@@ -1,7 +1,6 @@
 package gov.cdc.nbs.questionbank.page;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityManager;

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageMetaDataDownloaderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/download/PageMetaDataDownloaderTest.java
@@ -104,6 +104,7 @@ class PageMetaDataDownloaderTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void testFindPageMetadataByWaTemplateUid() {
     Long waTemplateUid = 1L;
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/CreatePageRuleSteps.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/CreatePageRuleSteps.java
@@ -1,7 +1,5 @@
 package gov.cdc.nbs.questionbank.pagerules;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
@@ -52,18 +53,40 @@ class PageRuleCreatorTest {
 
   @Test
   void should_fail_invalid_page() {
+    RuleRequest request = new RuleRequest(
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        Arrays.asList("test"),
+        null,
+        null);
     when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
 
-    assertThrows(RuleException.class, () -> creator.createPageRule(null, 1l, 3l));
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 1l, 3l));
   }
 
   @Test
   void should_fail_published_page() {
+    RuleRequest request = new RuleRequest(
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        Arrays.asList("test"),
+        null,
+        null);
     WaTemplate template = Mockito.mock(WaTemplate.class);
     when(template.getTemplateType()).thenReturn("Published");
     when(entityManager.find(WaTemplate.class, 1l)).thenReturn(template);
 
-    assertThrows(RuleException.class, () -> creator.createPageRule(null, 1l, 3l));
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 1l, 3l));
   }
 
   @Test
@@ -258,6 +281,54 @@ class PageRuleCreatorTest {
     when(repository.save(Mockito.any())).thenReturn(rule);
     creator.createPageRule(request, 1l, 2l);
     verify(repository).save(Mockito.any());
+  }
+
+  @Test
+  void should_reject_null_targets() {
+    RuleRequest request = new RuleRequest(
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 0, null));
+  }
+
+  @Test
+  void should_reject_empty_targets() {
+    RuleRequest request = new RuleRequest(
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        new ArrayList<>(),
+        null,
+        null);
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 0, null));
+  }
+
+  @Test
+  void should_reject_blank_targets() {
+    RuleRequest request = new RuleRequest(
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        Arrays.asList("", "test"),
+        null,
+        null);
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 0, null));
   }
 
   private PageContentCommand.AddRuleCommand command(long id) {

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/PageRuleCreatorTest.java
@@ -284,6 +284,12 @@ class PageRuleCreatorTest {
   }
 
   @Test
+  void should_reject_null_request() {
+    RuleRequest request = null;
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 0, null));
+  }
+
+  @Test
   void should_reject_null_targets() {
     RuleRequest request = new RuleRequest(
         null,
@@ -326,6 +332,22 @@ class PageRuleCreatorTest {
         null,
         null,
         Arrays.asList("", "test"),
+        null,
+        null);
+    assertThrows(RuleException.class, () -> creator.createPageRule(request, 0, null));
+  }
+
+  @Test
+  void should_reject_null_target_id() {
+    RuleRequest request = new RuleRequest(
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        Arrays.asList(null, "test"),
         null,
         null);
     assertThrows(RuleException.class, () -> creator.createPageRule(request, 0, null));

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/TargetSubsectionFinderTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/pagerules/TargetSubsectionFinderTest.java
@@ -1,15 +1,11 @@
 package gov.cdc.nbs.questionbank.pagerules;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import org.apache.poi.hpsf.Array;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;

--- a/libs/me-api/src/test/java/gov/cdc/nbs/me/MeControllerTest.java
+++ b/libs/me-api/src/test/java/gov/cdc/nbs/me/MeControllerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.me;
 
 import gov.cdc.nbs.authentication.NbsUserDetails;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -35,7 +36,7 @@ class MeControllerTest {
         .returns("first-name", Me::firstName)
         .returns("last-name", Me::lastName)
         .extracting(Me::permissions)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.LIST) 
         .contains("operation-one-object-one", "operation-two-object-two")
     ;
 

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/facility/autocomplete/FacilityOptionMother.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/facility/autocomplete/FacilityOptionMother.java
@@ -3,7 +3,6 @@ package gov.cdc.nbs.option.facility.autocomplete;
 import gov.cdc.nbs.option.Option;
 import gov.cdc.nbs.testing.support.Available;
 import io.cucumber.spring.ScenarioScope;
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;


### PR DESCRIPTION
## Description

1. Verifies question identifiers are provided when creating a rule. 
2. Removes some unused imports

## Tickets

* [CNFT2-2254](https://cdc-nbs.atlassian.net/browse/CNFT2-2254)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2254]: https://cdc-nbs.atlassian.net/browse/CNFT2-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ