### PR TITLE
[CNT-9] - E2E page library pagination 100 row defaulted after redirects

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -40,3 +40,9 @@ Feature: User can view existing page library data here.
     Scenario: User selects for 100 rows to show in the Page library
         And User select "100" left footer of the page to show the list of pages
         Then User should see only "100" rows in the library and for each subsequent list where applicable
+
+    Scenario: Verify the selection of 100 is displaying 10 rows after redirect back to Page Library
+        And User select "100" left footer of the page to show the list of pages
+        Then User navigates to the Create page
+        And User navigates to Page Library and views the Page library
+        Then User should see only "10" rows in the library and for each subsequent list where applicable


### PR DESCRIPTION
## Description

Added end to end test case for pagination with 100 rows selected and after it redirect from create page the pagination is defaulted to 10 ( [CNFT2-1008](https://cdc-nbs.atlassian.net/browse/CNFT2-1008) )
<img width="1503" alt="Screenshot 2024-04-24 at 1 10 53 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/599d6c62-bda6-4e29-ac13-6ada248bd78a">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-9)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1008]: https://cdc-nbs.atlassian.net/browse/CNFT2-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ