### PR TITLE
[CNT-18] - Verify selection of a single condition in the Condition(s) drop-down box

### DIFF
--- a/testing/regression/cypress/e2e/features/create-page/pageElements.feature
+++ b/testing/regression/cypress/e2e/features/create-page/pageElements.feature
@@ -24,3 +24,11 @@ Feature: User can verify existing create new page elements here.
       | Data mart name                                                         | Heading, text fields             |
       | Cancel                                                                 | Buttons                          |
       | Create page                                                            | Buttons                          |
+
+  Scenario: Select a single condition
+    And User clicks in the Condition field
+    Then A drop-down box displays with a list of conditions
+    When User clicks the check box to select a single condition
+    Then A single condition is added in the Conditions field
+    When User clicks the up or down arrow - right-side of the field
+    Then Drop-down list box closes

--- a/testing/regression/cypress/e2e/pages/create-page/pageElements.page.js
+++ b/testing/regression/cypress/e2e/pages/create-page/pageElements.page.js
@@ -17,6 +17,32 @@ class PageElementsPage {
         cy.contains(new RegExp(text, 'i'))
     }
 
+    clickConditionField() {
+        this.selectEventType()
+        cy.get("#conditionIds").click()
+    }
+
+    dropdownConditionsOpen() {
+        cy.get(".multi-select__control--menu-is-open").should('be.visible')
+    }
+
+    selectValueFromConditions() {
+        cy.get('#conditionIds .multi-select__option input[type="checkbox"]').eq(0).click()
+        cy.get('.multi-select__option--is-focused').click();
+    }
+
+    conditionFieldHasValue() {
+        cy.get('.multi-select__value-container--has-value').should('be.visible')
+    }
+
+    clickOnConditionDropdownArrow() {
+        cy.get('.multi-select__dropdown-indicator').click()
+    }
+
+    dropdownConditionsClose() {
+        cy.get(".multi-select__control--menu-is-open").should('not.exist')
+    }
+
 }
 
 export const pageElementsPage = new PageElementsPage()

--- a/testing/regression/cypress/step_definitions/create-page/pageElements.steps.js
+++ b/testing/regression/cypress/step_definitions/create-page/pageElements.steps.js
@@ -9,3 +9,27 @@ Then("User navigates to Create New Page and views the page", () => {
 Then("User should see the following required elements by {string} {string}", (string, string1) => {
     pageElementsPage.seeElementText(string, string1);
 });
+
+Then("User clicks in the Condition field", () => {
+    pageElementsPage.clickConditionField();
+});
+
+Then("A drop-down box displays with a list of conditions", () => {
+    pageElementsPage.dropdownConditionsOpen();
+});
+
+Then("User clicks the check box to select a single condition", () => {
+    pageElementsPage.selectValueFromConditions();
+});
+
+Then("A single condition is added in the Conditions field", () => {
+    pageElementsPage.conditionFieldHasValue();
+});
+
+Then("User clicks the up or down arrow - right-side of the field", () => {
+    pageElementsPage.clickOnConditionDropdownArrow();
+});
+
+Then("Drop-down list box closes", () => {
+    pageElementsPage.dropdownConditionsClose();
+});


### PR DESCRIPTION
## Description

Added end to end test case to verify selection of a single condition in the Condition(s) drop-down box ( [CNFT2-1251](https://cdc-nbs.atlassian.net/browse/CNFT2-1251) )
<img width="1360" alt="Screenshot 2024-05-14 at 11 20 00 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/42c5567e-2f4a-456f-88b2-42b0d3ff0a0b">

## Tickets

* [CNT-18](https://cdc-nbs.atlassian.net/browse/CNT-18)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1251]: https://cdc-nbs.atlassian.net/browse/CNFT2-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-18]: https://cdc-nbs.atlassian.net/browse/CNT-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ