### PR TITLE
removing line height from usa button

### DIFF
--- a/apps/modernization-ui/src/styles/_uswds.scss
+++ b/apps/modernization-ui/src/styles/_uswds.scss
@@ -84,7 +84,6 @@ table.usa-table {
     font-size: 1rem;
     font-style: normal;
     font-weight: 700;
-    line-height: 125%;
     &:has(svg) {
         align-items: center;
         padding: 0.75rem 1.25rem;


### PR DESCRIPTION
## Description

Removing line height to correct placement of text within our .usa-button
## Tickets

* [CNFT-2239](https://cdc-nbs.atlassian.net/browse/CNFT1-2339)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
