### PR TITLE
Remove deprecated constructor usage

### DIFF
--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
@@ -62,7 +62,7 @@ public class PatientMother {
     this.active = active;
     this.cleaner = cleaner;
     this.revisionCreator = revisionCreator;
-    this.faker = new Faker(new Locale("en-us"));
+    this.faker = new Faker(Locale.of("en-us"));
   }
 
   void reset() {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PatientProfileAddressSteps {
 
-  private final Faker faker = new Faker(new Locale("en-us"));
+  private final Faker faker = new Faker(Locale.of("en-us"));
 
   @Autowired
   PatientMother mother;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/change/PatientProfileAddressChangeSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/change/PatientProfileAddressChangeSteps.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PatientProfileAddressChangeSteps {
 
-    private final Faker faker = new Faker(new Locale("en-us"));
+    private final Faker faker = new Faker(Locale.of("en-us"));
 
     @Autowired
     Available<PatientIdentifier> patients;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/change/PatientMortalityChangeSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/change/PatientMortalityChangeSteps.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional
 public class PatientMortalityChangeSteps {
 
-    private final Faker faker = new Faker(new Locale("en-us"));
+    private final Faker faker = new Faker(Locale.of("en-us"));
 
     @Autowired
     Available<PatientIdentifier> patients;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/phone/change/PatientProfilePhoneChangeSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/phone/change/PatientProfilePhoneChangeSteps.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PatientProfilePhoneChangeSteps {
 
-  private final Faker faker = new Faker(new Locale("en-us"));
+  private final Faker faker = new Faker(Locale.of("en-us"));
 
   @Autowired
   Available<PatientIdentifier> patients;


### PR DESCRIPTION
## Description

Initialize `Locale` objects using static initializers instead of deprecated constructor.