### PR TITLE
CNFT1-2328 Resulted test auto-complete API

### DIFF
--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
@@ -5,18 +5,47 @@ import gov.cdc.nbs.option.jdbc.OptionRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class SQLBasedOptionResolver {
-
+  private static List<String> relatedClassCodes = Arrays.asList(
+      "ABXBACT",
+      "BC",
+      "CELLMARK",
+      "CHAL",
+      "CHALSKIN",
+      "CHEM",
+      "COAG",
+      "CYTO",
+      "DRUG",
+      "DRUG/TOX",
+      "HEM",
+      "HEM/BC",
+      "MICRO",
+      "MISC",
+      "PANEL.ABXBACT",
+      "PANEL.BC",
+      "PANEL.CHEM",
+      "PANEL.MICRO",
+      "PANEL.OBS",
+      "PANEL.SERO",
+      "PANEL.TOX",
+      "PANEL.UA",
+      "SERO",
+      "SPEC",
+      "TOX",
+      "UA",
+      "VACCIN");
 
   private static final String CRITERIA_PARAMETER = "criteria";
   private static final String PREFIX_CRITERIA_PARAMETER = "prefixCriteria";
   private static final String LIMIT_PARAMETER = "limit";
   private static final String SQL_WILDCARD = "%";
   private static final String QUICK_CODE = "quickCode";
+  private static final String RELATED_CLASS_CODES = "relatedClassCodes";
 
   private final String query;
   private final NamedParameterJdbcTemplate template;
@@ -34,6 +63,7 @@ public class SQLBasedOptionResolver {
         CRITERIA_PARAMETER, withWildcard(keyword),
         PREFIX_CRITERIA_PARAMETER, withPrefixWildcard(keyword),
         QUICK_CODE, keyword,
+        RELATED_CLASS_CODES, relatedClassCodes,
         LIMIT_PARAMETER, limit);
     return this.template.query(
         this.query,

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/jdbc/autocomplete/SQLBasedOptionResolver.java
@@ -5,47 +5,15 @@ import gov.cdc.nbs.option.jdbc.OptionRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class SQLBasedOptionResolver {
-  private static List<String> relatedClassCodes = Arrays.asList(
-      "ABXBACT",
-      "BC",
-      "CELLMARK",
-      "CHAL",
-      "CHALSKIN",
-      "CHEM",
-      "COAG",
-      "CYTO",
-      "DRUG",
-      "DRUG/TOX",
-      "HEM",
-      "HEM/BC",
-      "MICRO",
-      "MISC",
-      "PANEL.ABXBACT",
-      "PANEL.BC",
-      "PANEL.CHEM",
-      "PANEL.MICRO",
-      "PANEL.OBS",
-      "PANEL.SERO",
-      "PANEL.TOX",
-      "PANEL.UA",
-      "SERO",
-      "SPEC",
-      "TOX",
-      "UA",
-      "VACCIN");
-
   private static final String CRITERIA_PARAMETER = "criteria";
   private static final String PREFIX_CRITERIA_PARAMETER = "prefixCriteria";
   private static final String LIMIT_PARAMETER = "limit";
   private static final String SQL_WILDCARD = "%";
   private static final String QUICK_CODE = "quickCode";
-  private static final String RELATED_CLASS_CODES = "relatedClassCodes";
 
   private final String query;
   private final NamedParameterJdbcTemplate template;
@@ -63,7 +31,6 @@ public class SQLBasedOptionResolver {
         CRITERIA_PARAMETER, withWildcard(keyword),
         PREFIX_CRITERIA_PARAMETER, withPrefixWildcard(keyword),
         QUICK_CODE, keyword,
-        RELATED_CLASS_CODES, relatedClassCodes,
         LIMIT_PARAMETER, limit);
     return this.template.query(
         this.query,

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionAutocompleteController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionAutocompleteController.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.option.resultedtest.autocomplete;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+@RequestMapping("nbs/api/options/resulted-tests/search")
+class ResultedTestOptionAutocompleteController {
+
+  private final ResultedTestOptionResolver resolver;
+
+  ResultedTestOptionAutocompleteController(final ResultedTestOptionResolver finder) {
+    this.resolver = finder;
+  }
+
+  @Operation(
+      operationId = "resultedtest-autocomplete",
+      summary = "NBS Resulted Test Option Autocomplete",
+      description = "Provides options from Resulted Tests that have a name matching a criteria.",
+      tags = "ResultedTestOptions")
+  @GetMapping
+  Collection<Option> complete(
+      @RequestParam final String criteria,
+      @RequestParam(defaultValue = "15") final int limit) {
+    return this.resolver.resolve(criteria, limit);
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionResolver.java
@@ -1,0 +1,42 @@
+package gov.cdc.nbs.option.resultedtest.autocomplete;
+
+import gov.cdc.nbs.option.jdbc.autocomplete.SQLBasedOptionResolver;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ResultedTestOptionResolver extends SQLBasedOptionResolver {
+  private static final String QUERY = """
+      with [resultedtest]([value], [name]) as (
+          SELECT DISTINCT
+            lab_test_cd, lab_test_desc_txt
+          FROM
+            NBS_SRTE.dbo.Lab_test
+          WHERE
+            test_type_cd = 'R'
+          UNION
+          SELECT DISTINCT
+            loinc_cd, component_name
+          FROM
+            NBS_SRTE.dbo.LOINC_code
+          WHERE
+            related_class_cd in(:relatedClassCodes)
+      )
+      select
+          [value],
+          [name],
+          row_number() over( order by [name])
+      from [resultedtest]
+      where [name] like :criteria or [name] like :prefixCriteria or[value] like :criteria
+
+      order by
+          [name]
+
+      offset 0 rows
+      fetch next :limit rows only
+      """;
+
+  public ResultedTestOptionResolver(final NamedParameterJdbcTemplate template) {
+    super(QUERY, template);
+  }
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionResolver.java
@@ -6,35 +6,36 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ResultedTestOptionResolver extends SQLBasedOptionResolver {
-  private static final String QUERY = """
-      with [resultedtest]([value], [name]) as (
-          SELECT DISTINCT
-            lab_test_cd, lab_test_desc_txt
-          FROM
-            NBS_SRTE.dbo.Lab_test
-          WHERE
-            test_type_cd = 'R'
-          UNION
-          SELECT DISTINCT
-            loinc_cd, component_name
-          FROM
-            NBS_SRTE.dbo.LOINC_code
-          WHERE
-            related_class_cd in(:relatedClassCodes)
-      )
-      select
-          [value],
-          [name],
-          row_number() over( order by [name])
-      from [resultedtest]
-      where [name] like :criteria or [name] like :prefixCriteria or[value] like :criteria
+  private static final String QUERY =
+      """
+          with [resultedtest]([value], [name]) as (
+              SELECT DISTINCT
+                lab_test_cd, lab_test_desc_txt
+              FROM
+                NBS_SRTE.dbo.Lab_test
+              WHERE
+                test_type_cd = 'R'
+              UNION
+              SELECT DISTINCT
+                loinc_cd, component_name
+              FROM
+                NBS_SRTE.dbo.LOINC_code
+              WHERE
+                related_class_cd in('ABXBACT','BC','CELLMARK','CHAL','CHALSKIN','CHEM','COAG','CYTO','DRUG','DRUG/TOX','HEM','HEM/BC','MICRO','MISC','PANEL.ABXBACT','PANEL.BC','PANEL.CHEM','PANEL.MICRO','PANEL.OBS','PANEL.SERO','PANEL.TOX','PANEL.UA','SERO','SPEC','TOX','UA','VACCIN')
+          )
+          select
+              [value],
+              [name],
+              row_number() over( order by [name])
+          from [resultedtest]
+          where [name] like :criteria or [name] like :prefixCriteria or[value] like :criteria
 
-      order by
-          [name]
+          order by
+              [name]
 
-      offset 0 rows
-      fetch next :limit rows only
-      """;
+          offset 0 rows
+          fetch next :limit rows only
+          """;
 
   public ResultedTestOptionResolver(final NamedParameterJdbcTemplate template) {
     super(QUERY, template);

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestAutocompleteRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestAutocompleteRequester.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.resultedtest.autocomplete;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+class ResultedTestAutocompleteRequester {
+
+  private final MockMvc mvc;
+
+  ResultedTestAutocompleteRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions complete(final String criteria) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/resulted-tests/search")
+            .param("criteria", criteria))
+        .andDo(print());
+  }
+
+  ResultActions complete(final String criteria, final int limit) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/resulted-tests/search")
+            .param("criteria", criteria)
+            .param("limit", String.valueOf(limit)))
+        .andDo(print());
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestAutocompleteSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestAutocompleteSteps.java
@@ -1,0 +1,37 @@
+package gov.cdc.nbs.option.resultedtest.autocomplete;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class ResultedTestAutocompleteSteps {
+
+  private final ResultedTestAutocompleteRequester request;
+  private final Active<ResultActions> response;
+
+  ResultedTestAutocompleteSteps(
+      final ResultedTestAutocompleteRequester request,
+      final Active<ResultActions> response) {
+    this.request = request;
+    this.response = response;
+  }
+
+  @Before("@resultedtests")
+  public void reset() {
+    response.reset();
+  }
+
+  @When("I am trying to find resulted tests that start with {string}")
+  public void i_am_trying_to_find_resulted_tests_that_start_with(final String criteria) throws Exception {
+    response.active(request.complete(criteria));
+  }
+
+  @When("I am trying to find at most {int} resulted tests(s) that start with {string}")
+  public void i_am_trying_to_find_n_resulted_tests_that_start_with(
+      final int limit,
+      final String criteria) throws Exception {
+    response.active(request.complete(criteria, limit));
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionMother.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionMother.java
@@ -1,0 +1,82 @@
+package gov.cdc.nbs.option.resultedtest.autocomplete;
+
+import io.cucumber.spring.ScenarioScope;
+import jakarta.annotation.PreDestroy;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@ScenarioScope
+class ResultedTestOptionMother {
+
+  private static final String DELETE_LAB_TEST = """
+      delete from NBS_SRTE.dbo.Lab_test
+      """;
+
+  private static final String DELETE_LOINC_CODE = """
+      delete from NBS_SRTE.dbo.LOINC_code
+      """;
+
+  private static final String CREATE_LAB_TEST =
+      """
+              insert into NBS_SRTE.dbo.Lab_coding_system(laboratory_id) SELECT 'LABID1' WHERE NOT EXISTS (SELECT * FROM NBS_SRTE.dbo.Lab_coding_system WHERE laboratory_id='LABID1');
+              insert into NBS_SRTE.dbo.Lab_test(lab_test_cd,laboratory_id,lab_test_desc_txt,test_type_cd,nbs_uid) values (:code,'LABID1',:name,'R',1);
+          """;
+
+  private static final String CREATE_LOINC_CODE =
+      """
+              insert into NBS_SRTE.dbo.LOINC_code(loinc_cd,component_name,related_class_cd) values (:code,:name,'ABXBACT');
+          """;
+
+  private final NamedParameterJdbcTemplate template;
+
+  ResultedTestOptionMother(final JdbcTemplate template) {
+    this.template = new NamedParameterJdbcTemplate(template);
+  }
+
+  @PreDestroy
+  void reset() {
+    Map<String, List<String>> parameters = Map.of();
+
+    template.execute(
+        DELETE_LAB_TEST,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+    template.execute(
+        DELETE_LOINC_CODE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+
+  }
+
+  void createLoincResultedTest(final String code, final String name) {
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "code", code,
+        "name", name);
+
+    template.execute(
+        CREATE_LOINC_CODE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+  }
+
+  void createLocalResultedTest(final String code, final String name) {
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "code", code,
+        "name", name);
+
+    template.execute(
+        CREATE_LAB_TEST,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/resultedtest/autocomplete/ResultedTestOptionSteps.java
@@ -1,0 +1,22 @@
+package gov.cdc.nbs.option.resultedtest.autocomplete;
+
+import io.cucumber.java.en.Given;
+
+public class ResultedTestOptionSteps {
+
+  private final ResultedTestOptionMother mother;
+
+  ResultedTestOptionSteps(final ResultedTestOptionMother mother) {
+    this.mother = mother;
+  }
+
+  @Given("there is a LIONC resulted test for {string} {string}")
+  public void there_is_a_lionc_resulted_test(final String code, final String value) {
+    mother.createLoincResultedTest(code, value);
+  }
+
+  @Given("there is a local resulted test for {string} {string}")
+  public void there_is_a_local_resulted_test(final String code, final String value) {
+    mother.createLocalResultedTest(code, value);
+  }
+}

--- a/libs/options-api/src/test/resources/features/resultedtests/ResultedTestOptions.feature
+++ b/libs/options-api/src/test/resources/features/resultedtests/ResultedTestOptions.feature
@@ -1,0 +1,19 @@
+@resultedtests
+Feature: Resulted Test Options REST API
+
+  Background:
+    Given there is a LIONC resulted test for "prefix1code1a" "name1"
+    And there is a local resulted test for "prefix1code1b" "name2"
+    And there is a LIONC resulted test for "prefix2code2a" "name3"
+    And there is a local resulted test for "prefix2code2b" "name4"
+    And there is a LIONC resulted test for "prefix3code2a" "prefix1 name3"
+    And there is a local resulted test for "prefix3code2b" "prefix1 name4"
+
+  Scenario: I can find specific resulted tests
+    When I am trying to find resulted tests that start with "prefix1"
+    Then there are options available
+    And the option named "name1" is included
+    And the option named "name2" is included
+    And the option named "prefix1 name3" is included
+    And the option named "prefix1 name4" is included
+    And there are 4 options included


### PR DESCRIPTION
## Description

Reuse SQLBasedOptionResolver like other autocompletes.  Union Lab_test (local) and LOINC_code resulted tests.  Search codes and values.  ResultedTestOptionMother can create arbitrary entries to test with.

## Tickets

* [CNFT1-2328](https://cdc-nbs.atlassian.net/browse/CNFT1-2328)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2328]: https://cdc-nbs.atlassian.net/browse/CNFT1-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ