### PR TITLE
[CNT-9] - E2E page library pagination default value

### DIFF
--- a/apps/modernization-ui/src/components/Table/Table.tsx
+++ b/apps/modernization-ui/src/components/Table/Table.tsx
@@ -183,7 +183,7 @@ export const TableComponent = ({
                             </>
                         ) : (
                             <>
-                                Showing <RangeToggle /> of {totalResults}
+                                Showing <RangeToggle /> of <span id="totalRowCount">{totalResults}</span>
                             </>
                         )}
                     </div>

--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -1,0 +1,8 @@
+Feature: User can view existing page library data here.
+
+    Background:
+        Given I am logged in as "superuser" and password ""
+        When User navigates to Page Library and views the Page library
+
+    Scenario: User checks for 10 rows of pages listed in the library
+        Then User should see by default 10 rows of pages listed in the library

--- a/testing/regression/cypress/e2e/pages/page-library/pagination.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/pagination.page.js
@@ -1,0 +1,11 @@
+class PaginationPage {
+    checkForDefaultRows () {
+        cy.get('#range-toggle').should('have.value', '10')
+    }
+
+    get table() {
+        return "table[data-testid=table]";
+    }
+}
+
+export const pageLibraryPaginationPage = new PaginationPage()

--- a/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
@@ -1,0 +1,6 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+import {pageLibraryPaginationPage} from "@pages/page-library/pagination.page";
+
+Then("User should see by default 10 rows of pages listed in the library", () => {
+    pageLibraryPaginationPage.checkForDefaultRows();
+});


### PR DESCRIPTION
## Description

Added end to end test case for Page Library pagination for default value ( [CNFT2-975](https://cdc-nbs.atlassian.net/browse/CNFT2-975) )
<img width="1500" alt="Screenshot 2024-04-22 at 9 24 33 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/d2806b75-6037-4268-b2d2-f5632a48b59a">


## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-9

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-975]: https://cdc-nbs.atlassian.net/browse/CNFT2-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ