### PR TITLE
adding required header specificity for welcome page and skipLink styles

### DIFF
--- a/apps/modernization-ui/src/SkipLink/SkipLink.scss
+++ b/apps/modernization-ui/src/SkipLink/SkipLink.scss
@@ -1,8 +1,0 @@
-.skip-link {
-    position: absolute;
-    left: -100000px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-}

--- a/apps/modernization-ui/src/SkipLink/SkipLinkContext.tsx
+++ b/apps/modernization-ui/src/SkipLink/SkipLinkContext.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useContext, useState } from 'react';
-import './SkipLink.scss';
 
 interface SkipLinkContextType {
     skipTo: (id: string) => void;
@@ -38,7 +37,7 @@ export const SkipLinkProvider = ({ children }: SkipLinkProviderProps) => {
     return (
         <SkipLinkContext.Provider value={contextValue}>
             {currentFocusTarget && (
-                <a href={`#${currentFocusTarget}`} className="skip-link">
+                <a href={`#${currentFocusTarget}`} className="usa-skipnav">
                     Skip to main content
                 </a>
             )}

--- a/apps/modernization-ui/src/apps/landing/About/About.tsx
+++ b/apps/modernization-ui/src/apps/landing/About/About.tsx
@@ -14,19 +14,19 @@ export const About = () => {
                     find the documentation (Release Notes, User Guide, System Admin Guide, etc) on Github and NBS
                     Central:
                 </p>
-                <h3>GitHub</h3>
+                <strong>GitHub</strong>
                 <p>
                     <a href="https://github.com/CDCgov/NEDSS-Modernization/releases">
                         https://github.com/CDCgov/NEDSS-Modernization/releases
                     </a>
                 </p>
-                <h3>NBS Central (Latest release documentation)</h3>
+                <strong>NBS Central (Latest release documentation)</strong>
                 <p>
                     <a href="https://cdcnbscentral.com/projects/71release-materials/documents">
                         https://cdcnbscentral.com/projects/71release-materials/documents
                     </a>
                 </p>
-                <h3>Demo features guide (How to use the demo)</h3>
+                <strong>Demo features guide (How to use the demo)</strong>
                 <p>
                     <a href="https://cdcnbscentral.com/attachments/29901">
                         https://cdcnbscentral.com/attachments/29901
@@ -37,27 +37,30 @@ export const About = () => {
                     database to be more representative of a production environment.
                 </p>
             </div>
-            <h2>Feedback</h2>
-            <p>
-                Please provide feedback here:
-                <br />
-                <a href="https://cdcprime.gov1.qualtrics.com/jfe/form/SV_3NNZwwdTOlnIIxU">
-                    https://cdcprime.gov1.qualtrics.com/jfe/form/SV_3NNZwwdTOlnIIxU
-                </a>
-            </p>
-            <p>
-                If you cannot access the link, please reach out to us at <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>,
-                and we will work with you on an alternate method for feedback.
-            </p>
-            <h2>Technical Support</h2>
-            <p>
-                Our technical support can be reached at <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>. You can also
-                submit a ticket on NBS Central:
-                <br />
-                <a href="https://cdcnbscentral.com/projects/70collaboration/issues">
-                    https://cdcnbscentral.com/projects/70collaboration/issues
-                </a>
-            </p>
+            <div>
+                <h2>Feedback</h2>
+                <p>
+                    Please provide feedback here:
+                    <br />
+                    <a href="https://cdcprime.gov1.qualtrics.com/jfe/form/SV_3NNZwwdTOlnIIxU">
+                        https://cdcprime.gov1.qualtrics.com/jfe/form/SV_3NNZwwdTOlnIIxU
+                    </a>
+                </p>
+                <p>
+                    If you cannot access the link, please reach out to us at{' '}
+                    <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>, and we will work with you on an alternate method for
+                    feedback.
+                </p>
+                <h2>Technical Support</h2>
+                <p>
+                    Our technical support can be reached at <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>. You can also
+                    submit a ticket on NBS Central:
+                    <br />
+                    <a href="https://cdcnbscentral.com/projects/70collaboration/issues">
+                        https://cdcnbscentral.com/projects/70collaboration/issues
+                    </a>
+                </p>
+            </div>
         </>
     );
 };

--- a/apps/modernization-ui/src/apps/landing/Layout/WelcomeLayout.tsx
+++ b/apps/modernization-ui/src/apps/landing/Layout/WelcomeLayout.tsx
@@ -6,34 +6,36 @@ import { SignUp } from 'apps/landing/SignUp/SignUp';
 import { LoginWrapper } from './LoginWrapper';
 
 import style from './welcomeLayout.module.scss';
+import { SkipLinkProvider } from 'SkipLink/SkipLinkContext';
 
 const WelcomeLayout = () => {
     const [event, setEvent] = useState('login');
 
     return (
-        <LoginWrapper header={<h1>Welcome to the NBS 7 demo site</h1>}>
-            <div className={style.welcome}>
-                <main>
-                    <div className={style.information}>
-                        <TabNavigation className={style.tabs}>
-                            <TabNavigationEntry path={'about'}>About</TabNavigationEntry>
-                            <TabNavigationEntry path={'learn'}>Learn more</TabNavigationEntry>
-                        </TabNavigation>
-                        <div className={style['tab-content']}>
-                            <Outlet />
+        <SkipLinkProvider>
+            <LoginWrapper header={<h1>Welcome to the NBS 7 demo site</h1>}>
+                <div className={style.welcome}>
+                    <main>
+                        <div className={style.information}>
+                            <TabNavigation className={style.tabs}>
+                                <TabNavigationEntry path={'about'}>About</TabNavigationEntry>
+                                <TabNavigationEntry path={'learn'}>Learn more</TabNavigationEntry>
+                            </TabNavigation>
+                            <div className={style['tab-content']}>
+                                <Outlet />
+                            </div>
                         </div>
-                    </div>
-                </main>
-                <aside>
-                    {event === 'login' ? <SignIn handleWelcomeEvent={(event) => setEvent(event)} /> : <SignUp />}
-                    <div className={style.agency}>
-                        <img src="/cdc.svg" alt="" />
-                        <span>Centers for Disease Control and Prevention</span>
-                        <span>@ Copyright 2024 NEDSS Base System (NBS)</span>
-                    </div>
-                </aside>
-            </div>
-        </LoginWrapper>
+                    </main>
+                    <aside>
+                        {event === 'login' ? <SignIn handleWelcomeEvent={(event) => setEvent(event)} /> : <SignUp />}
+                        <div className={style.agency}>
+                            <img src="/cdc.svg" alt="" />
+                            <span>Centers for Disease Control and Prevention</span>
+                        </div>
+                    </aside>
+                </div>
+            </LoginWrapper>
+        </SkipLinkProvider>
     );
 };
 

--- a/apps/modernization-ui/src/apps/landing/Layout/login-wrapper.module.scss
+++ b/apps/modernization-ui/src/apps/landing/Layout/login-wrapper.module.scss
@@ -1,7 +1,7 @@
 @use 'styles/colors';
 
 .layout {
-    height: 100%;
+    min-height: 100%;
 
     background-image: url('./landing.png');
     background-position: bottom;

--- a/apps/modernization-ui/src/apps/landing/Learn/Learn.tsx
+++ b/apps/modernization-ui/src/apps/landing/Learn/Learn.tsx
@@ -38,22 +38,24 @@ export const Learn = () => {
                     <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a> if you are interested in joining the groups.
                 </p>
             </div>
-            <h3>The NBS User Group (NUG)</h3>
-            <p>
-                NUG calls provide a forum for participants to discuss the latest NBS software development, current
-                topics, and best practices. The user group also provides a platform for jurisdictions to collaborate,
-                discuss common issues, and share lessons learned.
-            </p>
-            <h3>The NBS Subject Matter Expert (SME) calls</h3>
-            <p>
-                They allow participants to discuss detailed NBS software release requirements and collaborate on NBS
-                software development and best practices.
-            </p>
-            <h2>More ways to get involved</h2>
-            <p>
-                If you are interested in becoming a pilot partner, or participating in the co-creation sessions, please
-                send us an email to <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>.
-            </p>
+            <div>
+                <strong>The NBS User Group (NUG)</strong>
+                <p>
+                    NUG calls provide a forum for participants to discuss the latest NBS software development, current
+                    topics, and best practices. The user group also provides a platform for jurisdictions to
+                    collaborate, discuss common issues, and share lessons learned.
+                </p>
+                <strong>The NBS Subject Matter Expert (SME) calls</strong>
+                <p>
+                    They allow participants to discuss detailed NBS software release requirements and collaborate on NBS
+                    software development and best practices.
+                </p>
+                <h2>More ways to get involved</h2>
+                <p>
+                    If you are interested in becoming a pilot partner, or participating in the co-creation sessions,
+                    please send us an email to <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>.
+                </p>
+            </div>
         </>
     );
 };

--- a/apps/modernization-ui/src/apps/landing/SignIn/SignIn.spec.tsx
+++ b/apps/modernization-ui/src/apps/landing/SignIn/SignIn.spec.tsx
@@ -1,29 +1,34 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SignIn } from './SignIn';
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    NavLink: ({ children, ...props }: any) => <a {...props}>{children}</a>
+jest.mock('SkipLink/SkipLinkContext', () => ({
+    useSkipLink: () => ({ skipTo: jest.fn() })
 }));
 
 describe('SignIn', () => {
     it('renders without crashing', () => {
-        const handleWelcomeEventMock = jest.fn();
-        const { getByText, getByRole } = render(<SignIn handleWelcomeEvent={handleWelcomeEventMock} />);
+        const { getByText, getByRole } = render(<SignIn />);
 
         expect(getByText('Login')).toBeInTheDocument();
-
         expect(
             getByText(
                 'Please be sure to avoid entering any real PHI/PII data on the demo site. All information entered will be viewable by other users.'
             )
         ).toBeInTheDocument();
 
-        const signUpButton = getByRole('button', { name: 'Sign up for demo access' });
-        expect(signUpButton).toBeInTheDocument();
+        expect(getByRole('link', { name: 'Login to NBS demo site' })).toBeInTheDocument();
+        expect(getByRole('button', { name: 'Sign up for demo access' })).toBeInTheDocument();
+    });
 
+    it('calls handleWelcomeEvent when Sign up button is clicked', () => {
+        const handleWelcomeEventMock = jest.fn();
+        const { getByRole } = render(<SignIn handleWelcomeEvent={handleWelcomeEventMock} />);
+
+        const signUpButton = getByRole('button', { name: 'Sign up for demo access' });
         userEvent.click(signUpButton);
+
         expect(handleWelcomeEventMock).toHaveBeenCalledWith('signUp');
     });
 });

--- a/apps/modernization-ui/src/apps/landing/SignIn/SignIn.tsx
+++ b/apps/modernization-ui/src/apps/landing/SignIn/SignIn.tsx
@@ -3,12 +3,20 @@ import classNames from 'classnames';
 import styles from './signIn.module.scss';
 import { LinkButton } from 'components/button';
 import { AlertBanner } from 'alert';
+import { useSkipLink } from 'SkipLink/SkipLinkContext';
+import { useEffect } from 'react';
 
 export type SignInProps = {
     handleWelcomeEvent?: (value: string) => void;
 };
 
 export const SignIn = ({ handleWelcomeEvent }: SignInProps) => {
+    const { skipTo } = useSkipLink();
+
+    useEffect(() => {
+        skipTo('login');
+    }, []);
+
     return (
         <div className="">
             <h2 className={classNames(styles.heading)}>Login</h2>
@@ -20,7 +28,7 @@ export const SignIn = ({ handleWelcomeEvent }: SignInProps) => {
                     </p>
                 </AlertBanner>
             </div>
-            <LinkButton href="/nbs/login" type="solid" className="margin-top-2">
+            <LinkButton id="login" href="/nbs/login" type="solid" className="margin-top-2">
                 Login to NBS demo site
             </LinkButton>
             <div className={classNames(styles.signUpDemoText)}>


### PR DESCRIPTION
adding required header specificity for welcome page and skipLink styles 

A skip link navigation button is needed in order to navigate to the main content of the Login page.

Adding the styles used from USWDS for the skipLink button


## Tickets

* [CNFT1-2273](https://cdc-nbs.atlassian.net/browse/CNFT1-2273)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2273]: https://cdc-nbs.atlassian.net/browse/CNFT1-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ