### PR TITLE
[CNT-14] - Page library filter by last updated using last 7 days date validation

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
+++ b/testing/regression/cypress/e2e/features/page-library/searchAndFilter.feature
@@ -66,3 +66,12 @@ Feature: User can search and filter the existing page library data here.
         And User clicks the Done button
         When User clicks the Apply button
         Then Added filters "Published" and "Status" are applied and only the records matching the filters are displayed in the Page Library list
+
+    Scenario: Filter by Last Updated using (Past 7 days) operator
+        Given Filter section already displayed
+        When User selects "Last updated" from the drop-down box
+        And User selects "LAST_7_DAYS" from the Operator field
+        Then Type a value field is hidden
+        When User clicks the Done button
+        When User clicks the Apply button
+        Then Added filters "LAST_7_DAYS" and "Last updated" are applied and only the records matching the filters are displayed in the Page Library list

--- a/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/searchAndFilter.page.js
@@ -93,6 +93,10 @@ class SearchAndFilterPage {
         cy.get('#add-filter').eq(0)
     }
 
+    checkValueFiledIsHidden() {
+        cy.get('#values').should('not.exist');
+    }
+
     get table() {
         return "table[data-testid=table]";
     }

--- a/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/searchAndFilter.steps.js
@@ -40,3 +40,6 @@ Then("The application will cancel adding a filter and return to display the + Ad
 Then("User enters {string} in the Type a value field - multi select", (string) => {
     searchAndFilterPage.enterTextInMultiInputValue(string);
 });
+Then("Type a value field is hidden", () => {
+    searchAndFilterPage.checkValueFiledIsHidden();
+});


### PR DESCRIPTION
## Description

Added end to end test case for filter by last updated using last 7 days date validation ( [CNFT2-1115](https://cdc-nbs.atlassian.net/browse/CNFT2-1115) )
Since the last 7 days don't have any data in page builder, so I have used MORE_THAN_30_DAYS for screenshot
<img width="1508" alt="Screenshot 2024-05-03 at 11 22 53 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/29a2f568-8f1f-495d-9e45-7f31f82a5734">

Last 7 days option shows no data in page builder
<img width="1510" alt="Screenshot 2024-05-03 at 11 35 15 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/0cb1641f-8aca-4090-a2b1-ce316fad252e">


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-14)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1115]: https://cdc-nbs.atlassian.net/browse/CNFT2-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ