### PR TITLE
[CNFT1-2421] - [CNFT1-2424] Search landing

### DIFF
--- a/apps/modernization-ui/src/apps/search/SearchPage.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchPage.tsx
@@ -1,0 +1,10 @@
+import { SearchProvider } from './useSearch';
+import { Outlet } from 'react-router-dom';
+
+const SearchPage = () => (
+    <SearchProvider>
+        <Outlet />
+    </SearchProvider>
+);
+
+export { SearchPage };

--- a/apps/modernization-ui/src/apps/search/SearchRouting.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchRouting.tsx
@@ -18,15 +18,15 @@ const routing = [
         children: [
             { index: true, element: <Navigate to="patient" /> },
             {
-                path: 'patient',
+                path: 'patients',
                 element: <PatientSearch />
             },
             {
-                path: 'laboratory-search',
+                path: 'lab-reports',
                 element: <LaboratoryReportSearch />
             },
             {
-                path: 'investigation',
+                path: 'investigations',
                 element: <InvestigationSearch />
             }
         ]

--- a/apps/modernization-ui/src/apps/search/SearchRouting.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchRouting.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom';
 import { AdvancedSearch } from './advancedSearch/AdvancedSearch';
 
 import { SearchPage } from './SearchPage';
-import { PatientSearch } from './patient';
+import { PatientSearch } from './patient/PatientSearch';
 import { LaboratoryReportSearch } from './laboratory-report';
 import { InvestigationSearch } from './investigation';
 
@@ -16,7 +16,7 @@ const routing = [
         path: 'search',
         element: <SearchPage />,
         children: [
-            { index: true, element: <Navigate to="patient" /> },
+            { index: true, element: <Navigate to="patients" /> },
             {
                 path: 'patients',
                 element: <PatientSearch />

--- a/apps/modernization-ui/src/apps/search/SearchRouting.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchRouting.tsx
@@ -1,5 +1,8 @@
 import { Navigate } from 'react-router-dom';
+
 import { AdvancedSearch } from './advancedSearch/AdvancedSearch';
+
+import { SearchPage } from './SearchPage';
 import { PatientSearch } from './patient';
 import { LaboratoryReportSearch } from './laboratory-report';
 import { InvestigationSearch } from './investigation';
@@ -11,6 +14,7 @@ const routing = [
     },
     {
         path: 'search',
+        element: <SearchPage />,
         children: [
             { index: true, element: <Navigate to="patient" /> },
             {

--- a/apps/modernization-ui/src/apps/search/SearchRouting.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchRouting.tsx
@@ -1,9 +1,31 @@
+import { Navigate } from 'react-router-dom';
 import { AdvancedSearch } from './advancedSearch/AdvancedSearch';
+import { PatientSearch } from './patient';
+import { LaboratoryReportSearch } from './laboratory-report';
+import { InvestigationSearch } from './investigation';
 
 const routing = [
     {
         path: '/advanced-search/:searchType?',
         element: <AdvancedSearch />
+    },
+    {
+        path: 'search',
+        children: [
+            { index: true, element: <Navigate to="patient" /> },
+            {
+                path: 'patient',
+                element: <PatientSearch />
+            },
+            {
+                path: 'laboratory-search',
+                element: <LaboratoryReportSearch />
+            },
+            {
+                path: 'investigation',
+                element: <InvestigationSearch />
+            }
+        ]
     }
 ];
 

--- a/apps/modernization-ui/src/apps/search/index.ts
+++ b/apps/modernization-ui/src/apps/search/index.ts
@@ -1,1 +1,2 @@
-export * from './SearchRouting';
+export { routing } from './SearchRouting';
+export * from './useSearch';

--- a/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
@@ -1,5 +1,16 @@
+import { SearchLayout, SearchNavigation } from 'apps/search/layout';
+
 const InvestigationSearch = () => {
-    return <></>;
+    return (
+        <SearchLayout
+            navigation={() => <SearchNavigation />}
+            criteria={() => <div>criteria</div>}
+            renderAsList={() => <div>result list</div>}
+            renderAsTable={() => <div>result table</div>}
+            onSearch={() => {}}
+            onClear={() => {}}
+        />
+    );
 };
 
 export { InvestigationSearch };

--- a/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
@@ -1,12 +1,11 @@
-import { SearchLayout, SearchNavigation } from 'apps/search/layout';
+import { SearchLayout } from 'apps/search/layout';
 
 const InvestigationSearch = () => {
     return (
         <SearchLayout
-            navigation={() => <SearchNavigation />}
             criteria={() => <div>criteria</div>}
-            renderAsList={() => <div>result list</div>}
-            renderAsTable={() => <div>result table</div>}
+            resultsAsList={() => <div>result list</div>}
+            resultsAsTable={() => <div>result table</div>}
             onSearch={() => {}}
             onClear={() => {}}
         />

--- a/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
@@ -1,0 +1,5 @@
+const InvestigationSearch = () => {
+    return <></>;
+};
+
+export { InvestigationSearch };

--- a/apps/modernization-ui/src/apps/search/investigation/index.ts
+++ b/apps/modernization-ui/src/apps/search/investigation/index.ts
@@ -1,0 +1,1 @@
+export { InvestigationSearch } from './InvestigationSearch';

--- a/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
@@ -1,5 +1,16 @@
+import { SearchLayout, SearchNavigation } from 'apps/search/layout';
+
 const LaboratoryReportSearch = () => {
-    return <></>;
+    return (
+        <SearchLayout
+            navigation={() => <SearchNavigation />}
+            criteria={() => <div>criteria</div>}
+            renderAsList={() => <div>result list</div>}
+            renderAsTable={() => <div>result table</div>}
+            onSearch={() => {}}
+            onClear={() => {}}
+        />
+    );
 };
 
 export { LaboratoryReportSearch };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
@@ -1,12 +1,11 @@
-import { SearchLayout, SearchNavigation } from 'apps/search/layout';
+import { SearchLayout } from 'apps/search/layout';
 
 const LaboratoryReportSearch = () => {
     return (
         <SearchLayout
-            navigation={() => <SearchNavigation />}
             criteria={() => <div>criteria</div>}
-            renderAsList={() => <div>result list</div>}
-            renderAsTable={() => <div>result table</div>}
+            resultsAsList={() => <div>result list</div>}
+            resultsAsTable={() => <div>result table</div>}
             onSearch={() => {}}
             onClear={() => {}}
         />

--- a/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
@@ -1,0 +1,5 @@
+const LaboratoryReportSearch = () => {
+    return <></>;
+};
+
+export { LaboratoryReportSearch };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/index.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/index.ts
@@ -1,0 +1,1 @@
+export { LaboratoryReportSearch } from './LaboratoryReportSearch';

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,24 +1,27 @@
 import { ReactNode } from 'react';
 import { Button } from 'components/button';
-
 import { Results, useSearch } from 'apps/search/useSearch';
 import { SearchLanding } from './landing';
+import { SearchResults } from './result';
+
 import styles from './search-layout.module.scss';
+import { Loading } from 'components/Spinner';
 
 type Renderer = () => ReactNode;
 
-type NavigationRenderer = (results: Results | null) => ReactNode;
+type NavigationRenderer = (results: Results) => ReactNode;
 
 type Props = {
     navigation: NavigationRenderer;
     criteria: Renderer;
-    results: Renderer;
+    renderAsList: Renderer;
+    renderAsTable: Renderer;
     onSearch: () => void;
     onClear: () => void;
 };
 
-const SearchLayout = ({ navigation, criteria, results, onSearch, onClear }: Props) => {
-    const { status, results: searchResults } = useSearch();
+const SearchLayout = ({ navigation, criteria, renderAsList, renderAsTable, onSearch, onClear }: Props) => {
+    const { view, status, results: searchResults } = useSearch();
 
     return (
         <section className={styles.search}>
@@ -35,7 +38,16 @@ const SearchLayout = ({ navigation, criteria, results, onSearch, onClear }: Prop
                         </Button>
                     </div>
                 </div>
-                <div className={styles.results}>{status === 'waiting' ? <SearchLanding /> : results()}</div>
+                <div className={styles.results}>
+                    {status === 'waiting' && <SearchLanding />}
+                    {status === 'searching' && <Loading className={styles.loading} />}
+                    {status === 'completed' && (
+                        <SearchResults>
+                            {view == 'list' && renderAsList()}
+                            {view == 'table' && renderAsTable()}
+                        </SearchResults>
+                    )}
+                </div>
             </div>
         </section>
     );

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react';
+
+import styles from './search-layout.module.scss';
+import { Button } from 'components/button';
+
+type Renderer = () => ReactNode;
+
+type Props = {
+    navigation: Renderer;
+    criteria: Renderer;
+    results: Renderer;
+};
+
+const SearchLayout = ({ navigation, criteria, results }: Props) => {
+    return (
+        <section className={styles.search}>
+            {navigation()}
+            <div className={styles.content}>
+                <div className={styles.criteria}>
+                    <search>{criteria()}</search>
+                    <div className={styles.actions}>
+                        <Button type="button">Search</Button>
+                        <Button type="button" outline>
+                            Clear all
+                        </Button>
+                    </div>
+                </div>
+                <main>{results()}</main>
+            </div>
+        </section>
+    );
+};
+
+export { SearchLayout };

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,31 +1,41 @@
 import { ReactNode } from 'react';
-
-import styles from './search-layout.module.scss';
 import { Button } from 'components/button';
+
+import { Results, useSearch } from 'apps/search/useSearch';
+import { SearchLanding } from './landing';
+import styles from './search-layout.module.scss';
 
 type Renderer = () => ReactNode;
 
+type NavigationRenderer = (results: Results | null) => ReactNode;
+
 type Props = {
-    navigation: Renderer;
+    navigation: NavigationRenderer;
     criteria: Renderer;
     results: Renderer;
+    onSearch: () => void;
+    onClear: () => void;
 };
 
-const SearchLayout = ({ navigation, criteria, results }: Props) => {
+const SearchLayout = ({ navigation, criteria, results, onSearch, onClear }: Props) => {
+    const { status, results: searchResults } = useSearch();
+
     return (
         <section className={styles.search}>
-            {navigation()}
+            {navigation(searchResults)}
             <div className={styles.content}>
                 <div className={styles.criteria}>
                     <search>{criteria()}</search>
                     <div className={styles.actions}>
-                        <Button type="button">Search</Button>
-                        <Button type="button" outline>
+                        <Button type="button" onClick={onSearch}>
+                            Search
+                        </Button>
+                        <Button type="button" outline onClick={onClear}>
                             Clear all
                         </Button>
                     </div>
                 </div>
-                <main>{results()}</main>
+                <div className={styles.results}>{status === 'waiting' ? <SearchLanding /> : results()}</div>
             </div>
         </section>
     );

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,31 +1,30 @@
 import { ReactNode } from 'react';
 import { Button } from 'components/button';
-import { Results, useSearch } from 'apps/search/useSearch';
+import { useSearch } from 'apps/search/useSearch';
 import { SearchLanding } from './landing';
 import { SearchResults } from './result';
 
 import styles from './search-layout.module.scss';
 import { Loading } from 'components/Spinner';
+import { SearchNavigation } from './navigation/SearchNavigation';
 
 type Renderer = () => ReactNode;
 
-type NavigationRenderer = (results: Results) => ReactNode;
-
 type Props = {
-    navigation: NavigationRenderer;
+    actions?: Renderer;
     criteria: Renderer;
-    renderAsList: Renderer;
-    renderAsTable: Renderer;
+    resultsAsList: Renderer;
+    resultsAsTable: Renderer;
     onSearch: () => void;
     onClear: () => void;
 };
 
-const SearchLayout = ({ navigation, criteria, renderAsList, renderAsTable, onSearch, onClear }: Props) => {
-    const { view, status, results: searchResults } = useSearch();
+const SearchLayout = ({ actions, criteria, resultsAsList, resultsAsTable, onSearch, onClear }: Props) => {
+    const { view, status } = useSearch();
 
     return (
         <section className={styles.search}>
-            {navigation(searchResults)}
+            <SearchNavigation actions={actions} />
             <div className={styles.content}>
                 <div className={styles.criteria}>
                     <search>{criteria()}</search>
@@ -43,8 +42,8 @@ const SearchLayout = ({ navigation, criteria, renderAsList, renderAsTable, onSea
                     {status === 'searching' && <Loading className={styles.loading} />}
                     {status === 'completed' && (
                         <SearchResults>
-                            {view == 'list' && renderAsList()}
-                            {view == 'table' && renderAsTable()}
+                            {view == 'list' && resultsAsList()}
+                            {view == 'table' && resultsAsTable()}
                         </SearchResults>
                     )}
                 </div>

--- a/apps/modernization-ui/src/apps/search/layout/index.ts
+++ b/apps/modernization-ui/src/apps/search/layout/index.ts
@@ -1,0 +1,1 @@
+export { SearchLayout } from './SearchLayout';

--- a/apps/modernization-ui/src/apps/search/layout/index.ts
+++ b/apps/modernization-ui/src/apps/search/layout/index.ts
@@ -1,1 +1,4 @@
 export { SearchLayout } from './SearchLayout';
+
+export { SearchNavigation } from './navigation/SearchNavigation';
+export { SearchResults } from './result/SearchResults';

--- a/apps/modernization-ui/src/apps/search/layout/index.ts
+++ b/apps/modernization-ui/src/apps/search/layout/index.ts
@@ -1,4 +1,3 @@
 export { SearchLayout } from './SearchLayout';
 
-export { SearchNavigation } from './navigation/SearchNavigation';
 export { SearchResults } from './result/SearchResults';

--- a/apps/modernization-ui/src/apps/search/layout/landing/SearchLanding.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/landing/SearchLanding.tsx
@@ -1,0 +1,14 @@
+import styles from './search-landing.module.scss';
+
+const SearchLanding = () => {
+    return (
+        <div className={styles.landing}>
+            <header>
+                <h2>Perform a search to see results</h2>
+                <span>No inquiry has been submitted</span>
+            </header>
+        </div>
+    );
+};
+
+export { SearchLanding };

--- a/apps/modernization-ui/src/apps/search/layout/landing/index.ts
+++ b/apps/modernization-ui/src/apps/search/layout/landing/index.ts
@@ -1,0 +1,1 @@
+export { SearchLanding } from './SearchLanding';

--- a/apps/modernization-ui/src/apps/search/layout/landing/search-landing.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/landing/search-landing.module.scss
@@ -1,0 +1,16 @@
+.landing {
+    padding: 3rem;
+
+    header {
+        display: flex;
+        padding: 2rem 0rem;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        align-self: stretch;
+
+        h2 {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/apps/modernization-ui/src/apps/search/layout/navigation/SearchNavigation.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/SearchNavigation.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import { TabNavigation, TabNavigationEntry } from 'components/TabNavigation/TabNavigation';
+
+import styles from './search-navigation.module.scss';
+
+type ActionRenderer = () => ReactNode;
+
+type Props = {
+    action?: ActionRenderer;
+};
+
+const SearchNavigation = ({ action }: Props) => {
+    return (
+        <nav className={styles.navigation}>
+            <h1>Search for:</h1>
+            <TabNavigation className={styles.tabs}>
+                <TabNavigationEntry path="/search/patient">Patient</TabNavigationEntry>
+                <TabNavigationEntry path="/search/investigation">Investigation</TabNavigationEntry>
+                <TabNavigationEntry path="/search/laboratory-search">Laboratory Report</TabNavigationEntry>
+            </TabNavigation>
+            {action && action()}
+        </nav>
+    );
+};
+
+export { SearchNavigation };

--- a/apps/modernization-ui/src/apps/search/layout/navigation/SearchNavigation.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/SearchNavigation.tsx
@@ -3,22 +3,22 @@ import { TabNavigation, TabNavigationEntry } from 'components/TabNavigation/TabN
 
 import styles from './search-navigation.module.scss';
 
-type ActionRenderer = () => ReactNode;
+type ActionsRenderer = () => ReactNode;
 
 type Props = {
-    action?: ActionRenderer;
+    actions?: ActionsRenderer;
 };
 
-const SearchNavigation = ({ action }: Props) => {
+const SearchNavigation = ({ actions }: Props) => {
     return (
         <nav className={styles.navigation}>
             <h1>Search for:</h1>
             <TabNavigation className={styles.tabs}>
-                <TabNavigationEntry path="/search/patient">Patient</TabNavigationEntry>
-                <TabNavigationEntry path="/search/investigation">Investigation</TabNavigationEntry>
-                <TabNavigationEntry path="/search/laboratory-search">Laboratory Report</TabNavigationEntry>
+                <TabNavigationEntry path="/search/patients">Patients</TabNavigationEntry>
+                <TabNavigationEntry path="/search/investigations">Investigations</TabNavigationEntry>
+                <TabNavigationEntry path="/search/lab-reports">Lab Reports</TabNavigationEntry>
             </TabNavigation>
-            {action && action()}
+            {actions && actions()}
         </nav>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
@@ -1,0 +1,17 @@
+.navigation {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    h1 {
+        margin: 0;
+    }
+
+    button {
+        margin: 0;
+    }
+
+    .tabs {
+        flex-grow: 1;
+    }
+}

--- a/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
@@ -3,6 +3,8 @@
     gap: 1rem;
     margin-bottom: 1rem;
 
+    height: 2.75rem;
+
     h1 {
         margin: 0;
     }

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -1,25 +1,20 @@
 import { ReactNode } from 'react';
 import { useSearch } from 'apps/search/useSearch';
+import { SearchResultsHeader } from './header/SearchResultsHeader';
 
 import styles from './search-results.module.scss';
 
-type Renderer = () => ReactNode;
-
 type Props = {
-    renderAsList: Renderer;
-    renderAsTable?: Renderer;
+    children: ReactNode;
 };
 
-const SearchResults = ({ renderAsList, renderAsTable }: Props) => {
-    const { view } = useSearch();
+const SearchResults = ({ children }: Props) => {
+    const { view, results } = useSearch();
 
     return (
         <div className={styles.results}>
-            <header></header>
-            <main>
-                {view === 'list' && renderAsList()}
-                {view === 'table' && renderAsTable && renderAsTable()}
-            </main>
+            <SearchResultsHeader view={view} results={results} />
+            <main>{children}</main>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { useSearch } from 'apps/search/useSearch';
+
+import styles from './search-results.module.scss';
+
+type Renderer = () => ReactNode;
+
+type Props = {
+    renderAsList: Renderer;
+    renderAsTable?: Renderer;
+};
+
+const SearchResults = ({ renderAsList, renderAsTable }: Props) => {
+    const { view } = useSearch();
+
+    return (
+        <div className={styles.results}>
+            <header></header>
+            <main>
+                {view === 'list' && renderAsList()}
+                {view === 'table' && renderAsTable && renderAsTable()}
+            </main>
+        </div>
+    );
+};
+
+export { SearchResults };

--- a/apps/modernization-ui/src/apps/search/layout/result/header/SearchResultsHeader.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/SearchResultsHeader.tsx
@@ -1,0 +1,22 @@
+import { Results, View } from 'apps/search';
+
+import { SearchTerms } from './terms/SearchTerms';
+import { SearchResultsOptionsBar } from './options/SearchResultsOptionsBar';
+
+import styles from './search-results-header.module.scss';
+
+type Props = {
+    view: View;
+    results: Results;
+};
+
+const SearchResultsHeader = ({ view, results }: Props) => {
+    return (
+        <header className={styles.header}>
+            <SearchTerms results={results} />
+            <SearchResultsOptionsBar view={view} disabled={results.total === 0} />
+        </header>
+    );
+};
+
+export { SearchResultsHeader };

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/SearchResultsOptionsBar.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/SearchResultsOptionsBar.tsx
@@ -1,0 +1,15 @@
+import { View } from 'apps/search';
+import { SearchResultsListOptions } from './list/SearchResultsListOptions';
+
+import style from './search-results-options.module.scss';
+
+type Props = {
+    view: View;
+    disabled?: boolean;
+};
+
+const SearchResultsOptionsBar = ({ view, disabled = false }: Props) => {
+    return <div className={style.options}>{view === 'list' && <SearchResultsListOptions disabled={disabled} />}</div>;
+};
+
+export { SearchResultsOptionsBar };

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/list/SearchResultsListOptions.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/list/SearchResultsListOptions.tsx
@@ -1,0 +1,14 @@
+import { Icon } from '@trussworks/react-uswds';
+import { Button } from 'components/button';
+
+import styles from './search-results-list-options.module.scss';
+
+type Props = {
+    disabled?: boolean;
+};
+
+const SearchResultsListOptions = ({ disabled = false }: Props) => {
+    return <Button className={styles.option} outline icon={<Icon.SortArrow />} disabled={disabled} />;
+};
+
+export { SearchResultsListOptions };

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/list/search-results-list-options.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/list/search-results-list-options.module.scss
@@ -1,0 +1,6 @@
+.option {
+    svg {
+        width: 1.75rem;
+        height: 1.75rem;
+    }
+}

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/search-results-options.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/search-results-options.module.scss
@@ -1,0 +1,8 @@
+.options {
+    display: flex;
+    gap: 0.5rem;
+
+    button {
+        margin: 0;
+    }
+}

--- a/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
@@ -1,0 +1,10 @@
+@use 'styles/borders';
+
+.header {
+    padding: 1rem;
+    display: flex;
+
+    justify-content: space-between;
+
+    @extend %thin-bottom;
+}

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -4,6 +4,7 @@ import { useSkipLink } from 'SkipLink/SkipLinkContext';
 import { focusedTarget } from 'utils';
 
 import styles from './search-terms.module.scss';
+import { useEffect } from 'react';
 
 type Props = {
     results: Results;
@@ -12,8 +13,10 @@ type Props = {
 const SearchTerms = ({ results }: Props) => {
     const { skipTo } = useSkipLink();
 
-    skipTo('resultsCount');
-    focusedTarget('resultsCount');
+    useEffect(() => {
+        skipTo('resultsCount');
+        focusedTarget('resultsCount');
+    }, []);
 
     return (
         <div

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -1,0 +1,29 @@
+import { Results } from 'apps/search';
+
+import { useSkipLink } from 'SkipLink/SkipLinkContext';
+import { focusedTarget } from 'utils';
+
+import styles from './search-terms.module.scss';
+
+type Props = {
+    results: Results;
+};
+
+const SearchTerms = ({ results }: Props) => {
+    const { skipTo } = useSkipLink();
+
+    skipTo('resultsCount');
+    focusedTarget('resultsCount');
+
+    return (
+        <div
+            className={styles.terms}
+            tabIndex={0}
+            id="resultsCount"
+            aria-label={results.total + ' Results have been found'}>
+            <h2>{results.total} results for:</h2>
+        </div>
+    );
+};
+
+export { SearchTerms };

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
@@ -1,0 +1,11 @@
+.terms {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    outline: none !important;
+
+    h2 {
+        margin: 0;
+    }
+}

--- a/apps/modernization-ui/src/apps/search/layout/result/index.ts
+++ b/apps/modernization-ui/src/apps/search/layout/result/index.ts
@@ -1,0 +1,1 @@
+export { SearchResults } from './SearchResults';

--- a/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
@@ -1,3 +1,3 @@
 .results {
-    background-color: pink;
+    height: 100%;
 }

--- a/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
@@ -1,0 +1,3 @@
+.results {
+    background-color: pink;
+}

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -2,6 +2,7 @@
 @use 'styles/borders';
 
 $actions-height: 8rem;
+$criteria-width: 320px;
 
 .search {
     padding: 1rem;
@@ -18,7 +19,7 @@ $actions-height: 8rem;
         @include borders.rounded();
 
         .criteria {
-            width: 320px;
+            width: $criteria-width;
 
             @include borders.bordered('border-right');
 
@@ -40,6 +41,11 @@ $actions-height: 8rem;
                     margin: 0;
                 }
             }
+        }
+
+        .results {
+            flex-grow: 1;
+            overflow-y: scroll;
         }
     }
 }

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -46,6 +46,11 @@ $criteria-width: 320px;
         .results {
             flex-grow: 1;
             overflow-y: scroll;
+
+            .loading {
+                height: 100%;
+                margin: auto;
+            }
         }
     }
 }

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -1,0 +1,45 @@
+@use 'styles/colors';
+@use 'styles/borders';
+
+$actions-height: 8rem;
+
+.search {
+    padding: 1rem;
+    height: calc(100vh - 74px);
+    display: flex;
+    flex-direction: column;
+
+    .content {
+        flex-grow: 1;
+        display: flex;
+        background-color: colors.$base-white;
+
+        @include borders.bordered();
+        @include borders.rounded();
+
+        .criteria {
+            width: 320px;
+
+            @include borders.bordered('border-right');
+
+            search {
+                height: calc(100% - $actions-height);
+                overflow-y: scroll;
+            }
+
+            .actions {
+                @extend %thin-top;
+
+                height: $actions-height;
+                padding: 1rem;
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
+
+                button {
+                    margin: 0;
+                }
+            }
+        }
+    }
+}

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -1,13 +1,13 @@
 import { useForm } from 'react-hook-form';
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
-import { SearchLayout, SearchNavigation } from 'apps/search/layout';
+import { SearchLayout } from 'apps/search/layout';
 import { useSearch } from 'apps/search';
 
 const PatientSearch = () => {
     //  this will be typed as the Patient Search Criteria
     const { handleSubmit, reset: resetForm } = useForm({ mode: 'onBlur' });
 
-    const { reset: resetSearch, complete, search } = useSearch();
+    const { reset: resetSearch, complete, search, results } = useSearch();
 
     const handleSearch = () => {
         //  initiate search
@@ -24,23 +24,19 @@ const PatientSearch = () => {
 
     return (
         <SearchLayout
-            navigation={(results) => (
-                <SearchNavigation
-                    actions={() => (
-                        <ButtonActionMenu
-                            label="Add new"
-                            items={[
-                                { label: 'Add new patient', action: () => {} },
-                                { label: 'Add new lab report', action: () => {} }
-                            ]}
-                            disabled={results.total === 0}
-                        />
-                    )}
+            actions={() => (
+                <ButtonActionMenu
+                    label="Add new"
+                    items={[
+                        { label: 'Add new patient', action: () => {} },
+                        { label: 'Add new lab report', action: () => {} }
+                    ]}
+                    disabled={results.total === 0}
                 />
             )}
             criteria={() => <div>criteria</div>}
-            renderAsList={() => <div>result list</div>}
-            renderAsTable={() => <div>result table</div>}
+            resultsAsList={() => <div>result list</div>}
+            resultsAsTable={() => <div>result table</div>}
             onSearch={() => {
                 handleSearch();
                 handleSubmit(handleSearch);

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -1,16 +1,20 @@
 import { useForm } from 'react-hook-form';
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
-import { SearchLayout, SearchNavigation, SearchResults } from 'apps/search/layout';
+import { SearchLayout, SearchNavigation } from 'apps/search/layout';
 import { useSearch } from 'apps/search';
 
 const PatientSearch = () => {
-    //  this will be typed with the Patient Search Criteria
+    //  this will be typed as the Patient Search Criteria
     const { handleSubmit, reset: resetForm } = useForm({ mode: 'onBlur' });
 
-    const { reset: resetSearch, complete } = useSearch();
+    const { reset: resetSearch, complete, search } = useSearch();
 
     const handleSearch = () => {
-        complete([], 0);
+        //  initiate search
+        search();
+
+        //  simulate a wait time
+        setTimeout(() => complete([], 0), 500);
     };
 
     const handleClear = () => {
@@ -22,20 +26,21 @@ const PatientSearch = () => {
         <SearchLayout
             navigation={(results) => (
                 <SearchNavigation
-                    action={() => (
+                    actions={() => (
                         <ButtonActionMenu
                             label="Add new"
                             items={[
                                 { label: 'Add new patient', action: () => {} },
                                 { label: 'Add new lab report', action: () => {} }
                             ]}
-                            disabled={results == null}
+                            disabled={results.total === 0}
                         />
                     )}
                 />
             )}
             criteria={() => <div>criteria</div>}
-            results={() => <SearchResults renderAsList={() => <div>result list</div>} />}
+            renderAsList={() => <div>result list</div>}
+            renderAsTable={() => <div>result table</div>}
             onSearch={() => {
                 handleSearch();
                 handleSubmit(handleSearch);

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -1,0 +1,27 @@
+import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
+import { SearchLayout } from 'apps/search/layout';
+import { SearchNavigation } from '../layout/navigation/SearchNavigation';
+
+const PatientSearch = () => {
+    return (
+        <SearchLayout
+            navigation={() => (
+                <SearchNavigation
+                    action={() => (
+                        <ButtonActionMenu
+                            label="Add new"
+                            items={[
+                                { label: 'Add new patient', action: () => {} },
+                                { label: 'Add new lab report', action: () => {} }
+                            ]}
+                            disabled
+                        />
+                    )}
+                />
+            )}
+            criteria={() => <div>criteria</div>}
+            results={() => <div>results</div>}></SearchLayout>
+    );
+};
+
+export { PatientSearch };

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -1,11 +1,26 @@
+import { useForm } from 'react-hook-form';
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
-import { SearchLayout } from 'apps/search/layout';
-import { SearchNavigation } from '../layout/navigation/SearchNavigation';
+import { SearchLayout, SearchNavigation, SearchResults } from 'apps/search/layout';
+import { useSearch } from 'apps/search';
 
 const PatientSearch = () => {
+    //  this will be typed with the Patient Search Criteria
+    const { handleSubmit, reset: resetForm } = useForm({ mode: 'onBlur' });
+
+    const { reset: resetSearch, complete } = useSearch();
+
+    const handleSearch = () => {
+        complete([], 0);
+    };
+
+    const handleClear = () => {
+        resetForm();
+        resetSearch();
+    };
+
     return (
         <SearchLayout
-            navigation={() => (
+            navigation={(results) => (
                 <SearchNavigation
                     action={() => (
                         <ButtonActionMenu
@@ -14,13 +29,19 @@ const PatientSearch = () => {
                                 { label: 'Add new patient', action: () => {} },
                                 { label: 'Add new lab report', action: () => {} }
                             ]}
-                            disabled
+                            disabled={results == null}
                         />
                     )}
                 />
             )}
             criteria={() => <div>criteria</div>}
-            results={() => <div>results</div>}></SearchLayout>
+            results={() => <SearchResults renderAsList={() => <div>result list</div>} />}
+            onSearch={() => {
+                handleSearch();
+                handleSubmit(handleSearch);
+            }}
+            onClear={handleClear}
+        />
     );
 };
 

--- a/apps/modernization-ui/src/apps/search/patient/index.ts
+++ b/apps/modernization-ui/src/apps/search/patient/index.ts
@@ -2,3 +2,5 @@ export { externalize } from './ExternalizePersonFilter';
 export { internalize } from './InternalizePersonFilter';
 
 export * from './result/PatientResult';
+
+export { PatientSearch } from './PatientSearch';

--- a/apps/modernization-ui/src/apps/search/useSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext, useEffect, useReducer } from 'react';
+import { ReactNode, createContext, useContext, useReducer } from 'react';
 import { PageProvider, PagingSettings } from 'page';
 import { SortingProvider, SortingSettings } from 'sorting';
 
@@ -26,7 +26,7 @@ type SearchState = { view: View } & (Waiting | Searching | Complete);
 type SearchInteraction = {
     status: 'waiting' | 'searching' | 'completed';
     view: View;
-    results: Results | null;
+    results: Results;
     reset: () => void;
     search: () => void;
     complete: (terms: Term[], total: number) => void;
@@ -37,6 +37,8 @@ const SearchContext = createContext<SearchInteraction | undefined>(undefined);
 type Action = { type: 'reset' } | { type: 'search' } | { type: 'complete'; terms: Term[]; total: number };
 
 const initial: SearchState = { status: 'waiting', view: 'list' };
+
+const emptyResults = { total: 0, terms: [] };
 
 const reducer = (current: SearchState, action: Action): SearchState => {
     console.log(action);
@@ -74,14 +76,10 @@ const SearchProvider = ({ sorting, paging, children }: Props) => {
 const InternalSearchProvider = ({ children }: { children: ReactNode }) => {
     const [state, dispatch] = useReducer(reducer, initial);
 
-    useEffect(() => {
-        console.log(state);
-    }, [state]);
-
     const value = {
         status: state.status,
         view: state.view,
-        results: state.status === 'completed' ? state.results : null,
+        results: state.status === 'completed' ? state.results : emptyResults,
         reset: () => dispatch({ type: 'reset' }),
         search: () => dispatch({ type: 'search' }),
         complete: (terms: Term[], total: number) => dispatch({ type: 'complete', terms, total })
@@ -94,12 +92,12 @@ const useSearch = () => {
     const context = useContext(SearchContext);
 
     if (context === undefined) {
-        throw new Error('useSorting must be used within a SearchProvider');
+        throw new Error('useSearch must be used within a SearchProvider');
     }
 
     return context;
 };
 
-export type { Term, Results };
+export type { Term, Results, View };
 
 export { SearchProvider, useSearch };

--- a/apps/modernization-ui/src/apps/search/useSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.tsx
@@ -41,7 +41,6 @@ const initial: SearchState = { status: 'waiting', view: 'list' };
 const emptyResults = { total: 0, terms: [] };
 
 const reducer = (current: SearchState, action: Action): SearchState => {
-    console.log(action);
     switch (action.type) {
         case 'reset': {
             return initial;

--- a/apps/modernization-ui/src/apps/search/useSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.tsx
@@ -1,0 +1,105 @@
+import { ReactNode, createContext, useContext, useEffect, useReducer } from 'react';
+import { PageProvider, PagingSettings } from 'page';
+import { SortingProvider, SortingSettings } from 'sorting';
+
+type View = 'list' | 'table';
+
+type Term = {
+    source: string;
+    name: string;
+    value: string | number;
+};
+
+type Results = {
+    terms: Term[];
+    total: number;
+};
+
+type Waiting = { status: 'waiting' };
+
+type Searching = { status: 'searching' };
+
+type Complete = { status: 'completed'; results: Results };
+
+type SearchState = { view: View } & (Waiting | Searching | Complete);
+
+type SearchInteraction = {
+    status: 'waiting' | 'searching' | 'completed';
+    view: View;
+    results: Results | null;
+    reset: () => void;
+    search: () => void;
+    complete: (terms: Term[], total: number) => void;
+};
+
+const SearchContext = createContext<SearchInteraction | undefined>(undefined);
+
+type Action = { type: 'reset' } | { type: 'search' } | { type: 'complete'; terms: Term[]; total: number };
+
+const initial: SearchState = { status: 'waiting', view: 'list' };
+
+const reducer = (current: SearchState, action: Action): SearchState => {
+    console.log(action);
+    switch (action.type) {
+        case 'reset': {
+            return initial;
+        }
+        case 'search': {
+            return { ...current, status: 'searching' };
+        }
+        case 'complete': {
+            return { ...current, status: 'completed', results: { terms: action.terms, total: action.total } };
+        }
+        default:
+            return current;
+    }
+};
+
+type Props = {
+    children: ReactNode;
+    sorting?: SortingSettings;
+    paging?: PagingSettings;
+};
+
+const SearchProvider = ({ sorting, paging, children }: Props) => {
+    return (
+        <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? true : sorting.appendToUrl}>
+            <PageProvider {...paging} appendToUrl={paging?.appendToUrl === undefined ? true : paging.appendToUrl}>
+                <InternalSearchProvider>{children}</InternalSearchProvider>
+            </PageProvider>
+        </SortingProvider>
+    );
+};
+
+const InternalSearchProvider = ({ children }: { children: ReactNode }) => {
+    const [state, dispatch] = useReducer(reducer, initial);
+
+    useEffect(() => {
+        console.log(state);
+    }, [state]);
+
+    const value = {
+        status: state.status,
+        view: state.view,
+        results: state.status === 'completed' ? state.results : null,
+        reset: () => dispatch({ type: 'reset' }),
+        search: () => dispatch({ type: 'search' }),
+        complete: (terms: Term[], total: number) => dispatch({ type: 'complete', terms, total })
+    };
+
+    return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;
+};
+
+const useSearch = () => {
+    const context = useContext(SearchContext);
+
+    if (context === undefined) {
+        throw new Error('useSorting must be used within a SearchProvider');
+    }
+
+    return context;
+};
+
+export type { Term, Results };
+
+export { SearchProvider, useSearch };

--- a/apps/modernization-ui/src/components/button/Button.tsx
+++ b/apps/modernization-ui/src/components/button/Button.tsx
@@ -4,6 +4,7 @@ import styles from './Button.module.scss';
 import classNames from 'classnames';
 
 type Props = {
+    className?: string;
     icon?: ReactNode;
     children?: string;
     outline?: boolean;
@@ -16,6 +17,7 @@ type Props = {
 } & JSX.IntrinsicElements['button'];
 
 const Button = ({
+    className,
     type = 'button',
     icon,
     children,
@@ -26,7 +28,7 @@ const Button = ({
     ...defaultProps
 }: Props) => {
     const isIconOnly = icon && !children;
-    const classesAarray = classNames({
+    const classesAarray = classNames(className, {
         [styles.destructive]: destructive,
         [styles.icon]: icon
     });

--- a/apps/modernization-ui/src/styles/_uswds.scss
+++ b/apps/modernization-ui/src/styles/_uswds.scss
@@ -84,15 +84,15 @@ table.usa-table {
     font-size: 1rem;
     font-style: normal;
     font-weight: 700;
+
+    height: 2.75rem;
+    min-width: 2.75rem;
+
     &:has(svg) {
         align-items: center;
         padding: 0.75rem 1.25rem;
         display: inline-flex;
         gap: 0.3125rem;
-    }
-
-    svg {
-        vertical-align: bottom;
     }
 }
 
@@ -150,7 +150,7 @@ table.usa-table {
         padding: 0;
         font-weight: 400;
     }
-    .usa-pagination__arrow .usa-button{
+    .usa-pagination__arrow .usa-button {
         font-weight: 700;
     }
 }


### PR DESCRIPTION
## Description

Adds the components that make up the base of the new search screen with placeholders for Patient, Lab report, and Investigation Search.

- Adds the `search` route to the new search page, patient search is selected by default
- Adds the `search/patients` route to route to the new patient search page
- Adds the `search/investigations` route to route to the new investigation search page  
- Adds the `search/lab-reports` route to route to the new lab report search page 

## Tickets

 [CNFT1-2421](https://cdc-nbs.atlassian.net/browse/CNFT1-2421)
 [CNFT1-2422](https://cdc-nbs.atlassian.net/browse/CNFT1-2422)
 [CNFT1-2423](https://cdc-nbs.atlassian.net/browse/CNFT1-2423)
 [CNFT1-2424](https://cdc-nbs.atlassian.net/browse/CNFT1-2424)  

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests

[CNFT1-2421]: https://cdc-nbs.atlassian.net/browse/CNFT1-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-2422]: https://cdc-nbs.atlassian.net/browse/CNFT1-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-2423]: https://cdc-nbs.atlassian.net/browse/CNFT1-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-2424]: https://cdc-nbs.atlassian.net/browse/CNFT1-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ