### PR TITLE
[CNT-14] - E2E page library filter by page name using contains operator

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/menu/PageLibraryMenu.tsx
@@ -26,6 +26,7 @@ const PageLibraryMenu = ({ properties, filters, onSearch, onFilter, onDownloadCs
                 overlayVisible={overlayVisible}
                 toggle={() => (
                     <Button
+                        id="filter-button"
                         type="button"
                         onClick={() => setOverlayVisible(!overlayVisible)}
                         outline

--- a/apps/modernization-ui/src/filters/entry/FilterEntryForm.tsx
+++ b/apps/modernization-ui/src/filters/entry/FilterEntryForm.tsx
@@ -57,6 +57,7 @@ const FilterEntryForm = ({ properties, onSave, onCancel }: FilterEditViewProps) 
                         rules={{ required: { value: true, message: 'A field is required.' } }}
                         render={({ field: { name, value, onBlur, onChange }, fieldState: { error } }) => (
                             <SelectInput
+                                id="select-column"
                                 name={name}
                                 htmlFor={name}
                                 label="Select a field"
@@ -76,6 +77,7 @@ const FilterEntryForm = ({ properties, onSave, onCancel }: FilterEditViewProps) 
                             rules={{ required: { value: true, message: 'An operator is required.' } }}
                             render={({ field: { name, value, onBlur, onChange }, fieldState: { error } }) => (
                                 <SelectInput
+                                    id="select-operator"
                                     name={name}
                                     htmlFor={name}
                                     label="Operator"
@@ -94,10 +96,10 @@ const FilterEntryForm = ({ properties, onSave, onCancel }: FilterEditViewProps) 
                 </FormProvider>
             </section>
             <footer>
-                <Button type="button" onClick={onCancel} outline>
+                <Button type="button" id="cancel-button" onClick={onCancel} outline>
                     Cancel
                 </Button>
-                <Button type="submit" disabled={!isValid} onClick={handleSubmit(onSubmit)}>
+                <Button type="submit" id="done-button" disabled={!isValid} onClick={handleSubmit(onSubmit)}>
                     Done
                 </Button>
             </footer>

--- a/apps/modernization-ui/src/filters/panel/FilterPanel.tsx
+++ b/apps/modernization-ui/src/filters/panel/FilterPanel.tsx
@@ -75,7 +75,7 @@ const FilterPanel = ({ label, properties, filters, onApply, close }: FilterPanel
                     onClick={handleClear}>
                     Clear filters
                 </Button>
-                <Button type="button" onClick={handleApply}>
+                <Button type="button" id="apply-button" onClick={handleApply}>
                     Apply
                 </Button>
             </footer>
@@ -89,7 +89,7 @@ type AddNewFilterProp = {
 
 const AddNewFilter = ({ onAddNew }: AddNewFilterProp) => {
     return (
-        <Button className={styles.addNew} type="button" unstyled onClick={onAddNew}>
+        <Button className={styles.addNew} type="button" unstyled onClick={onAddNew} id="add-filter">
             <Icon.Add />
             Add Filter
         </Button>

--- a/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
+++ b/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
@@ -13,3 +13,12 @@ Feature: User can search and filter the existing page library data here.
         And User enters keyword "Mum" in the Search field
         And User click the magnifying glass icon
         Then All pages related to "Mumps" will be returned as a list in the library in "Related condition(s)"
+
+    Scenario: Filter by Page Name using (Contains)
+        Given Filter section already displayed
+        When User selects "Page name" from the drop-down box
+        And User selects "CONTAINS" from the Operator field
+        And User enters "lar" in the Type a value field
+        And User clicks the Done button
+        When User clicks the Apply button
+        Then Added filters "lar" and "Page name" are applied and only the records matching the filters are displayed in the Page Library list

--- a/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
@@ -34,6 +34,56 @@ class SearchAndFilterPage {
         }
     }
 
+    getColumnValueByName(columnName) {
+        if (columnName === "Page name") {
+            return "name";
+        } else if (columnName === "Event type") {
+            return 1;
+        } else if (columnName === "Status") {
+            return 2;
+        } else if (columnName === "Last updated") {
+            return 3;
+        } else if (columnName === "Last updated by") {
+            return 4;
+        }
+    }
+
+    showFilterSection() {
+        cy.get('#filter-button').click();
+        cy.get('#add-filter').click();
+    }
+
+    selectColumn(columnName) {
+        cy.get('#select-column').select(this.getColumnValueByName(columnName));
+    }
+
+    selectOperator(operatorValue) {
+        cy.get('#select-operator').select(operatorValue);
+    }
+
+    enterValue(value) {
+        cy.get('#value').type(value);
+    }
+    clickDone() {
+        cy.get('#done-button').click();
+    }
+
+    clickCancel() {
+        cy.get('#done-button').click();
+    }
+
+    clickApply() {
+        cy.get('#apply-button').click();
+    }
+
+    showingContainedResults(text, columnName) {
+        this.checkMatchedSearchResult(text, columnName)
+    }
+
+    canSeeFilterOverlay() {
+        cy.get('#add-filter').eq(0)
+    }
+
     get table() {
         return "table[data-testid=table]";
     }

--- a/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
@@ -64,11 +64,8 @@ class SearchAndFilterPage {
     enterValue(value) {
         cy.get('#value').type(value);
     }
-    clickDone() {
-        cy.get('#done-button').click();
-    }
 
-    clickCancel() {
+    clickDone() {
         cy.get('#done-button').click();
     }
 

--- a/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
@@ -31,9 +31,3 @@ Then("User clicks the Apply button", () => {
 Then("Added filters {string} and {string} are applied and only the records matching the filters are displayed in the Page Library list", (string, string1) => {
     searchAndFilterPage.showingContainedResults(string, string1);
 });
-Then("User clicks the Cancel button", () => {
-    searchAndFilterPage.clickCancel();
-});
-Then("The application will cancel adding a filter and return to display the + Add Filter link", () => {
-    searchAndFilterPage.canSeeFilterOverlay();
-});

--- a/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
@@ -10,3 +10,30 @@ Then("User click the magnifying glass icon", () => {
 Then("All pages related to {string} will be returned as a list in the library in {string}", (string, string2) => {
     searchAndFilterPage.checkMatchedSearchResult(string, string2);
 });
+Then("Filter section already displayed", () => {
+    searchAndFilterPage.showFilterSection();
+});
+Then("User selects {string} from the drop-down box", (string) => {
+    searchAndFilterPage.selectColumn(string);
+});
+Then("User selects {string} from the Operator field", (string) => {
+    searchAndFilterPage.selectOperator(string);
+});
+Then("User enters {string} in the Type a value field", (string) => {
+    searchAndFilterPage.enterValue(string);
+});
+Then("User clicks the Done button", () => {
+    searchAndFilterPage.clickDone();
+});
+Then("User clicks the Apply button", () => {
+    searchAndFilterPage.clickApply();
+});
+Then("Added filters {string} and {string} are applied and only the records matching the filters are displayed in the Page Library list", (string, string1) => {
+    searchAndFilterPage.showingContainedResults(string, string1);
+});
+Then("User clicks the Cancel button", () => {
+    searchAndFilterPage.clickCancel();
+});
+Then("The application will cancel adding a filter and return to display the + Add Filter link", () => {
+    searchAndFilterPage.canSeeFilterOverlay();
+});


### PR DESCRIPTION
## Description

Added end to end test case for filter by page name using contains operator ( [CNFT2-1059](https://cdc-nbs.atlassian.net/browse/CNFT2-1059) )
<img width="1503" alt="Screenshot 2024-05-01 at 10 59 45 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/bdb95d06-1763-47ac-bd41-c411dee3d365">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-14)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1059]: https://cdc-nbs.atlassian.net/browse/CNFT2-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ