### PR TITLE
[CNT-14] - E2E page library filter by page name using not equal to operator

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
+++ b/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
@@ -30,3 +30,12 @@ Feature: User can search and filter the existing page library data here.
         And User enters "mum" in the Type a value field
         And User clicks the Cancel button
         Then The application will cancel adding a filter and return to display the + Add Filter link
+
+    Scenario: Filter by Page Name using (Not equal to)
+        Given Filter section already displayed
+        When User selects "Page name" from the drop-down box
+        And User selects "NOT_EQUAL_TO" from the Operator field
+        And User enters "Cov" in the Type a value field - multi select
+        And User clicks the Done button
+        When User clicks the Apply button
+        Then Added filters "Cov" and "Page name" are applied and only the records matching the filters are displayed in the Page Library list

--- a/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
@@ -38,13 +38,15 @@ class SearchAndFilterPage {
         if (columnName === "Page name") {
             return "name";
         } else if (columnName === "Event type") {
-            return 1;
+            return "event-type";
+        } else if (columnName === "Related Condition(s)") {
+            return "conditions";
         } else if (columnName === "Status") {
-            return 2;
+            return "status";
         } else if (columnName === "Last updated") {
-            return 3;
+            return "lastUpdate";
         } else if (columnName === "Last updated by") {
-            return 4;
+            return "lastUpdatedBy";
         }
     }
 
@@ -75,6 +77,12 @@ class SearchAndFilterPage {
 
     clickCancel() {
         cy.get('#cancel-button').click();
+    }
+
+    enterTextInMultiInputValue(value) {
+        cy.get('.multi-select__input').type(value);
+        cy.get('.multi-select__option--is-focused').click();
+        cy.get('#values').click();
     }
 
     showingContainedResults(text, columnName) {

--- a/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
@@ -37,3 +37,6 @@ Then("User clicks the Cancel button", () => {
 Then("The application will cancel adding a filter and return to display the + Add Filter link", () => {
     searchAndFilterPage.canSeeFilterOverlay();
 });
+Then("User enters {string} in the Type a value field - multi select", (string) => {
+    searchAndFilterPage.enterTextInMultiInputValue(string);
+});


### PR DESCRIPTION
## Description

Added end to end test case for filter by page name using not equal to operator ( [CNFT2-1061](https://cdc-nbs.atlassian.net/browse/CNFT2-1061) )
<img width="1502" alt="Screenshot 2024-05-02 at 9 17 28 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/d7ed93c7-11c9-406d-8b63-516db6a433fc">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-14)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1061]: https://cdc-nbs.atlassian.net/browse/CNFT2-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ