### PR TITLE
[CNT-8] - E2E Page library sorting Status Column

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library-sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library-sort.feature
@@ -15,3 +15,10 @@ Feature: User can view existing page library data here.
         Then Event type is listed in descending order
         And User click the up or down arrow in the Event type column
         Then Event type is listed in ascending order
+
+    Scenario: User list Status in descending and ascending order
+        And User click the up or down arrow in the Status column
+        Then Status is listed in descending order
+        And User click the up or down arrow in the Status column
+        Then Status is listed in ascending order
+

--- a/testing/regression/cypress/e2e/pages/page-library-sort.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library-sort.page.js
@@ -31,6 +31,17 @@ class PageLibrarySortPage {
         this.checkOrder("Event type", "ascending")
     }
 
+    statusArrowClick() {
+        cy.get(".usa-button.usa-button--unstyled").eq(2).click()
+    }
+
+    statusListedInDescendingOrder() {
+        this.checkOrder("Status", "descending")
+    }
+
+    statusListedInAscendingOrder() {
+        this.checkOrder("Status", "ascending")
+    }
     checkOrder(columnName, sortType, dataType) {
         const list = [];
         const index = this.getColumnIndexByName(columnName);

--- a/testing/regression/cypress/step_definitions/page.library.sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page.library.sort.steps.js
@@ -31,3 +31,16 @@ Then("Event type is listed in descending order", () => {
 Then("Event type is listed in ascending order", () => {
     pageLibrarySortPage.eventTypeListedInAscendingOrder();
 });
+
+// Status
+Then("User click the up or down arrow in the Status column", () => {
+    pageLibrarySortPage.statusArrowClick();
+});
+
+Then("Status is listed in descending order", () => {
+    pageLibrarySortPage.statusListedInDescendingOrder();
+});
+
+Then("Status is listed in ascending order", () => {
+    pageLibrarySortPage.statusListedInAscendingOrder();
+});


### PR DESCRIPTION
## Description

Added end to end test case for Page Library Event type column ( [CNFT2-1016](https://cdc-nbs.atlassian.net/browse/CNFT2-1016) )
<img width="1491" alt="Screenshot 2024-04-18 at 9 40 38 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/41772361-07a6-402f-b2f3-5d3687c0a372">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-8

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1016]: https://cdc-nbs.atlassian.net/browse/CNFT2-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ