### PR TITLE
fix padding on alerts

### DIFF
--- a/apps/modernization-ui/src/alert/alert.scss
+++ b/apps/modernization-ui/src/alert/alert.scss
@@ -2,7 +2,7 @@
 
 .usa-alert {
     min-width: 450px;
-    padding: 1rem 1rem 1rem 0.75rem !important;
+    padding: 0.5rem 1rem 0.5rem 0.75rem !important;
     position: fixed;
     z-index: 99999+1;
     top: 15px;

--- a/apps/modernization-ui/src/hooks/usePrompt.ts
+++ b/apps/modernization-ui/src/hooks/usePrompt.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type UnsavedChangesPromptProps = {
+    shouldShowPrompt: boolean; // Flag to indicate unsaved changes
+    onConfirmNavigation: () => void; // Callback for confirmed navigation
+    onCancelNavigation: () => void; // Callback for cancelling navigation
+};
+
+export const useUnsavedChangesPrompt = ({ shouldShowPrompt }: UnsavedChangesPromptProps) => {
+    const navigate = useNavigate();
+    const [showPrompt, setShowPrompt] = useState(false);
+    const history = useNavigate(); // Get history object
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+        if (shouldShowPrompt) {
+            event.preventDefault();
+            event.returnValue = ''; // Display custom warning message
+            return '';
+        }
+    };
+
+    useEffect(() => {
+        const unblock = history.block((location) => {
+            if (shouldShowPrompt) {
+                setShowPrompt(true);
+                return true; // Show prompt before navigation
+            }
+        });
+
+        return () => unblock();
+    }, [shouldShowPrompt, history]); // Dependency array
+
+    const handleConfirmNavigation = () => {
+        setShowPrompt(false);
+        unblock(); // Allow navigation
+        onConfirmNavigation(); // Call the provided callback
+    };
+
+    const handleCancelNavigation = () => {
+        setShowPrompt(false);
+        unblock(); // Allow navigation
+    };
+
+    return { showPrompt, onConfirmNavigation: handleConfirmNavigation, onCancelNavigation: handleCancelNavigation };
+};


### PR DESCRIPTION
## Description

Fixes the padding on alert pop ups.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/jira/software/c/projects/CNFT1/boards/112?assignee=712020%3A591f5469-427d-49e9-87dc-8b4df72a02b4&selectedIssue=CNFT1-2216)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
