### PR TITLE
PageBuilder misc bug fixes

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/DeleteQuestion/DeleteQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/DeleteQuestion/DeleteQuestion.tsx
@@ -4,10 +4,11 @@ import styles from './delete-question.module.scss';
 import { ConfirmationModal } from '../../../../confirmation';
 
 type CommonProps = {
+    isStaticElement: boolean;
     onDelete?: () => void;
 };
 
-const DeleteQuestion = ({ onDelete }: CommonProps) => {
+const DeleteQuestion = ({ onDelete, isStaticElement }: CommonProps) => {
     const deleteModalRef = useRef<ModalRef>(null);
     const handleDeleteQuetions = () => {
         onDelete?.();
@@ -20,8 +21,8 @@ const DeleteQuestion = ({ onDelete }: CommonProps) => {
             <ConfirmationModal
                 modal={deleteModalRef}
                 title="Warning"
-                message="Are you sure you want to delete the question?"
-                detail="Deleting this question cannot be undone. Are you sure you want to continue?"
+                message={`Are you sure you want to delete the ${isStaticElement ? 'static element' : 'question'}?`}
+                detail={`Deleting this ${isStaticElement ? 'static element' : 'question'} cannot be undone. Are you sure you want to continue?`}
                 confirmText="Yes, delete"
                 onConfirm={() => {
                     handleDeleteQuetions();

--- a/apps/modernization-ui/src/apps/page-builder/components/TabGroup/TabGroup.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/TabGroup/TabGroup.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './tab-group.module.scss';
 
 type Props = {
@@ -14,6 +14,10 @@ export const TabGroup = ({ initialSelection, tabs, onSelected }: Props) => {
         setSelected(id);
         onSelected(id);
     };
+
+    useEffect(() => {
+        setSelected(initialSelection);
+    }, [initialSelection]);
 
     return (
         <ul className={styles.tabs}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -5,6 +5,7 @@ import { PagesQuestion } from 'apps/page-builder/generated';
 import { Heading } from 'components/heading';
 import { useEffect, useState } from 'react';
 import styles from './question-header.module.scss';
+import { staticElementTypes } from '../staticelement/EditStaticElement';
 
 type Props = {
     question: PagesQuestion;
@@ -61,16 +62,25 @@ export const QuestionHeader = ({ question, onEditQuestion, onRequiredChange, onD
                 <Button unstyled className={styles.editButton} type="button" onClick={onEditQuestion}>
                     <Icon.Edit style={{ cursor: 'pointer' }} size={3} className="primary-color" />
                 </Button>
-                {!question.isStandard && !question.isPublished && <DeleteQuestion onDelete={onDeleteQuestion} />}
-                <div className={styles.divider}>|</div>
-                <div className={styles.requiredToggle}>Not required</div>
-                <ToggleButton
-                    checked={required}
-                    onChange={() => {
-                        setRequired(!required);
-                    }}
-                />
-                <div className={styles.requiredToggle}>Required</div>
+                {!question.isStandard && !question.isPublished && (
+                    <DeleteQuestion
+                        onDelete={onDeleteQuestion}
+                        isStaticElement={staticElementTypes.includes(question.displayComponent ?? 0)}
+                    />
+                )}
+                {!staticElementTypes.includes(question.displayComponent ?? 0) && (
+                    <>
+                        <div className={styles.divider}>|</div>
+                        <div className={styles.requiredToggle}>Not required</div>
+                        <ToggleButton
+                            checked={required}
+                            onChange={() => {
+                                setRequired(!required);
+                            }}
+                        />
+                        <div className={styles.requiredToggle}>Required</div>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -25,15 +25,11 @@ export const QuestionHeader = ({ question, onEditQuestion, onRequiredChange, onD
 
     useEffect(() => {
         if (question.required !== undefined) {
-            setRequired(question.required);
+            if (required !== question.required) {
+                onRequiredChange(required);
+            }
         }
-    }, [question.required]);
-
-    useEffect(() => {
-        if (required !== question.required) {
-            onRequiredChange(required);
-        }
-    }, [required]);
+    }, [required, question.required]);
 
     const getHeadingText = (displayComponent: number | undefined) => {
         switch (displayComponent) {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/EditStaticElement.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/staticelement/EditStaticElement.tsx
@@ -35,6 +35,8 @@ const lineSeparatorId = 1012;
 const originalElecDocId = 1036;
 const readOnlyPartId = 1030;
 
+export const staticElementTypes = [hyperlinkId, lineSeparatorId, readOnlyPartId, commentsReadOnlyId, originalElecDocId];
+
 type StaticElementFormValues = UpdateReadOnlyComments | UpdateHyperlink | UpdateDefault;
 
 export const EditStaticElement = ({ question, onCloseModal }: EditStaticProps) => {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
@@ -43,7 +43,7 @@ export const Subsection = ({
 }: Props) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(true);
     const { page, refresh } = usePageManagement();
-    const { showAlert } = useAlert();
+    const { showAlert, showError } = useAlert();
     const { setRequired } = useSetPageQuestionRequired();
 
     const handleAlert = (message: string) => {
@@ -59,18 +59,24 @@ export const Subsection = ({
             PageStaticControllerService.deleteStaticElement({
                 page: page.id,
                 requestBody: { componentId: id }
-            }).then(() => {
-                handleAlert(`Element deleted successfully`);
-                refresh();
-            });
+            })
+                .then(() => {
+                    handleAlert(`Element deleted successfully`);
+                    refresh();
+                })
+                .catch(() => showError({ message: 'Failed to delete static element' }));
         } else {
             PageQuestionControllerService.deleteQuestion({
                 page: page.id,
                 questionId: Number(id)
-            }).then(() => {
-                refresh();
-                handleAlert(`Question deleted successfully`);
-            });
+            })
+                .then(() => {
+                    refresh();
+                    handleAlert(`Question deleted successfully`);
+                })
+                .catch((error) => {
+                    showError({ message: error.body?.message ?? 'Failed to delete question' });
+                });
         }
     };
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
@@ -11,6 +11,7 @@ import { usePageManagement } from '../../usePageManagement';
 import { Question } from '../question/Question';
 import { SubsectionHeader } from './SubsectionHeader';
 import styles from './subsection.module.scss';
+import { staticElementTypes } from '../staticelement/EditStaticElement';
 
 type Props = {
     subsection: PagesSubSection;
@@ -22,14 +23,6 @@ type Props = {
     onEditValueset: (valuesetName: string) => void;
     onChangeValueset: (question: PagesQuestion) => void;
 };
-
-const hyperlinkID = 1003;
-const lineSeparatorID = 1012;
-const readOnlyParticipants = 1030;
-const readOnlyComments = 1014;
-const originalElecDoc = 1036;
-
-const staticElementTypes = [hyperlinkID, lineSeparatorID, readOnlyParticipants, readOnlyComments, originalElecDoc];
 
 export const Subsection = ({
     subsection,

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/Subsection.tsx
@@ -6,7 +6,7 @@ import {
     PagesSubSection
 } from 'apps/page-builder/generated';
 import { useSetPageQuestionRequired } from 'apps/page-builder/hooks/api/useSetPageQuestionRequired';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePageManagement } from '../../usePageManagement';
 import { Question } from '../question/Question';
 import { SubsectionHeader } from './SubsectionHeader';
@@ -37,7 +37,7 @@ export const Subsection = ({
     const [isExpanded, setIsExpanded] = useState<boolean>(true);
     const { page, refresh } = usePageManagement();
     const { showAlert, showError } = useAlert();
-    const { setRequired } = useSetPageQuestionRequired();
+    const { setRequired, response } = useSetPageQuestionRequired();
 
     const handleAlert = (message: string) => {
         showAlert({ message: message, type: 'success' });
@@ -75,8 +75,11 @@ export const Subsection = ({
 
     const handleRequiredChange = (question: number, required: boolean) => {
         setRequired(page.id, question, required);
-        refresh();
     };
+
+    useEffect(() => {
+        refresh();
+    }, [JSON.stringify(response)]);
 
     return (
         <div className={styles.subsection}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -9,6 +9,7 @@ import { ConfirmationModal } from 'confirmation';
 import { useRef, useState } from 'react';
 import { usePageManagement } from '../../usePageManagement';
 import styles from './subsection.module.scss';
+import { staticElementTypes } from '../staticelement/EditStaticElement';
 
 type Props = {
     subsection: PagesSubSection;
@@ -105,7 +106,11 @@ export const SubsectionHeader = ({
                         )}
                     {!subsection.isGrouped &&
                         page.status !== 'Published' &&
-                        subsection.questions.every((question) => question.isPublished === false) && (
+                        subsection.questions.every(
+                            (question) =>
+                                question.isPublished === false &&
+                                !staticElementTypes.includes(question.displayComponent ?? 0)
+                        ) && (
                             <>
                                 {subsection.isGroupable && subsection.questions.length > 0 && (
                                     <Button type="button" onClick={() => closeThenAct(onGroupQuestion)}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/header/tabs/PageTabs.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/header/tabs/PageTabs.tsx
@@ -27,8 +27,9 @@ type Props = {
     onAddSuccess?: () => void;
 };
 export const PageTabs = ({ pageId, tabs, onAddSuccess }: Props) => {
-    const { selected, select, selectStaticTab } = usePageManagement();
+    const { selected, select, displayStaticTab, selectStaticTab } = usePageManagement();
     const [displayedTabs, setDisplayedTabs] = useState<PagesTab[]>([]);
+    const [initialSelection, setInitialSelection] = useState<number>(0);
 
     useEffect(() => {
         if (!onAddSuccess) {
@@ -37,6 +38,18 @@ export const PageTabs = ({ pageId, tabs, onAddSuccess }: Props) => {
             setDisplayedTabs(tabs);
         }
     }, [JSON.stringify(tabs), onAddSuccess]);
+
+    useEffect(() => {
+        if (selected?.id) {
+            setInitialSelection(selected.id);
+        } else if (displayStaticTab) {
+            if (displayStaticTab === 'contactRecord') {
+                setInitialSelection(-1);
+            } else {
+                setInitialSelection(-2);
+            }
+        }
+    }, [selected?.id, displayStaticTab]);
 
     const handleSelectionChanged = (id: string | number) => {
         const tab = tabs.find((t) => t.id === id);
@@ -57,7 +70,7 @@ export const PageTabs = ({ pageId, tabs, onAddSuccess }: Props) => {
 
     return (
         <div className={styles.pageTabs}>
-            <TabGroup tabs={displayedTabs} onSelected={handleSelectionChanged} initialSelection={selected?.id} />
+            <TabGroup tabs={displayedTabs} onSelected={handleSelectionChanged} initialSelection={initialSelection} />
             {onAddSuccess ? <ManageTabs pageId={pageId} tabs={tabs} onAddSuccess={onAddSuccess} /> : null}
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
@@ -13,7 +13,7 @@ import { Loading } from 'components/Spinner';
 import { LinkButton } from 'components/button';
 import { NavLinkButton } from 'components/button/nav/NavLinkButton';
 import { ConfirmationModal } from 'confirmation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Heading } from '../../../../../components/heading';
 import { PageControllerService } from '../../../generated/services/PageControllerService';
@@ -23,6 +23,7 @@ import { PageInformation } from './information/PageInformation';
 import styles from './preview-page.module.scss';
 import { StaticTabContent } from './staticTabContent/StaticTabContent';
 import { PreviewTab } from './tab';
+import { PagesTab } from 'apps/page-builder/generated';
 
 const PreviewPage = () => {
     const { page, fetch, refresh } = useGetPageDetails();
@@ -37,7 +38,8 @@ const PreviewPage = () => {
 };
 
 const PreviewPageContent = () => {
-    const { page, selected, displayStaticTab, refresh } = usePageManagement();
+    const { page, selected, displayStaticTab, refresh, select, selectStaticTab } = usePageManagement();
+    const [visibleTabs, setVisibleTabs] = useState<PagesTab[]>([]);
     const saveTemplateRef = useRef<ModalRef>(null);
     const deleteDraftRef = useRef<ModalRef>(null);
     const publishDraftRef = useRef<ModalRef>(null);
@@ -45,6 +47,20 @@ const PreviewPageContent = () => {
     const { showAlert } = useAlert();
     const navigate = useNavigate();
     const [isPublishing, setIsPublishing] = useState(false);
+
+    useEffect(() => {
+        if (page.tabs) {
+            const filteredTabs = page.tabs.filter((t) => t.visible);
+            setVisibleTabs(filteredTabs);
+            if (filteredTabs.length > 0) {
+                select(filteredTabs[0]);
+            } else {
+                selectStaticTab('contactRecord');
+            }
+        } else {
+            setVisibleTabs([]);
+        }
+    }, [page.tabs]);
 
     const handleCreateDraft = () => {
         PageControllerService.savePageDraft({
@@ -115,7 +131,7 @@ const PreviewPageContent = () => {
     return (
         <>
             <PageManagementLayout name={page.name} mode={page.status}>
-                <PageHeader page={page} tabs={page.tabs ?? []}>
+                <PageHeader page={page} tabs={visibleTabs}>
                     <PageManagementMenu>
                         <NavLinkButton to={`/page-builder/pages/${page.id}/business-rules`} type="outline">
                             Business rules

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/section/PreviewSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/section/PreviewSection.tsx
@@ -15,11 +15,21 @@ const PreviewSection = ({ section }: PreviewSectionType) => {
         setIsExpanded(expanded);
     };
     return (
-        <section className={styles.section}>
-            <PreviewSectionHeader section={section} isExpanded={isExpanded} onExpandedChange={handleExpandedChange} />
-            {isExpanded &&
-                section?.subSections.map((subsection, k) => <PreviewSubsection subsection={subsection} key={k} />)}
-        </section>
+        <>
+            {section.visible && (
+                <section className={styles.section}>
+                    <PreviewSectionHeader
+                        section={section}
+                        isExpanded={isExpanded}
+                        onExpandedChange={handleExpandedChange}
+                    />
+                    {isExpanded &&
+                        section?.subSections.map((subsection, k) => (
+                            <PreviewSubsection subsection={subsection} key={k} />
+                        ))}
+                </section>
+            )}
+        </>
     );
 };
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
@@ -5,6 +5,7 @@ import { PreviewSubsectionHeader } from './PreviewSubsectionHeader';
 import { useState } from 'react';
 import { Heading } from '../../../../../../../components/heading';
 import { Button } from '@trussworks/react-uswds';
+import React from 'react';
 
 type Props = {
     subsection: PagesSubSection;
@@ -33,29 +34,28 @@ export const PreviewSubsection = ({ subsection }: Props) => {
                                 <div className={styles.grouped}>
                                     <div className={styles.groupedForm}>
                                         {subsection.questions.map((question, k) => (
-                                            <>
+                                            <React.Fragment key={k}>
                                                 {question.appearsInBatch && (
-                                                    <div className={styles.groupedQuestionName} key={k}>
+                                                    <div className={styles.groupedQuestionName}>
                                                         <Heading level={3}>
                                                             {question.batchLabel ?? question.name}
                                                         </Heading>
                                                     </div>
                                                 )}
-                                            </>
+                                            </React.Fragment>
                                         ))}
                                     </div>
                                     <p className={styles.groupedInfo}>No data has been entered.</p>
                                     <div className={styles.groupedQuestionsSection}>
                                         {subsection.questions.map((question, k) => (
-                                            <>
+                                            <React.Fragment key={k}>
                                                 {question.visible && (
                                                     <PreviewQuestion
                                                         question={question}
                                                         isGrouped={subsection.isGrouped}
-                                                        key={k}
                                                     />
                                                 )}
-                                            </>
+                                            </React.Fragment>
                                         ))}
                                     </div>
                                     <div className={styles.footer}>
@@ -67,7 +67,9 @@ export const PreviewSubsection = ({ subsection }: Props) => {
                             ) : (
                                 <>
                                     {subsection.questions.map((question, k) => (
-                                        <>{question?.visible && <PreviewQuestion question={question} key={k} />}</>
+                                        <React.Fragment key={k}>
+                                            {question?.visible && <PreviewQuestion question={question} />}
+                                        </React.Fragment>
                                     ))}
                                 </>
                             )}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionDeleter.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionDeleter.java
@@ -1,33 +1,80 @@
 package gov.cdc.nbs.questionbank.page.content.question;
 
-import gov.cdc.nbs.questionbank.entity.WaTemplate;
-import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
-import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
+import gov.cdc.nbs.questionbank.entity.WaTemplate;
+import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
+import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.question.exception.DeletePageQuestionException;
+import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
 import jakarta.persistence.EntityManager;
-import java.time.Instant;
 
 @Component
 @Transactional
 public class PageQuestionDeleter {
 
-    private final EntityManager entityManager;
+  private static final String SELECT_ALL_IDENTIFIERS_FOR_PAGE = """
+        SELECT
+        concat(source_question_identifier, ',', target_question_identifier)
+      FROM
+        WA_rule_metadata
+      WHERE
+        wa_template_uid = ?;
+              """;
 
-    public PageQuestionDeleter(
-        final EntityManager entityManager) {
-        this.entityManager = entityManager;
+  private final EntityManager entityManager;
+  private final JdbcTemplate template;
+
+  public PageQuestionDeleter(
+      final EntityManager entityManager,
+      final JdbcTemplate template) {
+    this.entityManager = entityManager;
+    this.template = template;
+  }
+
+  public void deleteQuestion(Long pageId, Long questionId, Long user) {
+    WaUiMetadata metadata = entityManager.find(WaUiMetadata.class, questionId);
+    if (metadata == null) {
+      throw new DeletePageQuestionException("Failed to find question");
+    }
+    if (isAssociatedWithRule(metadata.getQuestionIdentifier(), pageId)) {
+      throw new DeletePageQuestionException("Unable to delete question associated with a business rule");
     }
 
-    public void deleteQuestion(Long pageId, Long questionId, Long user) {
-
-        WaTemplate page = entityManager.find(WaTemplate.class, pageId);
-        if (page == null) {
-            throw new PageNotFoundException(pageId);
-        }
-        page.deleteQuestion(new PageContentCommand.DeleteQuestion(questionId, user, Instant.now()));
+    WaTemplate page = entityManager.find(WaTemplate.class, pageId);
+    if (page == null) {
+      throw new PageNotFoundException(pageId);
     }
+    page.deleteQuestion(new PageContentCommand.DeleteQuestion(questionId, user, Instant.now()));
+  }
+
+  private boolean isAssociatedWithRule(String questionIdentifier, long pageId) {
+    String[] identifiers = template.query(
+        SELECT_ALL_IDENTIFIERS_FOR_PAGE,
+        setter -> setter.setLong(1, pageId),
+        mapper())
+        .stream()
+        .collect(Collectors.joining(","))
+        .split(",");
+
+    return Arrays.asList(identifiers).contains(questionIdentifier);
+  }
+
+  private RowMapper<String> mapper() {
+    return new RowMapper<String>() {
+      @Override
+      public String mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return rs.getString(1);
+      }
+    };
+  }
 
 
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionUpdater.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionUpdater.java
@@ -69,7 +69,7 @@ public class PageQuestionUpdater {
     return finder.find(pageId, questionId);
   }
 
-  private WaUiMetadata findQuestion(long questionId, long pageId) {
+  WaUiMetadata findQuestion(long questionId, long pageId) {
     WaUiMetadata metadata = entityManager.find(WaUiMetadata.class, questionId);
     if (metadata == null || metadata.getWaTemplateUid().getId() != pageId) {
       throw new PageContentModificationException("Failed to find question");

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/exception/DeletePageQuestionException.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/exception/DeletePageQuestionException.java
@@ -1,0 +1,10 @@
+package gov.cdc.nbs.questionbank.page.content.question.exception;
+
+import gov.cdc.nbs.questionbank.exception.BadRequestException;
+
+public class DeletePageQuestionException extends BadRequestException {
+  public DeletePageQuestionException(String message) {
+    super(message);
+  }
+
+}

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionUpdater.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/subsection/SubSectionUpdater.java
@@ -8,6 +8,7 @@ import org.springframework.util.StringUtils;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
 import gov.cdc.nbs.questionbank.page.content.subsection.exception.UpdateSubSectionException;
 import gov.cdc.nbs.questionbank.page.content.subsection.model.SubSection;
 import gov.cdc.nbs.questionbank.page.content.subsection.request.UpdateSubSectionRequest;
@@ -16,41 +17,51 @@ import gov.cdc.nbs.questionbank.page.content.subsection.request.UpdateSubSection
 @Transactional
 public class SubSectionUpdater {
 
-    private final EntityManager entityManager;
+  private final EntityManager entityManager;
 
-    public SubSectionUpdater(final EntityManager entityManager) {
-        this.entityManager = entityManager;
+  public SubSectionUpdater(final EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  public SubSection update(Long pageId, Long subSectionId, UpdateSubSectionRequest request, Long userId) {
+    if (request == null || !StringUtils.hasLength(request.name())) {
+      throw new UpdateSubSectionException("SubSection Name is required");
     }
 
-    public SubSection update(Long pageId, Long subSectionId, UpdateSubSectionRequest request, Long userId) {
-        if (request == null || !StringUtils.hasLength(request.name())) {
-            throw new UpdateSubSectionException("SubSection Name is required");
-        }
+    WaTemplate page = entityManager.find(WaTemplate.class, pageId);
 
-        WaTemplate page = entityManager.find(WaTemplate.class, pageId);
-
-        if (page == null) {
-            throw new UpdateSubSectionException("Unable to find page with id: " + pageId);
-        }
-
-        WaUiMetadata section = page.updateSubSection(asCommand(userId, subSectionId, request));
-
-        entityManager.flush();
-        return new SubSection(
-                section.getId(),
-                section.getQuestionLabel(),
-                "T".equals(section.getDisplayInd()));
+    if (page == null) {
+      throw new UpdateSubSectionException("Unable to find page with id: " + pageId);
     }
 
-    private PageContentCommand.UpdateSubsection asCommand(
-            Long userId,
-            long subSectionId,
-            UpdateSubSectionRequest request) {
-        return new PageContentCommand.UpdateSubsection(
-                request.name(),
-                request.visible(),
-                subSectionId,
-                userId,
-                Instant.now());
+    WaUiMetadata section = page.updateSubSection(
+        asCommand(userId, subSectionId, request),
+        subsectionId -> findSubsection(subsectionId, pageId));
+
+    entityManager.flush();
+    return new SubSection(
+        section.getId(),
+        section.getQuestionLabel(),
+        "T".equals(section.getDisplayInd()));
+  }
+
+  WaUiMetadata findSubsection(long subsectionId, long pageId) {
+    WaUiMetadata metadata = entityManager.find(WaUiMetadata.class, subsectionId);
+    if (metadata == null || metadata.getWaTemplateUid().getId() != pageId || metadata.getNbsUiComponentUid() != 1016l) {
+      throw new PageContentModificationException("Failed to find subsection");
     }
+    return metadata;
+  }
+
+  private PageContentCommand.UpdateSubsection asCommand(
+      Long userId,
+      long subSectionId,
+      UpdateSubSectionRequest request) {
+    return new PageContentCommand.UpdateSubsection(
+        request.name(),
+        request.visible(),
+        subSectionId,
+        userId,
+        Instant.now());
+  }
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/tab/TabUpdater.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/tab/TabUpdater.java
@@ -8,6 +8,7 @@ import org.springframework.util.StringUtils;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
 import gov.cdc.nbs.questionbank.page.content.tab.exceptions.UpdateTabException;
 import gov.cdc.nbs.questionbank.page.content.tab.request.UpdateTabRequest;
 import gov.cdc.nbs.questionbank.page.content.tab.response.Tab;
@@ -16,43 +17,51 @@ import gov.cdc.nbs.questionbank.page.content.tab.response.Tab;
 @Transactional
 public class TabUpdater {
 
-    private final EntityManager entityManager;
+  private final EntityManager entityManager;
 
-    public TabUpdater(
-            final EntityManager entityManager) {
-        this.entityManager = entityManager;
+  public TabUpdater(
+      final EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  public Tab update(Long pageId, Long tab, UpdateTabRequest request, long user) {
+    if (request == null || !StringUtils.hasLength(request.name())) {
+      throw new UpdateTabException("Tab Name is required");
     }
 
-    public Tab update(Long pageId, Long tab, UpdateTabRequest request, long user) {
-        if (request == null || !StringUtils.hasLength(request.name())) {
-            throw new UpdateTabException("Tab Name is required");
-        }
+    WaTemplate page = entityManager.find(WaTemplate.class, pageId);
 
-        WaTemplate page = entityManager.find(WaTemplate.class, pageId);
-
-        if (page == null) {
-            throw new UpdateTabException("Unable to find page with id: " + pageId);
-        }
-
-        WaUiMetadata updatedTab = page.updateTab(asCommand(user, tab, request));
-
-        entityManager.flush();
-
-        return new Tab(
-                updatedTab.getId(),
-                updatedTab.getQuestionLabel(),
-                "T".equals(updatedTab.getDisplayInd()));
+    if (page == null) {
+      throw new UpdateTabException("Unable to find page with id: " + pageId);
     }
 
-    private PageContentCommand.UpdateTab asCommand(
-            long user,
-            long tab,
-            UpdateTabRequest request) {
-        return new PageContentCommand.UpdateTab(
-                request.name(),
-                request.visible(),
-                tab,
-                user,
-                Instant.now());
+    WaUiMetadata updatedTab = page.updateTab(asCommand(user, tab, request), tabId -> findTab(tabId, pageId));
+
+    entityManager.flush();
+
+    return new Tab(
+        updatedTab.getId(),
+        updatedTab.getQuestionLabel(),
+        "T".equals(updatedTab.getDisplayInd()));
+  }
+
+  WaUiMetadata findTab(long tabId, long pageId) {
+    WaUiMetadata metadata = entityManager.find(WaUiMetadata.class, tabId);
+    if (metadata == null || metadata.getWaTemplateUid().getId() != pageId || metadata.getNbsUiComponentUid() != 1010l) {
+      throw new PageContentModificationException("Failed to find tab");
     }
+    return metadata;
+  }
+
+  private PageContentCommand.UpdateTab asCommand(
+      long user,
+      long tab,
+      UpdateTabRequest request) {
+    return new PageContentCommand.UpdateTab(
+        request.name(),
+        request.visible(),
+        tab,
+        user,
+        Instant.now());
+  }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entity/WaTemplateTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/entity/WaTemplateTest.java
@@ -408,7 +408,8 @@ class WaTemplateTest {
     page.addSection(section);
 
     // And that section has a subsection
-    page.addSubSection(subsection(page, 4L, 4));
+    WaUiMetadata subsection = subsection(page, 4L, 4);
+    page.addSubSection(subsection);
 
     // When an update subsection command is processed
     Instant now = Instant.now();
@@ -418,7 +419,8 @@ class WaTemplateTest {
         4,
         998L,
         now);
-    WaUiMetadata updated = page.updateSubSection(command);
+    WaUiMetadata updated = page.updateSubSection(
+        command, ss -> subsection);
 
     // Then the subsection is updated
     assertNotNull(updated);
@@ -445,46 +447,7 @@ class WaTemplateTest {
         now);
 
     // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateSubSection(command));
-  }
-
-  @Test
-  void subsection_update_error_no_subsection() {
-    // Given a template
-    WaTemplate page = new WaTemplate();
-
-    // When an update subsection command is processed
-    Instant now = Instant.now();
-    PageContentCommand.UpdateSubsection command = new PageContentCommand.UpdateSubsection(
-        "updated subsection label",
-        false,
-        4,
-        998L,
-        now);
-
-    // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateSubSection(command));
-  }
-
-  @Test
-  void subsection_update_error_invalid_id() {
-    // Given a template
-    WaTemplate page = new WaTemplate();
-
-    // And it has a tab
-    page.addTab(tab(page, 2L, 2));
-
-    // When an update subsection command is processed
-    Instant now = Instant.now();
-    PageContentCommand.UpdateSubsection command = new PageContentCommand.UpdateSubsection(
-        "updated subsection label",
-        false,
-        2l,
-        998L,
-        now);
-
-    // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateSubSection(command));
+    assertThrows(PageContentModificationException.class, () -> page.updateSubSection(command, null));
   }
 
   @Test
@@ -496,7 +459,8 @@ class WaTemplateTest {
     page.addTab(tab(page, 2L, 2));
 
     // And that tab has a section
-    page.addSection(section(page, 3L, 3));
+    WaUiMetadata section = section(page, 3L, 3);
+    page.addSection(section);
 
     // When an update section command is processed
     Instant now = Instant.now();
@@ -506,7 +470,7 @@ class WaTemplateTest {
         3,
         998L,
         now);
-    WaUiMetadata updated = page.updateSection(command);
+    WaUiMetadata updated = page.updateSection(command, s -> section);
 
     // Then the subsection is updated
     assertNotNull(updated);
@@ -533,26 +497,9 @@ class WaTemplateTest {
         now);
 
     // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateSection(command));
+    assertThrows(PageContentModificationException.class, () -> page.updateSection(command, null));
   }
 
-  @Test
-  void section_update_error_no_section() {
-    // Given a template
-    WaTemplate page = new WaTemplate();
-
-    // When an update section command is processed
-    Instant now = Instant.now();
-    PageContentCommand.UpdateSection command = new PageContentCommand.UpdateSection(
-        "updated subsection label",
-        false,
-        4,
-        998L,
-        now);
-
-    // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateSection(command));
-  }
 
   @Test
   void tab_update() {
@@ -560,7 +507,8 @@ class WaTemplateTest {
     WaTemplate page = new WaTemplate();
 
     // And it has a tab
-    page.addTab(tab(page, 2L, 2));
+    WaUiMetadata tab = tab(page, 2L, 2);
+    page.addTab(tab);
 
     // When an update tab command is processed
     Instant now = Instant.now();
@@ -570,7 +518,7 @@ class WaTemplateTest {
         2,
         998L,
         now);
-    WaUiMetadata updated = page.updateTab(command);
+    WaUiMetadata updated = page.updateTab(command, t -> tab);
 
     // Then the subsection is updated
     assertNotNull(updated);
@@ -597,25 +545,7 @@ class WaTemplateTest {
         now);
 
     // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateSection(command));
-  }
-
-  @Test
-  void tab_update_error_no_section() {
-    // Given a template
-    WaTemplate page = new WaTemplate();
-
-    // When an update tab command is processed
-    Instant now = Instant.now();
-    PageContentCommand.UpdateTab command = new PageContentCommand.UpdateTab(
-        "updated tab label",
-        false,
-        4,
-        998L,
-        now);
-
-    // Then an exception is thrown
-    assertThrows(PageContentModificationException.class, () -> page.updateTab(command));
+    assertThrows(PageContentModificationException.class, () -> page.updateSection(command, null));
   }
 
   @Test

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionDeleterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionDeleterTest.java
@@ -1,131 +1,186 @@
 package gov.cdc.nbs.questionbank.page.content.question;
 
-import gov.cdc.nbs.questionbank.entity.WaTemplate;
-import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
-import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
-import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+import gov.cdc.nbs.questionbank.entity.WaTemplate;
+import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
+import gov.cdc.nbs.questionbank.page.content.question.exception.DeletePageQuestionException;
+import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
 import jakarta.persistence.EntityManager;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PageQuestionDeleterTest {
 
-    @Mock
-    private EntityManager entityManager;
+  @Mock
+  private EntityManager entityManager;
 
-    @Mock
-    private WaTemplate waTemplate;
+  @Mock
+  private JdbcTemplate template;
 
-    @InjectMocks
-    private PageQuestionDeleter deleter;
+  @Mock
+  private WaTemplate waTemplate;
+
+  @InjectMocks
+  private PageQuestionDeleter deleter;
 
 
-    @Test
-    void should_delete_question_from_page() {
-        // Given a page
-        WaTemplate page = new WaTemplate();
-        page.setId(1L);
-        when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
+  @Test
+  void should_delete_question_from_page() {
+    // Given a question
+    WaUiMetadata metadata = Mockito.mock(WaUiMetadata.class);
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(metadata);
 
-        List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
-        WaUiMetadata waUiMetadata = new WaUiMetadata();
-        waUiMetadata.setId(2L);
-        waUiMetadata.setQuestionIdentifier("q_identifier");
-        waUiMetadata.setStandardQuestionIndCd('F');
-        waUiMetadata.setOrderNbr(3);
-        waUiMetadata.setWaTemplateUid(page);
-        waUiMetadataList.add(waUiMetadata);
-        page.setUiMetadata(waUiMetadataList);
+    // Given a page
+    WaTemplate page = new WaTemplate();
+    page.setId(1L);
+    when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
 
-        Assertions.assertEquals(1, page.getUiMetadata().size());//before delete
-        deleter.deleteQuestion(1L, 2L, 3L);
-        Assertions.assertEquals(0, page.getUiMetadata().size());//after delete
-    }
+    List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
+    WaUiMetadata waUiMetadata = new WaUiMetadata();
+    waUiMetadata.setId(2L);
+    waUiMetadata.setQuestionIdentifier("q_identifier");
+    waUiMetadata.setStandardQuestionIndCd('F');
+    waUiMetadata.setOrderNbr(3);
+    waUiMetadata.setWaTemplateUid(page);
+    waUiMetadataList.add(waUiMetadata);
+    page.setUiMetadata(waUiMetadataList);
 
-    @Test
-    void should_not_delete_question_the_page_does_not_contain_the_question() {
-        // Given a page
-        WaTemplate page = new WaTemplate();
-        page.setId(1L);
+    Assertions.assertEquals(1, page.getUiMetadata().size());//before delete
+    deleter.deleteQuestion(1L, 2L, 3L);
+    Assertions.assertEquals(0, page.getUiMetadata().size());//after delete
+  }
 
-        WaTemplate tempPage = new WaTemplate();
-        tempPage.setId(2L);
-        when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
+  @Test
+  void should_not_delete_question_the_page_does_not_contain_the_question() {
+    // Given a question
+    WaUiMetadata metadata = Mockito.mock(WaUiMetadata.class);
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(metadata);
 
-        List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
-        WaUiMetadata waUiMetadata = new WaUiMetadata();
-        waUiMetadata.setId(2L);
-        waUiMetadata.setQuestionIdentifier("q_identifier_100");
-        waUiMetadata.setWaTemplateUid(tempPage);
-        waUiMetadataList.add(waUiMetadata);
-        page.setUiMetadata(new ArrayList<WaUiMetadata>());
+    // Given a page
+    WaTemplate page = new WaTemplate();
+    page.setId(1L);
 
-        PageContentModificationException exception =
-            assertThrows(PageContentModificationException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
-        Assertions.assertEquals("Unable to delete a question from a page, the page does not contain the question",
-            exception.getMessage());
-    }
+    WaTemplate tempPage = new WaTemplate();
+    tempPage.setId(2L);
+    when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
 
-    @Test
-    void should_not_delete_question_the_page_does_not_contain_the_question_id_null() {
-        // Given a page
-        WaTemplate page = new WaTemplate();
-        page.setId(1L);
+    List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
+    WaUiMetadata waUiMetadata = new WaUiMetadata();
+    waUiMetadata.setId(2L);
+    waUiMetadata.setQuestionIdentifier("q_identifier_100");
+    waUiMetadata.setWaTemplateUid(tempPage);
+    waUiMetadataList.add(waUiMetadata);
+    page.setUiMetadata(new ArrayList<WaUiMetadata>());
 
-        WaTemplate tempPage = new WaTemplate();
-        tempPage.setId(2L);
-        when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
+    PageContentModificationException exception =
+        assertThrows(PageContentModificationException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
+    Assertions.assertEquals("Unable to delete a question from a page, the page does not contain the question",
+        exception.getMessage());
+  }
 
-        List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
-        WaUiMetadata waUiMetadata = new WaUiMetadata();
-        waUiMetadata.setQuestionIdentifier("q_identifier_100");
-        waUiMetadata.setWaTemplateUid(tempPage);
-        waUiMetadataList.add(waUiMetadata);
-        page.setUiMetadata(new ArrayList<WaUiMetadata>());
+  @Test
+  void should_not_delete_question_the_page_does_not_contain_the_question_id_null() {
+    // Given a question
+    WaUiMetadata metadata = Mockito.mock(WaUiMetadata.class);
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(metadata);
 
-        PageContentModificationException exception =
-            assertThrows(PageContentModificationException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
-        Assertions.assertEquals("Unable to delete a question from a page, the page does not contain the question",
-            exception.getMessage());
-    }
+    // Given a page
+    WaTemplate page = new WaTemplate();
+    page.setId(1L);
 
-    @Test
-    void should_not_delete_question_from_page_the_question_is_standard() {
-        // Given a page
-        WaTemplate page = new WaTemplate();
-        page.setId(1L);
-        when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
+    WaTemplate tempPage = new WaTemplate();
+    tempPage.setId(2L);
+    when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
 
-        List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
-        WaUiMetadata waUiMetadata = new WaUiMetadata();
-        waUiMetadata.setId(2L);
-        waUiMetadata.setQuestionIdentifier("q_identifier_100");
-        waUiMetadata.setStandardQuestionIndCd('T');
-        waUiMetadata.setWaTemplateUid(page);
-        waUiMetadataList.add(waUiMetadata);
-        page.setUiMetadata(waUiMetadataList);
+    List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
+    WaUiMetadata waUiMetadata = new WaUiMetadata();
+    waUiMetadata.setQuestionIdentifier("q_identifier_100");
+    waUiMetadata.setWaTemplateUid(tempPage);
+    waUiMetadataList.add(waUiMetadata);
+    page.setUiMetadata(new ArrayList<WaUiMetadata>());
 
-        PageContentModificationException exception =
-            assertThrows(PageContentModificationException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
-        Assertions.assertEquals("Unable to delete standard question", exception.getMessage());
-    }
+    PageContentModificationException exception =
+        assertThrows(PageContentModificationException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
+    Assertions.assertEquals("Unable to delete a question from a page, the page does not contain the question",
+        exception.getMessage());
+  }
 
-    @Test
-    void should_not_delete_question_from_page_no_page_found() {
-        // Given a null page
-        when(entityManager.find(WaTemplate.class, 1L)).thenReturn(null);
+  @Test
+  void should_not_delete_question_from_page_the_question_is_standard() {
+    // Given a question
+    WaUiMetadata metadata = Mockito.mock(WaUiMetadata.class);
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(metadata);
 
-        // When a request is processed to delete a question , DeleteQuestionException is thrown
-        assertThrows(PageNotFoundException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
-    }
+    // Given a page
+    WaTemplate page = new WaTemplate();
+    page.setId(1L);
+    when(entityManager.find(WaTemplate.class, 1L)).thenReturn(page);
+
+    List<WaUiMetadata> waUiMetadataList = new ArrayList<>();
+    WaUiMetadata waUiMetadata = new WaUiMetadata();
+    waUiMetadata.setId(2L);
+    waUiMetadata.setQuestionIdentifier("q_identifier_100");
+    waUiMetadata.setStandardQuestionIndCd('T');
+    waUiMetadata.setWaTemplateUid(page);
+    waUiMetadataList.add(waUiMetadata);
+    page.setUiMetadata(waUiMetadataList);
+
+    PageContentModificationException exception =
+        assertThrows(PageContentModificationException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
+    Assertions.assertEquals("Unable to delete standard question", exception.getMessage());
+  }
+
+  @Test
+  void should_not_delete_question_from_page_no_page_found() {
+    // Given a question
+    WaUiMetadata metadata = Mockito.mock(WaUiMetadata.class);
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(metadata);
+
+    // Given a null page
+    when(entityManager.find(WaTemplate.class, 1L)).thenReturn(null);
+
+    // When a request is processed to delete a question , DeleteQuestionException is thrown
+    assertThrows(PageNotFoundException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
+  }
+
+  @Test
+  void should_not_delete_null_question() {
+    // Given a question that doesn't exist
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(null);
+
+    // When a request is processed to delete a question , DeletePageQuestionException is thrown
+    assertThrows(DeletePageQuestionException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void should_not_delete_question_associated_with_rule() {
+    // Given a question that is associated with a rule
+    WaUiMetadata metadata = Mockito.mock(WaUiMetadata.class);
+    when(metadata.getQuestionIdentifier()).thenReturn("identifier2");
+    when(entityManager.find(WaUiMetadata.class, 2l)).thenReturn(metadata);
+
+    List<String> identifiersFound = new ArrayList<>();
+    identifiersFound.add("identifier1,identifier2");
+    when(template.query(Mockito.anyString(),
+        Mockito.any(PreparedStatementSetter.class),
+        Mockito.any(RowMapper.class)))
+            .thenReturn(identifiersFound);
+
+    // When a request is processed to delete a question , DeletePageQuestionException is thrown
+    assertThrows(DeletePageQuestionException.class, () -> deleter.deleteQuestion(1L, 2L, 3L));
+  }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionUpdaterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/question/PageQuestionUpdaterTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.questionbank.page.content.question;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import jakarta.persistence.EntityManager;
@@ -7,8 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
+import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
 import gov.cdc.nbs.questionbank.page.content.question.exception.UpdatePageQuestionException;
 import gov.cdc.nbs.questionbank.page.content.question.request.UpdatePageCodedQuestionValuesetRequest;
 import gov.cdc.nbs.questionbank.page.content.question.request.UpdatePageQuestionRequest;
@@ -186,6 +190,39 @@ class PageQuestionUpdaterTest {
   void should_validate_valueset_update_null() {
     UpdatePageCodedQuestionValuesetRequest request = null;
     assertThrows(UpdatePageQuestionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
+
+  @Test
+  void should_find_question() {
+    // given a valid question
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata question = Mockito.mock(WaUiMetadata.class);
+    when(question.getWaTemplateUid()).thenReturn(page);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(question);
+
+    assertNotNull(updater.findQuestion(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_question_null() {
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(null);
+    assertThrows(PageContentModificationException.class, () -> updater.findQuestion(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_question_bad_page() {
+    // given a question with the wrong page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(3l);
+
+    WaUiMetadata question = Mockito.mock(WaUiMetadata.class);
+    when(question.getWaTemplateUid()).thenReturn(page);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(question);
+    assertThrows(PageContentModificationException.class, () -> updater.findQuestion(1l, 2l));
   }
 
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/section/SectionUpdaterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/section/SectionUpdaterTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.questionbank.page.content.section;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import jakarta.persistence.EntityManager;
@@ -14,77 +15,126 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
 import gov.cdc.nbs.questionbank.page.content.section.exception.UpdateSectionException;
 import gov.cdc.nbs.questionbank.page.content.section.request.UpdateSectionRequest;
 
 @ExtendWith(MockitoExtension.class)
 class SectionUpdaterTest {
 
-    @Mock
-    private EntityManager entityManager;
+  @Mock
+  private EntityManager entityManager;
 
-    @InjectMocks
-    private SectionUpdater updater;
-
-
-    @Test
-    void should_update_section() {
-        // Given a page
-        WaTemplate page = Mockito.mock(WaTemplate.class);
-        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
-        WaUiMetadata sectionMock = Mockito.mock(WaUiMetadata.class);
-        when(sectionMock.getId()).thenReturn(98l);
-        ArgumentCaptor<PageContentCommand.UpdateSection> captor =
-                ArgumentCaptor.forClass(PageContentCommand.UpdateSection.class);
-        when(page.updateSection(captor.capture())).thenReturn(sectionMock);
+  @InjectMocks
+  private SectionUpdater updater;
 
 
-        // When a valid request is made to update the section
-        UpdateSectionRequest request = new UpdateSectionRequest("New name", false);
-        updater.update(1l, 2l, request, 3l);
+  @Test
+  void should_update_section() {
+    // Given a page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
+    WaUiMetadata sectionMock = Mockito.mock(WaUiMetadata.class);
+    when(sectionMock.getId()).thenReturn(98l);
+    ArgumentCaptor<PageContentCommand.UpdateSection> captor =
+        ArgumentCaptor.forClass(PageContentCommand.UpdateSection.class);
+    when(page.updateSection(captor.capture(), Mockito.any())).thenReturn(sectionMock);
 
-        // Then the section is updated
-        assertEquals("New name", captor.getValue().label());
-        assertEquals(false, captor.getValue().visible());
-        assertEquals(2l, captor.getValue().sectionId());
-    }
 
-    @Test
-    void should_not_update_null_name() {
-        // When an invalid request is made
-        UpdateSectionRequest request = new UpdateSectionRequest(null, false);
+    // When a valid request is made to update the section
+    UpdateSectionRequest request = new UpdateSectionRequest("New name", false);
+    updater.update(1l, 2l, request, 3l);
 
-        // Then an exception is thrown
-        assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then the section is updated
+    assertEquals("New name", captor.getValue().label());
+    assertEquals(false, captor.getValue().visible());
+    assertEquals(2l, captor.getValue().sectionId());
+  }
 
-    @Test
-    void should_not_update_empty_name() {
-        // When an invalid request is made
-        UpdateSectionRequest request = new UpdateSectionRequest("", false);
+  @Test
+  void should_not_update_null_name() {
+    // When an invalid request is made
+    UpdateSectionRequest request = new UpdateSectionRequest(null, false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_null_request() {
-        // When an invalid request is made
-        UpdateSectionRequest request = null;
+  @Test
+  void should_not_update_empty_name() {
+    // When an invalid request is made
+    UpdateSectionRequest request = new UpdateSectionRequest("", false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_null_page() {
-        // Given a page does not exist
-        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
+  @Test
+  void should_not_update_null_request() {
+    // When an invalid request is made
+    UpdateSectionRequest request = null;
 
-        // When an request is made
-        UpdateSectionRequest request = new UpdateSectionRequest("new name", false);
+    // Then an exception is thrown
+    assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-        // Then an exception is thrown
-        assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+  @Test
+  void should_not_update_null_page() {
+    // Given a page does not exist
+    when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
+
+    // When an request is made
+    UpdateSectionRequest request = new UpdateSectionRequest("new name", false);
+
+    // Then an exception is thrown
+    assertThrows(UpdateSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
+
+  @Test
+  void should_find_section() {
+    // given a valid section
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata section = Mockito.mock(WaUiMetadata.class);
+    when(section.getWaTemplateUid()).thenReturn(page);
+    when(section.getNbsUiComponentUid()).thenReturn(1015l);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(section);
+
+    assertNotNull(updater.findSection(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_section_null() {
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(null);
+    assertThrows(PageContentModificationException.class, () -> updater.findSection(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_section_bad_component() {
+    // given a section with a bad component id
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata section = Mockito.mock(WaUiMetadata.class);
+    when(section.getWaTemplateUid()).thenReturn(page);
+    when(section.getNbsUiComponentUid()).thenReturn(1009l);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(section);
+    assertThrows(PageContentModificationException.class, () -> updater.findSection(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_section_bad_page() {
+    // given a section with the wrong page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(3l);
+
+    WaUiMetadata section = Mockito.mock(WaUiMetadata.class);
+    when(section.getWaTemplateUid()).thenReturn(page);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(section);
+    assertThrows(PageContentModificationException.class, () -> updater.findSection(1l, 2l));
+  }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/subsection/SubsectionUpdaterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/subsection/SubsectionUpdaterTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.questionbank.page.content.subsection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import jakarta.persistence.EntityManager;
@@ -14,77 +15,126 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
 import gov.cdc.nbs.questionbank.page.content.subsection.exception.UpdateSubSectionException;
 import gov.cdc.nbs.questionbank.page.content.subsection.request.UpdateSubSectionRequest;
 
 @ExtendWith(MockitoExtension.class)
 class SubsectionUpdaterTest {
 
-    @Mock
-    private EntityManager entityManager;
+  @Mock
+  private EntityManager entityManager;
 
-    @InjectMocks
-    private SubSectionUpdater updater;
-
-
-    @Test
-    void should_update_subsection() {
-        // Given a page
-        WaTemplate page = Mockito.mock(WaTemplate.class);
-        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
-        WaUiMetadata subSectionMock = Mockito.mock(WaUiMetadata.class);
-        when(subSectionMock.getId()).thenReturn(98l);
-        ArgumentCaptor<PageContentCommand.UpdateSubsection> captor =
-                ArgumentCaptor.forClass(PageContentCommand.UpdateSubsection.class);
-        when(page.updateSubSection(captor.capture())).thenReturn(subSectionMock);
+  @InjectMocks
+  private SubSectionUpdater updater;
 
 
-        // When a valid request is made to update the section
-        UpdateSubSectionRequest request = new UpdateSubSectionRequest("New name", false);
-        updater.update(1l, 2l, request, 3l);
+  @Test
+  void should_update_subsection() {
+    // Given a page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
+    WaUiMetadata subSectionMock = Mockito.mock(WaUiMetadata.class);
+    when(subSectionMock.getId()).thenReturn(98l);
+    ArgumentCaptor<PageContentCommand.UpdateSubsection> captor =
+        ArgumentCaptor.forClass(PageContentCommand.UpdateSubsection.class);
+    when(page.updateSubSection(captor.capture(), Mockito.any())).thenReturn(subSectionMock);
 
-        // Then the section is updated
-        assertEquals("New name", captor.getValue().label());
-        assertEquals(false, captor.getValue().visible());
-        assertEquals(2l, captor.getValue().subsection());
-    }
 
-    @Test
-    void should_not_update_null_name() {
-        // When an invalid request is made
-        UpdateSubSectionRequest request = new UpdateSubSectionRequest(null, false);
+    // When a valid request is made to update the section
+    UpdateSubSectionRequest request = new UpdateSubSectionRequest("New name", false);
+    updater.update(1l, 2l, request, 3l);
 
-        // Then an exception is thrown
-        assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then the section is updated
+    assertEquals("New name", captor.getValue().label());
+    assertEquals(false, captor.getValue().visible());
+    assertEquals(2l, captor.getValue().subsection());
+  }
 
-    @Test
-    void should_not_update_empty_name() {
-        // When an invalid request is made
-        UpdateSubSectionRequest request = new UpdateSubSectionRequest("", false);
+  @Test
+  void should_not_update_null_name() {
+    // When an invalid request is made
+    UpdateSubSectionRequest request = new UpdateSubSectionRequest(null, false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_null_request() {
-        // When an invalid request is made
-        UpdateSubSectionRequest request = null;
+  @Test
+  void should_not_update_empty_name() {
+    // When an invalid request is made
+    UpdateSubSectionRequest request = new UpdateSubSectionRequest("", false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_null_page() {
-        // Given a page does not exist
-        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
+  @Test
+  void should_not_update_null_request() {
+    // When an invalid request is made
+    UpdateSubSectionRequest request = null;
 
-        // When an request is made
-        UpdateSubSectionRequest request = new UpdateSubSectionRequest("new name", false);
+    // Then an exception is thrown
+    assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-        // Then an exception is thrown
-        assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l,  request, 3l));
-    }
+  @Test
+  void should_not_update_null_page() {
+    // Given a page does not exist
+    when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
+
+    // When an request is made
+    UpdateSubSectionRequest request = new UpdateSubSectionRequest("new name", false);
+
+    // Then an exception is thrown
+    assertThrows(UpdateSubSectionException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
+
+  @Test
+  void should_find_subsection() {
+    // given a valid subsection
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata subsection = Mockito.mock(WaUiMetadata.class);
+    when(subsection.getWaTemplateUid()).thenReturn(page);
+    when(subsection.getNbsUiComponentUid()).thenReturn(1016l);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(subsection);
+
+    assertNotNull(updater.findSubsection(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_subsection_null() {
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(null);
+    assertThrows(PageContentModificationException.class, () -> updater.findSubsection(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_subsection_bad_component() {
+    // given a subsection with a bad component id
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata subsection = Mockito.mock(WaUiMetadata.class);
+    when(subsection.getWaTemplateUid()).thenReturn(page);
+    when(subsection.getNbsUiComponentUid()).thenReturn(1009l);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(subsection);
+    assertThrows(PageContentModificationException.class, () -> updater.findSubsection(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_subsection_bad_page() {
+    // given a subsection with the wrong page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(3l);
+
+    WaUiMetadata subsection = Mockito.mock(WaUiMetadata.class);
+    when(subsection.getWaTemplateUid()).thenReturn(page);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(subsection);
+    assertThrows(PageContentModificationException.class, () -> updater.findSubsection(1l, 2l));
+  }
 }

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/tab/TabUpdaterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/content/tab/TabUpdaterTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.questionbank.page.content.tab;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -14,76 +15,125 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.entity.WaUiMetadata;
 import gov.cdc.nbs.questionbank.page.command.PageContentCommand;
+import gov.cdc.nbs.questionbank.page.content.PageContentModificationException;
 import gov.cdc.nbs.questionbank.page.content.tab.exceptions.UpdateTabException;
 import gov.cdc.nbs.questionbank.page.content.tab.request.UpdateTabRequest;
 
 @ExtendWith(MockitoExtension.class)
 class TabUpdaterTest {
-    @Mock
-    private EntityManager entityManager;
+  @Mock
+  private EntityManager entityManager;
 
-    @InjectMocks
-    private TabUpdater updater;
+  @InjectMocks
+  private TabUpdater updater;
 
-    @Test
-    void should_update_section() {
-        // Given a page
-        WaTemplate page = Mockito.mock(WaTemplate.class);
-        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
-        WaUiMetadata sectionMock = Mockito.mock(WaUiMetadata.class);
-        when(sectionMock.getId()).thenReturn(98l);
-        ArgumentCaptor<PageContentCommand.UpdateTab> captor =
-                ArgumentCaptor.forClass(PageContentCommand.UpdateTab.class);
-        when(page.updateTab(captor.capture())).thenReturn(sectionMock);
+  @Test
+  void should_update_section() {
+    // Given a page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(entityManager.find(WaTemplate.class, 1l)).thenReturn(page);
+    WaUiMetadata sectionMock = Mockito.mock(WaUiMetadata.class);
+    when(sectionMock.getId()).thenReturn(98l);
+    ArgumentCaptor<PageContentCommand.UpdateTab> captor =
+        ArgumentCaptor.forClass(PageContentCommand.UpdateTab.class);
+    when(page.updateTab(captor.capture(), Mockito.any())).thenReturn(sectionMock);
 
 
-        // When a valid request is made to update the tab
-        UpdateTabRequest request = new UpdateTabRequest("New name", false);
-        updater.update(1l, 2l, request, 3l);
+    // When a valid request is made to update the tab
+    UpdateTabRequest request = new UpdateTabRequest("New name", false);
+    updater.update(1l, 2l, request, 3l);
 
-        // Then the tab is updated
-        assertEquals("New name", captor.getValue().label());
-        assertEquals(false, captor.getValue().visible());
-        assertEquals(2l, captor.getValue().tab());
-    }
+    // Then the tab is updated
+    assertEquals("New name", captor.getValue().label());
+    assertEquals(false, captor.getValue().visible());
+    assertEquals(2l, captor.getValue().tab());
+  }
 
-    @Test
-    void should_not_update_null_name() {
-        // When an invalid request is made
-        UpdateTabRequest request = new UpdateTabRequest(null, false);
+  @Test
+  void should_not_update_null_name() {
+    // When an invalid request is made
+    UpdateTabRequest request = new UpdateTabRequest(null, false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_empty_name() {
-        // When an invalid request is made
-        UpdateTabRequest request = new UpdateTabRequest("", false);
+  @Test
+  void should_not_update_empty_name() {
+    // When an invalid request is made
+    UpdateTabRequest request = new UpdateTabRequest("", false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_null_request() {
-        // When an invalid request is made
-        UpdateTabRequest request = null;
+  @Test
+  void should_not_update_null_request() {
+    // When an invalid request is made
+    UpdateTabRequest request = null;
 
-        // Then an exception is thrown
-        assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
 
-    @Test
-    void should_not_update_null_page() {
-        // Given a page does not exist
-        when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
+  @Test
+  void should_not_update_null_page() {
+    // Given a page does not exist
+    when(entityManager.find(WaTemplate.class, 1l)).thenReturn(null);
 
-        // When an request is made
-        UpdateTabRequest request = new UpdateTabRequest("new name", false);
+    // When an request is made
+    UpdateTabRequest request = new UpdateTabRequest("new name", false);
 
-        // Then an exception is thrown
-        assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l,  request, 3l));
-    }
+    // Then an exception is thrown
+    assertThrows(UpdateTabException.class, () -> updater.update(1l, 2l, request, 3l));
+  }
+
+  @Test
+  void should_find_tab() {
+    // given a valid tab
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata tab = Mockito.mock(WaUiMetadata.class);
+    when(tab.getWaTemplateUid()).thenReturn(page);
+    when(tab.getNbsUiComponentUid()).thenReturn(1010l);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(tab);
+
+    assertNotNull(updater.findTab(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_tab_null() {
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(null);
+    assertThrows(PageContentModificationException.class, () -> updater.findTab(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_tab_bad_component() {
+    // given a tab with a bad component id
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(2l);
+
+    WaUiMetadata tab = Mockito.mock(WaUiMetadata.class);
+    when(tab.getWaTemplateUid()).thenReturn(page);
+    when(tab.getNbsUiComponentUid()).thenReturn(1011l);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(tab);
+    assertThrows(PageContentModificationException.class, () -> updater.findTab(1l, 2l));
+  }
+
+  @Test
+  void should_not_find_tab_bad_page() {
+    // given a tab with the wrong page
+    WaTemplate page = Mockito.mock(WaTemplate.class);
+    when(page.getId()).thenReturn(3l);
+
+    WaUiMetadata tab = Mockito.mock(WaUiMetadata.class);
+    when(tab.getWaTemplateUid()).thenReturn(page);
+
+    when(entityManager.find(WaUiMetadata.class, 1l)).thenReturn(tab);
+    assertThrows(PageContentModificationException.class, () -> updater.findTab(1l, 2l));
+  }
 
 }


### PR DESCRIPTION
## Description

Page Builder bug fixes

|Severity|Bug Description|
|------|----|
|Critical | Prevent deletion of question when question is source or target of a rule|
|Medium | Disable grouping when a subsection contains a static element|
|Low|Hide subsection in preview mode when visibility is `false`|
|Low|Hide tabs in preview mode when visibility is `false`|
|Low|Update confirmation message when deleting static element|
|Low|Remove `required` toggle from static element display|


## Tickets

* [CNFT2-2294](https://cdc-nbs.atlassian.net/browse/CNFT2-2294)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-2294]: https://cdc-nbs.atlassian.net/browse/CNFT2-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ