### PR TITLE
[CNT-18] - Page library data elements page name appear as link and Reports fix

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/dataElements.feature
+++ b/testing/regression/cypress/e2e/features/page-library/dataElements.feature
@@ -1,0 +1,9 @@
+Feature: User can view existing page library data elements here.
+
+    Background:
+        Given I am logged in as "superuser" and password ""
+        When User navigates to Page Library and views the Page library
+
+    Scenario: Verify the page names appear as links in the Page name column of the library
+        When User views the "Page name" column
+        Then User will see a list of the "Page name links" populated in the "Page name" column

--- a/testing/regression/cypress/e2e/features/page-library/pagination.feature
+++ b/testing/regression/cypress/e2e/features/page-library/pagination.feature
@@ -1,4 +1,4 @@
-Feature: User can view existing page library data here.
+Feature: User can view existing page library pagination here.
 
     Background:
         Given I am logged in as "superuser" and password ""

--- a/testing/regression/cypress/e2e/features/page-library/sort.feature
+++ b/testing/regression/cypress/e2e/features/page-library/sort.feature
@@ -1,4 +1,4 @@
-Feature: User can view existing page library data here.
+Feature: User can view existing page library sorting here.
 
     Background:
         Given I am logged in as "superuser" and password ""

--- a/testing/regression/cypress/e2e/pages/page-library/dataElements.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/dataElements.page.js
@@ -1,0 +1,34 @@
+class DataElementsPage {
+
+    userViewsColumnAndSeeList(columnName) {
+        const list = [];
+        const index = this.getColumnIndexByName(columnName);
+        this.openInvestigationTable.find("tbody tr").each(($tr) => {
+            list.push($tr.find("td").eq(index).text());
+        });
+    }
+
+    getColumnIndexByName(columnName) {
+        if (columnName === "Page name") {
+            return 0;
+        } else if (columnName === "Event type") {
+            return 1;
+        } else if (columnName === "Status") {
+            return 2;
+        } else if (columnName === "Last updated") {
+            return 3;
+        } else if (columnName === "Last updated by") {
+            return 4;
+        }
+    }
+
+    get table() {
+        return "table[data-testid=table]";
+    }
+
+    get openInvestigationTable() {
+        return cy.get(this.table).eq(0);
+    }
+}
+
+export const pageLibraryDataElementsPage = new DataElementsPage()

--- a/testing/regression/cypress/step_definitions/page-library/dataElements.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/dataElements.steps.js
@@ -1,0 +1,10 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+import {pageLibraryDataElementsPage} from "@pages/page-library/dataElements.page";
+
+Then("User views the {string} column", (string) => {
+    pageLibraryDataElementsPage.userViewsColumnAndSeeList(string);
+});
+
+Then("User will see a list of the {string} populated in the {string} column", (string, string1) => {
+    pageLibraryDataElementsPage.userViewsColumnAndSeeList(string1);
+});

--- a/testing/regression/package.json
+++ b/testing/regression/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "cypress": "cypress open",
     "cy:open": "cypress open",
-    "cy:e2e": "cypress run --spec cypress/e2e/**/*.feature",
+    "cy:e2e": "cypress run --spec 'cypress/e2e/**/*.feature'",
     "cy:api": "cypress run --spec cypress/api/**/*.feature",
     "report": "node cucumber-html-report.js"
   },
@@ -20,7 +20,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
     "@faker-js/faker": "^8.0.2",
     "cypress": "^13.6.0",
-    "multiple-cucumber-html-reporter": "^3.4.0"
+    "multiple-cucumber-html-reporter": "^3.6.2"
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": false,


### PR DESCRIPTION
## Description

Added end to end test case for page name appear as links in the page name column ( [CNFT2-964](https://cdc-nbs.atlassian.net/browse/CNFT2-964) ) and fixed the report not showing the page-builder artifacts
<img width="1503" alt="Screenshot 2024-05-08 at 10 22 28 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/23fcda89-a7a4-491e-afc4-5d61ca10dc04">
<img width="1497" alt="Screenshot 2024-05-08 at 10 35 10 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/a4706534-95ad-4480-9f38-33c1ac525c93">

## Tickets

* [CNT-18](https://cdc-nbs.atlassian.net/browse/CNT-18)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-964]: https://cdc-nbs.atlassian.net/browse/CNFT2-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-18]: https://cdc-nbs.atlassian.net/browse/CNT-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ