### PR TITLE
CNFT1-1331 test for search event program area

### DIFF
--- a/testing/regression/cypress/e2e/features/search-investigation-general-info.feature
+++ b/testing/regression/cypress/e2e/features/search-investigation-general-info.feature
@@ -3,8 +3,12 @@ Feature: Investigation Search by general search
 
   Background:
     Given I am logged in as "superuser" and password ""
+    Given I navigate the event investigation
 
   Scenario: Basic Info - Search by Condition
-    When I navigate the event investigation
     When I select a condition for event investigation
-    Then I should see Results with the Condition "Dengue"
+    Then I should see Results with the link "Dengue"
+
+  Scenario: Basic Info - Search by Program Area
+    When I select a program area for event investigation
+    Then I should see Results with the link "Dengue"

--- a/testing/regression/cypress/e2e/pages/searchEvent.page.js
+++ b/testing/regression/cypress/e2e/pages/searchEvent.page.js
@@ -14,6 +14,12 @@ class SearchEventPage {
     cy.wait(500);
   }
 
+  selectEventInvestigationProgramArea() {
+    let elm = cy.get("#react-select-5-placeholder").click({force: true});
+    let elm2 = cy.get("#react-select-5-option-0").click({force: true});
+    cy.wait(500);
+  }
+
   search() {
     let elm = cy.get('button[data-testid="search"]').click(({force: true}));
     cy.wait(500);

--- a/testing/regression/cypress/step_definitions/searchEvent.steps.js
+++ b/testing/regression/cypress/step_definitions/searchEvent.steps.js
@@ -10,6 +10,11 @@ Then("I select a condition for event investigation", () => {
   searchEventPage.search();
 });
 
-Then("I should see Results with the Condition {string}", (string) => {
+Then("I should see Results with the link {string}", (string) => {
   cy.get("a").contains(string).should("be.visible");
+});
+
+Then("I select a program area for event investigation", () => {
+  searchEventPage.selectEventInvestigationProgramArea();
+  searchEventPage.search();
 });


### PR DESCRIPTION
## Description

To verify that the application can successfully search for patients based on a specific program area related to the investigation event.

## Tickets

CNFT1-1331 (https://cdc-nbs.atlassian.net/browse/CNFT1-1331)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
