### PR TITLE
[CNT-8] - E2E Page library sorting Last Updated Column Date Format

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library/sort.feature
@@ -27,3 +27,7 @@ Feature: User can view existing page library data here.
         Then Last Updated is listed in descending order - latest date
         And User click the up or down arrow in the Last Updated column
         Then Last Updated is listed in ascending order - earliest date
+
+    Scenario: Verify Last Updated displays in the correct date format
+        When User views the Last Updated column
+        And Application should display the Last Updated date in the correct format

--- a/testing/regression/cypress/e2e/pages/page-library/sort.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/sort.page.js
@@ -1,4 +1,4 @@
-class PageLibrarySortPage {
+class SortPage {
     navigateToLibrary () {
         cy.visit('/page-builder/pages')
     }
@@ -42,7 +42,6 @@ class PageLibrarySortPage {
     statusListedInAscendingOrder() {
         this.checkOrder("Status", "ascending")
     }
-
     lastUpdatedArrowClick() {
         cy.get(".usa-button.usa-button--unstyled").eq(3).click()
     }
@@ -53,6 +52,13 @@ class PageLibrarySortPage {
 
     lastUpdatedListedInAscendingOrder() {
         this.checkOrder("Last updated", "ascending", "date")
+    }
+    lastUpdatedView() {
+        cy.get(".usa-button.usa-button--unstyled").eq(3)
+    }
+
+    lastUpdatedDateFormat() {
+        this.checkDateFormat("Last updated")
     }
 
     checkOrder(columnName, sortType, dataType) {
@@ -73,10 +79,12 @@ class PageLibrarySortPage {
     getColumnIndexByName(columnName) {
         if (columnName === "Page name") {
             return 0;
-        } else if (columnName === "Condition") {
+        } else if (columnName === "Event type") {
             return 1;
-        } else if (columnName === "Document type") {
-            return 0;
+        } else if (columnName === "Status") {
+            return 2;
+        } else if (columnName === "Last updated") {
+            return 3;
         }
     }
 
@@ -110,6 +118,25 @@ class PageLibrarySortPage {
             return value <= array[index - 1];
         });
     }
+
+    checkDateFormat(columnName) {
+        const list = [];
+        const index = this.getColumnIndexByName(columnName);
+        this.openInvestigationTable.find("tbody tr").each(($tr) => {
+            list.push($tr.find("td").eq(index).text());
+        });
+        let correctFormat = false;
+        const check = () => {
+            return list.every((value, index, array) => {
+                if (index === 0) {
+                    return true; // Skip the first element
+                }
+                return value.split("/").length === 3;
+            });
+        }
+        correctFormat = check();
+        expect(correctFormat).to.be.true;
+    }
 }
 
-export const pageLibrarySortPage = new PageLibrarySortPage()
+export const pageLibrarySortPage = new SortPage()

--- a/testing/regression/cypress/step_definitions/page-library/sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/sort.steps.js
@@ -1,5 +1,5 @@
 import {Then} from "@badeball/cypress-cucumber-preprocessor";
-import {pageLibrarySortPage} from "@pages/page-library-sort.page";
+import {pageLibrarySortPage} from "@pages/page-library/sort.page";
 
 Then("User navigates to Page Library and views the Page library", () => {
     pageLibrarySortPage.navigateToLibrary();
@@ -56,4 +56,13 @@ Then("Last Updated is listed in descending order - latest date", () => {
 
 Then("Last Updated is listed in ascending order - earliest date", () => {
     pageLibrarySortPage.lastUpdatedListedInAscendingOrder();
+});
+
+// Last updated - date format
+Then("User views the Last Updated column", () => {
+    pageLibrarySortPage.lastUpdatedView();
+});
+
+Then("Application should display the Last Updated date in the correct format", () => {
+    pageLibrarySortPage.lastUpdatedDateFormat();
 });


### PR DESCRIPTION
## Description

Added end to end test case for Page Library Last Updated column Date Format ( [CNFT2-1018](https://cdc-nbs.atlassian.net/browse/CNFT2-1018) )
<img width="1496" alt="Screenshot 2024-04-19 at 7 09 16 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/7f4bf1e6-e0ca-4e8b-8e5a-4b354aca3df7">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-8

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
