### PR TITLE
[CNT-14] - E2E page library Search and Filter equal to page name

### DIFF
--- a/apps/modernization-ui/src/components/Search/Search.tsx
+++ b/apps/modernization-ui/src/components/Search/Search.tsx
@@ -64,7 +64,7 @@ const Search = (props: SearchProps) => {
                     maxLength={50}
                 />
             )}
-            <Button aria-label="search" type="button" onClick={handleSearch}>
+            <Button id="searchButton" aria-label="search" type="button" onClick={handleSearch}>
                 <Icon.Search size={3} name="Search" />
             </Button>
         </search>

--- a/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
+++ b/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
@@ -1,0 +1,10 @@
+Feature: User can search and filter the existing page library data here.
+
+    Background:
+        Given I am logged in as "superuser" and password ""
+        When User navigates to Page Library and views the Page library
+
+    Scenario: User search for a page equal to the Page name
+        And User enters keyword "Malaria" in the Search field
+        And User click the magnifying glass icon
+        Then All pages related to "Malaria" will be returned as a list in the library in "Page name"

--- a/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
@@ -1,0 +1,47 @@
+class SearchAndFilterPage {
+
+    enterTextInSearchField(searchKeyword) {
+        cy.get('#page-search').type(searchKeyword)
+    }
+
+    clickOnSearchButton() {
+        cy.get('#searchButton').click()
+        cy.wait(1000)
+    }
+
+    checkMatchedSearchResult(searchedKeyword, columnName) {
+        const list = [];
+        const index = this.getColumnIndexByName(columnName);
+        this.openInvestigationTable.find("tbody tr").each(($tr) => {
+            list.push($tr.find("td").eq(index).text());
+        });
+        if (list.length) {
+            expect(list[0].includes(searchedKeyword)).to.be.true;
+        }
+    }
+
+    getColumnIndexByName(columnName) {
+        if (columnName === "Page name") {
+            return 0;
+        } else if (columnName === "Event type") {
+            return 1;
+        } else if (columnName === "Status") {
+            return 2;
+        } else if (columnName === "Last updated") {
+            return 3;
+        } else if (columnName === "Last updated by") {
+            return 4;
+        }
+    }
+
+    get table() {
+        return "table[data-testid=table]";
+    }
+
+    get openInvestigationTable() {
+        cy.wait(1500);
+        return cy.get(this.table).eq(0);
+    }
+}
+
+export const searchAndFilterPage = new SearchAndFilterPage()

--- a/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
@@ -1,0 +1,12 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+import {searchAndFilterPage} from "@pages/page-library/searchAndFilter.page";
+
+Then("User enters keyword {string} in the Search field", (string) => {
+    searchAndFilterPage.enterTextInSearchField(string);
+});
+Then("User click the magnifying glass icon", () => {
+    searchAndFilterPage.clickOnSearchButton();
+});
+Then("All pages related to {string} will be returned as a list in the library in {string}", (string, string2) => {
+    searchAndFilterPage.checkMatchedSearchResult(string, string2);
+});


### PR DESCRIPTION
## Description

Added end to end test case for Search and Filter - Search for a page equal to page name ( CNFT2-1021 )
<img width="1507" alt="Screenshot 2024-04-30 at 12 26 20 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/b6e1cf96-542a-4cdd-a683-ff54753610ea">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-14)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
