### PR TITLE
transformObject that takes an object of type FormLabReportFilter and …

### DIFF
--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -1,7 +1,7 @@
 import { LaboratoryEventDateSearch, LabReportEventId, LabReportProviderSearch } from 'generated/graphql/schema';
 import { Selectable } from 'options';
 
-export type FormLabReportFilter = {
+export type LabReportFilterEntry = {
     codedResult?: Selectable;
     createdBy?: Selectable;
     enteredBy?: Selectable[];

--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -1,0 +1,29 @@
+import { Selectable } from 'components/FormInputs/SelectInput';
+
+export type FormLabReportFilter = {
+    eventDate?: {
+        type?: string;
+        from?: string | null | undefined;
+        to?: string | null | undefined;
+    };
+    eventId?: {
+        labEventType?: string;
+        labEventId?: string;
+    };
+    patientId?: number;
+    providerSearch?: {
+        providerType?: string;
+        providerId?: string;
+    };
+    eventStatus?: Selectable[];
+    jurisdictions?: Selectable[];
+    lastUpdatedBy?: Selectable[];
+    pregnancyStatus?: Selectable[];
+    processingStatus?: Selectable[];
+    programAreas?: Selectable[];
+    resultedTest?: Selectable[];
+    codedResult?: Selectable[];
+    createdBy?: Selectable[];
+    enteredBy?: Selectable[];
+    entryMethods?: Selectable[];
+};

--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -1,4 +1,4 @@
-import { Selectable } from 'components/FormInputs/SelectInput';
+import { Selectable } from 'options';
 
 export type FormLabReportFilter = {
     eventDate?: {

--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -1,29 +1,20 @@
+import { LaboratoryEventDateSearch, LabReportEventId, LabReportProviderSearch } from 'generated/graphql/schema';
 import { Selectable } from 'options';
 
 export type FormLabReportFilter = {
-    eventDate?: {
-        type?: string;
-        from?: string | null | undefined;
-        to?: string | null | undefined;
-    };
-    eventId?: {
-        labEventType?: string;
-        labEventId?: string;
-    };
-    patientId?: number;
-    providerSearch?: {
-        providerType?: string;
-        providerId?: string;
-    };
-    eventStatus?: Selectable[];
-    jurisdictions?: Selectable[];
-    lastUpdatedBy?: Selectable[];
-    pregnancyStatus?: Selectable[];
-    processingStatus?: Selectable[];
-    programAreas?: Selectable[];
-    resultedTest?: Selectable[];
-    codedResult?: Selectable[];
-    createdBy?: Selectable[];
+    codedResult?: Selectable;
+    createdBy?: Selectable;
     enteredBy?: Selectable[];
     entryMethods?: Selectable[];
+    eventDate?: LaboratoryEventDateSearch | null;
+    eventId?: LabReportEventId | null;
+    eventStatus?: Selectable[];
+    jurisdictions?: Selectable[];
+    lastUpdatedBy?: Selectable;
+    patientId?: number | null;
+    providerSearch?: LabReportProviderSearch | null;
+    pregnancyStatus?: Selectable;
+    processingStatus?: Selectable[];
+    programAreas?: Selectable[];
+    resultedTest?: Selectable;
 };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
@@ -1,0 +1,67 @@
+import { transformObject } from './transformer';
+
+describe('transformObject', () => {
+    it('should transform an object with Selectable arrays correctly', () => {
+        const input = {
+            codedResult: [{ value: 'result1', name: 'Result 1' }],
+            eventStatus: [{ value: 'status1', name: 'Status 1' }]
+        };
+
+        const expected = {
+            codedResult: ['result1'],
+            eventStatus: ['status1']
+        };
+
+        const result = transformObject(input);
+        expect(result).toEqual(expected);
+    });
+
+    it('should transform an object with string values correctly', () => {
+        const input = {
+            eventId: {
+                labEventType: 'type1',
+                labEventId: 'id1'
+            }
+        };
+
+        const expected = {
+            eventId: {
+                labEventType: 'type1',
+                labEventId: 'id1'
+            }
+        };
+
+        const result = transformObject(input);
+        expect(result).toEqual(expected);
+    });
+
+    it('should transform an object with nested objects correctly', () => {
+        const input = {
+            eventDate: {
+                type: 'type1',
+                from: '2023-05-01',
+                to: '2023-05-31'
+            }
+        };
+
+        const expected = {
+            eventDate: {
+                type: 'type1',
+                from: '2023-05-01',
+                to: '2023-05-31'
+            }
+        };
+
+        const result = transformObject(input);
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle an empty object', () => {
+        const input = {};
+
+        const expected = {};
+
+        const result = transformObject(input);
+        expect(result).toEqual(expected);
+    });
+});

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
@@ -7,12 +7,12 @@ import {
     PregnancyStatus,
     UserType
 } from 'generated/graphql/schema';
-import { FormLabReportFilter } from './labReportFormTypes';
+import { LabReportFilterEntry } from './labReportFormTypes';
 import { transformObject } from './transformer';
 
 describe('transformObject', () => {
     it('should transform an object with Selectable arrays correctly', () => {
-        const input: FormLabReportFilter = {
+        const input: LabReportFilterEntry = {
             codedResult: { value: 'result-values', name: 'result-name', label: 'result-name' },
             eventStatus: [{ value: 'status1', name: 'Status 1', label: 'Status 1' }]
         };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
@@ -1,14 +1,16 @@
+import { LaboratoryEventIdType, LaboratoryReportEventDateType } from 'generated/graphql/schema';
+import { FormLabReportFilter } from './labReportFormTypes';
 import { transformObject } from './transformer';
 
 describe('transformObject', () => {
     it('should transform an object with Selectable arrays correctly', () => {
-        const input = {
-            codedResult: [{ value: 'result-values', name: 'result-name', label: 'result-label' }],
-            eventStatus: [{ value: 'status1', name: 'Status 1', label: 'Status label' }]
+        const input: FormLabReportFilter = {
+            codedResult: { value: 'result-values', name: 'result-name', label: 'result-name' },
+            eventStatus: [{ value: 'status1', name: 'Status 1', label: 'Status 1' }]
         };
 
         const expected = {
-            codedResult: ['result-values'],
+            codedResult: 'result-values',
             eventStatus: ['status1']
         };
 
@@ -19,15 +21,15 @@ describe('transformObject', () => {
     it('should transform an object with string values correctly', () => {
         const input = {
             eventId: {
-                labEventType: 'type1',
-                labEventId: 'id1'
+                labEventId: 'type1',
+                labEventType: LaboratoryEventIdType.AccessionNumber
             }
         };
 
         const expected = {
             eventId: {
-                labEventType: 'type1',
-                labEventId: 'id1'
+                labEventId: 'type1',
+                labEventType: LaboratoryEventIdType.LabId
             }
         };
 
@@ -38,7 +40,7 @@ describe('transformObject', () => {
     it('should transform an object with nested objects correctly', () => {
         const input = {
             eventDate: {
-                type: 'type1',
+                type: LaboratoryReportEventDateType.DateOfReport,
                 from: '2023-05-01',
                 to: '2023-05-31'
             }

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
@@ -1,4 +1,12 @@
-import { LaboratoryEventIdType, LaboratoryReportEventDateType } from 'generated/graphql/schema';
+import {
+    EntryMethod,
+    EventStatus,
+    LaboratoryEventIdType,
+    LaboratoryReportEventDateType,
+    LaboratoryReportStatus,
+    PregnancyStatus,
+    UserType
+} from 'generated/graphql/schema';
 import { FormLabReportFilter } from './labReportFormTypes';
 import { transformObject } from './transformer';
 
@@ -55,6 +63,76 @@ describe('transformObject', () => {
                     from: '2023-05-01',
                     to: '2023-05-31'
                 }
+            })
+        );
+    });
+
+    it('should include entered by when present', () => {
+        const criteria = {
+            enteredBy: [{ name: 'Internal', label: 'Intenral', value: 'INTERNAL' }]
+        };
+
+        const result = transformObject(criteria);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                enteredBy: expect.arrayContaining([UserType.Internal])
+            })
+        );
+    });
+
+    it('should include entry method when present', () => {
+        const criteria = {
+            enteredBy: [{ name: 'Manual', label: 'Manual', value: 'ELECTRONIC' }]
+        };
+
+        const result = transformObject(criteria);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                enteredBy: expect.arrayContaining([EntryMethod.Electronic])
+            })
+        );
+    });
+
+    it('should include event status when present', () => {
+        const criteria = {
+            enteredBy: [{ name: 'Update', label: 'Update', value: 'UPDATE' }]
+        };
+
+        const result = transformObject(criteria);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                enteredBy: expect.arrayContaining([EventStatus.Update])
+            })
+        );
+    });
+
+    it('should include pregnancy status when present', () => {
+        const criteria = {
+            enteredBy: [{ name: 'Unknown', label: 'Unknown', value: 'UNKNOWN' }]
+        };
+
+        const result = transformObject(criteria);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                enteredBy: expect.arrayContaining([PregnancyStatus.Unknown])
+            })
+        );
+    });
+
+    it('should include processing status when present', () => {
+        const criteria = {
+            enteredBy: [{ name: 'Unprocessed', label: 'Unprocessed', value: 'UNPROCESSED' }]
+        };
+
+        const result = transformObject(criteria);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                enteredBy: expect.arrayContaining([LaboratoryReportStatus.Unprocessed])
             })
         );
     });

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
@@ -29,7 +29,7 @@ describe('transformObject', () => {
         const expected = {
             eventId: {
                 labEventId: 'type1',
-                labEventType: LaboratoryEventIdType.LabId
+                labEventType: LaboratoryEventIdType.AccessionNumber
             }
         };
 
@@ -51,7 +51,7 @@ describe('transformObject', () => {
         expect(result).toEqual(
             expect.objectContaining({
                 eventDate: {
-                    type: 'type1',
+                    type: LaboratoryReportEventDateType.DateOfReport,
                     from: '2023-05-01',
                     to: '2023-05-31'
                 }

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.spec.ts
@@ -3,12 +3,12 @@ import { transformObject } from './transformer';
 describe('transformObject', () => {
     it('should transform an object with Selectable arrays correctly', () => {
         const input = {
-            codedResult: [{ value: 'result1', name: 'Result 1' }],
-            eventStatus: [{ value: 'status1', name: 'Status 1' }]
+            codedResult: [{ value: 'result-values', name: 'result-name', label: 'result-label' }],
+            eventStatus: [{ value: 'status1', name: 'Status 1', label: 'Status label' }]
         };
 
         const expected = {
-            codedResult: ['result1'],
+            codedResult: ['result-values'],
             eventStatus: ['status1']
         };
 
@@ -44,16 +44,17 @@ describe('transformObject', () => {
             }
         };
 
-        const expected = {
-            eventDate: {
-                type: 'type1',
-                from: '2023-05-01',
-                to: '2023-05-31'
-            }
-        };
-
         const result = transformObject(input);
-        expect(result).toEqual(expected);
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                eventDate: {
+                    type: 'type1',
+                    from: '2023-05-01',
+                    to: '2023-05-31'
+                }
+            })
+        );
     });
 
     it('should handle an empty object', () => {

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
@@ -6,10 +6,10 @@ import {
     PregnancyStatus,
     UserType
 } from 'generated/graphql/schema';
-import { FormLabReportFilter } from './labReportFormTypes';
+import { LabReportFilterEntry } from './labReportFormTypes';
 import { asValue, asValues } from 'options/selectable';
 
-export const transformObject = (data: FormLabReportFilter): LabReportFilter => {
+export const transformObject = (data: LabReportFilterEntry): LabReportFilter => {
     return {
         ...data,
         codedResult: data.codedResult ? (asValue(data.codedResult) as string) : undefined,

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
@@ -1,6 +1,7 @@
 import { Selectable } from 'components/FormInputs/SelectInput';
 import { LabReportFilter } from 'generated/graphql/schema';
 import { FormLabReportFilter } from './labReportFormTypes';
+import { asValues } from 'options/selectable';
 
 export const transformObject = (data: FormLabReportFilter): LabReportFilter => {
     const transformedObj: {
@@ -18,5 +19,9 @@ export const transformObject = (data: FormLabReportFilter): LabReportFilter => {
             transformedObj[key] = value;
         }
     }
-    return transformedObj;
+    return {
+        ...data,
+        ...(data.jurisdictions && { jurisdictions: asValues(data.jurisdictions) }),
+        ...(data.codedResult && { codedResult: asValues(data.codedResult) })
+    };
 };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
@@ -1,27 +1,29 @@
-import { Selectable } from 'components/FormInputs/SelectInput';
-import { LabReportFilter } from 'generated/graphql/schema';
+import {
+    EntryMethod,
+    EventStatus,
+    LaboratoryReportStatus,
+    LabReportFilter,
+    PregnancyStatus,
+    UserType
+} from 'generated/graphql/schema';
 import { FormLabReportFilter } from './labReportFormTypes';
-import { asValues } from 'options/selectable';
+import { asValue, asValues } from 'options/selectable';
 
 export const transformObject = (data: FormLabReportFilter): LabReportFilter => {
-    const transformedObj: {
-        [key: string]: any;
-    } = {};
-
-    for (const [key, value] of Object.entries(data)) {
-        if (Array.isArray(value)) {
-            if (typeof value[0] === 'object') {
-                transformedObj[key] = (value as Selectable[]).map((obj) => obj.value);
-            } else {
-                transformedObj[key] = value;
-            }
-        } else {
-            transformedObj[key] = value;
-        }
-    }
     return {
         ...data,
-        ...(data.jurisdictions && { jurisdictions: asValues(data.jurisdictions) }),
-        ...(data.codedResult && { codedResult: asValues(data.codedResult) })
+        codedResult: data.codedResult ? (asValue(data.codedResult) as string) : undefined,
+        createdBy: data.createdBy ? (asValue(data.createdBy) as string) : undefined,
+        jurisdictions: data.jurisdictions ? (asValues(data.jurisdictions) as string[]) : undefined,
+        eventStatus: data.eventStatus ? (asValues(data.eventStatus) as EventStatus[]) : undefined,
+        processingStatus: data.processingStatus
+            ? (asValues(data.processingStatus) as LaboratoryReportStatus[])
+            : undefined,
+        programAreas: data.programAreas ? (asValues(data.programAreas) as string[]) : undefined,
+        resultedTest: data.resultedTest ? (asValue(data.resultedTest) as string) : undefined,
+        entryMethods: data.entryMethods ? (asValues(data.entryMethods) as EntryMethod[]) : undefined,
+        enteredBy: data.enteredBy ? (asValues(data.enteredBy) as UserType[]) : undefined,
+        lastUpdatedBy: data.lastUpdatedBy ? (asValue(data.lastUpdatedBy) as string) : undefined,
+        pregnancyStatus: data.pregnancyStatus ? (asValue(data.pregnancyStatus) as PregnancyStatus) : undefined
     };
 };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/transformer.ts
@@ -1,0 +1,22 @@
+import { Selectable } from 'components/FormInputs/SelectInput';
+import { LabReportFilter } from 'generated/graphql/schema';
+import { FormLabReportFilter } from './labReportFormTypes';
+
+export const transformObject = (data: FormLabReportFilter): LabReportFilter => {
+    const transformedObj: {
+        [key: string]: any;
+    } = {};
+
+    for (const [key, value] of Object.entries(data)) {
+        if (Array.isArray(value)) {
+            if (typeof value[0] === 'object') {
+                transformedObj[key] = (value as Selectable[]).map((obj) => obj.value);
+            } else {
+                transformedObj[key] = value;
+            }
+        } else {
+            transformedObj[key] = value;
+        }
+    }
+    return transformedObj;
+};

--- a/apps/modernization-ui/src/options/selectable.spec.ts
+++ b/apps/modernization-ui/src/options/selectable.spec.ts
@@ -1,0 +1,34 @@
+import { asValue, asValues } from './selectable';
+
+describe('when getting the value of a Selectable', () => {
+    it('should return the value of the selectable', () => {
+        const actual = asValue({ name: 'name', value: 'value', label: 'label' });
+
+        expect(actual).toEqual('value');
+    });
+
+    it('should return null when given null', () => {
+        const actual = asValue(null);
+
+        expect(actual).toBeNull();
+    });
+
+    it('should return null when given undefined', () => {
+        const actual = asValue(undefined);
+
+        expect(actual).toBeNull();
+    });
+});
+
+describe('when getting the value of multiple Selectables', () => {
+    it('should return the values of each Selectable', () => {
+        const actual = asValues([
+            { name: 'name-one', value: 'value-one', label: 'label-one' },
+            { name: 'name-two', value: 'value-two', label: 'label-two' },
+            { name: 'name-three', value: 'value-three', label: 'label-three' },
+            { name: 'name-four', value: 'value-four', label: 'label-four' }
+        ]);
+
+        expect(actual).toEqual(expect.arrayContaining(['value-one', 'value-two', 'value-three', 'value-four']));
+    });
+});

--- a/apps/modernization-ui/src/options/selectable.spec.ts
+++ b/apps/modernization-ui/src/options/selectable.spec.ts
@@ -2,7 +2,7 @@ import { asValue, asValues } from './selectable';
 
 describe('when getting the value of a Selectable', () => {
     it('should return the value of the selectable', () => {
-        const actual = asValue({ name: 'name', value: 'value', label: 'label' });
+        const actual = asValue({ name: 'name', value: 'value' });
 
         expect(actual).toEqual('value');
     });
@@ -23,10 +23,10 @@ describe('when getting the value of a Selectable', () => {
 describe('when getting the value of multiple Selectables', () => {
     it('should return the values of each Selectable', () => {
         const actual = asValues([
-            { name: 'name-one', value: 'value-one', label: 'label-one' },
-            { name: 'name-two', value: 'value-two', label: 'label-two' },
-            { name: 'name-three', value: 'value-three', label: 'label-three' },
-            { name: 'name-four', value: 'value-four', label: 'label-four' }
+            { name: 'name-one', value: 'value-one' },
+            { name: 'name-two', value: 'value-two' },
+            { name: 'name-three', value: 'value-three' },
+            { name: 'name-four', value: 'value-four' }
         ]);
 
         expect(actual).toEqual(expect.arrayContaining(['value-one', 'value-two', 'value-three', 'value-four']));

--- a/apps/modernization-ui/src/options/selectable.ts
+++ b/apps/modernization-ui/src/options/selectable.ts
@@ -10,19 +10,13 @@ type Selectable = {
 
 export type { Selectable };
 
-type HasValue = { value: string | number };
+type HasValue = { value: string | number; name: string };
 
-/* eslint-disable no-redeclare */
-function asValue(selectable: HasValue): string;
-function asValue(selectable: null | undefined): null;
-function asValue(selectable: HasValue | null | undefined) {
+function asValue(selectable: HasValue | null | undefined): string | number | null {
     return selectable?.value || null;
 }
 
-/* eslint-disable no-redeclare */
-function asValues(selectables: undefined): undefined;
-function asValues(selectables: HasValue[]): string[];
-function asValues(selectables: HasValue[] | undefined): string[] | undefined {
+function asValues(selectables: HasValue[] | undefined): (string | number | null)[] | undefined {
     return selectables && selectables.map((m) => asValue(m));
 }
 export { asValue, asValues };

--- a/apps/modernization-ui/src/options/selectable.ts
+++ b/apps/modernization-ui/src/options/selectable.ts
@@ -9,3 +9,20 @@ type Selectable = {
 } & WithDisplay;
 
 export type { Selectable };
+
+type HasValue = { value: string | number };
+
+/* eslint-disable no-redeclare */
+function asValue(selectable: HasValue): string;
+function asValue(selectable: null | undefined): null;
+function asValue(selectable: HasValue | null | undefined) {
+    return selectable?.value || null;
+}
+
+/* eslint-disable no-redeclare */
+function asValues(selectables: undefined): undefined;
+function asValues(selectables: HasValue[]): string[];
+function asValues(selectables: HasValue[] | undefined): string[] | undefined {
+    return selectables && selectables.map((m) => asValue(m));
+}
+export { asValue, asValues };


### PR DESCRIPTION
The function transformObject takes an object of type `FormLabReportFilter` and transforms it into an object of type LabReportFilter
This transformation is needed to prepare the data in the format expected by the API 

FormLabReportFilter is used to define the shape of the data expected from the form 
## Description

Please include a summary of the changes and any key information a reviewer may need.

## Tickets

* [CNFT1-2425](https://cdc-nbs.atlassian.net/browse/CNFT1-2425)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2425]: https://cdc-nbs.atlassian.net/browse/CNFT1-2425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ