### PR TITLE
[CNT-26] - Delete a section without subsection

### DIFF
--- a/testing/regression/cypress/e2e/features/edit-page/deleteSection.feature
+++ b/testing/regression/cypress/e2e/features/edit-page/deleteSection.feature
@@ -4,9 +4,16 @@ Feature: Page Builder - User can verify edit page here.
     Given I am logged in as "superuser" and password ""
     When User navigates to Edit page and views Edit page
 
-    # 2295
   Scenario: Delete Section with subsections via edit page view
     And clicks on 3 dots next to section
     Then click on 'Delete section' link
     Then verify warning pop up window is displayed with message "Section cannot be deleted." and "This section contains elements (subsections and questions) inside it. Remove the contents first, and then the section can be deleted."
     And verify 'Okay' button is displayed and enabled section will be displayed with the entered information on Edit page
+
+  Scenario: Delete Section without elements via edit page view
+    And clicks on 3 dots next to section without subsections
+    Then click on 'Delete section' link without subsections
+    And user gets a warning pop up window with message "Are you sure you want to delete the section?" "Deleting this section cannot be undone. Are you sure you want to continue?"
+    Then user clicks on 'Yes, delete' button
+    Then verify success message "You have successfully deleted" is displayed on top right corner
+

--- a/testing/regression/cypress/step_definitions/edit-page/deleteSection.steps.js
+++ b/testing/regression/cypress/step_definitions/edit-page/deleteSection.steps.js
@@ -24,3 +24,20 @@ Then("verify {string} button is displayed and enabled section will be displayed 
 Then("clicks on 3 dots next to section without subsections", () => {
     deleteSectionPage.clickMenuIconWithoutSubsections();
 });
+
+Then("click on 'Delete section' link without subsections", () => {
+    deleteSectionPage.clickDeleteSubsectionWithoutSubsections();
+});
+
+Then("user gets a warning pop up window with message {string} {string}", (description1, description2) => {
+    deleteSectionPage.verifyWaringMessageWithoutSubsections(description1, description2);
+});
+
+Then("user clicks on 'Yes, delete' button", () => {
+    deleteSectionPage.clickYesDeleteBtnWithoutSubsections();
+});
+
+Then("verify success message {string} is displayed on top right corner", (text) => {
+    deleteSectionPage.verifyMessageSectionDeleted(text);
+});
+


### PR DESCRIPTION
## Description

Added end to end test case for delete a section without subsection ( [CNFT2-2296](https://cdc-nbs.atlassian.net/browse/CNFT2-2296) )
<img width="1512" alt="Screenshot 2024-05-30 at 12 09 05 PM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/b46d4819-f1c6-40b3-b10e-b9782b3eb67f">

## Tickets

* [CNT-26](https://cdc-nbs.atlassian.net/browse/CNT-26)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-2296]: https://cdc-nbs.atlassian.net/browse/CNFT2-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-26]: https://cdc-nbs.atlassian.net/browse/CNT-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ