### PR TITLE
[FIX] CVE-2024-22262

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-springBoot = '3.2.4'
-spring-security = '6.2.3'
+springBoot = '3.2.5'
+spring-security = '6.2.4'
 jackson = '2.15.4'
 queryDSL = '5.0.0'
 spring-kafka = '3.1.3'


### PR DESCRIPTION
## Description

Updates Spring Boot to 3.2.5 to resolve [CVE-2024-22262](https://avd.aquasec.com/nvd/2024/cve-2024-22262/) which first appeared on [this scan](https://github.com/CDCgov/NEDSS-Modernization/security/code-scanning/436).