### PR TITLE
[CNT-26] - E2E to verify Manage sections modal displays key elements

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/content/PageSideMenu.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/content/PageSideMenu.tsx
@@ -15,7 +15,8 @@ export const PageSideMenu = ({ onAddSection, onManageSection, onReorderModal }: 
                 <li
                     onClick={() => {
                         onManageSection();
-                    }}>
+                    }}
+                    className="manageSections">
                     <Icon.Edit size={3} />
                     Manage sections
                 </li>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/AddSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/AddSection.tsx
@@ -123,7 +123,8 @@ export const AddSection = ({
                         <Button
                             type="button"
                             onClick={onSubmit}
-                            disabled={!form.formState.isDirty || !form.formState.isValid}>
+                            disabled={!form.formState.isDirty || !form.formState.isValid}
+                            className="saveChangesBtn">
                             Save changes
                         </Button>
                     ) : (

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSection.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSection.tsx
@@ -119,7 +119,7 @@ export const ManageSection = ({
                                 onClick={() => {
                                     handleUpdateState('add');
                                 }}
-                                className={styles.addSectionBtn}
+                                className={`${styles.addSectionBtn} addNewSectionBtn`}
                                 disabled={onAction}>
                                 <Icon.Add size={3} className={styles.addIcon} />
                                 Add new section
@@ -186,7 +186,8 @@ export const ManageSection = ({
                                 setConfirmDelete(undefined);
                             }}
                             type={'button'}
-                            outline>
+                            outline
+                            className="manageSectionsCloseBtn">
                             Close
                         </Button>
                     </div>

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSectionTile/ManageSectionTile.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/manage/ManageSectionTile/ManageSectionTile.tsx
@@ -77,7 +77,8 @@ export const ManageSectionTile = ({
                                                     handleDelete?.(section);
                                                     setSelectedForDelete(undefined);
                                                     setOnAction(false);
-                                                }}>
+                                                }}
+                                                className="yesDelete">
                                                 Yes, delete
                                             </div>
                                             <div className={styles.separator}>|</div>
@@ -122,7 +123,7 @@ export const ManageSectionTile = ({
                                     outline
                                     className={styles.iconBtn}
                                     disabled={onAction}>
-                                    <Icon.Edit style={{ cursor: 'pointer' }} size={3} />
+                                    <Icon.Edit data-testId="editIcon" style={{ cursor: 'pointer' }} size={3} />
                                 </Button>
                                 <Button
                                     type="button"
@@ -133,7 +134,7 @@ export const ManageSectionTile = ({
                                         setSelectedForDelete(section);
                                         setOnAction(true);
                                     }}>
-                                    <Icon.Delete style={{ cursor: 'pointer' }} size={3} />
+                                    <Icon.Delete data-testId="deleteIcon" style={{ cursor: 'pointer' }} size={3} />
                                 </Button>
                                 {section.visible ? (
                                     <Button
@@ -144,7 +145,11 @@ export const ManageSectionTile = ({
                                         onClick={() => {
                                             onChangeVisibility(section, false);
                                         }}>
-                                        <Icon.Visibility style={{ cursor: 'pointer' }} size={3} />
+                                        <Icon.Visibility
+                                            data-testId="visibilityIcon"
+                                            style={{ cursor: 'pointer' }}
+                                            size={3}
+                                        />
                                     </Button>
                                 ) : (
                                     <Button

--- a/testing/regression/cypress/e2e/features/create-page/pageElements.feature
+++ b/testing/regression/cypress/e2e/features/create-page/pageElements.feature
@@ -1,4 +1,4 @@
-Feature: Page Builder - User can verify existing create new page elements here.
+Feature: Page Builder - User can verify create new page elements here.
 
   Background:
     Given I am logged in as "superuser" and password ""

--- a/testing/regression/cypress/e2e/features/edit-page/addSection.feature
+++ b/testing/regression/cypress/e2e/features/edit-page/addSection.feature
@@ -1,4 +1,4 @@
-Feature: Page Builder - User can verify edit page here.
+Feature: Page Builder - User can verify add section while editing the page here.
 
   Background:
     Given I am logged in as "superuser" and password ""

--- a/testing/regression/cypress/e2e/features/edit-page/deleteSection.feature
+++ b/testing/regression/cypress/e2e/features/edit-page/deleteSection.feature
@@ -1,4 +1,4 @@
-Feature: Page Builder - User can verify edit page here.
+Feature: Page Builder - User can verify delete section while editing the page here.
 
   Background:
     Given I am logged in as "superuser" and password ""

--- a/testing/regression/cypress/e2e/features/edit-page/manageSection.feature
+++ b/testing/regression/cypress/e2e/features/edit-page/manageSection.feature
@@ -1,0 +1,18 @@
+Feature: Page Builder - User can verify manage page here.
+
+  Background:
+    Given I am logged in as "superuser" and password ""
+    When User navigates to Edit page and views Manage section pop-up window
+
+  Scenario Outline: Manage sections modal to display key elements
+    Then User will see the following by "<Content>" "<Type>" "<Description>"
+    Examples:
+      | Content         | Type    | Description                      |
+      | Manage sections | title   | main title                       |
+      | Add new section | button  | to add new section               |
+      | Patient         | heading | tab heading                      |
+      | Six dots        | icon    | with other available sections    |
+      | Pencil          | icon    | for editing                      |
+      | Trash can       | icon    | for deleting a section           |
+      | Cross-eye       | icon    | for not visible / visible        |
+      | Close           | button  | to close the pop-up modal window |

--- a/testing/regression/cypress/e2e/pages/edit-page/manageSection.page.js
+++ b/testing/regression/cypress/e2e/pages/edit-page/manageSection.page.js
@@ -1,0 +1,108 @@
+class ManageSectionPage {
+
+    navigateEditPage () {
+        cy.visit('/page-builder/pages/1010436/edit')
+    }
+
+    openManageSectionsPopup() {
+        cy.get('.manageSections').eq(0).click();
+    }
+
+    seeElementOnManageSection(content, type, description) {
+        if (type === "title" || type === "heading" || type === "button") {
+            cy.contains(content);
+        } else if (type === "icon") {
+            if (content === "Six dots") {
+                cy.get('img[src="/icons/drag.svg"]');
+            } else if (content === "Pencil") {
+                cy.get('[data-testId="editIcon"]');
+            } else if (content === "Trash can") {
+                cy.get('[data-testId="deleteIcon"]');
+            } else if (content === "Cross-eye") {
+                cy.get('[data-testId="visibilityIcon"]');
+            }
+        }
+    }
+
+    viewTrashIcon() {
+        cy.get('[data-testId="deleteIcon"]');
+    }
+
+    clickTrashIcon() {
+        cy.get('[data-testId="deleteIcon"]').eq(0).click();
+    }
+
+    viewDeleteConfirmationDialogText(texts) {
+        texts.forEach((text) => {
+            cy.contains(text);
+        });
+    }
+
+    clickYesDeleteBtn() {
+        cy.get('.yesDelete').eq(0).click()
+    }
+
+    closeDeleteConfirmationDialog() {
+        cy.get('.warningModalHeader').should('not.exist');
+    }
+
+    showDeleteConfirmationText(text) {
+        cy.contains(text);
+    }
+
+    checkSectionDeleted() {
+        cy.get('.manageSectionsCloseBtn').eq(0).click();
+    }
+
+    verifyManageSectionsHeader(title) {
+        cy.contains(title)
+    }
+
+    clickAddNewSection() {
+        cy.get('.addNewSectionBtn').eq(0).click({ force: true });
+    }
+
+    enterSectionName() {
+        cy.get('.sectionName').eq(0).type("test new section");
+    }
+
+    clickAddSectionBtn() {
+        cy.get('.addSectionBtn').eq(0).click();
+    }
+
+    checkAddedSectionExist() {
+        cy.contains("test new section");
+    }
+
+    viewPencilIcon() {
+        cy.get('[data-testId="editIcon"]');
+    }
+
+    clickPencilIcon() {
+        cy.get('[data-testId="editIcon"]').eq(0).click();
+    }
+
+    viewEditSectionModalWindow() {
+        cy.contains("Edit section");
+    }
+
+    modifySectionName() {
+        const newSecName = Math.random().toString(36).substring(2, 12);
+        cy.get('.sectionName').eq(0).clear().type(`Modified text section name ${newSecName}`);
+    }
+
+    clickSaveBtn() {
+        cy.get('.saveChangesBtn').eq(0).click({ force: true });
+    }
+
+    closeEditSectionModal() {
+        cy.contains("Edit section").should('not.be.visible');
+    }
+
+    checkConfirmationMessageShowing(text) {
+        cy.contains(text);
+    }
+
+}
+
+export const manageSectionPage = new ManageSectionPage()

--- a/testing/regression/cypress/step_definitions/edit-page/manageSection.steps.js
+++ b/testing/regression/cypress/step_definitions/edit-page/manageSection.steps.js
@@ -1,0 +1,87 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+import {manageSectionPage} from "@pages/edit-page/manageSection.page";
+
+Then("User navigates to Edit page and views Manage section pop-up window", () => {
+    manageSectionPage.navigateEditPage();
+    manageSectionPage.openManageSectionsPopup();
+});
+
+Then("User will see the following by {string} {string} {string}", (content, type, description) => {
+    manageSectionPage.seeElementOnManageSection(content, type, description);
+});
+
+Then("User views the trash icon to the right of the section name", () => {
+    manageSectionPage.viewTrashIcon();
+});
+
+Then("User clicks the trash icon", () => {
+    manageSectionPage.clickTrashIcon();
+});
+
+Then("Yellow inline message {string} displays above the section name with options {string} and {string}", (string, string1, string2) => {
+    manageSectionPage.viewDeleteConfirmationDialogText([string, string1, string2]);
+});
+
+Then("User clicks Yes, delete button", () => {
+    manageSectionPage.clickYesDeleteBtn();
+});
+
+Then("Yellow banner message closes", () => {
+    manageSectionPage.closeDeleteConfirmationDialog();
+});
+
+Then("Green inline confirmation message {string} whatever the section name displays under the Manage sections heading at the top", (string) => {
+    manageSectionPage.showDeleteConfirmationText(string);
+});
+
+Then("Deleted section is removed from Manage sections modal and Edit page", () => {
+    manageSectionPage.checkSectionDeleted();
+});
+
+Then("verify page header as {string}", (title) => {
+    manageSectionPage.verifyManageSectionsHeader(title);
+});
+
+Then("click on 'Add new section' from the pop up window", () => {
+    manageSectionPage.clickAddNewSection();
+});
+
+Then("enter section name", () => {
+    manageSectionPage.enterSectionName();
+});
+
+Then("click on 'Add section' button", () => {
+    manageSectionPage.clickAddSectionBtn();
+});
+
+Then("verify same section is visible in edit page view", () => {
+    manageSectionPage.checkAddedSectionExist();
+});
+
+Then("User views the pencil icon to the right of the section name", () => {
+    manageSectionPage.viewPencilIcon();
+});
+
+Then("User clicks the pencil icon", () => {
+    manageSectionPage.clickPencilIcon();
+});
+
+Then("Edit section modal window displays", () => {
+    manageSectionPage.viewEditSectionModalWindow();
+});
+
+Then("User modifies the section name", () => {
+    manageSectionPage.modifySectionName();
+});
+
+Then("clicks the Save button", () => {
+    manageSectionPage.clickSaveBtn();
+});
+
+Then("Edit section modal closes", () => {
+    manageSectionPage.closeEditSectionModal();
+});
+
+Then("Inline confirmation message {string} displays under the Manage sections heading at the top", (text) => {
+    manageSectionPage.checkConfirmationMessageShowing(text);
+});


### PR DESCRIPTION
## Description

Added end to end test case to verify Manage sections modal displays key elements ( [CNFT2-1803](https://cdc-nbs.atlassian.net/browse/CNFT2-1803) )
<img width="1503" alt="Screenshot 2024-05-31 at 7 41 04 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/ff1fa673-8da3-4b51-902c-c7f22f7e8c22">

## Tickets

* [CNT-26](https://cdc-nbs.atlassian.net/browse/CNT-26)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1803]: https://cdc-nbs.atlassian.net/browse/CNFT2-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-26]: https://cdc-nbs.atlassian.net/browse/CNT-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ