### PR TITLE
[CNT-9] - E2E page library pagination 50 row defaulted after redirects

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -8,25 +8,32 @@ Feature: User can view existing page library data here.
         Then User should see by default 10 rows of pages listed in the library
 
     Scenario: User selects for 20 rows to show in the Page library
-        And User select 20 left footer of the page to show the list of pages
-        Then User should see only 20 rows in the library and for each subsequent list where applicable
+        And User select "20" left footer of the page to show the list of pages
+        Then User should see only "20" rows in the library and for each subsequent list where applicable
 
     Scenario: Verify the selection of 20 is displaying 10 rows after redirect back to Page Library
-        And User select 20 left footer of the page to show the list of pages
+        And User select "20" left footer of the page to show the list of pages
         Then User navigates to the Create page
         And User navigates to Page Library and views the Page library
-        Then User should only see 10 rows in the library and for each subsequent list where applicable
+        Then User should see only "10" rows in the library and for each subsequent list where applicable
 
     Scenario: User selects for 30 rows to show in the Page library
-        And User select 30 left footer of the page to show the list of pages
-        Then User should see only 30 rows in the library and for each subsequent list where applicable
+        And User select "30" left footer of the page to show the list of pages
+        Then User should see only "30" rows in the library and for each subsequent list where applicable
 
     Scenario: Verify the selection of 30 is displaying 10 rows after redirect back to Page Library
-        And User select 30 left footer of the page to show the list of pages
+        And User select "30" left footer of the page to show the list of pages
         Then User navigates to the Create page
         And User navigates to Page Library and views the Page library
-        Then User should only see 10 rows in the library and for each subsequent list where applicable
+        Then User should see only "10" rows in the library and for each subsequent list where applicable
 
     Scenario: User selects for 50 rows to show in the Page library
-        And User select 50 left footer of the page to show the list of pages
-        Then User should see only 50 rows in the library and for each subsequent list where applicable
+        And User select "50" left footer of the page to show the list of pages
+        Then User should see only "50" rows in the library and for each subsequent list where applicable
+
+    Scenario: Verify the selection of 50 is displaying 10 rows after redirect back to Page Library
+        And User select "50" left footer of the page to show the list of pages
+        Then User navigates to the Create page
+        And User navigates to Page Library and views the Page library
+        Then User should see only "10" rows in the library and for each subsequent list where applicable
+

--- a/testing/regression/cypress/e2e/pages/page-library/pagination.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/pagination.page.js
@@ -36,6 +36,7 @@ class PaginationPage {
     }
 
     get openInvestigationTable() {
+        cy.wait(1500);
         return cy.get(this.table).eq(0);
     }
 
@@ -45,6 +46,7 @@ class PaginationPage {
                 return parseInt(text, 10)
             });
     }
+
     navigateToCreatePage () {
         cy.visit('/page-builder/pages/add')
     }

--- a/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
@@ -5,28 +5,14 @@ Then("User should see by default 10 rows of pages listed in the library", () => 
     pageLibraryPaginationPage.checkForDefaultRows();
 });
 
-Then("User select 20 left footer of the page to show the list of pages", () => {
-    pageLibraryPaginationPage.selectNumberOfRows('20');
+Then("User select {string} left footer of the page to show the list of pages", (string) => {
+    pageLibraryPaginationPage.selectNumberOfRows(string);
 });
 
-Then("User should see only 20 rows in the library and for each subsequent list where applicable", () => {
-    pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(20);
+Then("User should see only {string} rows in the library and for each subsequent list where applicable", (string) => {
+    pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(string);
 });
+
 Then("User navigates to the Create page", () => {
     pageLibraryPaginationPage.navigateToCreatePage();
-});
-Then("User should only see 10 rows in the library and for each subsequent list where applicable", () => {
-    pageLibraryPaginationPage.checkForDefaultRows();
-});
-Then("User select 30 left footer of the page to show the list of pages", () => {
-    pageLibraryPaginationPage.selectNumberOfRows('30');
-});
-Then("User should see only 30 rows in the library and for each subsequent list where applicable", () => {
-    pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(30);
-});
-Then("User select 50 left footer of the page to show the list of pages", () => {
-    pageLibraryPaginationPage.selectNumberOfRows('50');
-});
-Then("User should see only 50 rows in the library and for each subsequent list where applicable", () => {
-    pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(50);
 });


### PR DESCRIPTION
## Description

Added end to end test case for pagination with 50 rows selected and after it redirect from create page the pagination is defaulted to 10 ( [CNFT2-1006](https://cdc-nbs.atlassian.net/browse/CNFT2-1006) )
<img width="1510" alt="Screenshot 2024-04-24 at 10 52 22 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/8dd992b9-6a40-4f81-8580-79274c06ea0d">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-9)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1006]: https://cdc-nbs.atlassian.net/browse/CNFT2-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ