### PR TITLE
[CNT-9] - E2E page library pagination after redirect default to 10

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -10,3 +10,9 @@ Feature: User can view existing page library data here.
     Scenario: User selects for 20 rows to show in the Page library
         And User select 20 left footer of the page to show the list of pages
         Then User should see only 20 rows in the library and for each subsequent list where applicable
+
+    Scenario: Verify the selection of 20 is displaying 10 rows after redirect back to Page Library
+        And User select 20 left footer of the page to show the list of pages
+        Then User navigates to the Create page
+        And User navigates to Page Library and views the Page library
+        Then User should only see 10 rows in the library and for each subsequent list where applicable

--- a/testing/regression/cypress/e2e/pages/page-library/pagination.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/pagination.page.js
@@ -45,6 +45,9 @@ class PaginationPage {
                 return parseInt(text, 10)
             });
     }
+    navigateToCreatePage () {
+        cy.visit('/page-builder/pages/add')
+    }
 }
 
 export const pageLibraryPaginationPage = new PaginationPage()

--- a/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
@@ -12,3 +12,9 @@ Then("User select 20 left footer of the page to show the list of pages", () => {
 Then("User should see only 20 rows in the library and for each subsequent list where applicable", () => {
     pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(20);
 });
+Then("User navigates to the Create page", () => {
+    pageLibraryPaginationPage.navigateToCreatePage();
+});
+Then("User should only see 10 rows in the library and for each subsequent list where applicable", () => {
+    pageLibraryPaginationPage.checkForDefaultRows();
+});


### PR DESCRIPTION
## Description

Added end to end test case for Page Library pagination after it redirect from create page still defaulted to 10 ( [CNFT2-981](https://cdc-nbs.atlassian.net/browse/CNFT2-981) )
<img width="1499" alt="Screenshot 2024-04-23 at 8 35 26 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/1ba87cb1-a0a6-4a46-a147-9dbd2d073406">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-9

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-981]: https://cdc-nbs.atlassian.net/browse/CNFT2-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ