### PR TITLE
[CNT-8] - E2E page library sort page name column

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/PageLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/PageLibrary.tsx
@@ -71,7 +71,7 @@ const PageLibraryContent = () => {
         <>
             <CustomFieldAdminBanner />
             <PageBuilder nav>
-                <section className={styles.library}>
+                <section className={styles.library} id="pageLibrary">
                     <header>
                         <h2 aria-label="Page library">Page library</h2>
                         {!config.loading && config.features.pageBuilder.page.management.create.enabled ? (

--- a/testing/regression/cypress/e2e/features/page-library-sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library-sort.feature
@@ -1,0 +1,12 @@
+Feature: User can view existing page library data here.
+
+    Background:
+        Given I am logged in as "superuser" and password ""
+
+    Scenario: User list Page name in descending and ascending order
+        Given User navigates to Page Library
+        When User views the Page library
+        And User click the up or down arrow in the Page name column
+        Then Page names are listed in descending order
+        When User click the page name up or down arrow again
+        Then Page names are listed in ascending order

--- a/testing/regression/cypress/e2e/features/page-library-sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library-sort.feature
@@ -8,5 +8,5 @@ Feature: User can view existing page library data here.
         When User views the Page library
         And User click the up or down arrow in the Page name column
         Then Page names are listed in descending order
-        When User click the page name up or down arrow again
+        And User click the up or down arrow in the Page name column
         Then Page names are listed in ascending order

--- a/testing/regression/cypress/e2e/pages/page-library-sort.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library-sort.page.js
@@ -1,0 +1,78 @@
+class PageLibrarySortPage {
+    navigateToLibrary () {
+        cy.visit('/page-builder/pages')
+    }
+
+    userViewsPageLibrary() {
+        cy.get("#pageLibrary")
+    }
+
+    pageNameArrowClick() {
+        cy.get(".usa-button.usa-button--unstyled").first().click()
+    }
+
+    pageNameListedInDescendingOrder() {
+        this.checkOrder("Page name", "descending")
+    }
+
+    pageNameListedInAscendingOrder() {
+        this.checkOrder("Page name", "ascending")
+    }
+    checkOrder(columnName, sortType, dataType) {
+        const list = [];
+        const index = this.getColumnIndexByName(columnName);
+        this.openInvestigationTable.find("tbody tr").each(($tr) => {
+            list.push($tr.find("td").eq(index).text());
+        });
+        let isOrdered = false;
+        if (sortType === 'ascending') {
+            isOrdered = this.isAscending(list, dataType);
+        } else if (sortType === 'descending') {
+            isOrdered = this.isDescending(list, dataType);
+        }
+        expect(isOrdered).to.be.true;
+    }
+
+    getColumnIndexByName(columnName) {
+        if (columnName === "Page name") {
+            return 0;
+        } else if (columnName === "Condition") {
+            return 1;
+        } else if (columnName === "Document type") {
+            return 0;
+        }
+    }
+
+    get table() {
+        return "table[data-testid=table]";
+    }
+    get openInvestigationTable() {
+        return cy.get(this.table).eq(0);
+    }
+
+    isAscending(list, dataType) {
+        return list.every((value, index, array) => {
+            if (index === 0) {
+                return true; // Skip the first element
+            }
+            if (dataType === "date") {
+                return new Date(value) - new Date(array[index - 1]);
+            }
+            return value >= array[index - 1];
+        });
+    }
+
+    isDescending(list, dataType) {
+        return list.every((value, index, array) => {
+            if (index === 0) {
+                return true; // Skip the first element
+            }
+            if (dataType === "date") {
+                return new Date(array[index - 1]) - new Date(value);
+            }
+            return value <= array[index - 1];
+        });
+    }
+}
+
+export const pageLibrarySortPage = new PageLibrarySortPage()

--- a/testing/regression/cypress/step_definitions/page.library.sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page.library.sort.steps.js
@@ -1,0 +1,32 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+import {pageLibrarySortPage} from "@pages/page-library-sort.page";
+
+Then("User navigates to Page Library", () => {
+    pageLibrarySortPage.navigateToLibrary();
+});
+
+Then("User views the Page library", () => {
+    pageLibrarySortPage.userViewsPageLibrary();
+});
+
+Then("User already on Page Library", () => {
+    pageLibrarySortPage.navigateToLibrary();
+    pageLibrarySortPage.userViewsPageLibrary();
+});
+
+// Page name
+Then("User click the up or down arrow in the Page name column", () => {
+    pageLibrarySortPage.pageNameArrowClick();
+});
+
+Then("Page names are listed in descending order", () => {
+    pageLibrarySortPage.pageNameListedInDescendingOrder();
+});
+
+Then("User click the page name up or down arrow again", () => {
+    pageLibrarySortPage.pageNameArrowClick();
+});
+
+Then("Page names are listed in ascending order", () => {
+    pageLibrarySortPage.pageNameListedInAscendingOrder();
+});

--- a/testing/regression/cypress/step_definitions/page.library.sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page.library.sort.steps.js
@@ -9,11 +9,6 @@ Then("User views the Page library", () => {
     pageLibrarySortPage.userViewsPageLibrary();
 });
 
-Then("User already on Page Library", () => {
-    pageLibrarySortPage.navigateToLibrary();
-    pageLibrarySortPage.userViewsPageLibrary();
-});
-
 // Page name
 Then("User click the up or down arrow in the Page name column", () => {
     pageLibrarySortPage.pageNameArrowClick();
@@ -21,10 +16,6 @@ Then("User click the up or down arrow in the Page name column", () => {
 
 Then("Page names are listed in descending order", () => {
     pageLibrarySortPage.pageNameListedInDescendingOrder();
-});
-
-Then("User click the page name up or down arrow again", () => {
-    pageLibrarySortPage.pageNameArrowClick();
 });
 
 Then("Page names are listed in ascending order", () => {


### PR DESCRIPTION
## Description

Added end to end test case for Page Library Page name column ( [CNFT2-1012](https://cdc-nbs.atlassian.net/browse/CNFT2-1012) )
<img width="1480" alt="Screenshot 2024-04-17 at 8 19 34 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/e27d1024-277e-47b8-a42e-f0c84a5648c7">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-8

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1012]: https://cdc-nbs.atlassian.net/browse/CNFT2-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ