### PR TITLE
[CNT-8] - E2E page library sort Event type column

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library-sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library-sort.feature
@@ -10,3 +10,10 @@ Feature: User can view existing page library data here.
         Then Page names are listed in descending order
         And User click the up or down arrow in the Page name column
         Then Page names are listed in ascending order
+
+    Scenario: User list Event type in descending and ascending order
+        Given User already on Page Library
+        And User click the up or down arrow in the Event type column
+        Then Event type is listed in descending order
+        And User click the up or down arrow in the Event type column
+        Then Event type is listed in ascending order

--- a/testing/regression/cypress/e2e/features/page-library-sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library-sort.feature
@@ -2,17 +2,15 @@ Feature: User can view existing page library data here.
 
     Background:
         Given I am logged in as "superuser" and password ""
+        When User navigates to Page Library and views the Page library
 
     Scenario: User list Page name in descending and ascending order
-        Given User navigates to Page Library
-        When User views the Page library
         And User click the up or down arrow in the Page name column
         Then Page names are listed in descending order
         And User click the up or down arrow in the Page name column
         Then Page names are listed in ascending order
 
     Scenario: User list Event type in descending and ascending order
-        Given User already on Page Library
         And User click the up or down arrow in the Event type column
         Then Event type is listed in descending order
         And User click the up or down arrow in the Event type column

--- a/testing/regression/cypress/e2e/pages/page-library-sort.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library-sort.page.js
@@ -18,6 +18,19 @@ class PageLibrarySortPage {
     pageNameListedInAscendingOrder() {
         this.checkOrder("Page name", "ascending")
     }
+
+    eventTypeArrowClick() {
+        cy.get(".usa-button.usa-button--unstyled").eq(1).click()
+    }
+
+    eventTypeListedInDescendingOrder() {
+        this.checkOrder("Event type", "descending")
+    }
+
+    eventTypeListedInAscendingOrder() {
+        this.checkOrder("Event type", "ascending")
+    }
+
     checkOrder(columnName, sortType, dataType) {
         const list = [];
         const index = this.getColumnIndexByName(columnName);

--- a/testing/regression/cypress/step_definitions/page.library.sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page.library.sort.steps.js
@@ -9,6 +9,11 @@ Then("User views the Page library", () => {
     pageLibrarySortPage.userViewsPageLibrary();
 });
 
+Then("User already on Page Library", () => {
+    pageLibrarySortPage.navigateToLibrary();
+    pageLibrarySortPage.userViewsPageLibrary();
+});
+
 // Page name
 Then("User click the up or down arrow in the Page name column", () => {
     pageLibrarySortPage.pageNameArrowClick();
@@ -20,4 +25,17 @@ Then("Page names are listed in descending order", () => {
 
 Then("Page names are listed in ascending order", () => {
     pageLibrarySortPage.pageNameListedInAscendingOrder();
+});
+
+// Event type
+Then("User click the up or down arrow in the Event type column", () => {
+    pageLibrarySortPage.eventTypeArrowClick();
+});
+
+Then("Event type is listed in descending order", () => {
+    pageLibrarySortPage.eventTypeListedInDescendingOrder();
+});
+
+Then("Event type is listed in ascending order", () => {
+    pageLibrarySortPage.eventTypeListedInAscendingOrder();
 });

--- a/testing/regression/cypress/step_definitions/page.library.sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page.library.sort.steps.js
@@ -1,15 +1,7 @@
 import {Then} from "@badeball/cypress-cucumber-preprocessor";
 import {pageLibrarySortPage} from "@pages/page-library-sort.page";
 
-Then("User navigates to Page Library", () => {
-    pageLibrarySortPage.navigateToLibrary();
-});
-
-Then("User views the Page library", () => {
-    pageLibrarySortPage.userViewsPageLibrary();
-});
-
-Then("User already on Page Library", () => {
+Then("User navigates to Page Library and views the Page library", () => {
     pageLibrarySortPage.navigateToLibrary();
     pageLibrarySortPage.userViewsPageLibrary();
 });


### PR DESCRIPTION
## Description

Added end to end test case for Page Library Event type column ( [CNFT2-1013](https://cdc-nbs.atlassian.net/browse/CNFT2-1013) )
<img width="1493" alt="Screenshot 2024-04-17 at 12 13 31 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/071cac54-f2bd-4949-bae1-8aca851d88f6">

## Tickets

* [Jira Ticket]  https://cdc-nbs.atlassian.net/browse/CNT-8

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1013]: https://cdc-nbs.atlassian.net/browse/CNFT2-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ