### PR TITLE
Display ungroup option for published with draft

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.spec.tsx
@@ -1,0 +1,224 @@
+import { render } from '@testing-library/react';
+import { SubsectionHeader } from './SubsectionHeader';
+import { PagesResponse, PagesSubSection } from 'apps/page-builder/generated';
+import { PageManagementProvider } from '../../usePageManagement';
+import { AlertProvider } from 'alert';
+import userEvent from '@testing-library/user-event';
+
+const onAdd = jest.fn();
+const handleExpanded = jest.fn();
+const onDelete = jest.fn();
+const onEdit = jest.fn();
+const onGroup = jest.fn();
+
+const unGroupedSubsection: PagesSubSection = {
+    id: 1,
+    name: 'Test Subsection',
+    order: 23,
+    visible: true,
+    isGrouped: false,
+    isGroupable: true,
+    questionIdentifier: 'TSTSBSCTN',
+    blockName: undefined,
+    questions: [{ id: 2, name: 'test Question', order: 24, isPublished: false }]
+};
+
+const groupedSubsection: PagesSubSection = {
+    id: 1,
+    name: 'Test Subsection',
+    order: 23,
+    visible: true,
+    isGrouped: true,
+    isGroupable: false,
+    questionIdentifier: 'TSTSBSCTN',
+    blockName: 'BLOCK_NAME',
+    questions: [{ id: 2, name: 'test Question', order: 24, isPublished: false }]
+};
+
+describe('Subsection header', () => {
+    it('should display group question option for Draft page', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Draft'
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={unGroupedSubsection}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Group questions')).toBeInTheDocument();
+    });
+
+    it('should display group question option for Published with Draft page', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Published with Draft'
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={unGroupedSubsection}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Group questions')).toBeInTheDocument();
+    });
+
+    it('should not display group question option for Published page', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Published'
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={unGroupedSubsection}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Group questions')).not.toBeInTheDocument();
+    });
+    it('should not display group question option if a question is published', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Published with Draft'
+        };
+
+        const subsectionWithPublishedQuestion: PagesSubSection = {
+            id: 1,
+            name: 'Test Subsection',
+            order: 23,
+            visible: true,
+            isGrouped: false,
+            isGroupable: true,
+            questionIdentifier: 'TSTSBSCTN',
+            blockName: 'BLOCK_NAME',
+            questions: [{ id: 2, name: 'test Question', order: 24, isPublished: true }]
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={subsectionWithPublishedQuestion}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Group questions')).not.toBeInTheDocument();
+    });
+
+    it('should not display ungroup question option for Published page', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Published'
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={groupedSubsection}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Ungroup questions')).not.toBeInTheDocument();
+    });
+
+    it('should display ungroup question option for Draft page', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Draft'
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={groupedSubsection}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Ungroup questions')).toBeInTheDocument();
+    });
+
+    it('should display ungroup question option for Published with Draft page', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Published with Draft'
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={groupedSubsection}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Ungroup questions')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.spec.tsx
@@ -110,6 +110,7 @@ describe('Subsection header', () => {
         userEvent.click(getByRole('menu'));
         expect(queryByText('Group questions')).not.toBeInTheDocument();
     });
+
     it('should not display group question option if a question is published', () => {
         const page: PagesResponse = {
             id: 12039120,
@@ -220,5 +221,42 @@ describe('Subsection header', () => {
         );
         userEvent.click(getByRole('menu'));
         expect(queryByText('Ungroup questions')).toBeInTheDocument();
+    });
+
+    it('should not display ungroup question option if a question is published', () => {
+        const page: PagesResponse = {
+            id: 12039120,
+            name: 'Test Page',
+            status: 'Published with Draft'
+        };
+
+        const subsectionWithPublishedQuestion: PagesSubSection = {
+            id: 1,
+            name: 'Test Subsection',
+            order: 23,
+            visible: true,
+            isGrouped: true,
+            isGroupable: true,
+            questionIdentifier: 'TSTSBSCTN',
+            blockName: 'BLOCK_NAME',
+            questions: [{ id: 2, name: 'test Question', order: 24, isPublished: true }]
+        };
+        const { queryByText, getByRole } = render(
+            <AlertProvider>
+                <PageManagementProvider page={page} fetch={jest.fn()} refresh={jest.fn} loading={false}>
+                    <SubsectionHeader
+                        subsection={subsectionWithPublishedQuestion}
+                        onAddQuestion={onAdd}
+                        onExpandedChange={handleExpanded}
+                        isExpanded={true}
+                        onDeleteSubsection={onDelete}
+                        onEditSubsection={onEdit}
+                        onGroupQuestion={onGroup}
+                    />
+                </PageManagementProvider>
+            </AlertProvider>
+        );
+        userEvent.click(getByRole('menu'));
+        expect(queryByText('Ungroup questions')).not.toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -93,14 +93,16 @@ export const SubsectionHeader = ({
                     <Button type="button" onClick={() => closeThenAct(onEditSubsection)}>
                         <Icon.Edit size={3} /> Edit subsection
                     </Button>
-                    {subsection.isGrouped && page.status !== 'Published' && (
-                        <ModalToggleButton
-                            type="button"
-                            modalRef={ungroupSubsectionModalRef}
-                            onClick={() => setCloseOptions(true)}>
-                            <IconComponent name={'group'} size={'s'} /> Ungroup questions
-                        </ModalToggleButton>
-                    )}
+                    {subsection.isGrouped &&
+                        page.status !== 'Published' &&
+                        subsection.questions.every((question) => question.isPublished === false) && (
+                            <ModalToggleButton
+                                type="button"
+                                modalRef={ungroupSubsectionModalRef}
+                                onClick={() => setCloseOptions(true)}>
+                                <IconComponent name={'group'} size={'s'} /> Ungroup questions
+                            </ModalToggleButton>
+                        )}
                     {!subsection.isGrouped &&
                         page.status !== 'Published' &&
                         subsection.questions.every((question) => question.isPublished === false) && (

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -88,31 +88,30 @@ export const SubsectionHeader = ({
                     Add question
                 </Button>
                 <MoreOptions
-                    header={<Icon.MoreVert size={4} onClick={() => setCloseOptions(false)} />}
+                    header={<Icon.MoreVert role="menu" size={4} onClick={() => setCloseOptions(false)} />}
                     close={closeOptions}>
                     <Button type="button" onClick={() => closeThenAct(onEditSubsection)}>
                         <Icon.Edit size={3} /> Edit subsection
                     </Button>
-                    {subsection.isGrouped
-                        ? page?.status !== 'Published with Draft' && (
-                              <ModalToggleButton
-                                  type="button"
-                                  modalRef={ungroupSubsectionModalRef}
-                                  onClick={() => setCloseOptions(true)}>
-                                  <IconComponent name={'group'} size={'s'} /> Ungroup questions
-                              </ModalToggleButton>
-                          )
-                        : null}
-                    {subsection.isGrouped === false &&
-                    subsection.questions.every((question) => question.isPublished === false) ? (
-                        <>
-                            {subsection.isGroupable && subsection.questions.length > 0 && (
-                                <Button type="button" onClick={() => closeThenAct(onGroupQuestion)}>
-                                    <IconComponent name={'group'} size={'s'} /> Group questions
-                                </Button>
-                            )}
-                        </>
-                    ) : null}
+                    {subsection.isGrouped && page.status !== 'Published' && (
+                        <ModalToggleButton
+                            type="button"
+                            modalRef={ungroupSubsectionModalRef}
+                            onClick={() => setCloseOptions(true)}>
+                            <IconComponent name={'group'} size={'s'} /> Ungroup questions
+                        </ModalToggleButton>
+                    )}
+                    {!subsection.isGrouped &&
+                        page.status !== 'Published' &&
+                        subsection.questions.every((question) => question.isPublished === false) && (
+                            <>
+                                {subsection.isGroupable && subsection.questions.length > 0 && (
+                                    <Button type="button" onClick={() => closeThenAct(onGroupQuestion)}>
+                                        <IconComponent name={'group'} size={'s'} /> Group questions
+                                    </Button>
+                                )}
+                            </>
+                        )}
                     <ModalToggleButton type="button" modalRef={addStaticElementModalRef}>
                         <Icon.Add size={3} /> Add static element
                     </ModalToggleButton>


### PR DESCRIPTION
## Description

Allow ungrouping of subsection if page is `Published with Draft`.
Do not allow grouping / ungrouping if subsection contains a `published` question.

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
