### PR TITLE
CNFT1-2223 Validate heading levels

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/AddQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/AddQuestion.tsx
@@ -3,7 +3,6 @@ import { useAlert } from 'alert';
 import { CreateCodedQuestionRequest } from 'apps/page-builder/generated';
 import { CreateQuestionRequest, useCreateQuestion } from 'apps/page-builder/hooks/api/useCreateQuestion';
 import classNames from 'classnames';
-import { Heading } from 'components/heading';
 import { PageProvider } from 'page';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
@@ -99,7 +98,7 @@ const AddQuestionContent = ({ onBack, onClose, onSubmit, onFindValueSet }: AddQu
             />
             <div className={styles.scrollableContent}>
                 <div className={styles.heading}>
-                    <Heading level={3}>Let's create a new question</Heading>
+                    <h3>Let's create a new question</h3>
                     <div className={styles.fieldInfo}>
                         All fields with <span className={styles.mandatory}>*</span> are required
                     </div>

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/add-question.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/add-question.module.scss
@@ -24,7 +24,10 @@
         .heading {
             padding: 2rem 0;
             text-align: center;
-
+            h3 {
+                font-size: 1rem;
+                margin: 0;
+            }
             .fieldInfo {
                 margin-top: 0.25rem;
                 font-size: 0.875rem;

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/AdministrativeFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/AdministrativeFields.tsx
@@ -1,5 +1,4 @@
 import { Label, Textarea } from '@trussworks/react-uswds';
-import { Heading } from 'components/heading';
 import { Controller, useFormContext } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
 import { CreateQuestionForm } from '../QuestionForm';
@@ -9,9 +8,7 @@ export const AdministrativeFields = () => {
     const form = useFormContext<CreateQuestionForm>();
     return (
         <>
-            <Heading className={styles.heading} level={4}>
-                Administrative
-            </Heading>
+            <h4>Administrative</h4>
             <Controller
                 control={form.control}
                 name="adminComments"

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/BasicInformationFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/BasicInformationFields.tsx
@@ -1,5 +1,4 @@
 import { ErrorMessage, Label, Radio, Textarea } from '@trussworks/react-uswds';
-import { Heading } from 'components/heading';
 
 import { QuestionValidationRequest } from 'apps/page-builder/generated/models/QuestionValidationRequest';
 import { useOptions } from 'apps/page-builder/hooks/api/useOptions';
@@ -70,7 +69,7 @@ export const BasicInformationFields = ({ editing = false }: Props) => {
 
     return (
         <>
-            <Heading level={4}>Basic information</Heading>
+            <h4>Basic information</h4>
             <Controller
                 control={form.control}
                 name="codeSet"

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/DataMartFields.tsx
@@ -3,12 +3,10 @@ import { useOptions } from 'apps/page-builder/hooks/api/useOptions';
 import { usePageQuestionDataMartValidation } from 'apps/page-builder/hooks/api/usePageQuestionValidation';
 import { useQuestionValidation } from 'apps/page-builder/hooks/api/useQuestionValidation';
 import { Input } from 'components/FormInputs/Input';
-import { Heading } from 'components/heading';
 import { ChangeEvent, useEffect } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
 import { CreateQuestionForm } from '../QuestionForm';
-import styles from '../question-form.module.scss';
 
 type Props = {
     editing?: boolean;
@@ -84,9 +82,7 @@ export const DataMartFields = ({ editing = false, page, questionId }: Props) => 
 
     return (
         <>
-            <Heading className={styles.heading} level={4}>
-                Data mart
-            </Heading>
+            <h4>Data mart</h4>
             <Controller
                 control={form.control}
                 name="dataMartInfo.reportLabel"

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/MessagingFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/MessagingFields.tsx
@@ -1,7 +1,6 @@
 import { useOptions } from 'apps/page-builder/hooks/api/useOptions';
 import { Input } from 'components/FormInputs/Input';
 import { SelectInput } from 'components/FormInputs/SelectInput';
-import { Heading } from 'components/heading';
 import { useEffect } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
@@ -31,9 +30,7 @@ export const MessagingFields = () => {
 
     return (
         <>
-            <Heading className={styles.heading} level={4}>
-                Messaging
-            </Heading>
+            <h4>Messaging</h4>
             <label htmlFor="messagingInfo.includedInMessage" className={styles.toggleLabel}>
                 Included in message? <span className={styles.mandatory}>*</span>
             </label>

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/UserInterfaceFields.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/fields/UserInterfaceFields.tsx
@@ -1,6 +1,5 @@
 import { ErrorMessage, Label, Textarea } from '@trussworks/react-uswds';
 import { Input } from 'components/FormInputs/Input';
-import { Heading } from 'components/heading';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
 import { CreateQuestionForm } from '../QuestionForm';
@@ -100,7 +99,7 @@ export const UserInterfaceFields = ({ published = false }: Props) => {
 
     return (
         <>
-            <Heading level={4}>User interface</Heading>
+            <h4>User interface</h4>
             <Controller
                 control={form.control}
                 name="label"

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/question-form.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/question-form.module.scss
@@ -4,6 +4,9 @@
     display: flex;
     flex-direction: column;
     padding-bottom: 4rem;
+    h4 {
+        font-size: 1.05rem;
+    }
 }
 
 .radioButtons {

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/valueset/ValuesetSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/valueset/ValuesetSearch.tsx
@@ -1,5 +1,4 @@
 import { Button, Icon } from '@trussworks/react-uswds';
-import { Heading } from 'components/heading';
 import { useEffect, useState } from 'react';
 import { ButtonBar } from '../../ButtonBar/ButtonBar';
 import { CloseableHeader } from '../../CloseableHeader/CloseableHeader';
@@ -62,7 +61,7 @@ export const ValuesetSearch = ({ onCancel, onClose, onAccept, onCreateNew }: Pro
             />
             <div className={styles.scrollableContent}>
                 <div className={styles.heading}>
-                    <Heading level={3}>Let's find the right value set for your single choice question</Heading>
+                    <h3>Let's find the right value set for your single choice question</h3>
                 </div>
                 <div className={styles.tableContainer}>
                     <ValuesetSearchTable

--- a/apps/modernization-ui/src/apps/page-builder/components/ImportTemplate/ImportTemplate.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/ImportTemplate/ImportTemplate.scss
@@ -27,6 +27,10 @@
             flex-direction: column;
             align-items: center;
             gap: 4px;
+            h2 {
+                font-size: 1rem;
+                margin: 0;
+            }
         }
         .drop-area {
             display: flex;

--- a/apps/modernization-ui/src/apps/page-builder/components/ImportTemplate/ImportTemplate.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/ImportTemplate/ImportTemplate.tsx
@@ -5,7 +5,6 @@ import { Spinner } from 'components/Spinner/Spinner';
 import React, { useEffect, useState } from 'react';
 import { AlertBanner } from '../AlertBanner/AlertBanner';
 import './ImportTemplate.scss';
-import { Heading } from 'components/heading';
 
 type ImportTemplateProps = {
     onTemplateCreated: (template: Template) => void;
@@ -77,7 +76,7 @@ export const ImportTemplate = ({ onTemplateCreated, onCancel }: ImportTemplatePr
                 )}
 
                 <div className="heading">
-                    <Heading level={3}>Import a new template</Heading>
+                    <h2>Import a new template</h2>
                 </div>
                 <label htmlFor="importTempId">
                     <input

--- a/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.tsx
@@ -1,7 +1,6 @@
 import { Button, Icon } from '@trussworks/react-uswds';
 import { ConditionSort, useConditionSearch } from 'apps/page-builder/condition/search/useConditionSearch';
 import { Search } from 'components/Search';
-import { Heading } from 'components/heading';
 import { PageProvider, Status, usePage } from 'page';
 import { useEffect, useState } from 'react';
 import { ConditionTable } from './ConditionTable';
@@ -83,11 +82,11 @@ const ConditionSearchContent = ({ onConditionSelect, onCancel, onCreateNew }: Pr
     return (
         <div className={styles.conditionSearch}>
             <div className={styles.header}>
-                <Heading level={2}>Search and add condition(s)</Heading>
+                <h2>Search and add condition(s)</h2>
                 <Icon.Close size={4} onClick={handleCancel} />
             </div>
             <div className={styles.content}>
-                <Heading level={3}>You can search for existing condition(s) or create a new one.</Heading>
+                <h3>You can search for existing condition(s) or create a new one.</h3>
                 <div className={styles.controls}>
                     {resetTable === false && (
                         <Search

--- a/apps/modernization-ui/src/apps/page-builder/condition/search/condition-search.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/condition-search.module.scss
@@ -13,7 +13,9 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-
+        h2 {
+            margin: 0;
+        }
         @extend %thin;
         @include borders.rounded('top');
 
@@ -29,7 +31,9 @@
         flex-grow: 1;
         flex-direction: column;
         overflow-y: auto;
-
+        h3 {
+            margin: 0;
+        }
         .controls {
             display: flex;
             justify-content: flex-end;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionContent.tsx
@@ -1,6 +1,5 @@
 import styles from './question-content.module.scss';
 import { Input } from 'components/FormInputs/Input';
-import { Heading } from 'components/heading';
 import { useEffect, useState } from 'react';
 import { SelectInput } from 'components/FormInputs/SelectInput';
 import { Selectable } from 'options/selectable';
@@ -60,7 +59,7 @@ export const QuestionContent = ({
     const renderLabelWithComponent = (
         <div className={styles.content}>
             <div className={styles.questionHeader}>
-                <Heading level={2}>{name}</Heading>
+                <span>{name}</span>
                 <div className={styles.identifier}>{`(${identifier})`}</div>
             </div>
             <div className={styles.questionContent}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/QuestionHeader.tsx
@@ -2,7 +2,6 @@ import { Button, Icon } from '@trussworks/react-uswds';
 import DeleteQuestion from 'apps/page-builder/components/DeleteQuestion/DeleteQuestion';
 import { ToggleButton } from 'apps/page-builder/components/ToggleButton';
 import { PagesQuestion } from 'apps/page-builder/generated';
-import { Heading } from 'components/heading';
 import { useEffect, useState } from 'react';
 import styles from './question-header.module.scss';
 import { staticElementTypes } from '../staticelement/EditStaticElement';
@@ -52,7 +51,7 @@ export const QuestionHeader = ({ question, onEditQuestion, onRequiredChange, onD
             <div className={styles.typeDisplay}>
                 {question.isStandard && <div className={styles.standardIndicator}>S</div>}
                 {!question.isStandard && question.isPublished && <div className={styles.publishedIndicator}>P</div>}
-                <Heading level={3}>{getHeadingText(question.displayComponent)}</Heading>
+                <h5>{getHeadingText(question.displayComponent)}</h5>
             </div>
             <div className={`${styles.questionButtons} question-header-button`}>
                 <Button unstyled className={styles.editButton} type="button" onClick={onEditQuestion}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-content.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-content.module.scss
@@ -31,7 +31,11 @@
         .questionHeader {
             display: flex;
             align-items: flex-start;
-
+            span {
+                font-size: 1.25rem;
+                font-weight: 700;
+                margin-bottom: 0.5rem;
+            }
             .identifier {
                 margin: 0%;
                 margin-top: 0.4rem;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-header.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/question-header.module.scss
@@ -8,7 +8,11 @@
     border: 1px solid colors.$base-lightest;
     background: colors.$base-white;
     justify-content: space-between;
-
+    h5 {
+        font-size: 1rem;
+        text-transform: none;
+        margin: 0;
+    }
     .typeDisplay {
         display: flex;
         align-items: center;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/SectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/SectionHeader.tsx
@@ -32,7 +32,9 @@ export const SectionHeader = ({
     return (
         <div className={classNames(styles.header, { [styles.expanded]: isExpanded })}>
             <div className={styles.info}>
-                <div className={styles.name}>{name}</div>
+                <div className={styles.name}>
+                    <h3>{name}</h3>
+                </div>
                 <div className={styles.subsectionCount}>
                     {subsectionCount} subsection{subsectionCount > 1 ? 's' : ''}
                 </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/AddSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/AddSection.tsx
@@ -8,7 +8,6 @@ import {
 import { Controller, useForm } from 'react-hook-form';
 import { ToggleButton } from 'apps/page-builder/components/ToggleButton';
 import styles from './addsection.module.scss';
-import { Heading } from 'components/heading';
 import { useEffect } from 'react';
 import { maxLengthRule, validPageNameRule } from 'validation/entry';
 import { Input } from 'components/FormInputs/Input';
@@ -72,9 +71,7 @@ export const AddSection = ({
 
     return (
         <div className={styles.addSection}>
-            <div className={styles.header}>
-                {isEdit ? <Heading level={4}>Edit section</Heading> : <Heading level={4}>Add a section</Heading>}
-            </div>
+            <div className={styles.header}>{isEdit ? <h2>Edit section</h2> : <h2>Add a section</h2>}</div>
             <Form onSubmit={onSubmit} className={styles.form}>
                 <div className={styles.content}>
                     <Controller

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSection.tsx
@@ -4,7 +4,6 @@ import { Icon as NbsIcon } from 'components/Icon/Icon';
 import styles from './managesection.module.scss';
 import { useState } from 'react';
 import { AddSection } from './AddSection';
-import { Heading } from 'components/heading';
 import { AlertInLineProps } from './ManageSectionModal';
 import { ManageSectionTile } from './ManageSectionTile/ManageSectionTile';
 import { useDragDrop } from 'apps/page-builder/context/DragDropProvider';
@@ -112,7 +111,7 @@ export const ManageSection = ({
                 <div className={styles.managesection}>
                     <div className={styles.header}>
                         <div className={styles.manageSectionHeader} data-testid="header">
-                            <Heading level={4}>Manage sections</Heading>
+                            <h2>Manage sections</h2>
                         </div>
                         <div className={styles.addSectionHeader}>
                             <Button

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/addsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/addsection.module.scss
@@ -18,8 +18,10 @@
         align-items: center;
         font-size: 1.375rem;
         padding: 1.5rem;
-
         border-bottom: 1px solid colors.$base-lightest;
+        h2 {
+            margin: 0;
+        }
     }
 
     .form {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/managesection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/managesection.module.scss
@@ -18,7 +18,9 @@
         width: 100%;
         justify-content: space-between;
         border-bottom: 1px solid colors.$base-lightest;
-
+        h2 {
+            margin: 0;
+        }
         .manageSectionHeader {
             display: flex;
             justify-content: flex-start;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/section.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/section.module.scss
@@ -33,10 +33,13 @@
 
             .info {
                 .name {
-                    color: colors.$base-black;
-                    text-align: center;
-                    font-size: 1.375rem;
-                    font-weight: 700;
+                    h3{
+                        color: colors.$base-black;
+                        text-align: center;
+                        font-size: 1.375rem;
+                        font-weight: 700;
+                        margin: 0;
+                    }
                 }
 
                 .subsectionCount {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -78,7 +78,9 @@ export const SubsectionHeader = ({
             <div className={styles.info}>
                 {subsection.isGrouped !== false ? <div className={styles.indicator}>R</div> : null}
                 <div>
-                    <div className={styles.name}>{subsection.name}</div>
+                    <div className={styles.name}>
+                        <h4>{subsection.name}</h4>
+                    </div>
                     <div className={styles.count}>
                         {`${subsection.questions?.length} question${subsection.questions?.length > 1 ? 's' : ''}`}
                     </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/AddSubSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/AddSubSection.tsx
@@ -6,7 +6,6 @@ import {
 } from 'apps/page-builder/generated';
 import { Controller, useForm } from 'react-hook-form';
 import styles from './addsubsection.module.scss';
-import { Heading } from 'components/heading';
 import { Button, Form, Icon } from '@trussworks/react-uswds';
 import { ToggleButton } from 'apps/page-builder/components/ToggleButton';
 import { maxLengthRule } from 'validation/entry';
@@ -66,11 +65,7 @@ export const AddSubSection = ({
         <div className={styles.subSection}>
             <div className={styles.header}>
                 <div className={styles.headerContent}>
-                    {isEdit ? (
-                        <Heading level={4}>Edit subsection</Heading>
-                    ) : (
-                        <Heading level={4}>Add subsection</Heading>
-                    )}
+                    {isEdit ? <h2>Edit subsection</h2> : <h2>Add subsection</h2>}
                 </div>
                 <Icon.Close
                     size={3}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/ManageSubsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/ManageSubsection.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import styles from './managesubsection.module.scss';
 import { Button, Icon } from '@trussworks/react-uswds';
-import { Heading } from 'components/heading';
 import { AlertInLineProps } from '../../section/manage/ManageSectionModal';
 import { Icon as NbsIcon } from 'components/Icon/Icon';
 import { PagesSection, PagesSubSection, SubSectionControllerService } from 'apps/page-builder/generated';
@@ -97,7 +96,7 @@ export const ManageSubsection = ({ alert, onResetAlert, section, onSetAlert, onC
                 <div className={styles.manageSubsection}>
                     <div className={styles.header}>
                         <div className={styles.manageSubsectionHeader} data-testid="header">
-                            <Heading level={4}>Manage subsections</Heading>
+                            <h2>Manage subsections</h2>
                         </div>
                         <div className={styles.addSubsectionHeader}>
                             <Button

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/addsubsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/addsubsection.module.scss
@@ -24,6 +24,9 @@
         .headerContent {
             display: flex;
             justify-content: flex-start;
+            h2 {
+                margin: 0;
+            }
         }
         .closeBtn:hover {
             cursor: pointer;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/managesubsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/manage/managesubsection.module.scss
@@ -18,7 +18,9 @@
         width: 100%;
         justify-content: space-between;
         border-bottom: 1px solid colors.$base-lightest;
-
+        h2 {
+            margin: 0;
+        }
         .manageSubsectionHeader {
             display: flex;
             justify-content: flex-start;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/subsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/subsection.module.scss
@@ -12,18 +12,20 @@
         align-self: stretch;
         background: colors.$cool-accent-lighter;
 
+        .name {
+            h4 {
+                color: colors.$base-black;
+                font-size: 1rem;
+                font-weight: 700;
+                margin: 0 0 0.5rem;
+            }
+        }
         .info {
             display: flex;
             flex-direction: row;
             align-items: center;
             gap: 0.5rem;
 
-            .name {
-                color: colors.$base-black;
-                font-size: 1rem;
-                font-weight: 700;
-                margin-bottom: 0.5rem;
-            }
 
             .count {
                 color: colors.$base-darkest;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/tabs/ManageTabs/ManageTabs.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/tabs/ManageTabs/ManageTabs.tsx
@@ -3,7 +3,6 @@ import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanne
 import { PagesTab, Tab } from 'apps/page-builder/generated';
 import { AddEditTab } from 'apps/page-builder/page/management/edit/tabs/AddEditTab/AddEditTab';
 import { addTab, updateTab } from 'apps/page-builder/services/tabsAPI';
-import { Heading } from 'components/heading';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import './ManageTabModal.scss';
@@ -140,7 +139,7 @@ export const ManageTabs = ({ pageId, onAddSuccess, tabs }: Props) => {
                 modalRef={modalRef}
                 data-testid="openManageTabs">
                 <Icon.Edit />
-                <Heading level={3}>Manage tabs</Heading>
+                <h2>Manage tabs</h2>
             </ModalToggleButton>
             <Modal id={'manage-tab-modal'} ref={modalRef} className={'manage-tab-modal'} isLarge forceAction>
                 <div className={styles.manageTabModal}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/tabs/ManageTabs/manageTabs.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/tabs/ManageTabs/manageTabs.module.scss
@@ -1,11 +1,16 @@
 @use 'styles/colors';
 @use 'styles/borders';
 
+
 .manageButton {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     text-decoration: none;
+    h2 {
+        font-size: 1rem;
+        margin: 0;
+    }
 }
 
 .manageTabModal {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/layout/PageManagementLayout.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/layout/PageManagementLayout.tsx
@@ -27,10 +27,10 @@ const PageManagementLayout = ({ name, mode, children }: PageBuilderLayoutProps) 
                 <Breadcrumb start="/page-builder/pages" currentPage={name}>
                     Page library
                 </Breadcrumb>
-                <span className={classNames(isEditing ? styles.modeEditing : styles.mode)}>
+                <h2 className={classNames(isEditing ? styles.modeEditing : styles.mode)}>
                     {isEditing ? 'EDITING: ' : 'PREVIEWING: '}
                     {mode}
-                </span>
+                </h2>
             </div>
             <div className={styles.content}>{children}</div>
         </section>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/layout/page-management-layout.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/layout/page-management-layout.module.scss
@@ -24,8 +24,15 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-
         padding: 0 1rem;
+            h2 {
+                display: flex;
+                gap: 0.25rem;
+                align-items: center;
+                font-weight: 400;
+                font-size: 1rem;
+                margin: 0;
+            }
 
         .mode {
             padding: 0.25rem 0.5rem;
@@ -38,6 +45,9 @@
             border-radius: 0.125rem;
             text-transform: uppercase;
             background: colors.$warning;
+            font-size: 1rem;
+            font-weight: 400;
+            margin: 0;
         }
     }
 }

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
@@ -15,7 +15,6 @@ import { NavLinkButton } from 'components/button/nav/NavLinkButton';
 import { ConfirmationModal } from 'confirmation';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Heading } from '../../../../../components/heading';
 import { PageControllerService } from '../../../generated/services/PageControllerService';
 import { PublishPage } from './PublishPage/PublishPage';
 import { SaveTemplate } from './SaveTemplate/SaveTemplate';
@@ -242,10 +241,10 @@ const PreviewPageContent = () => {
                         <div className={styles.loaderContent}>
                             <Loading center className={styles.loaderIcon} />
                             <div className={styles.loaderText}>
-                                <Heading level={2}>Publishing...</Heading>
+                                <h2>Publishing...</h2>
                             </div>
                             <div className={styles.loaderText}>
-                                <Heading level={2}>This may take a moment</Heading>
+                                <h2>This may take a moment</h2>
                             </div>
                         </div>
                     }

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
@@ -6,7 +6,6 @@ import {
     PageInformationService
 } from 'apps/page-builder/generated';
 import { useDownloadPageMetadata } from 'apps/page-builder/hooks/api/useDownloadPageMetadata';
-import { Heading } from 'components/heading';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { usePageManagement } from '../../usePageManagement';
@@ -86,7 +85,7 @@ const PageInformation = () => {
     return (
         <section className={styles.information}>
             <header>
-                <Heading level={2}>Page information</Heading>
+                <h3>Page information</h3>
                 <Button type="button" outline onClick={handleDownloadMetadata} className={styles.icon}>
                     <Icon.FileDownload />
                     Metadata

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/page-information.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/page-information.module.scss
@@ -13,6 +13,10 @@
         display: flex;
         justify-content: space-between;
         @extend %thin-bottom;
+        h3 {
+            margin: 0;
+            font-size: 1.35rem;
+        }
     }
 
     .tabs {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSection/StaticSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSection/StaticSection.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, useState } from 'react';
-import { Heading } from 'components/heading';
 import { Icon } from '@trussworks/react-uswds';
 import styles from './static-section.module.scss';
 
@@ -13,7 +12,7 @@ export const StaticSection = ({ title, children }: Props) => {
     return (
         <div className={styles.section}>
             <div className={styles.header}>
-                <Heading level={2}>{title}</Heading>
+                <h3>{title}</h3>
                 <div className={styles.collapseIcon}>
                     {isExpanded ? (
                         <Icon.ExpandLess size={4} onClick={() => setIsExpanded(false)} />

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSection/static-section.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSection/static-section.module.scss
@@ -15,6 +15,10 @@
         .collapseIcon {
             cursor: pointer;
         }
+        h3 {
+            font-size: 1.35rem;
+            margin: 0;
+        }
     }
 
     .sectionContent {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSubsection/StaticSubsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSubsection/StaticSubsection.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, useState } from 'react';
 import styles from './static-subsection.module.scss';
-import { Heading } from 'components/heading';
 import { Icon } from '@trussworks/react-uswds';
 
 type Props = {
@@ -13,7 +12,7 @@ export const StaticSubsection = ({ title, children }: Props) => {
     return (
         <div className={styles.subsection}>
             <div className={styles.subsectionHeader}>
-                <Heading level={3}>{title}</Heading>
+                <h4>{title}</h4>
                 <div className={styles.collapseIcon}>
                     {isExpanded ? (
                         <Icon.ExpandLess size={4} onClick={() => setIsExpanded(false)} />

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSubsection/static-subsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/staticTabContent/StaticSubsection/static-subsection.module.scss
@@ -15,5 +15,9 @@
         .collapseIcon {
             cursor: pointer;
         }
+        h4 {
+            font-size: 1rem;
+            margin: 0;
+        }
     }
 }

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/section/PreviewSectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/section/PreviewSectionHeader.tsx
@@ -1,7 +1,6 @@
 import styles from './preview-section.module.scss';
 import { Icon } from '@trussworks/react-uswds';
 import { PagesSection } from '../../../../../generated';
-import { Heading } from '../../../../../../../components/heading';
 import classNames from 'classnames';
 
 type Props = {
@@ -14,7 +13,7 @@ export const PreviewSectionHeader = ({ section, isExpanded, onExpandedChange }: 
     return (
         <div className={classNames(styles.header, { [styles.expanded]: isExpanded })}>
             <header>
-                <Heading level={2}>{section.name}</Heading>
+                <h3>{section.name}</h3>
                 <p>{section.subSections.length} sub sections</p>
             </header>
             <div className={styles.buttons}>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/section/preview-section.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/section/preview-section.module.scss
@@ -19,15 +19,14 @@
         &.expanded {
             border-bottom: 1px solid colors.$base-lighter;
         }
-
+        h3 {
+            color: colors.$base-black;
+            text-align: center;
+            font-size: 1.375rem;
+            font-weight: 700;
+            margin: 0;
+        }
         .info {
-            .name {
-                color: colors.$base-black;
-                text-align: center;
-                font-size: 1.375rem;
-                font-weight: 700;
-            }
-
             .subsectionCount {
                 color: colors.$base-darkest;
                 font-size: 0.875rem;

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsection.tsx
@@ -3,7 +3,6 @@ import { PagesSubSection } from '../../../../../generated';
 import { PreviewQuestion } from '../question/PreviewQuestion';
 import { PreviewSubsectionHeader } from './PreviewSubsectionHeader';
 import { useState } from 'react';
-import { Heading } from '../../../../../../../components/heading';
 import { Button } from '@trussworks/react-uswds';
 import React from 'react';
 
@@ -37,9 +36,7 @@ export const PreviewSubsection = ({ subsection }: Props) => {
                                             <React.Fragment key={k}>
                                                 {question.appearsInBatch && (
                                                     <div className={styles.groupedQuestionName}>
-                                                        <Heading level={3}>
-                                                            {question.batchLabel ?? question.name}
-                                                        </Heading>
+                                                        <span>{question.batchLabel ?? question.name}</span>
                                                     </div>
                                                 )}
                                             </React.Fragment>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/PreviewSubsectionHeader.tsx
@@ -14,7 +14,9 @@ export const PreviewSubsectionHeader = ({ subsection, isExpanded, onExpandedChan
             <div className={styles.info}>
                 {subsection.isGrouped ? <div className={styles.indicator}>R</div> : null}
                 <div>
-                    <div className={styles.name}>{subsection.name}</div>
+                    <div className={styles.name}>
+                        <h4>{subsection.name}</h4>
+                    </div>
                     <div className={styles.count}>
                         {`${subsection.questions?.length} question${subsection.questions?.length > 1 ? 's' : ''}`}
                     </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/preview-subsection.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/tab/subsection/preview-subsection.module.scss
@@ -21,11 +21,13 @@
       align-items: center;
       gap: 0.5rem;
       .name {
-        color: colors.$base-black;
-        text-align: center;
-        font-size: 1rem;
-        font-weight: 700;
-        margin-bottom: 0.5rem;
+        h4 {
+          color: colors.$base-black;
+          text-align: center;
+          font-size: 1rem;
+          font-weight: 700;
+          margin: 0 0 0.5rem;
+        }
       }
       .count {
         color: colors.$base-darkest;
@@ -71,6 +73,9 @@
         border-left: 1px solid colors.$border;
         &:first-child {
           border: none;
+        }
+        span {
+          font-weight: 700;
         }
       }
     }

--- a/apps/modernization-ui/src/apps/page-builder/page/management/status/StatusModal.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/status/StatusModal.tsx
@@ -1,7 +1,6 @@
 import { Button, Icon, Modal, ModalFooter, ModalHeading, ModalRef } from '@trussworks/react-uswds';
 import { RefObject } from 'react';
 import styles from './statusmodal.module.scss';
-import { Heading } from 'components/heading';
 
 type Props = {
     modal: RefObject<ModalRef>;
@@ -24,13 +23,15 @@ export const StatusModal = ({
 }: Props) => {
     return (
         <Modal forceAction ref={modal} className={styles.modal} id={id}>
-            <ModalHeading className={styles.title}>{title}</ModalHeading>
+            <ModalHeading className={styles.title}>
+                <h2>{title}</h2>
+            </ModalHeading>
             <div className={styles.content}>
                 <div className={styles.warning}>
                     <Icon.Warning size={4} />
                 </div>
                 <div className={styles.message}>
-                    <Heading level={3}>{messageHeader}</Heading>
+                    <h3>{messageHeader}</h3>
                     <p>{message}</p>
                 </div>
             </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/status/statusmodal.module.scss
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/status/statusmodal.module.scss
@@ -5,15 +5,21 @@ $max-height: 80svh;
 .modal {
     padding: 0;
 
+    .title {
+        font-weight: bold;
+        h2 {
+            margin: 0;
+        }
+    }
     .content {
         display: flex;
         margin: 1.5rem;
-
         border-left: 0.5rem solid colors.$warning;
-
+        h3 {
+            margin: 0;
+        }
 
         .warning {
-            
             color: colors.$warning;
             margin-left: 1rem;
             margin-right: 1rem;
@@ -28,9 +34,6 @@ $max-height: 80svh;
             display: flex;
             flex-direction: column;
 
-            .title {
-                font-weight: bold;
-            }
         }
     }
 

--- a/apps/modernization-ui/src/apps/patient/profile/DetailsModal.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/DetailsModal.tsx
@@ -3,7 +3,6 @@ import { RefObject } from 'react';
 import { NoData } from 'components/NoData';
 
 import styles from './details-modal.module.scss';
-import { Heading } from 'components/heading';
 import classNames from 'classnames';
 
 export type Detail = {
@@ -36,8 +35,8 @@ const maybeRender = (value: string | number | null | undefined) => <>{value}</> 
 export const DetailsModal = ({ modal, title, onClose, details, onEdit, onDelete }: Props) => {
     return (
         <Modal id={`${title}-detail`} forceAction ref={modal} className={classNames(styles.modal)}>
-            <header>
-                <Heading level={2}>{title}</Heading>
+            <header className={styles.header}>
+                <h2>{title}</h2>
                 <Icon.Close size={3} onClick={onClose} />
             </header>
             <div className={styles.content}>

--- a/apps/modernization-ui/src/apps/patient/profile/details-modal.module.scss
+++ b/apps/modernization-ui/src/apps/patient/profile/details-modal.module.scss
@@ -1,1 +1,7 @@
 @forward './profile-modal';
+
+.header {
+    h2 {
+        margin: 0;
+    }
+}


### PR DESCRIPTION
## Description

Here we make sure every page uses `<h>` tags in descending order.
Modals start with `<h2>` headers.
<img width="1054" alt="image" src="https://github.com/CDCgov/NEDSS-Modernization/assets/124739504/157dd549-1653-4ada-aa2a-2361f26bb2f5">


## Tickets

* [CNFT1-2223](https://cdc-nbs.atlassian.net/browse/CNFT1-2223)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2223]: https://cdc-nbs.atlassian.net/browse/CNFT1-2223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ