### PR TITLE
[FIX] Updates the nbs-gateway routes to allow logout

### DIFF
--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/NBSClassicServiceProvider.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/NBSClassicServiceProvider.java
@@ -1,11 +1,9 @@
 package gov.cdc.nbs.gateway.classic;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.gateway.route.RouteLocator;
-import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import gov.cdc.nbs.gateway.ui.UIService;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -19,25 +17,4 @@ class NBSClassicServiceProvider {
     return new NBSClassicService(uri);
   }
 
-  @Bean
-  RouteLocator logoutRouteLocator(
-      final RouteLocatorBuilder builder,
-      final UIService uiService) {
-    return builder.routes()
-        .route(
-            "classic-logout-redirect", route -> route.path("/nbs/logOut")
-                .filters(filters -> filters.redirect(302, uiService.path("/goodbye"))).uri("no://op"))
-        .build();
-  }
-
-  @Bean
-  RouteLocator timeoutRouteLocator(
-      final RouteLocatorBuilder builder,
-      final UIService uiService) {
-    return builder.routes()
-        .route(
-            "classic-timeout-redirect", route -> route.path("/nbs/timeout")
-                .filters(filters -> filters.redirect(302, uiService.path("/expired"))).uri("no://op"))
-        .build();
-  }
 }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/ui/ModernizedUIRoutes.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/ui/ModernizedUIRoutes.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.gateway.ui;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class ModernizedUIRoutes {
+
+  @Bean
+  RouteLocator goodbyeRouteLocator(
+      final RouteLocatorBuilder builder,
+      final UIService uiService) {
+    return builder.routes()
+        .route(
+            "classic-logout-redirect",
+            route -> route.path("/nbs/logOut")
+                .filters(filters -> filters.redirect(302, uiService.path("/goodbye"))
+                ).uri("no://op")
+        )
+        .build();
+  }
+
+  @Bean
+  RouteLocator timeoutRouteLocator(
+      final RouteLocatorBuilder builder,
+      final UIService uiService) {
+    return builder.routes()
+        .route(
+            "classic-timeout-redirect",
+            route -> route.path("/nbs/timeout")
+                .filters(
+                    filters -> filters.redirect(302, uiService.path("/expired"))
+                ).uri("no://op")
+        )
+        .build();
+  }
+
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfiguration.java
@@ -15,13 +15,15 @@ class NBS6LogoutRouteLocatorConfiguration {
 
   @Bean
   RouteLocator logout(final RouteLocatorBuilder builder) {
-    return builder.routes().route(
-        "nbs-logout",
-        route -> route.path("/nbs/logout")
-            .filters(
-                filters -> filters
-                    .redirect(302, "/goodbye"))
-            .uri("no://op"))
+    return builder.routes()
+        .route(
+            "nbs-logout",
+            route -> route.path("/nbs/logout")
+                .filters(
+                    filters -> filters.redirect(302, "/logout")
+                )
+                .uri("no://op")
+        )
         .build();
   }
 

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/ui/ModernizedUIRoutesTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/ui/ModernizedUIRoutesTest.java
@@ -1,0 +1,39 @@
+package gov.cdc.nbs.gateway.ui;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ModernizedUIRoutesTest {
+
+  @Autowired
+  WebTestClient webClient;
+
+  @Test
+  void should_redirect_the_timeout_page_to_the_ui_expired_page() {
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/timeout")
+                .build()
+        )
+        .exchange()
+        .expectStatus()
+        .is3xxRedirection().expectHeader().location("/expired");
+  }
+
+  @Test
+  void should_route_the_logOut_page_to_the_ui_goodbye_page() {
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/logOut")
+                .build()
+        )
+        .exchange()
+        .expectStatus()
+        .is3xxRedirection().expectHeader().location("/goodbye");
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfigurationTest.java
@@ -35,9 +35,10 @@ class NBS6LogoutRouteLocatorConfigurationTest {
         .get().uri(
             builder -> builder
                 .path("/nbs/logout")
-                .build())
+                .build()
+        )
         .exchange()
-        .expectHeader().location("/goodbye")
+        .expectHeader().location("/logout")
         .expectStatus().is3xxRedirection();
   }
 
@@ -49,7 +50,8 @@ class NBS6LogoutRouteLocatorConfigurationTest {
         .get().uri(
             builder -> builder
                 .path("/nbs/logged-out")
-                .build())
+                .build()
+        )
         .exchange().expectStatus().isOk();;
   }
 


### PR DESCRIPTION
## Description

- Ensures that `/nbs/logout` redirects to `/logout` when OIDC is enabled.
- Ensures that `/nbs/logOut` redirects to `/goodbye`

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
