### PR TITLE
[CNT-8] - E2E page library sort last updated by column

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library/sort.feature
@@ -31,3 +31,9 @@ Feature: User can view existing page library data here.
     Scenario: Verify Last Updated displays in the correct date format
         When User views the Last Updated column
         And Application should display the Last Updated date in the correct format
+
+    Scenario: User list Last Updated by in descending and ascending order
+        And User click the up or down arrow in the Last Updated by column
+        Then Last Updated by is listed in descending order
+        And User click the up or down arrow in the Last Updated by column
+        Then Last Updated by is listed in ascending order

--- a/testing/regression/cypress/e2e/pages/page-library/sort.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/sort.page.js
@@ -61,6 +61,18 @@ class SortPage {
         this.checkDateFormat("Last updated")
     }
 
+    lastUpdatedByArrowClick() {
+        cy.get(".usa-button.usa-button--unstyled").eq(4).click()
+    }
+
+    lastUpdatedByListedInDescendingOrder() {
+        this.checkOrder("Last updated by", "descending", "date")
+    }
+
+    lastUpdatedByListedInAscendingOrder() {
+        this.checkOrder("Last updated by", "ascending", "date")
+    }
+
     checkOrder(columnName, sortType, dataType) {
         const list = [];
         const index = this.getColumnIndexByName(columnName);
@@ -85,6 +97,8 @@ class SortPage {
             return 2;
         } else if (columnName === "Last updated") {
             return 3;
+        } else if (columnName === "Last updated by") {
+            return 4;
         }
     }
 

--- a/testing/regression/cypress/step_definitions/page-library/sort.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/sort.steps.js
@@ -66,3 +66,16 @@ Then("User views the Last Updated column", () => {
 Then("Application should display the Last Updated date in the correct format", () => {
     pageLibrarySortPage.lastUpdatedDateFormat();
 });
+
+// Last updated by
+Then("User click the up or down arrow in the Last Updated by column", () => {
+    pageLibrarySortPage.lastUpdatedByArrowClick();
+});
+
+Then("Last Updated by is listed in descending order", () => {
+    pageLibrarySortPage.lastUpdatedByListedInDescendingOrder();
+});
+
+Then("Last Updated by is listed in ascending order", () => {
+    pageLibrarySortPage.lastUpdatedByListedInAscendingOrder();
+});


### PR DESCRIPTION
## Description

Added end to end test case for Page Library sorting on Last Updated by column  ( [CNFT2-1019](https://cdc-nbs.atlassian.net/browse/CNFT2-1019) )
<img width="1502" alt="Screenshot 2024-04-19 at 8 15 23 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/d7f1a876-cca6-4b12-9467-74cabd365efa">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-8

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1019]: https://cdc-nbs.atlassian.net/browse/CNFT2-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ