### PR TITLE
[CNT-30] - E2E to verify question added to a page is not searchable

### DIFF
--- a/testing/regression/cypress/e2e/features/edit-page/addEditSearchDeleteQuestion.feature
+++ b/testing/regression/cypress/e2e/features/edit-page/addEditSearchDeleteQuestion.feature
@@ -3,7 +3,7 @@ Feature: Page Builder - User can verify managing question while editing the page
   Background:
     Given I am logged in as "superuser" and password ""
     When User navigates to Edit page and views Edit page and Subsection already expanded
-#
+
   Scenario: Create a question (Text Only)
     When User clicks the Add question button
     Then Question library pop-up modal displays
@@ -35,4 +35,12 @@ Feature: Page Builder - User can verify managing question while editing the page
     When User clicks Yes, delete to delete question
     Then A success message displays "Question deleted successfully"
     And Application deletes the selected question and remain on the page
+
+  Scenario: Verify question added to a page is not searchable
+    When User clicks the Add question button
+    Then Question library pop-up modal displays
+    Then User enters a question already added to a page in the search field
+    Then User clicks the magnifying glass icon
+    Then Question already added to a page will not display in the question library
+    And Message "Can't find what you're looking for?" and "Create new" button will display to create a new question
 

--- a/testing/regression/cypress/e2e/pages/edit-page/addEditSearchDeleteQuestion.page.js
+++ b/testing/regression/cypress/e2e/pages/edit-page/addEditSearchDeleteQuestion.page.js
@@ -27,7 +27,7 @@ class AddEditSearchDeleteQuestion {
         cy.contains('Add question');
     }
 
-    fillAllRequiredFields(withUniqueID) {
+    fillAllRequiredFields({ withUniqueID, fieldTypeNumeric, fieldTypeDatePicker } = {}) {
         if(withUniqueID) {
             cy.get('#uniqueId').type('NBS104');
         }
@@ -36,8 +36,15 @@ class AddEditSearchDeleteQuestion {
         cy.get('#label').type('new question label');
         cy.get('.subgroupSelect').eq(0).select(1, { force: true });
         cy.get('#description').type('new test description');
-        cy.get('.fieldType-option-0').eq(0).click();
-        cy.get('#valueSet').select(2);
+        if (fieldTypeNumeric) {
+            cy.get('.fieldType-option-1').eq(0).click();
+            cy.get('#fieldLength').type(5);
+        } else if(fieldTypeDatePicker){
+            cy.get('.fieldType-option-3').eq(0).click();
+        } else {
+            cy.get('.fieldType-option-0').eq(0).click();
+            cy.get('#valueSet').select(2);
+        }
         cy.get('#tooltip').type('new question tooltip');
         cy.get('[data-testid="displayType"]').select(1);
         cy.get('.defaultLabelInReport').eq(0).type('label report');
@@ -102,6 +109,35 @@ class AddEditSearchDeleteQuestion {
 
     errorMessageForDuplicateUniqueID(text) {
          cy.contains('Error');
+    }
+
+    enterExistingQuestionUniqueID() {
+        cy.get('#question-search').type('NBS104');
+    }
+
+    clickQuestionSearchBtn() {
+        cy.get('#searchButton').click();
+    }
+
+    showEmptyQuestionSearchList() {
+        cy.contains('Showing 0 of 0');
+    }
+
+    showCreateNewSection(text, text1) {
+        cy.contains(text);
+        cy.contains(text1);
+    }
+
+    enterInactiveQuestionInSearchField() {
+        cy.get('#question-search').type('ARD1157');
+    }
+
+    InactiveQuestionNotDisplayed() {
+        cy.contains('Showing 0 of 0');
+    }
+
+    checkUniqueIDisBlank() {
+        cy.get('#uniqueId').should('not.have.value');
     }
 
 }

--- a/testing/regression/cypress/step_definitions/edit-page/addEditSearchDeleteQuestion.steps.js
+++ b/testing/regression/cypress/step_definitions/edit-page/addEditSearchDeleteQuestion.steps.js
@@ -59,7 +59,7 @@ Then("Application will close the Edit question pop-window with the changes saved
 });
 
 Then("Enters an existing Unique ID and completes all required and applicable fields, selecting Text only", () => {
-    addEditSearchDeleteQuestion.fillAllRequiredFields(true);
+    addEditSearchDeleteQuestion.fillAllRequiredFields({ withUniqueID: true });
 });
 
 Then("An error message should display similar to {string}", (text) => {
@@ -84,4 +84,48 @@ Then("A success message displays {string}", (text) => {
 
 Then("Application deletes the selected question and remain on the page", () => {
     addEditSearchDeleteQuestion.checkPageStayedOnEdit();
+});
+
+Then("User enters a question already added to a page in the search field", () => {
+    addEditSearchDeleteQuestion.enterExistingQuestionUniqueID();
+});
+
+Then("User clicks the magnifying glass icon", () => {
+    addEditSearchDeleteQuestion.clickQuestionSearchBtn();
+});
+
+Then("Question already added to a page will not display in the question library", () => {
+    addEditSearchDeleteQuestion.showEmptyQuestionSearchList();
+});
+
+Then("Message {string} and {string} button will display to create a new question", (text, text1) => {
+    addEditSearchDeleteQuestion.showCreateNewSection(text, text1);
+});
+
+Then("User enters an Inactive question in the search field", () => {
+    addEditSearchDeleteQuestion.enterInactiveQuestionInSearchField();
+});
+
+Then("Inactive question will not display in the question library", () => {
+    addEditSearchDeleteQuestion.InactiveQuestionNotDisplayed();
+});
+
+Then("Unique ID field is blank", () => {
+    addEditSearchDeleteQuestion.checkUniqueIDisBlank();
+});
+
+Then("All required and applicable fields completed", () => {
+    addEditSearchDeleteQuestion.fillAllRequiredFields();
+});
+
+Then("Numeric field is selected with Mask as Integer And All other required and applicable fields completed", () => {
+    addEditSearchDeleteQuestion.fillAllRequiredFields({ fieldTypeNumeric: true });
+});
+
+Then("Date picker field is selected with Date format And All other required and applicable fields completed", () => {
+    addEditSearchDeleteQuestion.fillAllRequiredFields({ fieldTypeDatePicker: true });
+});
+
+Then("Value Set field is selected And New value set created And All other required and applicable fields completed", () => {
+    addEditSearchDeleteQuestion.fillAllRequiredFields();
 });


### PR DESCRIPTION
## Description

Added end to end test to verify question added to a page is not searchable ( [CNFT2-1833](https://cdc-nbs.atlassian.net/browse/CNFT2-1833) )
<img width="1501" alt="Screenshot 2024-06-07 at 7 42 03 AM" src="https://github.com/CDCgov/NEDSS-Modernization/assets/132704359/c0c77e6f-438c-4d43-abfd-c91e73261f6c">

## Tickets

* [CNT-30](https://cdc-nbs.atlassian.net/browse/CNT-30)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1833]: https://cdc-nbs.atlassian.net/browse/CNFT2-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-30]: https://cdc-nbs.atlassian.net/browse/CNT-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ