### PR TITLE
Bug/event-type being sent as empty string

### DIFF
--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -23,12 +23,13 @@ type InvestigationGeneralAccordionProps = {
 };
 export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordionProps): ReactElement => {
     const watch = useWatch({ control: form.control });
+
     const handleEventDateTypeChange = (
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
         // Clear date fields if date type is deselected
-        if (e.target.value === '') {
+        if (!e.target.value) {
             form.resetField('eventDate.from');
             form.resetField('eventDate.to');
         }
@@ -39,9 +40,8 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
-        console.log('eventIdTypeChange', e.target.value);
         // Clear event id field on deselect
-        if (e.target.value === '') {
+        if (!e.target.value) {
             form.resetField('eventId.id');
         }
         onChange(e);

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -39,6 +39,7 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
+        console.log('eventIdTypeChange', e.target.value);
         // Clear event id field on deselect
         if (e.target.value === '') {
             form.resetField('eventId.id');
@@ -51,7 +52,7 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
         // Clear event id field on deselect
-        if (e.target.value === '') {
+        if (!e.target.value) {
             form.resetField('providerFacilitySearch.id');
         }
         onChange(e);


### PR DESCRIPTION
## Description

This prevents the event type from being set to "" in form, however the api is returning errors for any event type other than "Investigation ID" or "Notification ID"

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT1/boards/112?selectedIssue=CNFT1-2285)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
