### PR TITLE
[CNT-9] - E2E page library pagination click next page link advances to next subsequent page

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -50,3 +50,9 @@ Feature: User can view existing page library data here.
     Scenario: User advances to the next page/pages in the library
         And User click 2 in the pagination section bottom right
         Then User should see the subsequent rows listed in the library for the number of rows selected and Same results when paginating pages 3, 4, and 5
+
+    Scenario: User advances to the next list of pages in the library using the Next (link)
+        And User click the Next link bottom right
+        Then User should see the subsequent row of pages listed in the library
+        When User click the Next link bottom right
+        Then User should see the next list in sequence

--- a/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/pagination.steps.js
@@ -24,3 +24,15 @@ Then("User click 2 in the pagination section bottom right", () => {
 Then("User should see the subsequent rows listed in the library for the number of rows selected and Same results when paginating pages 3, 4, and 5", () => {
     pageLibraryPaginationPage.clickByPageNumber();
 });
+
+Then("User click the Next link bottom right", () => {
+    pageLibraryPaginationPage.clickNextPage();
+});
+
+Then("User should see the subsequent row of pages listed in the library", () => {
+    pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(10, true, 2);
+});
+
+Then("User should see the next list in sequence", () => {
+    pageLibraryPaginationPage.checkDisplayingNumberOfRowsSubsequently(10, true, 3);
+});


### PR DESCRIPTION
## Description

Added end to end test case for pagination that retrieve next set of pages while clicking the next link ( [CNFT2-1011](https://cdc-nbs.atlassian.net/browse/CNFT2-1011) )
<img width="1503" alt="Screenshot 2024-04-25 at 10 38 40 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/d83c3573-4c5f-4e90-a099-2d769e2a5564">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-9)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1011]: https://cdc-nbs.atlassian.net/browse/CNFT2-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ