### PR TITLE
CNFT1-2324 API: Event Search (Investigation) UI passing an empty string for Event type ID field

### DIFF
--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationCriteria.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationCriteria.tsx
@@ -16,14 +16,15 @@ type InvestigationCriteriaProps = {
     form: UseFormReturn<InvestigationFilter>;
 };
 export const InvestigationCriteria = ({ form }: InvestigationCriteriaProps): ReactElement => {
-    const handleChangeWithUndefinedDefaultValue = (
+    const handleChangeToDefaultValue = (
         name: String,
+        value: any,
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
         // Clear event id field on deselect
         if (!e.target.value) {
-            form.setValue(name as any, undefined as any, {
+            form.setValue(name as any, value, {
                 shouldDirty: true,
                 shouldValidate: true
             });
@@ -41,7 +42,7 @@ export const InvestigationCriteria = ({ form }: InvestigationCriteriaProps): Rea
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleChangeWithUndefinedDefaultValue(name, e, onChange)}
+                        onChange={(e) => handleChangeToDefaultValue(name, undefined, e, onChange)}
                         label="Investigation status"
                         htmlFor={name}
                         dataTestid={name}

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationCriteria.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationCriteria.tsx
@@ -8,31 +8,15 @@ import {
     ProcessingStatus
 } from 'generated/graphql/schema';
 import { SearchCriteriaContext } from 'providers/SearchCriteriaContext';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { formatInterfaceString } from 'utils/util';
+import { handleChangeToDefaultValue } from 'forms/event';
 
 type InvestigationCriteriaProps = {
     form: UseFormReturn<InvestigationFilter>;
 };
 export const InvestigationCriteria = ({ form }: InvestigationCriteriaProps): ReactElement => {
-    const handleChangeToDefaultValue = (
-        name: String,
-        value: any,
-        e: ChangeEvent<HTMLSelectElement>,
-        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
-    ): void => {
-        // Clear event id field on deselect
-        if (!e.target.value) {
-            form.setValue(name as any, value, {
-                shouldDirty: true,
-                shouldValidate: true
-            });
-            return;
-        }
-        onChange(e);
-    };
-
     return (
         <div id="criteria">
             <Controller
@@ -42,7 +26,7 @@ export const InvestigationCriteria = ({ form }: InvestigationCriteriaProps): Rea
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleChangeToDefaultValue(name, undefined, e, onChange)}
+                        onChange={(e) => handleChangeToDefaultValue(form, name, undefined, e, onChange)}
                         label="Investigation status"
                         htmlFor={name}
                         dataTestid={name}

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationCriteria.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationCriteria.tsx
@@ -8,7 +8,7 @@ import {
     ProcessingStatus
 } from 'generated/graphql/schema';
 import { SearchCriteriaContext } from 'providers/SearchCriteriaContext';
-import { ReactElement } from 'react';
+import { ChangeEvent, ReactElement } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { formatInterfaceString } from 'utils/util';
 
@@ -16,6 +16,22 @@ type InvestigationCriteriaProps = {
     form: UseFormReturn<InvestigationFilter>;
 };
 export const InvestigationCriteria = ({ form }: InvestigationCriteriaProps): ReactElement => {
+    const handleChangeWithUndefinedDefaultValue = (
+        name: String,
+        e: ChangeEvent<HTMLSelectElement>,
+        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
+    ): void => {
+        // Clear event id field on deselect
+        if (!e.target.value) {
+            form.setValue(name as any, undefined as any, {
+                shouldDirty: true,
+                shouldValidate: true
+            });
+            return;
+        }
+        onChange(e);
+    };
+
     return (
         <div id="criteria">
             <Controller
@@ -25,7 +41,7 @@ export const InvestigationCriteria = ({ form }: InvestigationCriteriaProps): Rea
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={onChange}
+                        onChange={(e) => handleChangeWithUndefinedDefaultValue(name, e, onChange)}
                         label="Investigation status"
                         htmlFor={name}
                         dataTestid={name}

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -30,8 +30,8 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
     ): void => {
         // Clear date fields if date type is deselected
         if (!e.target.value) {
-            form.resetField('eventDate.from');
-            form.resetField('eventDate.to');
+            form.setValue('eventDate', { type: undefined } as any, { shouldDirty: true, shouldValidate: true });
+            return;
         }
         onChange(e);
     };
@@ -40,9 +40,14 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
+        console.log(form.getValues());
         // Clear event id field on deselect
         if (!e.target.value) {
-            form.resetField('eventId.id');
+            form.setValue('eventId', { investigationEventType: undefined } as any, {
+                shouldDirty: true,
+                shouldValidate: true
+            });
+            return;
         }
         onChange(e);
     };
@@ -53,7 +58,11 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
     ): void => {
         // Clear event id field on deselect
         if (!e.target.value) {
-            form.resetField('providerFacilitySearch.id');
+            form.setValue('providerFacilitySearch', { entityType: undefined } as any, {
+                shouldDirty: true,
+                shouldValidate: true
+            });
+            return;
         }
         onChange(e);
     };

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -24,56 +24,15 @@ type InvestigationGeneralAccordionProps = {
 export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordionProps): ReactElement => {
     const watch = useWatch({ control: form.control });
 
-    const handleEventDateTypeChange = (
-        e: ChangeEvent<HTMLSelectElement>,
-        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
-    ): void => {
-        // Clear date fields if date type is deselected
-        if (!e.target.value) {
-            form.setValue('eventDate', { type: undefined } as any, { shouldDirty: true, shouldValidate: true });
-            return;
-        }
-        onChange(e);
-    };
-
-    const handleEventIdTypeChange = (
-        e: ChangeEvent<HTMLSelectElement>,
-        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
-    ): void => {
-        // Clear event id field on deselect
-        if (!e.target.value) {
-            form.setValue('eventId', { investigationEventType: undefined } as any, {
-                shouldDirty: true,
-                shouldValidate: true
-            });
-            return;
-        }
-        onChange(e);
-    };
-
-    const handleChangeWithUndefinedDefaultValue = (
+    const handleChangeToDefaultValue = (
         name: String,
+        value: any,
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
         // Clear event id field on deselect
         if (!e.target.value) {
-            form.setValue(name as any, undefined as any, {
-                shouldDirty: true,
-                shouldValidate: true
-            });
-            return;
-        }
-        onChange(e);
-    };
-
-    const handleFacilityTypeChange = (
-        e: ChangeEvent<HTMLSelectElement>,
-        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
-    ): void => {
-        // Clear event id field on deselect
-        if (!e.target.value) {
-            form.setValue('providerFacilitySearch', { entityType: undefined } as any, {
+            form.setValue(name as any, value, {
                 shouldDirty: true,
                 shouldValidate: true
             });
@@ -152,7 +111,7 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleChangeWithUndefinedDefaultValue(name, e, onChange)}
+                        onChange={(e) => handleChangeToDefaultValue(name, undefined, e, onChange)}
                         label="Pregnancy test"
                         htmlFor={name}
                         dataTestid={name}
@@ -171,7 +130,9 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleEventIdTypeChange(e, onChange)}
+                        onChange={(e) =>
+                            handleChangeToDefaultValue('eventId', { investigationEventType: undefined }, e, onChange)
+                        }
                         label="Event id type"
                         dataTestid={name}
                         htmlFor={name}
@@ -217,7 +178,7 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleEventDateTypeChange(e, onChange)}
+                        onChange={(e) => handleChangeToDefaultValue('eventDate', { type: undefined }, e, onChange)}
                         label="Event date type"
                         htmlFor={name}
                         dataTestid={name}
@@ -302,7 +263,9 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleFacilityTypeChange(e, onChange)}
+                        onChange={(e) =>
+                            handleChangeToDefaultValue('providerFacilitySearch', { entityType: undefined }, e, onChange)
+                        }
                         label="Event provider/facility type"
                         htmlFor={name}
                         dataTestid={name}

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -11,35 +11,19 @@ import {
     ReportingEntityType
 } from 'generated/graphql/schema';
 import { SearchCriteriaContext } from 'providers/SearchCriteriaContext';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Controller, UseFormReturn, useWatch } from 'react-hook-form';
 import { formatInterfaceString } from 'utils/util';
 import { UserAutocomplete } from 'options/autocompete/UserAutocomplete';
 import { ProviderAutocomplete } from 'options/autocompete/ProviderAutocomplete';
 import { FacilityAutocomplete } from 'options/autocompete/FacilityAutocomplete';
+import { handleChangeToDefaultValue } from 'forms/event';
 
 type InvestigationGeneralAccordionProps = {
     form: UseFormReturn<InvestigationFilter>;
 };
 export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordionProps): ReactElement => {
     const watch = useWatch({ control: form.control });
-
-    const handleChangeToDefaultValue = (
-        name: String,
-        value: any,
-        e: ChangeEvent<HTMLSelectElement>,
-        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
-    ): void => {
-        // Clear event id field on deselect
-        if (!e.target.value) {
-            form.setValue(name as any, value, {
-                shouldDirty: true,
-                shouldValidate: true
-            });
-            return;
-        }
-        onChange(e);
-    };
 
     return (
         <>
@@ -111,7 +95,7 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleChangeToDefaultValue(name, undefined, e, onChange)}
+                        onChange={(e) => handleChangeToDefaultValue(form, name, undefined, e, onChange)}
                         label="Pregnancy test"
                         htmlFor={name}
                         dataTestid={name}
@@ -131,7 +115,13 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                         name={name}
                         value={value as string | undefined}
                         onChange={(e) =>
-                            handleChangeToDefaultValue('eventId', { investigationEventType: undefined }, e, onChange)
+                            handleChangeToDefaultValue(
+                                form,
+                                'eventId',
+                                { investigationEventType: undefined },
+                                e,
+                                onChange
+                            )
                         }
                         label="Event id type"
                         dataTestid={name}
@@ -178,7 +168,9 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={(e) => handleChangeToDefaultValue('eventDate', { type: undefined }, e, onChange)}
+                        onChange={(e) =>
+                            handleChangeToDefaultValue(form, 'eventDate', { type: undefined }, e, onChange)
+                        }
                         label="Event date type"
                         htmlFor={name}
                         dataTestid={name}
@@ -264,7 +256,13 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                         name={name}
                         value={value as string | undefined}
                         onChange={(e) =>
-                            handleChangeToDefaultValue('providerFacilitySearch', { entityType: undefined }, e, onChange)
+                            handleChangeToDefaultValue(
+                                form,
+                                'providerFacilitySearch',
+                                { entityType: undefined },
+                                e,
+                                onChange
+                            )
                         }
                         label="Event provider/facility type"
                         htmlFor={name}

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -40,7 +40,6 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
     ): void => {
-        console.log(form.getValues());
         // Clear event id field on deselect
         if (!e.target.value) {
             form.setValue('eventId', { investigationEventType: undefined } as any, {

--- a/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/InvestigationSearch/InvestigationGeneralFields.tsx
@@ -51,6 +51,22 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
         onChange(e);
     };
 
+    const handleChangeWithUndefinedDefaultValue = (
+        name: String,
+        e: ChangeEvent<HTMLSelectElement>,
+        onChange: (event: ChangeEvent<HTMLSelectElement>) => void
+    ): void => {
+        // Clear event id field on deselect
+        if (!e.target.value) {
+            form.setValue(name as any, undefined as any, {
+                shouldDirty: true,
+                shouldValidate: true
+            });
+            return;
+        }
+        onChange(e);
+    };
+
     const handleFacilityTypeChange = (
         e: ChangeEvent<HTMLSelectElement>,
         onChange: (event: ChangeEvent<HTMLSelectElement>) => void
@@ -136,7 +152,7 @@ export const InvestigationGeneralFields = ({ form }: InvestigationGeneralAccordi
                     <SelectInput
                         name={name}
                         value={value as string | undefined}
-                        onChange={onChange}
+                        onChange={(e) => handleChangeWithUndefinedDefaultValue(name, e, onChange)}
                         label="Pregnancy test"
                         htmlFor={name}
                         dataTestid={name}

--- a/apps/modernization-ui/src/forms/event.ts
+++ b/apps/modernization-ui/src/forms/event.ts
@@ -1,0 +1,19 @@
+import { ChangeEvent } from 'react';
+
+export const handleChangeToDefaultValue = (
+    form: any,
+    name: String,
+    value: any,
+    e: ChangeEvent<HTMLSelectElement>,
+    onChange: (event: ChangeEvent<HTMLSelectElement>) => void
+): void => {
+    // Clear event id field on deselect
+    if (!e.target.value) {
+        form.setValue(name as any, value, {
+            shouldDirty: true,
+            shouldValidate: true
+        });
+        return;
+    }
+    onChange(e);
+};

--- a/apps/modernization-ui/src/forms/event.ts
+++ b/apps/modernization-ui/src/forms/event.ts
@@ -1,7 +1,8 @@
 import { ChangeEvent } from 'react';
+import { UseFormReturn } from 'react-hook-form/dist/types/form';
 
 export const handleChangeToDefaultValue = (
-    form: any,
+    form: UseFormReturn,
     name: String,
     value: any,
     e: ChangeEvent<HTMLSelectElement>,

--- a/apps/modernization-ui/src/forms/event.ts
+++ b/apps/modernization-ui/src/forms/event.ts
@@ -7,7 +7,6 @@ export const handleChangeToDefaultValue = (
     e: ChangeEvent<HTMLSelectElement>,
     onChange: (event: ChangeEvent<HTMLSelectElement>) => void
 ): void => {
-    // Clear event id field on deselect
     if (!e.target.value) {
         form.setValue(name as any, value, {
             shouldDirty: true,


### PR DESCRIPTION
resetField and typescript won't allow you to set the field back to it's original value (generally `undefined` or `{type: undefined}`) so use `any` with `dirty` and `revalidate` and don't propagate the event.  Note~ exception to typescript do's dont's.

## Description

Please include a summary of the changes and any key information a reviewer may need.

## Tickets

* [CNFT1-2324](https://cdc-nbs.atlassian.net/browse/CNFT1-2324)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2324]: https://cdc-nbs.atlassian.net/browse/CNFT1-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ