### PR TITLE
[CNT-26] - E2E for Delete Section with subsections via edit page view

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/MoreOptions/MoreOptions.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/MoreOptions/MoreOptions.tsx
@@ -2,7 +2,7 @@ import './MoreOptions.scss';
 import useComponentVisible from './useComponentVisible';
 import { useEffect } from 'react';
 
-export const MoreOptions = ({ children, header, close }: any) => {
+export const MoreOptions = ({ children, header, close, className }: any) => {
     const { ref, isComponentVisible, setIsComponentVisible } = useComponentVisible(false);
     useEffect(() => {
         if (close === true) {
@@ -12,7 +12,7 @@ export const MoreOptions = ({ children, header, close }: any) => {
     return (
         <div className="more-options">
             <div
-                className={`more-options__header ${isComponentVisible ? 'active' : ''}`}
+                className={`more-options__header ${className} ${isComponentVisible ? 'active' : ''}`}
                 onClick={(e) => {
                     if (isComponentVisible) {
                         setIsComponentVisible(false);

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/SectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/SectionHeader.tsx
@@ -46,12 +46,15 @@ export const SectionHeader = ({
                 <Button type="button" onClick={handleManageSubsection} outline className={styles.settingBtn}>
                     <Icon.Settings size={3} />
                 </Button>
-                <MoreOptions header={<Icon.MoreVert size={4} onClick={() => setClose(false)} />} close={close}>
+                <MoreOptions
+                    header={<Icon.MoreVert size={4} onClick={() => setClose(false)} />}
+                    close={close}
+                    className={`moreOptionsSection-${subsectionCount ? 'yes' : 'no'}`}>
                     <Button type="button" onClick={handleEditSection}>
                         <Icon.Edit size={3} /> Edit section
                     </Button>
 
-                    <Button type="button" onClick={handleDeleteSectionClick}>
+                    <Button type="button" onClick={handleDeleteSectionClick} className="deleteSectionBtn">
                         <Icon.Delete size={3} /> Delete section
                     </Button>
                 </MoreOptions>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -128,7 +128,8 @@ export const SubsectionHeader = ({
                         type="button"
                         onClick={() => {
                             closeThenAct(onDeleteSubsection);
-                        }}>
+                        }}
+                        className="deleteSubsectionBtn">
                         <Icon.Delete size={3} /> Delete subsection
                     </Button>
                 </MoreOptions>

--- a/testing/regression/cypress/e2e/features/edit-page/deleteSection.feature
+++ b/testing/regression/cypress/e2e/features/edit-page/deleteSection.feature
@@ -1,0 +1,12 @@
+Feature: Page Builder - User can verify edit page here.
+
+  Background:
+    Given I am logged in as "superuser" and password ""
+    When User navigates to Edit page and views Edit page
+
+    # 2295
+  Scenario: Delete Section with subsections via edit page view
+    And clicks on 3 dots next to section
+    Then click on 'Delete section' link
+    Then verify warning pop up window is displayed with message "Section cannot be deleted." and "This section contains elements (subsections and questions) inside it. Remove the contents first, and then the section can be deleted."
+    And verify 'Okay' button is displayed and enabled section will be displayed with the entered information on Edit page

--- a/testing/regression/cypress/e2e/pages/edit-page/deleteSection.page.js
+++ b/testing/regression/cypress/e2e/pages/edit-page/deleteSection.page.js
@@ -1,0 +1,50 @@
+class DeleteSectionPage {
+
+    navigateEditPage () {
+        cy.visit('/page-builder/pages/1010436/edit')
+    }
+
+    clickMenuIcon() {
+        cy.get(".moreOptionsSection-yes").eq(0).click();
+    }
+
+    clickDeleteSubsection() {
+        cy.get(".moreOptionsSection-yes").eq(0)
+            .get('.deleteSectionBtn').eq(0).click();
+    }
+
+    verifyWaringMessage(title, description) {
+        cy.contains(title);
+        cy.contains(description);
+    }
+
+    verifyOkayBtnShowing(text) {
+        cy.contains(text)
+    }
+
+    clickMenuIconWithoutSubsections() {
+        cy.get(".moreOptionsSection-no").eq(0).click();
+    }
+
+    clickDeleteSubsectionWithoutSubsections() {
+        cy.get(".moreOptionsSection-no").eq(0)
+            .get('.deleteSectionBtn').eq(0).click();
+    }
+
+    verifyWaringMessageWithoutSubsections(description1, description2) {
+        cy.contains(description1);
+        cy.contains(description2);
+    }
+
+    clickYesDeleteBtnWithoutSubsections() {
+        cy.get('.usa-modal').filter(':visible')
+            .contains('button', 'Yes, delete').click();
+    }
+
+    verifyMessageSectionDeleted(text) {
+        cy.contains(text);
+    }
+
+}
+
+export const deleteSectionPage = new DeleteSectionPage()

--- a/testing/regression/cypress/step_definitions/edit-page/deleteSection.steps.js
+++ b/testing/regression/cypress/step_definitions/edit-page/deleteSection.steps.js
@@ -1,0 +1,26 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+import {deleteSectionPage} from "@pages/edit-page/deleteSection.page";
+
+Then("User navigates to Edit page and views Edit page", () => {
+    deleteSectionPage.navigateEditPage();
+});
+
+Then("clicks on 3 dots next to section", () => {
+    deleteSectionPage.clickMenuIcon();
+});
+
+Then("click on 'Delete section' link", () => {
+    deleteSectionPage.clickDeleteSubsection();
+});
+
+Then("verify warning pop up window is displayed with message {string} and {string}", (title, description) => {
+    deleteSectionPage.verifyWaringMessage(title, description);
+});
+
+Then("verify {string} button is displayed and enabled section will be displayed with the entered information on Edit page", (text) => {
+    deleteSectionPage.verifyOkayBtnShowing(text);
+});
+
+Then("clicks on 3 dots next to section without subsections", () => {
+    deleteSectionPage.clickMenuIconWithoutSubsections();
+});


### PR DESCRIPTION
## Description

Added end to end test case for delete a section with subsections via edit page view ( [CNFT2-2295](https://cdc-nbs.atlassian.net/browse/CNFT2-2295) )
<img width="1501" alt="Screenshot 2024-05-30 at 8 13 23 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/48262c65-c43c-4638-acf0-aa38b4e86f40">

## Tickets

* [CNT-26](https://cdc-nbs.atlassian.net/browse/CNT-26)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2295]: https://cdc-nbs.atlassian.net/browse/CNFT2-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-26]: https://cdc-nbs.atlassian.net/browse/CNT-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ