### PR TITLE
[CNT-8] - E2E Page library sorting Last Updated Column

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library-sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library-sort.feature
@@ -22,3 +22,8 @@ Feature: User can view existing page library data here.
         And User click the up or down arrow in the Status column
         Then Status is listed in ascending order
 
+    Scenario: User list Last Updated in descending and ascending order
+        And User click the up or down arrow in the Last Updated column
+        Then Last Updated is listed in descending order - latest date
+        And User click the up or down arrow in the Last Updated column
+        Then Last Updated is listed in ascending order - earliest date

--- a/testing/regression/cypress/e2e/pages/page-library-sort.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library-sort.page.js
@@ -42,6 +42,19 @@ class PageLibrarySortPage {
     statusListedInAscendingOrder() {
         this.checkOrder("Status", "ascending")
     }
+
+    lastUpdatedArrowClick() {
+        cy.get(".usa-button.usa-button--unstyled").eq(3).click()
+    }
+
+    lastUpdatedListedInDescendingOrder() {
+        this.checkOrder("Last updated", "descending", "date")
+    }
+
+    lastUpdatedListedInAscendingOrder() {
+        this.checkOrder("Last updated", "ascending", "date")
+    }
+
     checkOrder(columnName, sortType, dataType) {
         const list = [];
         const index = this.getColumnIndexByName(columnName);

--- a/testing/regression/cypress/step_definitions/page.library.sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page.library.sort.steps.js
@@ -44,3 +44,16 @@ Then("Status is listed in descending order", () => {
 Then("Status is listed in ascending order", () => {
     pageLibrarySortPage.statusListedInAscendingOrder();
 });
+
+// Last updated
+Then("User click the up or down arrow in the Last Updated column", () => {
+    pageLibrarySortPage.lastUpdatedArrowClick();
+});
+
+Then("Last Updated is listed in descending order - latest date", () => {
+    pageLibrarySortPage.lastUpdatedListedInDescendingOrder();
+});
+
+Then("Last Updated is listed in ascending order - earliest date", () => {
+    pageLibrarySortPage.lastUpdatedListedInAscendingOrder();
+});


### PR DESCRIPTION
## Description

Added end to end test case for Page Library Last Updated column ( [CNFT2-1017](https://cdc-nbs.atlassian.net/browse/CNFT2-1017) )
<img width="1501" alt="Screenshot 2024-04-18 at 12 03 33 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/f38a9472-f39a-4277-b9cb-659c119dc2ac">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-8

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1017]: https://cdc-nbs.atlassian.net/browse/CNFT2-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ