### PR TITLE
[CNFT1-2429] adds /goodbye and /expired to the ignored paths of moderniztion-api

### DIFF
--- a/apps/modernization-api/src/main/resources/application.yml
+++ b/apps/modernization-api/src/main/resources/application.yml
@@ -50,6 +50,8 @@ nbs:
         - /favicon.ico
         - /static/**
         - /nbs/timeout
+        - /goodbye
+        - /expired
 
 logging:
   file.name:

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/OIDCAuthenticationConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/OIDCAuthenticationConfiguration.java
@@ -43,7 +43,9 @@ class OIDCAuthenticationConfiguration {
                     "/favicon.ico",
                     "/static/**",
                     "/logout",
-                    "/goodbye")
+                    "/goodbye",
+                    "/expired"
+                )
                 .permitAll()
                 .anyExchange()
                 .authenticated())


### PR DESCRIPTION
## Description

Adds `/goodbye` and `/expired` to the ignored paths of `moderniztion-api` so that they accessible without the need for authentication.

## Tickets

* [CNFT1-2429](https://cdc-nbs.atlassian.net/browse/CNFT1-2429)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2429]: https://cdc-nbs.atlassian.net/browse/CNFT1-2429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ