### PR TITLE
CNFT1-2428 Feature flag simple to advanced search

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/redirect/SearchRedirectController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/redirect/SearchRedirectController.java
@@ -5,6 +5,7 @@ import gov.cdc.nbs.event.search.InvestigationFilter;
 import gov.cdc.nbs.redirect.search.EventFilterResolver;
 import gov.cdc.nbs.redirect.search.PatientFilterFromRequestParamResolver;
 import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,7 +17,7 @@ import java.util.Map;
 
 @RestController
 public class SearchRedirectController {
-  private static final String ADVANCED_SEARCH = "/advanced-search";
+  private final String advancedSearchPath;
 
   private final PatientFilterFromRequestParamResolver patientFilterFromRequestParamResolver;
 
@@ -25,15 +26,15 @@ public class SearchRedirectController {
   private final EncryptionService encryptionService;
 
   public SearchRedirectController(
+      @Value("${nbs.advanced-search-path: /advanced-search}") final String advancedSearchPath,
       final PatientFilterFromRequestParamResolver patientFilterFromRequestParamResolver,
       final EventFilterResolver eventFilterResolver,
       final EncryptionService encryptionService) {
     this.patientFilterFromRequestParamResolver = patientFilterFromRequestParamResolver;
     this.eventFilterResolver = eventFilterResolver;
     this.encryptionService = encryptionService;
+    this.advancedSearchPath = advancedSearchPath;
   }
-
-
 
   /**
    * Intercepts legacy home page search requests, pulls out the current user from the JSESSIONID, the search criteria
@@ -44,9 +45,9 @@ public class SearchRedirectController {
   public RedirectView redirectSimpleSearch(
       final RedirectAttributes attributes,
       @RequestParam final Map<String, String> incomingParams) {
-    var redirect = new RedirectView(ADVANCED_SEARCH);
+    var redirect = new RedirectView(advancedSearchPath);
     var redirectedUrl = redirect.getUrl();
-    if (redirectedUrl != null && redirectedUrl.equals(ADVANCED_SEARCH) && incomingParams.size() > 0) {
+    if (redirectedUrl != null && redirectedUrl.equals(advancedSearchPath) && incomingParams.size() > 0) {
 
       // Event filter takes precedence
       var eventFilter = eventFilterResolver.resolve(incomingParams);
@@ -69,6 +70,6 @@ public class SearchRedirectController {
   @Hidden
   @GetMapping("/nbs/redirect/advancedSearch")
   public RedirectView redirectAdvancedSearch() {
-    return new RedirectView(ADVANCED_SEARCH);
+    return new RedirectView(advancedSearchPath);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/redirect/SearchRedirectController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/redirect/SearchRedirectController.java
@@ -26,7 +26,7 @@ public class SearchRedirectController {
   private final EncryptionService encryptionService;
 
   public SearchRedirectController(
-      @Value("${nbs.advanced-search-path: /advanced-search}") final String advancedSearchPath,
+      @Value("${nbs.search.advanced-search-path}") final String advancedSearchPath,
       final PatientFilterFromRequestParamResolver patientFilterFromRequestParamResolver,
       final EventFilterResolver eventFilterResolver,
       final EncryptionService encryptionService) {

--- a/apps/modernization-api/src/main/resources/application-development.yml
+++ b/apps/modernization-api/src/main/resources/application-development.yml
@@ -31,6 +31,7 @@ logging:
           search: INFO
 
 nbs:
+  advanced-search-path: /advanced-search
   security:
     oidc:
       enabled: false

--- a/apps/modernization-api/src/main/resources/application-development.yml
+++ b/apps/modernization-api/src/main/resources/application-development.yml
@@ -31,7 +31,8 @@ logging:
           search: INFO
 
 nbs:
-  advanced-search-path: /advanced-search
+  search:
+    advanced-search-path: /search
   security:
     oidc:
       enabled: false

--- a/apps/modernization-api/src/main/resources/application.yml
+++ b/apps/modernization-api/src/main/resources/application.yml
@@ -23,6 +23,7 @@ nbs:
     server: localhost
     port: 1433
   search:
+    advanced-search-path: /advanced-search
     max-page-size: 25
     patient:
       index:

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/redirect/AdvancedSearchRedirectSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/redirect/AdvancedSearchRedirectSteps.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.springframework.beans.factory.annotation.Value;
 
 public class AdvancedSearchRedirectSteps {
 
@@ -15,12 +16,14 @@ public class AdvancedSearchRedirectSteps {
   private final Active<ResultActions> response;
 
   private final AdvancedSearchRedirectRequester requester;
+  private final String advancedSearchPath;
 
   public AdvancedSearchRedirectSteps(
+      @Value("${nbs.search.advanced-search-path}") final String advancedSearchPath,
       final Active<ActiveUser> activeUser,
       final AdvancedSearchRedirectRequester requester,
-      final Active<ResultActions> response
-  ) {
+      final Active<ResultActions> response) {
+    this.advancedSearchPath = advancedSearchPath;
     this.activeUser = activeUser;
     this.requester = requester;
     this.response = response;
@@ -35,15 +38,14 @@ public class AdvancedSearchRedirectSteps {
   public void i_am_redirected_to_advanced_search() throws Exception {
     this.response.active()
         .andExpect(status().isFound())
-        .andExpect(header().string("Location", startsWith("/advanced-search")));
+        .andExpect(header().string("Location", startsWith(advancedSearchPath)));
   }
 
   @Then("I am redirected to the timeout page")
   public void i_am_redirected_to_the_timeout_page() throws Exception {
     this.response.active()
         .andExpect(status().isFound())
-        .andExpect(header().string("Location", "/nbs/timeout"))
-    ;
+        .andExpect(header().string("Location", "/nbs/timeout"));
   }
 
   @Then("the user Id is present in the redirect")


### PR DESCRIPTION
## Description

We need to be able to switch from simple to the new advanced search.  Feature flag the current `advanced-search` to allow it to be replaced with `search` the new advanced search and store the value in application.yml under `nbs.search.advanced-search-path`

## Tickets

* [CNFT1-2428](https://cdc-nbs.atlassian.net/browse/CNFT1-2428)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2428]: https://cdc-nbs.atlassian.net/browse/CNFT1-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ