### PR TITLE
[CNT-9] - E2E page library pagination 30 row defaulted after it redirect

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -20,3 +20,9 @@ Feature: User can view existing page library data here.
     Scenario: User selects for 30 rows to show in the Page library
         And User select 30 left footer of the page to show the list of pages
         Then User should see only 30 rows in the library and for each subsequent list where applicable
+
+    Scenario: Verify the selection of 30 is displaying 10 rows after redirect back to Page Library
+        And User select 30 left footer of the page to show the list of pages
+        Then User navigates to the Create page
+        And User navigates to Page Library and views the Page library
+        Then User should only see 10 rows in the library and for each subsequent list where applicable


### PR DESCRIPTION
## Description

Added end to end test case for pagination with 30 rows selected and after it redirect from create page the pagination is defaulted to 10 ( [CNFT2-997](https://cdc-nbs.atlassian.net/browse/CNFT2-997) )
<img width="1356" alt="Screenshot 2024-04-23 at 12 28 08 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/fdeeac59-e00b-4156-8d21-0695e26e813b">

## Tickets

* [Jira Ticket] https://cdc-nbs.atlassian.net/browse/CNT-9

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-997]: https://cdc-nbs.atlassian.net/browse/CNFT2-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ