### PR TITLE
[CNFT1-2302] timeout / expired routing

### DIFF
--- a/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
+++ b/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
@@ -1,23 +1,23 @@
 import { Suspense } from 'react';
-import { Await, Navigate, useLoaderData } from 'react-router-dom';
+import { Await, Navigate, useLoaderData, useNavigate } from 'react-router-dom';
+
 import { User, UserContextProvider } from 'providers/UserContext';
 
-import { Configuration, ConfigurationProvider } from 'configuration';
+import { Configuration, ConfigurationProvider, useConfiguration } from 'configuration';
 import { AnalyticsProvider } from 'analytics';
 import { Spinner } from 'components/Spinner';
 import { Layout } from '../layout/Layout';
 import { InitializationLoaderResult } from './initializationLoader';
 import IdleTimer from './IdleTimer';
 
-const timeout = 60 * 15; // 15 minutes
-const warningTimeout = 60 * 5; // 5 minutes
-
 const ProtectedLayout = () => {
     const data = useLoaderData() as InitializationLoaderResult;
+    const navigate = useNavigate();
+    const {
+        settings: { session }
+    } = useConfiguration();
 
-    const handleIdle = () => {
-        window.location.href = '/nbs/logout';
-    };
+    const handleIdle = () => navigate('/expired');
 
     const WithUser = (user: User) => {
         const data = useLoaderData() as InitializationLoaderResult;
@@ -41,7 +41,11 @@ const ProtectedLayout = () => {
 
     return (
         <Suspense fallback={<Spinner />}>
-            <IdleTimer onIdle={handleIdle} timeout={timeout} warningTimeout={warningTimeout} />
+            <IdleTimer
+                onIdle={handleIdle}
+                timeout={session.warning}
+                warningTimeout={session.expiration - session.warning}
+            />
             <Await resolve={data?.user} errorElement={<Navigate to={'/login'} />}>
                 {WithUser}
             </Await>

--- a/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
+++ b/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
@@ -9,16 +9,15 @@ import { Layout } from '../layout/Layout';
 import { InitializationLoaderResult } from './initializationLoader';
 import IdleTimer from './IdleTimer';
 
+const timeout = 60 * 15; // 15 minutes
+const warningTimeout = 60 * 5; // 5 minutes
+
 const ProtectedLayout = () => {
     const data = useLoaderData() as InitializationLoaderResult;
-    const logoutUrl = `${window.location.protocol}//${window.location.host}/nbs/logout`;
 
     const handleIdle = () => {
-        window.location.href = logoutUrl;
+        window.location.href = '/nbs/logout';
     };
-
-    const timeout = 1000 * 60 * 15; // 15 minutes
-    const warningTimeout = 1000 * 60 * 5; // 5 minutes
 
     const WithUser = (user: User) => {
         const data = useLoaderData() as InitializationLoaderResult;

--- a/apps/modernization-ui/src/configuration/configuration.ts
+++ b/apps/modernization-ui/src/configuration/configuration.ts
@@ -1,4 +1,8 @@
 type Settings = {
+    session: {
+        warning: number;
+        expiration: number;
+    };
     smarty?: {
         key: string;
     };

--- a/apps/modernization-ui/src/configuration/currentConfiguration.ts
+++ b/apps/modernization-ui/src/configuration/currentConfiguration.ts
@@ -2,7 +2,7 @@ import { Configuration } from './configuration';
 import { ConfigurationControllerService } from 'generated';
 
 const currentConfiguration = () =>
-    ConfigurationControllerService.getConfiguration().then((response) => response as Configuration);
+    ConfigurationControllerService.getConfiguration().then((response) => response as Partial<Configuration>);
 
 type CurrentConfigurationResponse = Awaited<ReturnType<typeof currentConfiguration>>;
 

--- a/apps/modernization-ui/src/configuration/defaults.ts
+++ b/apps/modernization-ui/src/configuration/defaults.ts
@@ -28,7 +28,12 @@ const defaultProperties: Properties = {
     stdProgramAreas: []
 };
 
-const defaultSettings: Settings = {};
+const defaultSettings: Settings = {
+    session: {
+        warning: 1000 * 60 * 15,
+        expiration: 1000 * 60 * 20
+    }
+};
 
 const defaultConfiguration: Configuration = {
     settings: defaultSettings,

--- a/apps/modernization-ui/src/configuration/useConfiguration.tsx
+++ b/apps/modernization-ui/src/configuration/useConfiguration.tsx
@@ -8,7 +8,7 @@ type InternalState =
     | { status: 'loading'; configuration: Configuration }
     | { status: 'ready'; configuration: Configuration };
 
-type Action = { type: 'load' } | { type: 'loaded'; configuration: Configuration };
+type Action = { type: 'load' } | { type: 'loaded'; configuration: Partial<Configuration> };
 
 const reducer = (state: InternalState, action: Action): InternalState => {
     switch (action.type) {

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/NBS6LoginRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/NBS6LoginRouteLocatorConfiguration.java
@@ -24,7 +24,8 @@ class NBS6LoginRouteLocatorConfiguration {
       final RouteLocatorBuilder builder,
       @Qualifier("defaults") final List<GatewayFilter> defaults,
       final NBSClassicService classic,
-      final HomeService home) {
+      final HomeService home
+  ) {
     return builder.routes()
         .route(
             "nbs6-login-bypass",
@@ -42,8 +43,8 @@ class NBS6LoginRouteLocatorConfiguration {
                 .query("UserName")
                 .filters(
                     filters -> filters
-                        .redirect(302, home
-                            .base()))
+                        .redirect(302, home.base())
+                )
                 .uri("no://op"))
         .build();
   }
@@ -54,10 +55,9 @@ class NBS6LoginRouteLocatorConfiguration {
         .flatMap(
             user -> chain.filter(
                 exchange.mutate().request(
-                        request -> request.path(
-                                "/nbs/nfc?UserName="
-                                    + user)
-                            .build())
+                        request -> request.path("/nbs/nfc?UserName=" + user)
+                            .build()
+                    )
                     .build()));
   }
 

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfiguration.java
@@ -14,20 +14,6 @@ import java.util.List;
 class NBS6LogoutRouteLocatorConfiguration {
 
   @Bean
-  RouteLocator logout(final RouteLocatorBuilder builder) {
-    return builder.routes()
-        .route(
-            "nbs-logout",
-            route -> route.path("/nbs/logout")
-                .filters(
-                    filters -> filters.redirect(302, "/logout")
-                )
-                .uri("no://op")
-        )
-        .build();
-  }
-
-  @Bean
   RouteLocator loggedOut(
       final RouteLocatorBuilder builder,
       @Qualifier("defaults") final List<GatewayFilter> defaults,

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/OIDCAuthenticationConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/security/oidc/OIDCAuthenticationConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.client.oidc.web.server.logout.OidcCli
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -21,37 +22,40 @@ class OIDCAuthenticationConfiguration {
     return http
         .authorizeExchange(
             authorize ->
-            //  the landing page
-            authorize.pathMatchers(
-                HttpMethod.GET,
-                "/welcome/**").permitAll()
-                //  paths associated with authentication
-                .pathMatchers(
-                    HttpMethod.GET,
-                    "/nbs/logged-out",
-                    "/nbs/timeout",
-                    "/nbs/logOut")
-                .permitAll()
-                //  assets that do not require authentication
-                .pathMatchers(
-                    HttpMethod.GET,
-                    "/nbs/*.js",
-                    "/nbs/*.css",
-                    "/nbs/*.gif",
-                    "/nbs/task_button/**",
-                    "/images/nedssLogo.jpg",
-                    "/favicon.ico",
-                    "/static/**",
-                    "/logout",
-                    "/goodbye",
-                    "/expired"
-                )
-                .permitAll()
-                .anyExchange()
-                .authenticated())
+                //  the landing page
+                authorize.pathMatchers(
+                        HttpMethod.GET,
+                        "/welcome/**").permitAll()
+                    //  paths associated with authentication
+                    .pathMatchers(
+                        HttpMethod.GET,
+                        "/nbs/logged-out",
+                        "/nbs/timeout",
+                        "/nbs/logOut")
+                    .permitAll()
+                    //  assets that do not require authentication
+                    .pathMatchers(
+                        HttpMethod.GET,
+                        "/",
+                        "/nbs/*.js",
+                        "/nbs/*.css",
+                        "/nbs/*.gif",
+                        "/nbs/task_button/**",
+                        "/images/nedssLogo.jpg",
+                        "/favicon.ico",
+                        "/static/**",
+                        "/logout",
+                        "/goodbye",
+                        "/expired"
+                    )
+                    .permitAll()
+                    .anyExchange()
+                    .authenticated())
         .oauth2Client(withDefaults())
         .oauth2Login(withDefaults())
-        .logout(logout -> logout.logoutSuccessHandler(oidcLogoutSuccessHandler(repository)))
+        .logout(logout -> logout
+            .requiresLogout(ServerWebExchangeMatchers.pathMatchers("/nbs/logout"))
+            .logoutSuccessHandler(oidcLogoutSuccessHandler(repository)))
         .csrf(ServerHttpSecurity.CsrfSpec::disable)
         .build();
   }

--- a/apps/nbs-gateway/src/main/resources/application.yml
+++ b/apps/nbs-gateway/src/main/resources/application.yml
@@ -65,4 +65,4 @@ logging:
     org:
       springframework:
         security: ${nbs.gateway.security.log.level:INFO}
-        cloud.gateway.handler.RoutePredicateHandlerMapping: ${nbs.gateway.log.level:DEBUG}
+        cloud.gateway.handler.RoutePredicateHandlerMapping: ${nbs.gateway.log.level:INFO}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/security/oidc/NBS6LogoutRouteLocatorConfigurationTest.java
@@ -30,19 +30,6 @@ class NBS6LogoutRouteLocatorConfigurationTest {
   WebTestClient webClient;
 
   @Test
-  void should_redirect_to_spring_security_logout_endpoint() {
-    webClient
-        .get().uri(
-            builder -> builder
-                .path("/nbs/logout")
-                .build()
-        )
-        .exchange()
-        .expectHeader().location("/logout")
-        .expectStatus().is3xxRedirection();
-  }
-
-  @Test
   void should_redirect_to_NBS_logout() {
     classic.stubFor(get(urlPathMatching("/nbs/logout")).willReturn(ok()));
 


### PR DESCRIPTION
## Description

The idle timer was routing to `/nbs/logout` since it was created before the `expired` page existed.  It seemed to work because it was hitting NBS6 unauthenticated forcing a redirect to the timeout page.  

- The settings for the warning and expiration times were added to the UI configuration
- Changes the security configuration to remove the Spring Security default logout page with confirmation.

## Tickets

* [CNFT1-2302](https://cdc-nbs.atlassian.net/browse/CNFT1-2302)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2302]: https://cdc-nbs.atlassian.net/browse/CNFT1-2302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ