### PR TITLE
ui Idle session timer

### DIFF
--- a/apps/modernization-ui/src/authorization/IdleTimer.tsx
+++ b/apps/modernization-ui/src/authorization/IdleTimer.tsx
@@ -1,0 +1,84 @@
+import { Button } from 'components/button';
+import React, { useState, useEffect } from 'react';
+
+interface IdleTimerProps {
+    timeout: number; // Timeout in milliseconds
+    onIdle: () => void; // Callback function to execute when idle
+}
+
+const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, onIdle }) => {
+    const [idle, setIdle] = useState(false);
+    const [showWarningModal, setShowWarningModal] = useState(false);
+
+    useEffect(() => {
+        let idleTimer: number;
+        let warningTimer: number;
+
+        const resetIdleTimer = () => {
+            console.log('reset');
+            clearTimeout(idleTimer);
+            idleTimer = window.setTimeout(() => {
+                setIdle(true);
+                removeEventListeners();
+                startWarningTimer();
+            }, timeout);
+        };
+
+        const startWarningTimer = () => {
+            setShowWarningModal(true);
+            clearTimeout(warningTimer);
+            warningTimer = window.setTimeout(() => {
+                onIdle();
+                setShowWarningModal(false);
+            }, 120000); // 2 minutes?
+        };
+
+        const removeEventListeners = () => {
+            const events = ['mousemove', 'keydown', 'mousedown', 'touchstart'];
+            events.forEach((event) => {
+                document.removeEventListener(event, handleActivity);
+            });
+        };
+
+        const addEventListeners = () => {
+            const events = ['mousemove', 'keydown', 'mousedown', 'touchstart'];
+            events.forEach((event) => {
+                document.addEventListener(event, handleActivity);
+            });
+        };
+
+        const handleActivity = () => {
+            resetIdleTimer();
+        };
+
+        if (!idle) {
+            addEventListeners();
+            resetIdleTimer();
+        }
+
+        return () => {
+            clearTimeout(idleTimer);
+            clearTimeout(warningTimer);
+            removeEventListeners();
+        };
+    }, [timeout, onIdle, idle]);
+
+    return (
+        <>
+            {showWarningModal && (
+                <div className="warning-modal">
+                    <p>Warning: Only 2 minutes remaining of idle time!</p>
+                    <Button
+                        onClick={() => {
+                            setShowWarningModal(false);
+                            setIdle(false);
+                        }}>
+                        I'm still here
+                    </Button>
+                </div>
+            )}
+        </>
+    );
+};
+
+export default IdleTimer;

--- a/apps/modernization-ui/src/authorization/IdleTimer.tsx
+++ b/apps/modernization-ui/src/authorization/IdleTimer.tsx
@@ -3,10 +3,11 @@ import React, { useState, useEffect } from 'react';
 
 interface IdleTimerProps {
     timeout: number; // Timeout in milliseconds
+    warningTimeout: number; // Warning Timeout in milliseconds
     onIdle: () => void; // Callback function to execute when idle
 }
 
-const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, onIdle }) => {
+const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, warningTimeout, onIdle }) => {
     const [idle, setIdle] = useState(false);
     const [showWarningModal, setShowWarningModal] = useState(false);
 
@@ -26,13 +27,10 @@ const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, onIdle }) => {
         const startWarningTimer = () => {
             setShowWarningModal(true);
             clearTimeout(warningTimer);
-            warningTimer = window.setTimeout(
-                () => {
-                    onIdle();
-                    setShowWarningModal(false);
-                },
-                1000 * 60 * 5
-            ); // 5 minutes?
+            warningTimer = window.setTimeout(() => {
+                onIdle();
+                setShowWarningModal(false);
+            }, warningTimeout);
         };
 
         const removeEventListeners = () => {

--- a/apps/modernization-ui/src/authorization/IdleTimer.tsx
+++ b/apps/modernization-ui/src/authorization/IdleTimer.tsx
@@ -15,7 +15,6 @@ const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, onIdle }) => {
         let warningTimer: number;
 
         const resetIdleTimer = () => {
-            console.log('reset');
             clearTimeout(idleTimer);
             idleTimer = window.setTimeout(() => {
                 setIdle(true);
@@ -27,10 +26,13 @@ const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, onIdle }) => {
         const startWarningTimer = () => {
             setShowWarningModal(true);
             clearTimeout(warningTimer);
-            warningTimer = window.setTimeout(() => {
-                onIdle();
-                setShowWarningModal(false);
-            }, 120000); // 2 minutes?
+            warningTimer = window.setTimeout(
+                () => {
+                    onIdle();
+                    setShowWarningModal(false);
+                },
+                1000 * 60 * 5
+            ); // 5 minutes?
         };
 
         const removeEventListeners = () => {

--- a/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
+++ b/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
@@ -18,6 +18,7 @@ const ProtectedLayout = () => {
     };
 
     const timeout = 1000 * 60 * 15; // 15 minutes
+    const warningTimeout = 1000 * 60 * 5; // 5 minutes
 
     const WithUser = (user: User) => {
         const data = useLoaderData() as InitializationLoaderResult;
@@ -40,31 +41,12 @@ const ProtectedLayout = () => {
 
     return (
         <Suspense fallback={<Spinner />}>
-            <IdleTimer onIdle={handleIdle} timeout={timeout} />
+            <IdleTimer onIdle={handleIdle} timeout={timeout} warningTimeout={warningTimeout} />
             <Await resolve={data?.user} errorElement={<Navigate to={'/login'} />}>
                 {WithUser}
             </Await>
         </Suspense>
     );
 };
-
-// const WithUser = (user: User) => {
-//     const data = useLoaderData() as InitializationLoaderResult;
-//     return (
-//         <UserContextProvider initial={user}>
-//             <Await resolve={data?.configuration}>{WithConfiguration}</Await>
-//         </UserContextProvider>
-//     );
-// };
-
-// const WithConfiguration = (configuration: Configuration) => {
-//     return (
-//         <ConfigurationProvider initial={configuration}>
-//             <AnalyticsProvider>
-//                 <Layout />
-//             </AnalyticsProvider>
-//         </ConfigurationProvider>
-//     );
-// };
 
 export { ProtectedLayout };

--- a/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
+++ b/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { Await, Navigate, useLoaderData } from 'react-router-dom';
+import { Await, Navigate, redirect, useLoaderData } from 'react-router-dom';
 import { User, UserContextProvider } from 'providers/UserContext';
 
 import { Configuration, ConfigurationProvider } from 'configuration';
@@ -7,12 +7,40 @@ import { AnalyticsProvider } from 'analytics';
 import { Spinner } from 'components/Spinner';
 import { Layout } from '../layout/Layout';
 import { InitializationLoaderResult } from './initializationLoader';
+import IdleTimer from './IdleTimer';
 
 const ProtectedLayout = () => {
     const data = useLoaderData() as InitializationLoaderResult;
 
+    const handleIdle = () => {
+        redirect('/nbs/logout/');
+    };
+
+    // const timeout = 1000 * 60 * 15; // 15 minutes
+    const timeout = 3000;
+
+    const WithUser = (user: User) => {
+        const data = useLoaderData() as InitializationLoaderResult;
+        return (
+            <UserContextProvider initial={user}>
+                <Await resolve={data?.configuration}>{WithConfiguration}</Await>
+            </UserContextProvider>
+        );
+    };
+
+    const WithConfiguration = (configuration: Configuration) => {
+        return (
+            <ConfigurationProvider initial={configuration}>
+                <AnalyticsProvider>
+                    <Layout />
+                </AnalyticsProvider>
+            </ConfigurationProvider>
+        );
+    };
+
     return (
         <Suspense fallback={<Spinner />}>
+            <IdleTimer onIdle={handleIdle} timeout={timeout} />
             <Await resolve={data?.user} errorElement={<Navigate to={'/login'} />}>
                 {WithUser}
             </Await>
@@ -20,23 +48,23 @@ const ProtectedLayout = () => {
     );
 };
 
-const WithUser = (user: User) => {
-    const data = useLoaderData() as InitializationLoaderResult;
-    return (
-        <UserContextProvider initial={user}>
-            <Await resolve={data?.configuration}>{WithConfiguration}</Await>
-        </UserContextProvider>
-    );
-};
+// const WithUser = (user: User) => {
+//     const data = useLoaderData() as InitializationLoaderResult;
+//     return (
+//         <UserContextProvider initial={user}>
+//             <Await resolve={data?.configuration}>{WithConfiguration}</Await>
+//         </UserContextProvider>
+//     );
+// };
 
-const WithConfiguration = (configuration: Configuration) => {
-    return (
-        <ConfigurationProvider initial={configuration}>
-            <AnalyticsProvider>
-                <Layout />
-            </AnalyticsProvider>
-        </ConfigurationProvider>
-    );
-};
+// const WithConfiguration = (configuration: Configuration) => {
+//     return (
+//         <ConfigurationProvider initial={configuration}>
+//             <AnalyticsProvider>
+//                 <Layout />
+//             </AnalyticsProvider>
+//         </ConfigurationProvider>
+//     );
+// };
 
 export { ProtectedLayout };

--- a/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
+++ b/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { Await, Navigate, redirect, useLoaderData } from 'react-router-dom';
+import { Await, Navigate, useLoaderData, useNavigate } from 'react-router-dom';
 import { User, UserContextProvider } from 'providers/UserContext';
 
 import { Configuration, ConfigurationProvider } from 'configuration';
@@ -11,13 +11,13 @@ import IdleTimer from './IdleTimer';
 
 const ProtectedLayout = () => {
     const data = useLoaderData() as InitializationLoaderResult;
+    const navigate = useNavigate();
 
     const handleIdle = () => {
-        redirect('/nbs/logout/');
+        navigate('/expired');
     };
 
-    // const timeout = 1000 * 60 * 15; // 15 minutes
-    const timeout = 3000;
+    const timeout = 1000 * 60 * 15; // 15 minutes
 
     const WithUser = (user: User) => {
         const data = useLoaderData() as InitializationLoaderResult;


### PR DESCRIPTION
## Description

Creates the functionality to track a user's idle time, as well as a second timer that can start once a warning message is displayed.

There are several things still in question at this point mainly.

- there does not appear to be designs yet for a warning modal/page/alert?
- How long can a user be idle before the warning is displayed. (right now just set to 15 minutes)
- How long will the warning stay up? (currently set to 5 minutes)

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT1/boards/112?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT1-2325)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
