### PR TITLE
creating out of tab order component

### DIFF
--- a/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
@@ -574,7 +574,7 @@ export const AdvancedSearch = () => {
                                 <p className="margin-0 font-sans-3xs margin-top-05 text-normal text-base">
                                     Showing {resultStartCount} - {resultEndCount} of {resultTotal}
                                 </p>
-                                <OutOfTabOrder submitted={submitted} className="top-pagination">
+                                <OutOfTabOrder focusable={!submitted} selector="button">
                                     <Pagination
                                         style={{ justifyContent: 'flex-end' }}
                                         totalPages={Math.ceil(resultTotal / 25)}

--- a/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
@@ -34,6 +34,7 @@ import { focusedTarget } from 'utils';
 import { Icon as NBSIcon } from 'components/Icon/Icon';
 import { TabNavigationEntry, TabNavigation } from 'components/TabNavigation/TabNavigation';
 import { Button } from 'components/button/Button';
+import { OutOfTabOrder } from './components/OutOfTabOrder';
 
 export enum SEARCH_TYPE {
     PERSON = 'search',
@@ -573,15 +574,17 @@ export const AdvancedSearch = () => {
                                 <p className="margin-0 font-sans-3xs margin-top-05 text-normal text-base">
                                     Showing {resultStartCount} - {resultEndCount} of {resultTotal}
                                 </p>
-                                <Pagination
-                                    style={{ justifyContent: 'flex-end' }}
-                                    totalPages={Math.ceil(resultTotal / 25)}
-                                    currentPage={currentPage}
-                                    pathname={'/advanced-search'}
-                                    onClickNext={() => handlePagination(currentPage + 1)}
-                                    onClickPrevious={() => handlePagination(currentPage - 1)}
-                                    onClickPageNumber={(_, page) => handlePagination(page)}
-                                />
+                                <OutOfTabOrder submitted={submitted} className="top-pagination">
+                                    <Pagination
+                                        style={{ justifyContent: 'flex-end' }}
+                                        totalPages={Math.ceil(resultTotal / 25)}
+                                        currentPage={currentPage}
+                                        pathname={'/advanced-search'}
+                                        onClickNext={() => handlePagination(currentPage + 1)}
+                                        onClickPrevious={() => handlePagination(currentPage - 1)}
+                                        onClickPageNumber={(_, page) => handlePagination(page)}
+                                    />
+                                </OutOfTabOrder>
                             </Grid>
                         )}
                         {isLoading() && (

--- a/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.spec.tsx
@@ -1,39 +1,79 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { OutOfTabOrder } from './OutOfTabOrder';
 
-describe('OuterTabOrder', () => {
+describe('OutOfTabOrder', () => {
     it('renders the component with children', () => {
         const { getByText } = render(
-            <OutOfTabOrder submitted={false}>
+            <OutOfTabOrder focusable={true} selector="button">
                 <button>Click me</button>
             </OutOfTabOrder>
         );
         expect(getByText('Click me')).toBeInTheDocument();
     });
 
-    it('changes tabIndex of buttons when submitted is true', () => {
+    it('sets tabIndex of elements with specified selector to -1 when focusable is false', async () => {
         const { getByText } = render(
-            <OutOfTabOrder submitted={true}>
+            <OutOfTabOrder focusable={false} selector="button">
                 <button>Click me</button>
             </OutOfTabOrder>
         );
 
         const button = getByText('Click me');
-        expect(button.tabIndex).toBe(0);
+        await waitFor(() => {
+            expect(button.tabIndex).toBe(-1);
+        });
     });
 
-    it('maintains unchanged tabIndex when submitted remains false', () => {
+    it('does not change tabIndex of elements with specified selector when focusable is true', async () => {
+        const { getByText } = render(
+            <OutOfTabOrder focusable={true} selector="button">
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+
+        const button = getByText('Click me');
+        await waitFor(() => {
+            expect(button.tabIndex).toBe(0);
+        });
+    });
+
+    it('resets tabIndex to 0 when focusable changes from false to true', async () => {
         const { getByText, rerender } = render(
-            <OutOfTabOrder submitted={false}>
+            <OutOfTabOrder focusable={false} selector="button">
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+
+        const button = getByText('Click me');
+        await waitFor(() => {
+            expect(button.tabIndex).toBe(-1);
+        });
+
+        rerender(
+            <OutOfTabOrder focusable={true} selector="button">
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        expect(button.tabIndex).toBe(-1);
+    });
+
+    it('maintains unchanged tabIndex of elements with specified selector when focusable remains true', async () => {
+        const { getByText, rerender } = render(
+            <OutOfTabOrder focusable={true} selector="button">
                 <button>Click me</button>
             </OutOfTabOrder>
         );
 
         let button = getByText('Click me');
-        expect(button.tabIndex).toBe(0);
+        await waitFor(() => {
+            expect(button.tabIndex).toBe(0);
+        });
 
         rerender(
-            <OutOfTabOrder submitted={false}>
+            <OutOfTabOrder focusable={true} selector="button">
                 <button>Click me</button>
             </OutOfTabOrder>
         );

--- a/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.spec.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { OutOfTabOrder } from './OutOfTabOrder';
+
+describe('OuterTabOrder', () => {
+    it('renders the component with children', () => {
+        const { getByText } = render(
+            <OutOfTabOrder submitted={false}>
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+        expect(getByText('Click me')).toBeInTheDocument();
+    });
+
+    it('changes tabIndex of buttons when submitted is true', () => {
+        const { getByText } = render(
+            <OutOfTabOrder submitted={true}>
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+
+        const button = getByText('Click me');
+        expect(button.tabIndex).toBe(0);
+    });
+
+    it('maintains unchanged tabIndex when submitted remains false', () => {
+        const { getByText, rerender } = render(
+            <OutOfTabOrder submitted={false}>
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+
+        let button = getByText('Click me');
+        expect(button.tabIndex).toBe(0);
+
+        rerender(
+            <OutOfTabOrder submitted={false}>
+                <button>Click me</button>
+            </OutOfTabOrder>
+        );
+
+        button = getByText('Click me');
+        expect(button.tabIndex).toBe(0);
+    });
+});

--- a/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.tsx
@@ -2,30 +2,23 @@ import { ReactNode, useEffect, useRef } from 'react';
 
 export const OutOfTabOrder = ({
     children,
-    submitted,
-    className
+    focusable,
+    selector
 }: {
     children: ReactNode;
-    submitted: boolean;
-    className?: string;
+    focusable: boolean;
+    selector: string;
 }) => {
     const element = useRef<HTMLElement>(null);
 
     useEffect(() => {
-        if (element.current && className) {
-            const selector = document.querySelector(`.${className}`);
-            if (selector) {
-                const querySelectors = element.current.querySelectorAll('button');
-                if (querySelectors) {
-                    querySelectors.forEach((querySelector) => ((querySelector as HTMLElement).tabIndex = -1));
-                }
+        if (element.current && !focusable) {
+            const elements = element.current.querySelectorAll(selector);
+            if (elements) {
+                elements.forEach((element) => ((element as HTMLElement).tabIndex = -1));
             }
         }
-    }, [element.current, submitted]);
+    }, [element.current, focusable]);
 
-    return (
-        <span className={className} ref={element}>
-            {children}
-        </span>
-    );
+    return <span ref={element}>{children}</span>;
 };

--- a/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/OutOfTabOrder.tsx
@@ -1,0 +1,31 @@
+import { ReactNode, useEffect, useRef } from 'react';
+
+export const OutOfTabOrder = ({
+    children,
+    submitted,
+    className
+}: {
+    children: ReactNode;
+    submitted: boolean;
+    className?: string;
+}) => {
+    const element = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+        if (element.current && className) {
+            const selector = document.querySelector(`.${className}`);
+            if (selector) {
+                const querySelectors = element.current.querySelectorAll('button');
+                if (querySelectors) {
+                    querySelectors.forEach((querySelector) => ((querySelector as HTMLElement).tabIndex = -1));
+                }
+            }
+        }
+    }, [element.current, submitted]);
+
+    return (
+        <span className={className} ref={element}>
+            {children}
+        </span>
+    );
+};

--- a/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/index.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/components/OutOfTabOrder/index.tsx
@@ -1,0 +1,1 @@
+export * from './OutOfTabOrder';

--- a/apps/modernization-ui/src/apps/search/patient/result/PatientResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/PatientResult.tsx
@@ -1,5 +1,5 @@
+import React from 'react';
 import './PatientResult.scss';
-
 import { ReactNode } from 'react';
 import classNames from 'classnames';
 import { Grid } from '@trussworks/react-uswds';
@@ -20,6 +20,13 @@ type PatientResultProps = {
 };
 
 const PatientResult = ({ result, onSelected }: PatientResultProps) => {
+    const handleKeyPress = (event: React.KeyboardEvent) => {
+        event.preventDefault();
+        if (event.key === 'Enter' || event.key === ' ') {
+            onSelected(result);
+        }
+    };
+
     return (
         <Grid row gap={3}>
             <Grid col={4}>
@@ -27,6 +34,7 @@ const PatientResult = ({ result, onSelected }: PatientResultProps) => {
                     <Grid col={12} className="margin-bottom-2">
                         <p className="margin-0 text-normal search-result-item-label text-gray-50">LEGAL NAME</p>
                         <a
+                            onKeyUp={handleKeyPress}
                             onClick={() => onSelected(result)}
                             tabIndex={0}
                             className="margin-0 font-sans-md margin-top-05 text-bold text-primary word-break"


### PR DESCRIPTION
Creating a component to enable skipping through the tab order when wrapping the child element within the outOfTabOrder component.
Ensuring that from the Sort By dropdown we can tab directly to the first element in the search results.

Tickets
[CNFT-1980](https://cdc-nbs.atlassian.net/browse/CNFT1-1980)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
