### PR TITLE
Cypress e2e action for INT1 

### DIFF
--- a/.github/workflows/Regression-tests.yaml
+++ b/.github/workflows/Regression-tests.yaml
@@ -1,0 +1,49 @@
+name: Regression tests
+on:
+  schedule:
+    # weekdays at 7am UTC -> 3am EST
+    - cron: "0 7 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: "Spec to run"
+        required: false
+        type: string
+        default: "cypress/**/*.feature"
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - int1
+          - test
+        default: "test"
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Install npm dependencies, cache them, run tests
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        continue-on-error: true # perform next steps even on failure
+        with:
+          working-directory: testing/regression/
+          spec: ${{ inputs.spec }}
+        env:
+          CYPRESS_BASE_URL: ${{ inputs.environment == 'test' && 'https://app.test.nbspreview.com/' || 'https://app.int1.nbspreview.com/' }}
+      # Create cypress html report
+      - name: Build report
+        working-directory: testing/regression/
+        run: npm run githubReport
+      # Zip up report
+      - name: Zip report
+        working-directory: testing/regression/
+        run: zip -r cypress-report.zip reports/cucumber-report/*
+      # Upload artifact
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cypress-report
+          path: testing/regression/cypress-report.zip

--- a/testing/regression/.gitignore
+++ b/testing/regression/.gitignore
@@ -1,2 +1,3 @@
 downloads/
 screenshots/
+results.json

--- a/testing/regression/cypress.config.js
+++ b/testing/regression/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require("cypress");
 const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
 const preprocessor = require("@badeball/cypress-cucumber-preprocessor");
 const createEsbuildPlugin = require("@badeball/cypress-cucumber-preprocessor/esbuild");
+const fs = require("fs").promises;
 
 async function setupNodeEvents(on, config) {
   await preprocessor.addCucumberPreprocessorPlugin(on, config);
@@ -12,6 +13,28 @@ async function setupNodeEvents(on, config) {
       plugins: [createEsbuildPlugin.default(config)],
     })
   );
+  on("after:run", async (results) => {
+    if (results) {
+      await preprocessor.afterRunHandler(config);
+      await fs.writeFile(
+        "results.json",
+        JSON.stringify(
+          {
+            browserName: results.browserName,
+            browserVersion: results.browserVersion,
+            osName: results.osName,
+            osVersion: results.osVersion,
+            nodeVersion: results.config.resolvedNodeVersion,
+            cypressVersion: results.cypressVersion,
+            startedTestsAt: results.startedTestsAt,
+            endedTestsAt: results.endedTestsAt,
+          },
+          null,
+          "\t"
+        )
+      );
+    }
+  });
   return config;
 }
 
@@ -21,7 +44,7 @@ module.exports = defineConfig({
     specPattern: "./cypress/**/**/*.feature",
     baseUrl: "http://localhost:8080/",
     //baseUrl: "https://app.test.nbspreview.com/",
-    //baseUrl: "https://app.int1.nbspreview.com/",
+    // baseUrl: "https://app.int1.nbspreview.com/",
     chromeWebSecurity: false,
     video: false,
   },

--- a/testing/regression/github-report.js
+++ b/testing/regression/github-report.js
@@ -1,0 +1,63 @@
+const report = require("multiple-cucumber-html-reporter");
+const fs = require("fs");
+const dayjs = require("dayjs");
+
+const runInfo = JSON.parse(fs.readFileSync("results.json", "utf8"));
+
+const getOSName = () => {
+  return (
+    {
+      darwin: "osx",
+      win32: "windows",
+      ubuntu: "ubuntu",
+    }[runInfo.osName] ||
+    runInfo.osName ||
+    "unknown"
+  );
+};
+
+const getBrowser = () => {
+  return (
+    {
+      chrome: "chrome",
+      electron: "chrome",
+      firefox: "firefox",
+    }[runInfo.browserName] ||
+    runInfo.browserName ||
+    "unknown"
+  );
+};
+
+report.generate({
+  jsonDir: "./reports/", // ** Path of .json file **//
+  reportPath: "./reports/cucumber-report",
+  openReportInBrowser: false,
+  metadata: {
+    browser: {
+      name: getBrowser(),
+      version: runInfo.browserVersion,
+    },
+    device: "GitHub Action - ubuntu",
+    platform: {
+      name: getOSName(),
+      version: runInfo.osVersion,
+    },
+  },
+  customData: {
+    title: "Run Info",
+    data: [
+      { label: "Cypress Version", value: runInfo["cypressVersion"] },
+      { label: "Node Version", value: runInfo["nodeVersion"] },
+      {
+        label: "Execution Start Time",
+        value: dayjs(runInfo["startedTestsAt"]).format(
+          "YYYY-MM-DD HH:mm:ss.SSS"
+        ),
+      },
+      {
+        label: "Execution End Time",
+        value: dayjs(runInfo["endedTestsAt"]).format("YYYY-MM-DD HH:mm:ss.SSS"),
+      },
+    ],
+  },
+});

--- a/testing/regression/package-lock.json
+++ b/testing/regression/package-lock.json
@@ -13,7 +13,7 @@
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
         "@faker-js/faker": "^8.0.2",
         "cypress": "^13.6.0",
-        "multiple-cucumber-html-reporter": "^3.4.0"
+        "multiple-cucumber-html-reporter": "^3.6.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3592,24 +3592,24 @@
       "dev": true
     },
     "node_modules/multiple-cucumber-html-reporter": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/multiple-cucumber-html-reporter/-/multiple-cucumber-html-reporter-3.4.0.tgz",
-      "integrity": "sha512-Y2FQA/OosmlsB/ZQUPJvnkKKYFKa/J+Qv2QUl5PsO3BC77jXwyPE8fAWopLH+CEYlRTs7fcdfydmWFitGMFi0A==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/multiple-cucumber-html-reporter/-/multiple-cucumber-html-reporter-3.6.2.tgz",
+      "integrity": "sha512-Q0GUt9WXk1dkT1Dp1issCJMdnjXUFHnWGAL4OdiL9EaG9XjfjfaCguUJ1g39LXXXzklRInVqm9rDcOWYjWLyGA==",
       "dev": true,
       "dependencies": {
         "find": "^0.3.0",
-        "fs-extra": "^11.1.1",
+        "fs-extra": "^11.2.0",
         "jsonfile": "^6.1.0",
         "lodash": "^4.17.21",
-        "luxon": "^3.3.0",
+        "luxon": "^3.4.4",
         "open": "^8.4.2",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/multiple-cucumber-html-reporter/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -3621,12 +3621,25 @@
       }
     },
     "node_modules/multiple-cucumber-html-reporter/node_modules/luxon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
-      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/multiple-cucumber-html-reporter/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/mz": {

--- a/testing/regression/package.json
+++ b/testing/regression/package.json
@@ -7,7 +7,8 @@
     "cy:open": "cypress open",
     "cy:e2e": "cypress run --spec 'cypress/e2e/**/*.feature'",
     "cy:api": "cypress run --spec cypress/api/**/*.feature",
-    "report": "node cucumber-html-report.js"
+    "report": "node cucumber-html-report.js",
+    "githubReport": "node github-report.js"
   },
   "keywords": [
     "cypress",


### PR DESCRIPTION
## Description

Creates a GitHub Action to execute Cypress tests against the specified environment.

The tests will run nightly at 3am EST against the int1 environment. There is also a `workflow_dispatch` added to allow manual execution of the workflow. 

## Tickets

* [CNT-28](https://cdc-nbs.atlassian.net/browse/CNT-28)

[Workflow run](https://github.com/CDCgov/NEDSS-Modernization/actions/runs/9276096208)

[CNT-28]: https://cdc-nbs.atlassian.net/browse/CNT-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ