### PR TITLE
[CNT-20] - Verify Event Type field displays required values (upon selection) on Add new page

### DIFF
--- a/testing/regression/cypress/e2e/features/create-page/pageElements.feature
+++ b/testing/regression/cypress/e2e/features/create-page/pageElements.feature
@@ -39,6 +39,21 @@ Feature: User can verify existing create new page elements here.
     When User enters a Page name in the text field
     Then Page name field allows entry of text successfully
 
+  Scenario Outline: Event Type field displays required values in the drop-down box (upon selection) on Add new page
+    And User clicks the Event Type field
+    Then Event Type field is highlighted with a rectangular blue box
+    And Drop-down box displays with the following required values by "<Option text>"
+
+    Examples:
+      | Option text          |
+      | Contact Record       |
+      | Interview            |
+      | Investigation        |
+      | Lab Isolate Tracking |
+      | Lab Report           |
+      | Lab Susceptibility   |
+      | Vaccination          |
+
   Scenario: Verify selection of a Template populates the field
     And User clicks the Template field
     Then Template field is highlighted with a rectangular blue box

--- a/testing/regression/cypress/e2e/pages/create-page/pageElements.page.js
+++ b/testing/regression/cypress/e2e/pages/create-page/pageElements.page.js
@@ -60,6 +60,18 @@ class PageElementsPage {
         cy.get('#name').should('have.value', 'Malaria Investigation')
     }
 
+    clickEventTypeField() {
+        cy.get('#eventType').select('')
+    }
+
+    eventTypeFieldFocused() {
+        cy.get('#eventType').should('be.focused')
+    }
+
+    eventTypeFieldHasValue(optionText) {
+        cy.get('#eventType').should('contain', optionText)
+    }
+
     clickTemplateField() {
         this.selectEventType()
         cy.wait(500)

--- a/testing/regression/cypress/step_definitions/create-page/pageElements.steps.js
+++ b/testing/regression/cypress/step_definitions/create-page/pageElements.steps.js
@@ -50,6 +50,18 @@ Then("Page name field allows entry of text successfully", () => {
     pageElementsPage.pageNameFieldAllows();
 });
 
+Then("User clicks the Event Type field", () => {
+    pageElementsPage.clickEventTypeField();
+});
+
+Then("Event Type field is highlighted with a rectangular blue box", () => {
+    pageElementsPage.eventTypeFieldFocused();
+});
+
+Then("Drop-down box displays with the following required values by {string}", (string) => {
+    pageElementsPage.eventTypeFieldHasValue(string);
+});
+
 Then("User clicks the Template field", () => {
     pageElementsPage.clickTemplateField();
 });


### PR DESCRIPTION
## Description

Added end to end test case to verify Event Type field displays required values (upon selection) on Add new page ( [CNFT2-1257](https://cdc-nbs.atlassian.net/browse/CNFT2-1257) )
<img width="1509" alt="Screenshot 2024-05-15 at 1 39 17 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/7637fc27-fdc2-4d3f-9cf2-f63403094850">

## Tickets

* [CNT-20](https://cdc-nbs.atlassian.net/browse/CNT-20)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1257]: https://cdc-nbs.atlassian.net/browse/CNFT2-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-20]: https://cdc-nbs.atlassian.net/browse/CNT-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ