### PR TITLE
[CNFT1-2392] Adds routing that allows reports to be run in NBS6

### DIFF
--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/NBSClassicService.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/NBSClassicService.java
@@ -1,6 +1,12 @@
 package gov.cdc.nbs.gateway.classic;
 
+import gov.cdc.nbs.gateway.Service;
+
 import java.net.URI;
 
-public record NBSClassicService(URI uri) {
+public class NBSClassicService extends Service {
+
+  public NBSClassicService(final URI uri) {
+    super(uri);
+  }
 }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfiguration.java
@@ -29,7 +29,7 @@ class NBS6ReportCancelRouteLocatorConfiguration {
         .route(
             "nbs6-report-cookie-clear",
             route -> route.order(RouteOrdering.NBS_6.before())
-                .path("/nbs/ManageReport.do")
+                .path("/nbs/ManageReports.do")
                 .and()
                 .cookie(NBSReportCookie.NAME, ".+")
                 .filters(

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfiguration.java
@@ -1,0 +1,44 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import gov.cdc.nbs.gateway.RouteOrdering;
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+import java.util.List;
+
+@Configuration
+class NBS6ReportCancelRouteLocatorConfiguration {
+
+  /**
+   * Creates a {@link RouteLocator} that clears the value of the {@code NBS-Report} when a request is made to the report
+   * selection route {@code /nbs/ManageReport.do}.
+   */
+  @Bean
+  RouteLocator nbs6ReportClearingRouteLocator(
+      final RouteLocatorBuilder builder,
+      @Qualifier("defaults") final List<GatewayFilter> defaults,
+      final NBSClassicService classic
+  ) {
+    return builder.routes()
+        .route(
+            "nbs6-report-cookie-clear",
+            route -> route.order(RouteOrdering.NBS_6.before())
+                .path("/nbs/ManageReport.do")
+                .and()
+                .cookie(NBSReportCookie.NAME, ".+")
+                .filters(
+                    filter -> filter.filters(defaults)
+                        .addResponseHeader(HttpHeaders.SET_COOKIE, NBSReportCookie.empty().toResponseCookie().toString())
+                )
+
+                .uri(classic.uri())
+
+        ).build();
+  }
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpCookie;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -38,7 +39,7 @@ class NBS6ReportPageRouteLocatorConfiguration {
     return builder.routes()
         .route(
             "nbs6-report-cookie-applier",
-            route -> route.path("/nbs/report/{page:[a-zA-z]+}")
+            route -> route.path("/nbs/report/{page:reports|basic|advanced|column|run|save|error}")
                 .filters(
                     filter -> filter.filters(defaults)
                         .filter(this::applyReportCookie)

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfiguration.java
@@ -1,0 +1,68 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The NBS-Gateway uses the {@code Referrer-Policy} of {@code no-referrer} which signals to browsers to not apply the
+ * {@code Referer} HTTP header however, the NBS6 ReportWebProcessor uses the Referer HTTP header to resolve which report
+ * to run.  To ensure that a report can be run the {@code NBS-Report} cookie has been introduced to store the report
+ * name.  When a POST request is made to the {@code /nbs/nfc} route the {@code NBS-Report} is then used to apply the
+ * {@code Referer} header expected by the NBS6 ReportWebProcessor.
+ */
+@Configuration
+class NBS6ReportPageRouteLocatorConfiguration {
+
+  /**
+   * Creates a {@link RouteLocator} that adds a cookie to the response of any {@code /nbs/report} request with the name
+   * of the report chosen.
+   */
+  @Bean
+  RouteLocator nbs6ReportPageRouteLocator(
+      final RouteLocatorBuilder builder,
+      @Qualifier("defaults") final List<GatewayFilter> defaults,
+      final NBSClassicService classic
+  ) {
+    return builder.routes()
+        .route(
+            "nbs6-report-cookie-applier",
+            route -> route.path("/nbs/report/{page:[a-zA-z]+}")
+                .filters(
+                    filter -> filter.filters(defaults)
+                        .filter(this::applyReportCookie)
+                )
+                .uri(classic.uri())
+        )
+        .build();
+  }
+
+  private Mono<Void> applyReportCookie(
+      final ServerWebExchange exchange,
+      final GatewayFilterChain chain
+  ) {
+
+    Map<String, String> uriVariables = ServerWebExchangeUtils.getUriTemplateVariables(exchange);
+
+    String segment = uriVariables.get("page");
+
+    return chain.filter(exchange).then(
+        Mono.fromRunnable(
+            () -> exchange.getResponse().addCookie(
+                new NBSReportCookie(segment).toResponseCookie()
+            )
+        )
+    );
+  }
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfiguration.java
@@ -9,7 +9,6 @@ import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpCookie;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfiguration.java
@@ -1,0 +1,98 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import gov.cdc.nbs.gateway.RouteOrdering;
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Configuration
+class NBS6ReportRunnerRouteLocatorConfiguration {
+
+  /**
+   * Creates a {@link RouteLocator} that uses the value of the {@code NBS-Report} cookie to set the {@code Referer}
+   * header on the upstream request to the NBS6 {@code ReportWebProcessor}.  The response will be modified to clear the
+   * value of the {@code NBS-Report} cookie.
+   */
+  @Bean
+  RouteLocator nbs6ReportRunnerRouteLocator(
+      final RouteLocatorBuilder builder,
+      @Qualifier("defaults") final List<GatewayFilter> defaults,
+      final NBSClassicService classic
+  ) {
+    return builder.routes()
+        .route(
+            "nbs6-report-runner",
+            route -> route.order(RouteOrdering.NBS_6.before())
+                .method(HttpMethod.POST)
+                .and()
+                .path("/nbs/nfc")
+                .and()
+                .cookie(NBSReportCookie.NAME, ".+")
+                .filters(
+                    filter -> filter.filters(defaults)
+                        .filter(
+                            (exchange, chain) -> resolveReport(
+                                classic,
+                                exchange,
+                                chain
+                            )
+                        )
+                        .addResponseHeader(HttpHeaders.SET_COOKIE, NBSReportCookie.empty().toResponseCookie().toString())
+                )
+                .uri(classic.uri())
+        )
+        .build();
+  }
+
+  private Mono<Void> resolveReport(
+      final NBSClassicService classic,
+      final ServerWebExchange exchange,
+      final GatewayFilterChain chain
+  ) {
+
+    HttpCookie cookie = exchange.getRequest().getCookies().getFirst(NBSReportCookie.NAME);
+
+    ServerWebExchange serverWebExchange = (cookie != null) ?
+        withReferer(
+            classic,
+            cookie,
+            exchange
+        ) : exchange;
+
+    return chain.filter(serverWebExchange);
+  }
+
+  private ServerWebExchange withReferer(
+      final NBSClassicService classic,
+      final HttpCookie cookie,
+      final ServerWebExchange exchange
+  ) {
+
+    String referer = UriComponentsBuilder.fromUri(classic.uri())
+        .pathSegment("report", cookie.getValue())
+        .toUriString();
+
+    return exchange.mutate()
+        .request(
+            builder -> builder.headers(
+                headers -> headers.set(HttpHeaders.REFERER, referer)
+            )
+        )
+        .build();
+
+
+  }
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfiguration.java
@@ -23,8 +23,7 @@ class NBS6ReportRunnerRouteLocatorConfiguration {
 
   /**
    * Creates a {@link RouteLocator} that uses the value of the {@code NBS-Report} cookie to set the {@code Referer}
-   * header on the upstream request to the NBS6 {@code ReportWebProcessor}.  The response will be modified to clear the
-   * value of the {@code NBS-Report} cookie.
+   * header on the upstream request to the NBS6 {@code ReportWebProcessor}.
    */
   @Bean
   RouteLocator nbs6ReportRunnerRouteLocator(
@@ -50,7 +49,6 @@ class NBS6ReportRunnerRouteLocatorConfiguration {
                                 chain
                             )
                         )
-                        .addResponseHeader(HttpHeaders.SET_COOKIE, NBSReportCookie.empty().toResponseCookie().toString())
                 )
                 .uri(classic.uri())
         )

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBSReportCookie.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBSReportCookie.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import org.springframework.http.ResponseCookie;
+
+/**
+ * The report selected by the user to be run.
+ *
+ * @param report The unique name of the path that identifies the report.
+ */
+public record NBSReportCookie(String report) {
+
+  private static final NBSReportCookie EMPTY = new NBSReportCookie("");
+
+  public static final String NAME = "NBS-Report";
+
+  public static NBSReportCookie empty() {
+    return EMPTY;
+  }
+
+  public ResponseCookie toResponseCookie() {
+    ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(NAME, report())
+        .httpOnly(true)
+        .secure(true)
+        .path("/nbs/nfc")
+        .sameSite("Strict");
+
+    if (report().isEmpty()) {
+      builder.maxAge(0);
+    }
+
+    return builder
+        .build();
+  }
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBSReportCookie.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/report/NBSReportCookie.java
@@ -21,7 +21,7 @@ public record NBSReportCookie(String report) {
     ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(NAME, report())
         .httpOnly(true)
         .secure(true)
-        .path("/nbs/nfc")
+        .path("/nbs")
         .sameSite("Strict");
 
     if (report().isEmpty()) {

--- a/apps/nbs-gateway/src/main/resources/application.yml
+++ b/apps/nbs-gateway/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
           order: 1000
           predicates:
             - Path=/nbs/**
+          filters:
+            - RemoveRequestHeader=Referer
         - id: nbs-logo
           uri: ${nbs.gateway.classic}
           predicates:

--- a/apps/nbs-gateway/src/main/resources/application.yml
+++ b/apps/nbs-gateway/src/main/resources/application.yml
@@ -13,8 +13,6 @@ spring:
           order: 1000
           predicates:
             - Path=/nbs/**
-          filters:
-            - RemoveRequestHeader=Referer
         - id: nbs-logo
           uri: ${nbs.gateway.classic}
           predicates:

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfigurationTest.java
@@ -35,12 +35,12 @@ class NBS6ReportCancelRouteLocatorConfigurationTest {
 
   @Test
   void should_should_clear_NBS_Report_cookie_if_present() {
-    classic.stubFor(get(urlEqualTo("/nbs/ManageReport.do")).willReturn(ok()));
+    classic.stubFor(get(urlEqualTo("/nbs/ManageReports.do")).willReturn(ok()));
 
     webClient
         .get().uri(
             builder -> builder
-                .path("/nbs/ManageReport.do")
+                .path("/nbs/ManageReports.do")
                 .build()
         ).cookie("NBS-Report", "basic")
         .exchange()
@@ -49,7 +49,7 @@ class NBS6ReportCancelRouteLocatorConfigurationTest {
             HttpHeaders.SET_COOKIE,
             allOf(
                 containsString("NBS-Report=;"),
-                containsString("Path=/nbs/nfc"),
+                containsString("Path=/nbs"),
                 containsString("Secure"),
                 containsString("HttpOnly"),
                 containsString("SameSite=Strict"),
@@ -63,12 +63,12 @@ class NBS6ReportCancelRouteLocatorConfigurationTest {
 
   @Test
   void should_should_not_clear_NBS_Report_cookie_when_not_present() {
-    classic.stubFor(get(urlEqualTo("/nbs/ManageReport.do")).willReturn(ok()));
+    classic.stubFor(get(urlEqualTo("/nbs/ManageReports.do")).willReturn(ok()));
 
     webClient
         .get().uri(
             builder -> builder
-                .path("/nbs/ManageReport.do")
+                .path("/nbs/ManageReports.do")
                 .build()
         )
         .exchange()

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportCancelRouteLocatorConfigurationTest.java
@@ -1,0 +1,80 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000"
+    }
+)
+class NBS6ReportCancelRouteLocatorConfigurationTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Autowired
+  NBSClassicService service;
+
+  @Test
+  void should_should_clear_NBS_Report_cookie_if_present() {
+    classic.stubFor(get(urlEqualTo("/nbs/ManageReport.do")).willReturn(ok()));
+
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/ManageReport.do")
+                .build()
+        ).cookie("NBS-Report", "basic")
+        .exchange()
+        .expectHeader()
+        .value(
+            HttpHeaders.SET_COOKIE,
+            allOf(
+                containsString("NBS-Report=;"),
+                containsString("Path=/nbs/nfc"),
+                containsString("Secure"),
+                containsString("HttpOnly"),
+                containsString("SameSite=Strict"),
+                containsString("Max-Age=0"),
+                containsString("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+            )
+        )
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void should_should_not_clear_NBS_Report_cookie_when_not_present() {
+    classic.stubFor(get(urlEqualTo("/nbs/ManageReport.do")).willReturn(ok()));
+
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/ManageReport.do")
+                .build()
+        )
+        .exchange()
+        .expectHeader()
+        .doesNotExist(HttpHeaders.SET_COOKIE)
+        .expectStatus()
+        .isOk();
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfigurationTest.java
@@ -48,7 +48,7 @@ class NBS6ReportPageRouteLocatorConfigurationTest {
         .expectCookie()
         .value("NBS-Report", equalTo(page))
         .expectCookie()
-        .path("NBS-Report", "/nbs/nfc")
+        .path("NBS-Report", "/nbs")
         .expectCookie()
         .httpOnly("NBS-Report", true)
         .expectCookie()

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfigurationTest.java
@@ -34,7 +34,7 @@ class NBS6ReportPageRouteLocatorConfigurationTest {
   NBSClassicService service;
 
   @ParameterizedTest
-  @ValueSource(strings = {"reports", "basic", "advanced", "column", "run", "save", "error", "other"})
+  @ValueSource(strings = {"reports", "basic", "advanced", "column", "run", "save", "error"})
   void should_apply_NBS_report_cookies_with_report_page(final String page) {
     classic.stubFor(get(urlEqualTo("/nbs/report/" + page)).willReturn(ok()));
 
@@ -56,6 +56,21 @@ class NBS6ReportPageRouteLocatorConfigurationTest {
         .expectCookie()
         .sameSite("NBS-Report", "Strict")
     ;
+  }
+
+  @Test
+  void should_not_apply_NBS_report_cookies_proxy_route() {
+    classic.stubFor(get(urlEqualTo("/nbs/report/proxy")).willReturn(ok()));
+
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/report/proxy")
+                .build()
+        )
+        .exchange()
+        .expectCookie()
+        .doesNotExist("NBS-Report");
   }
 
   @Test

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportPageRouteLocatorConfigurationTest.java
@@ -1,0 +1,90 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000"
+    }
+)
+class NBS6ReportPageRouteLocatorConfigurationTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Autowired
+  NBSClassicService service;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"reports", "basic", "advanced", "column", "run", "save", "error", "other"})
+  void should_apply_NBS_report_cookies_with_report_page(final String page) {
+    classic.stubFor(get(urlEqualTo("/nbs/report/" + page)).willReturn(ok()));
+
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/report/" + page)
+                .build()
+        )
+        .exchange()
+        .expectCookie()
+        .value("NBS-Report", equalTo(page))
+        .expectCookie()
+        .path("NBS-Report", "/nbs/nfc")
+        .expectCookie()
+        .httpOnly("NBS-Report", true)
+        .expectCookie()
+        .secure("NBS-Report", true)
+        .expectCookie()
+        .sameSite("NBS-Report", "Strict")
+    ;
+  }
+
+  @Test
+  void should_not_apply_NBS_report_cookies_for_report_assets() {
+    classic.stubFor(get(urlEqualTo("/nbs/report/asset.gif")).willReturn(ok()));
+
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/report/asset.gif")
+                .build()
+        )
+        .exchange()
+        .expectCookie()
+        .doesNotExist("NBS-Report");
+  }
+
+  @Test
+  void should_not_apply_NBS_report_cookies_for_sub_path_report_assets() {
+    classic.stubFor(get(urlEqualTo("/nbs/report/basic/asset.gif")).willReturn(ok()));
+
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/report/basic/asset.gif")
+                .build()
+        )
+        .exchange()
+        .expectCookie()
+        .doesNotExist("NBS-Report");
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfigurationTest.java
@@ -1,0 +1,67 @@
+package gov.cdc.nbs.gateway.classic.report;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000"
+    }
+)
+class NBS6ReportRunnerRouteLocatorConfigurationTest {
+
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Autowired
+  NBSClassicService service;
+
+  @Test
+  void should_apply_report_path_to_referer_from_the_NBS_Report_cookie() {
+    classic.stubFor(
+        post(urlEqualTo("/nbs/nfc"))
+            .withHeader(HttpHeaders.REFERER, equalTo("http://localhost:10000/report/basic"))
+            .willReturn(ok())
+    );
+
+    webClient
+        .post().uri(
+            builder -> builder
+                .path("/nbs/nfc")
+                .build()
+        ).cookie("NBS-Report", "basic")
+        .exchange()
+        .expectHeader()
+        .value(
+            HttpHeaders.SET_COOKIE,
+            allOf(
+                containsString("NBS-Report=;"),
+                containsString("Path=/nbs/nfc"),
+                containsString("Secure"),
+                containsString("HttpOnly"),
+                containsString("SameSite=Strict"),
+                containsString("Max-Age=0"),
+                containsString("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+            )
+        )
+        .expectStatus()
+        .isOk();
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfigurationTest.java
@@ -11,8 +11,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -48,19 +46,6 @@ class NBS6ReportRunnerRouteLocatorConfigurationTest {
                 .build()
         ).cookie("NBS-Report", "basic")
         .exchange()
-        .expectHeader()
-        .value(
-            HttpHeaders.SET_COOKIE,
-            allOf(
-                containsString("NBS-Report=;"),
-                containsString("Path=/nbs/nfc"),
-                containsString("Secure"),
-                containsString("HttpOnly"),
-                containsString("SameSite=Strict"),
-                containsString("Max-Age=0"),
-                containsString("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
-            )
-        )
         .expectStatus()
         .isOk();
   }
@@ -76,7 +61,6 @@ class NBS6ReportRunnerRouteLocatorConfigurationTest {
     classic.stubFor(
         post(urlEqualTo("/nbs/nfc"))
             .willReturn(ok())
-            .willReturn(badRequest())
     );
 
     webClient

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/report/NBS6ReportRunnerRouteLocatorConfigurationTest.java
@@ -64,4 +64,29 @@ class NBS6ReportRunnerRouteLocatorConfigurationTest {
         .expectStatus()
         .isOk();
   }
+
+  @Test
+  void should_not_apply_report_path_to_referer_without_the_NBS_Report_cookie() {
+    classic.stubFor(
+        post(urlEqualTo("/nbs/nfc"))
+            .withHeader(HttpHeaders.REFERER, equalTo("http://localhost:10000/report/basic"))
+            .willReturn(badRequest())
+    );
+
+    classic.stubFor(
+        post(urlEqualTo("/nbs/nfc"))
+            .willReturn(ok())
+            .willReturn(badRequest())
+    );
+
+    webClient
+        .post().uri(
+            builder -> builder
+                .path("/nbs/nfc")
+                .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
 }


### PR DESCRIPTION
## Description

The `nbs-gateway` sets the `Referrer-Policy` to `no-referrer` which prevents the `Referer` header from being added to requests.  The NBS6 `ReportWebProcessor` relies on the value of the `Referer `header to resolve which report to run.  The `NBS-Report` cookie has been added to store which report is being run.  The value of the cookie is used to create an appropriate `Referer` header for the NBS6 `ReportWebProcessor`.

## Tickets

* [CNFT1-2392](https://cdc-nbs.atlassian.net/browse/CNFT1-2392)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2392]: https://cdc-nbs.atlassian.net/browse/CNFT1-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ