### PR TITLE
[CNT-14] - E2E page library cancel filter by page name using starts with operator

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
+++ b/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
@@ -22,3 +22,11 @@ Feature: User can search and filter the existing page library data here.
         And User clicks the Done button
         When User clicks the Apply button
         Then Added filters "lar" and "Page name" are applied and only the records matching the filters are displayed in the Page Library list
+
+    Scenario: Cancel Filter by Page Name using (Starts With)
+        Given Filter section already displayed
+        When User selects "Page name" from the drop-down box
+        And User selects "STARTS_WITH" from the Operator field
+        And User enters "mum" in the Type a value field
+        And User clicks the Cancel button
+        Then The application will cancel adding a filter and return to display the + Add Filter link

--- a/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
@@ -73,6 +73,10 @@ class SearchAndFilterPage {
         cy.get('#apply-button').click();
     }
 
+    clickCancel() {
+        cy.get('#cancel-button').click();
+    }
+
     showingContainedResults(text, columnName) {
         this.checkMatchedSearchResult(text, columnName)
     }

--- a/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
@@ -31,3 +31,9 @@ Then("User clicks the Apply button", () => {
 Then("Added filters {string} and {string} are applied and only the records matching the filters are displayed in the Page Library list", (string, string1) => {
     searchAndFilterPage.showingContainedResults(string, string1);
 });
+Then("User clicks the Cancel button", () => {
+    searchAndFilterPage.clickCancel();
+});
+Then("The application will cancel adding a filter and return to display the + Add Filter link", () => {
+    searchAndFilterPage.canSeeFilterOverlay();
+});


### PR DESCRIPTION
## Description

Added end to end test case for cancel filter by page name using starts with operator ( [CNFT2-1066](https://cdc-nbs.atlassian.net/browse/CNFT2-1066) )
<img width="1500" alt="Screenshot 2024-05-01 at 12 43 23 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/ef5a4ecb-db4c-47e5-ad75-64d1c0d47645">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-14)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
