### PR TITLE
[CNT-20] - Select a Template to populate the field

### DIFF
--- a/testing/regression/cypress/e2e/features/create-page/pageElements.feature
+++ b/testing/regression/cypress/e2e/features/create-page/pageElements.feature
@@ -33,8 +33,15 @@ Feature: User can verify existing create new page elements here.
     When User clicks the up or down arrow - right-side of the field
     Then Drop-down list box closes
 
-    Scenario: Verify Page name field allows entry of text characters
-        And User clicks in the Page name field
-        Then Page name field is highlighted with a rectangular blue box
-        When User enters a Page name in the text field
-        Then Page name field allows entry of text successfully
+  Scenario: Verify Page name field allows entry of text characters
+    And User clicks in the Page name field
+    Then Page name field is highlighted with a rectangular blue box
+    When User enters a Page name in the text field
+    Then Page name field allows entry of text successfully
+
+  Scenario: Verify selection of a Template populates the field
+    And User clicks the Template field
+    Then Template field is highlighted with a rectangular blue box
+    And Drop-down box displays with a list of Templates to select
+    When User selects a Template
+    Then A Template is populated successfully in the Templates field template

--- a/testing/regression/cypress/e2e/pages/create-page/pageElements.page.js
+++ b/testing/regression/cypress/e2e/pages/create-page/pageElements.page.js
@@ -60,6 +60,30 @@ class PageElementsPage {
         cy.get('#name').should('have.value', 'Malaria Investigation')
     }
 
+    clickTemplateField() {
+        this.selectEventType()
+        cy.wait(500)
+        cy.get('#templateId').select('')
+    }
+
+    templateFieldFocused() {
+        cy.get('#templateId').should('be.focused')
+    }
+
+    templateFieldHasValueList() {
+        cy.get('#templateId').find('option').should('have.length.gt', 1)
+    }
+
+    selectValueFromTemplateList() {
+        cy.get('#templateId').find('option').eq(1).then((option) => {
+            cy.get('#templateId').select(option.attr('value'))
+        })
+    }
+
+    templateFieldHasValue() {
+        cy.get('#templateId').invoke('val').should('exist')
+    }
+
 }
 
 export const pageElementsPage = new PageElementsPage()

--- a/testing/regression/cypress/step_definitions/create-page/pageElements.steps.js
+++ b/testing/regression/cypress/step_definitions/create-page/pageElements.steps.js
@@ -49,3 +49,23 @@ Then("User enters a Page name in the text field", () => {
 Then("Page name field allows entry of text successfully", () => {
     pageElementsPage.pageNameFieldAllows();
 });
+
+Then("User clicks the Template field", () => {
+    pageElementsPage.clickTemplateField();
+});
+
+Then("Template field is highlighted with a rectangular blue box", () => {
+    pageElementsPage.templateFieldFocused();
+});
+
+Then("Drop-down box displays with a list of Templates to select", () => {
+    pageElementsPage.templateFieldHasValueList();
+});
+
+Then("User selects a Template", () => {
+    pageElementsPage.selectValueFromTemplateList();
+});
+
+Then("A Template is populated successfully in the Templates field template", () => {
+    pageElementsPage.templateFieldHasValue();
+});


### PR DESCRIPTION
## Description

Added end to end test case to select a Template to populate the field ( [CNFT2-1260](https://cdc-nbs.atlassian.net/browse/CNFT2-1260) )
<img width="1509" alt="Screenshot 2024-05-15 at 12 48 13 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/bf5bb618-3aab-4abf-98fb-330ffe1e8952">

## Tickets

* [CNT-20](https://cdc-nbs.atlassian.net/browse/CNT-20)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1260]: https://cdc-nbs.atlassian.net/browse/CNFT2-1260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-20]: https://cdc-nbs.atlassian.net/browse/CNT-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ