### PR TITLE
[CNFT1-2473] patient search api integration

### DIFF
--- a/apps/modernization-ui/.vscode/launch.json
+++ b/apps/modernization-ui/.vscode/launch.json
@@ -2,17 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "chrome",
-            "request": "launch",
-            "name": "Launch Chrome against localhost",
-            "url": "http://localhost:3000/",
-            "webRoot": "${workspaceFolder}/src"
-        },
-        {
             "name": "Launch Firefox agains localhost",
             "type": "firefox",
             "request": "launch",
             "reAttach": true,
+            "url": "http://localhost:3000/",
+            "webRoot": "${workspaceFolder}/src"
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
             "url": "http://localhost:3000/",
             "webRoot": "${workspaceFolder}/src"
         }

--- a/apps/modernization-ui/src/apps/search/SearchPage.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchPage.tsx
@@ -1,10 +1,10 @@
-import { SearchProvider } from './useSearch';
 import { Outlet } from 'react-router-dom';
+import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 
 const SearchPage = () => (
-    <SearchProvider paging={{ pageSize: 25 }}>
+    <SearchResultDisplayProvider paging={{ pageSize: 25 }}>
         <Outlet />
-    </SearchProvider>
+    </SearchResultDisplayProvider>
 );
 
 export { SearchPage };

--- a/apps/modernization-ui/src/apps/search/SearchPage.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchPage.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router-dom';
 import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 
 const SearchPage = () => (
-    <SearchResultDisplayProvider paging={{ pageSize: 25 }}>
+    <SearchResultDisplayProvider>
         <Outlet />
     </SearchResultDisplayProvider>
 );

--- a/apps/modernization-ui/src/apps/search/SearchPage.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchPage.tsx
@@ -2,7 +2,7 @@ import { SearchProvider } from './useSearch';
 import { Outlet } from 'react-router-dom';
 
 const SearchPage = () => (
-    <SearchProvider>
+    <SearchProvider paging={{ pageSize: 25 }}>
         <Outlet />
     </SearchProvider>
 );

--- a/apps/modernization-ui/src/apps/search/index.ts
+++ b/apps/modernization-ui/src/apps/search/index.ts
@@ -1,2 +1,3 @@
 export { routing } from './SearchRouting';
+export * from './useSearchResultDisplay';
 export * from './useSearch';

--- a/apps/modernization-ui/src/apps/search/investigation/InvestigationFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/investigation/InvestigationFormTypes.ts
@@ -1,5 +1,5 @@
-import { Selectable } from 'components/FormInputs/SelectInput';
 import { EventId, InvestigationStatus, ProviderFacilitySearch } from 'generated/graphql/schema';
+import { Selectable } from 'options';
 
 export type InvestigationFilterEntry = {
     createdBy?: Selectable;

--- a/apps/modernization-ui/src/apps/search/investigation/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/investigation/transformer.spec.ts
@@ -5,8 +5,8 @@ import { transformObject } from './transformer';
 describe('transformObject', () => {
     it('should transform an object with Selectable arrays correctly', () => {
         const input: InvestigationFilterEntry = {
-            createdBy: { value: 'result-values', name: 'result-name' },
-            conditions: [{ value: 'status1', name: 'Status 1' }]
+            createdBy: { value: 'result-values', name: 'result-name', label: 'result-label' },
+            conditions: [{ value: 'status1', name: 'Status 1', label: 'status-label' }]
         };
 
         const expected = {
@@ -87,7 +87,7 @@ describe('transformObject', () => {
 
     it('should include pregnancy status when present', () => {
         const criteria = {
-            pregnancyStatus: { name: 'Unknown', value: 'UNKNOWN' }
+            pregnancyStatus: { name: 'Unknown', label: 'Unknown', value: 'UNKNOWN' }
         };
 
         const result = transformObject(criteria);

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Button } from 'components/button';
-import { useSearch } from 'apps/search/useSearch';
+import { useSearchResultDisplay } from 'apps/search';
 import { SearchLanding } from './landing';
 import { SearchResults } from './result';
 
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const SearchLayout = ({ actions, criteria, resultsAsList, resultsAsTable, onSearch, onClear }: Props) => {
-    const { view, status } = useSearch();
+    const { view, status } = useSearchResultDisplay();
 
     return (
         <section className={styles.search}>

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -24,7 +24,7 @@ const SearchLayout = ({ actions, criteria, resultsAsList, resultsAsTable, onSear
 
     return (
         <section className={styles.search}>
-            <SearchNavigation actions={actions} />
+            <SearchNavigation className={styles.navigation} actions={actions} />
             <div className={styles.content}>
                 <div className={styles.criteria}>
                     <search>{criteria()}</search>

--- a/apps/modernization-ui/src/apps/search/layout/index.ts
+++ b/apps/modernization-ui/src/apps/search/layout/index.ts
@@ -1,3 +1,5 @@
 export { SearchLayout } from './SearchLayout';
 
 export { SearchResults } from './result/SearchResults';
+
+export { SearchResultList } from './result/list/SearchResultList';

--- a/apps/modernization-ui/src/apps/search/layout/navigation/SearchNavigation.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/SearchNavigation.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import classNames from 'classnames';
 import { TabNavigation, TabNavigationEntry } from 'components/TabNavigation/TabNavigation';
 
 import styles from './search-navigation.module.scss';
@@ -6,12 +7,13 @@ import styles from './search-navigation.module.scss';
 type ActionsRenderer = () => ReactNode;
 
 type Props = {
+    className?: string;
     actions?: ActionsRenderer;
 };
 
-const SearchNavigation = ({ actions }: Props) => {
+const SearchNavigation = ({ className, actions }: Props) => {
     return (
-        <nav className={styles.navigation}>
+        <nav className={classNames(styles.navigation, className)}>
             <h1>Search for:</h1>
             <TabNavigation className={styles.tabs}>
                 <TabNavigationEntry path="/search/patients">Patients</TabNavigationEntry>

--- a/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
@@ -1,9 +1,7 @@
 .navigation {
     display: flex;
     gap: 1rem;
-    margin-bottom: 1rem;
-
-    height: 2.75rem;
+    flex-shrink: 0;
 
     h1 {
         margin: 0;
@@ -11,6 +9,7 @@
 
     button {
         margin: 0;
+        height: 2.75rem;
     }
 
     .tabs {

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -13,8 +13,9 @@ const SearchResults = ({ children }: Props) => {
 
     return (
         <div className={styles.results}>
-            <SearchResultsHeader view={view} results={results} />
-            <main>{children}</main>
+            <SearchResultsHeader className={styles.header} view={view} results={results} />
+            <main className={styles.content}>{children}</main>
+            <div className={styles.pagingation}></div>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { useSearch } from 'apps/search/useSearch';
+import { useSearchResultDisplay } from 'apps/search';
 import { SearchResultsHeader } from './header/SearchResultsHeader';
 
 import styles from './search-results.module.scss';
@@ -14,7 +14,7 @@ const SearchResults = ({ children }: Props) => {
         page: { total }
     } = usePage();
 
-    const { view, terms } = useSearch();
+    const { view, terms } = useSearchResultDisplay();
 
     return (
         <div className={styles.results}>

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -3,17 +3,22 @@ import { useSearch } from 'apps/search/useSearch';
 import { SearchResultsHeader } from './header/SearchResultsHeader';
 
 import styles from './search-results.module.scss';
+import { usePage } from 'page';
 
 type Props = {
     children: ReactNode;
 };
 
 const SearchResults = ({ children }: Props) => {
-    const { view, results } = useSearch();
+    const {
+        page: { total }
+    } = usePage();
+
+    const { view, terms } = useSearch();
 
     return (
         <div className={styles.results}>
-            <SearchResultsHeader className={styles.header} view={view} results={results} />
+            <SearchResultsHeader className={styles.header} view={view} total={total} terms={terms} />
             <main className={styles.content}>{children}</main>
             <div className={styles.pagingation}></div>
         </div>

--- a/apps/modernization-ui/src/apps/search/layout/result/header/SearchResultsHeader.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/SearchResultsHeader.tsx
@@ -1,22 +1,23 @@
 import classNames from 'classnames';
 
-import { Results, View } from 'apps/search';
+import { Term, View } from 'apps/search';
 import { SearchTerms } from './terms/SearchTerms';
 import { SearchResultsOptionsBar } from './options/SearchResultsOptionsBar';
 
 import styles from './search-results-header.module.scss';
 
 type Props = {
-    className?: string;
     view: View;
-    results: Results;
+    className?: string;
+    total: number;
+    terms: Term[];
 };
 
-const SearchResultsHeader = ({ className, view, results }: Props) => {
+const SearchResultsHeader = ({ className, view, total, terms }: Props) => {
     return (
         <header className={classNames(styles.header, className)}>
-            <SearchTerms results={results} />
-            <SearchResultsOptionsBar view={view} disabled={results.total === 0} />
+            <SearchTerms total={total} terms={terms} />
+            <SearchResultsOptionsBar view={view} disabled={total === 0} />
         </header>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/result/header/SearchResultsHeader.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/SearchResultsHeader.tsx
@@ -1,18 +1,20 @@
-import { Results, View } from 'apps/search';
+import classNames from 'classnames';
 
+import { Results, View } from 'apps/search';
 import { SearchTerms } from './terms/SearchTerms';
 import { SearchResultsOptionsBar } from './options/SearchResultsOptionsBar';
 
 import styles from './search-results-header.module.scss';
 
 type Props = {
+    className?: string;
     view: View;
     results: Results;
 };
 
-const SearchResultsHeader = ({ view, results }: Props) => {
+const SearchResultsHeader = ({ className, view, results }: Props) => {
     return (
-        <header className={styles.header}>
+        <header className={classNames(styles.header, className)}>
             <SearchTerms results={results} />
             <SearchResultsOptionsBar view={view} disabled={results.total === 0} />
         </header>

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/search-results-options.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/search-results-options.module.scss
@@ -1,5 +1,6 @@
 .options {
     display: flex;
+    align-self: center;
     gap: 0.5rem;
 
     button {

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -1,4 +1,4 @@
-import { Results } from 'apps/search';
+import { Term } from 'apps/search';
 
 import { useSkipLink } from 'SkipLink/SkipLinkContext';
 import { focusedTarget } from 'utils';
@@ -7,10 +7,11 @@ import styles from './search-terms.module.scss';
 import { useEffect } from 'react';
 
 type Props = {
-    results: Results;
+    total: number;
+    terms: Term[];
 };
 
-const SearchTerms = ({ results }: Props) => {
+const SearchTerms = ({ total, terms }: Props) => {
     const { skipTo } = useSkipLink();
 
     useEffect(() => {
@@ -19,12 +20,9 @@ const SearchTerms = ({ results }: Props) => {
     }, []);
 
     return (
-        <div
-            className={styles.terms}
-            tabIndex={0}
-            id="resultsCount"
-            aria-label={results.total + ' Results have been found'}>
-            <h2>{results.total} results for:</h2>
+        <div className={styles.terms} tabIndex={0} id="resultsCount" aria-label={total + ' Results have been found'}>
+            <h2>{total} results for:</h2>
+            {terms.map((term) => term.name)}
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/result/list/SearchResultList.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/list/SearchResultList.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+import styles from './search-result-list.module.scss';
+
+type Props<T> = {
+    results: T[];
+    render: (result: T) => ReactNode;
+};
+
+const SearchResultList = <T,>({ results, render }: Props<T>) => {
+    return results.map((result, index) => (
+        <div className={styles.result} key={index}>
+            {render(result)}
+        </div>
+    ));
+};
+
+export { SearchResultList };

--- a/apps/modernization-ui/src/apps/search/layout/result/list/search-result-list.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/list/search-result-list.module.scss
@@ -1,0 +1,9 @@
+@use 'styles/colors';
+
+.result {
+    padding: 1rem;
+
+    &:nth-child(even) {
+        background-color: colors.$base-lightest;
+    }
+}

--- a/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
@@ -1,3 +1,18 @@
+$header-height: 3.75rem;
+$pagination-height: 4.75rem;
+
 .results {
     height: 100%;
+    .header {
+        height: $header-height;
+    }
+
+    .content {
+        height: calc(100% - #{$header-height} - #{$pagination-height});
+        overflow: scroll;
+    }
+
+    .pagingation {
+        height: $pagination-height;
+    }
 }

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -2,16 +2,17 @@
 @use 'styles/borders';
 
 $search-height: calc(100vh - 74px);
-$navigation-height: 4.75rem;
+$navigation-height: 2.75rem;
 $actions-height: 8rem;
 $criteria-width: 320px;
-$content-height: calc($search-height - $navigation-height);
+$content-height: calc($search-height - $navigation-height - 2rem);
 
 .search {
     padding: 1rem;
     height: $search-height;
     display: flex;
     flex-direction: column;
+    gap: 1rem;
 
     .navigation {
         height: $navigation-height;

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -1,18 +1,26 @@
 @use 'styles/colors';
 @use 'styles/borders';
 
+$search-height: calc(100vh - 74px);
+$navigation-height: 4.75rem;
 $actions-height: 8rem;
 $criteria-width: 320px;
+$content-height: calc($search-height - $navigation-height);
 
 .search {
     padding: 1rem;
-    height: calc(100vh - 74px);
+    height: $search-height;
     display: flex;
     flex-direction: column;
 
+    .navigation {
+        height: $navigation-height;
+    }
+
     .content {
-        flex-grow: 1;
+        height: $content-height;
         display: flex;
+
         background-color: colors.$base-white;
 
         @include borders.bordered();
@@ -45,10 +53,8 @@ $criteria-width: 320px;
 
         .results {
             flex-grow: 1;
-            overflow-y: scroll;
 
             .loading {
-                height: 100%;
                 margin: auto;
             }
         }

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -2,19 +2,30 @@ import { useForm } from 'react-hook-form';
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
 import { SearchLayout } from 'apps/search/layout';
 import { useSearch } from 'apps/search';
+import { usePatientSearch } from './usePatientSearch';
+import { PatientCriteriaEntry, initial } from './criteria';
+import { useEffect } from 'react';
 
 const PatientSearch = () => {
-    //  this will be typed as the Patient Search Criteria
-    const { handleSubmit, reset: resetForm } = useForm({ mode: 'onBlur' });
+    const { handleSubmit, reset: resetForm } = useForm<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>({
+        defaultValues: initial,
+        mode: 'onBlur'
+    });
 
     const { reset: resetSearch, complete, search, results } = useSearch();
 
-    const handleSearch = () => {
-        //  initiate search
-        search();
+    const patientSearch = usePatientSearch();
 
-        //  simulate a wait time
-        setTimeout(() => complete([], 0), 500);
+    useEffect(() => {
+        if (patientSearch.status === 'loading') {
+            search();
+        } else if (patientSearch.status === 'completed') {
+            complete([], patientSearch.results?.total || 0);
+        }
+    }, [patientSearch.status, patientSearch.results?.total || 0, search, complete]);
+
+    const handleSearch = (criteria: PatientCriteriaEntry) => {
+        patientSearch.search(criteria);
     };
 
     const handleClear = () => {
@@ -38,7 +49,6 @@ const PatientSearch = () => {
             resultsAsList={() => <div>result list</div>}
             resultsAsTable={() => <div>result table</div>}
             onSearch={() => {
-                handleSearch();
                 handleSubmit(handleSearch);
             }}
             onClear={handleClear}

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -2,8 +2,8 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { PatientSearchResult } from 'generated/graphql/schema';
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
+import { usePage } from 'page';
 import { SearchLayout, SearchResultList } from 'apps/search/layout';
-import { useSearch } from 'apps/search';
 import { usePatientSearch } from './usePatientSearch';
 import { PatientCriteriaEntry, initial } from './criteria';
 import { PatientSearchResultListItem } from './result/list';
@@ -15,8 +15,8 @@ const PatientSearch = () => {
     });
 
     const {
-        results: { total }
-    } = useSearch();
+        page: { total }
+    } = usePage();
 
     const { status, search, reset, results } = usePatientSearch();
 

--- a/apps/modernization-ui/src/apps/search/patient/criteria.ts
+++ b/apps/modernization-ui/src/apps/search/patient/criteria.ts
@@ -37,7 +37,7 @@ type PatientCriteriaEntry = BasicInformation & Address & Contact & RaceEthnicity
 export type { PatientCriteriaEntry };
 
 const initial: PatientCriteriaEntry = {
-    status: [{ name: 'Active', label: 'Active', value: 'active' }]
+    status: [{ name: 'Active', label: 'Active', value: 'ACTIVE' }]
 };
 
 export { initial };

--- a/apps/modernization-ui/src/apps/search/patient/criteria.ts
+++ b/apps/modernization-ui/src/apps/search/patient/criteria.ts
@@ -1,0 +1,37 @@
+import { Selectable } from 'options';
+
+type BasicInformation = {
+    lastName?: string;
+    firstName?: string;
+    dateOfBirth?: string;
+    gender?: Selectable;
+    id?: string;
+    status: Selectable[];
+    disableSoundex?: boolean;
+};
+
+type Address = {
+    address?: string;
+    city?: string;
+    state?: Selectable;
+    zip?: number;
+};
+
+type Contact = {
+    phoneNumber?: string;
+    email?: string;
+};
+
+type RaceEthnicity = {
+    race?: Selectable;
+    ethnicity?: Selectable;
+};
+
+type Identification = {
+    identification?: string;
+    identificationType?: Selectable;
+};
+
+type PatientCriteria = BasicInformation & Address & Contact & RaceEthnicity & Identification;
+
+export type { PatientCriteria };

--- a/apps/modernization-ui/src/apps/search/patient/criteria.ts
+++ b/apps/modernization-ui/src/apps/search/patient/criteria.ts
@@ -32,6 +32,12 @@ type Identification = {
     identificationType?: Selectable;
 };
 
-type PatientCriteria = BasicInformation & Address & Contact & RaceEthnicity & Identification;
+type PatientCriteriaEntry = BasicInformation & Address & Contact & RaceEthnicity & Identification;
 
-export type { PatientCriteria };
+export type { PatientCriteriaEntry };
+
+const initial: PatientCriteriaEntry = {
+    status: [{ name: 'Active', label: 'Active', value: 'active' }]
+};
+
+export { initial };

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
@@ -1,0 +1,199 @@
+import { PatientCriteriaEntry } from './criteria';
+import { patientTermsResolver } from './patientTermsResovler';
+
+describe('when the PatientCriteria contains Basic Information criteria', () => {
+    it('should resolve terms with status', () => {
+        const input: PatientCriteriaEntry = {
+            status: [
+                { name: 'Inactive', label: 'Inactive', value: 'INACTIVE' },
+                { name: 'Active', label: 'Active', value: 'ACTIVE' }
+            ]
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual([]);
+    });
+
+    it('should resolve terms', () => {
+        const input: PatientCriteriaEntry = {
+            disableSoundex: true,
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual([]);
+    });
+
+    it('should resolve terms with last name', () => {
+        const input: PatientCriteriaEntry = {
+            lastName: 'last-name-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([{ source: 'lastName', name: 'LAST', value: 'last-name-value' }])
+        );
+    });
+
+    it('should resolve terms with first name', () => {
+        const input: PatientCriteriaEntry = {
+            firstName: 'first-name-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([{ source: 'firstName', name: 'FIRST', value: 'first-name-value' }])
+        );
+    });
+
+    it('should resolve terms with gender', () => {
+        const input: PatientCriteriaEntry = {
+            gender: { name: 'Female', label: 'Female', value: 'F' },
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'gender', name: 'SEX', value: 'Female' }]));
+    });
+
+    it('should resolve terms with patient id', () => {
+        const input: PatientCriteriaEntry = {
+            id: 'id-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'id', name: 'ID', value: 'id-value' }]));
+    });
+});
+
+describe('when the PatientCriteria contains Address criteria', () => {
+    it('should resolve terms with Street address', () => {
+        const input: PatientCriteriaEntry = {
+            address: 'address-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([{ source: 'address', name: 'ADDRESS', value: 'address-value' }])
+        );
+    });
+
+    it('should resolve terms with City', () => {
+        const input: PatientCriteriaEntry = {
+            city: 'city-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'city', name: 'CITY', value: 'city-value' }]));
+    });
+
+    it('should resolve terms with State', () => {
+        const input: PatientCriteriaEntry = {
+            state: { name: 'State Name', label: 'State Label', value: 'state-value' },
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'state', name: 'STATE', value: 'State Name' }]));
+    });
+
+    it('should resolve terms with Zip', () => {
+        const input: PatientCriteriaEntry = {
+            zip: 1051,
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'zip', name: 'ZIP', value: '1051' }]));
+    });
+});
+
+describe('when the PatientCriteria contains Contact criteria', () => {
+    it('should resolve terms with phone number', () => {
+        const input: PatientCriteriaEntry = {
+            phoneNumber: 'phone-number-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([{ source: 'phoneNumber', name: 'PHONE', value: 'phone-number-value' }])
+        );
+    });
+
+    it('should resolve terms with email', () => {
+        const input: PatientCriteriaEntry = {
+            email: 'email-value',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'email', name: 'EMAIL', value: 'email-value' }]));
+    });
+});
+
+describe('when the PatientCriteria contains Race / Ethnicity criteria', () => {
+    it('should resolve terms with race', () => {
+        const input: PatientCriteriaEntry = {
+            race: { name: 'Race Name', label: 'Race Label', value: 'race-value' },
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(expect.arrayContaining([{ source: 'race', name: 'RACE', value: 'Race Name' }]));
+    });
+
+    it('should resolve terms with ethnicity', () => {
+        const input: PatientCriteriaEntry = {
+            ethnicity: { name: 'Ethnicity Name', label: 'Ethnicity Label', value: 'ethnicity-value' },
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([{ source: 'ethnicity', name: 'ETHNICITY', value: 'Ethnicity Name' }])
+        );
+    });
+});
+
+describe('when the PatientCriteria contains Identification criteria', () => {
+    it('should resolve terms with identification', () => {
+        const input: PatientCriteriaEntry = {
+            identification: 'identification-value',
+            identificationType: {
+                name: 'Identification Type Name',
+                label: 'Identification Type Label',
+                value: 'identification-type-value'
+            },
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                { source: 'identificationType', name: 'ID TYPE', value: 'Identification Type Name' },
+                { source: 'identification', name: 'ID', value: 'identification-value' }
+            ])
+        );
+    });
+});

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResovler.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResovler.ts
@@ -1,0 +1,63 @@
+import { Term } from 'apps/search';
+import { PatientCriteriaEntry } from './criteria';
+
+const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
+    const terms: Term[] = [];
+
+    if (entry.lastName) {
+        terms.push({ source: 'lastName', name: 'LAST', value: entry.lastName });
+    }
+
+    if (entry.firstName) {
+        terms.push({ source: 'firstName', name: 'FIRST', value: entry.firstName });
+    }
+
+    if (entry.gender) {
+        terms.push({ source: 'gender', name: 'SEX', value: entry.gender.name });
+    }
+
+    if (entry.id) {
+        terms.push({ source: 'id', name: 'ID', value: entry.id });
+    }
+
+    if (entry.address) {
+        terms.push({ source: 'address', name: 'ADDRESS', value: entry.address });
+    }
+
+    if (entry.city) {
+        terms.push({ source: 'city', name: 'CITY', value: entry.city });
+    }
+
+    if (entry.state) {
+        terms.push({ source: 'state', name: 'STATE', value: entry.state.name });
+    }
+
+    if (entry.zip) {
+        terms.push({ source: 'zip', name: 'ZIP', value: String(entry.zip) });
+    }
+
+    if (entry.email) {
+        terms.push({ source: 'email', name: 'EMAIL', value: entry.email });
+    }
+
+    if (entry.phoneNumber) {
+        terms.push({ source: 'phoneNumber', name: 'PHONE', value: entry.phoneNumber });
+    }
+
+    if (entry.race) {
+        terms.push({ source: 'race', name: 'RACE', value: entry.race.name });
+    }
+
+    if (entry.ethnicity) {
+        terms.push({ source: 'ethnicity', name: 'ETHNICITY', value: entry.ethnicity.name });
+    }
+
+    if (entry.identification && entry.identificationType) {
+        terms.push({ source: 'identificationType', name: 'ID TYPE', value: entry.identificationType.name });
+        terms.push({ source: 'identification', name: 'ID', value: entry.identification });
+    }
+
+    return terms;
+};
+
+export { patientTermsResolver };

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
@@ -1,0 +1,9 @@
+import { PatientSearchResult } from 'generated/graphql/schema';
+
+type Props = {
+    result: PatientSearchResult;
+};
+
+const PatientSearchResultListItem = ({ result }: Props) => <>{result.patient}</>;
+
+export { PatientSearchResultListItem };

--- a/apps/modernization-ui/src/apps/search/patient/result/list/index.ts
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/index.ts
@@ -1,0 +1,1 @@
+export { PatientSearchResultListItem } from './PatientSearchResultListItem';

--- a/apps/modernization-ui/src/apps/search/patient/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/transformer.spec.ts
@@ -1,0 +1,191 @@
+import { RecordStatus } from 'generated/graphql/schema';
+import { PatientCriteriaEntry } from './criteria';
+import { transform } from './transformer';
+
+describe('when the PatientCriteria contains Basic Information criteria', () => {
+    it('should transform with status', () => {
+        const input: PatientCriteriaEntry = {
+            status: [{ name: 'Inactive', label: 'Inactive', value: 'INACTIVE' }]
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(
+            expect.objectContaining({ recordStatus: expect.arrayContaining([RecordStatus.Inactive]) })
+        );
+    });
+
+    it('should transform', () => {
+        const input: PatientCriteriaEntry = {
+            disableSoundex: true,
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ disableSoundex: true }));
+    });
+
+    it('should transform with last name', () => {
+        const input: PatientCriteriaEntry = {
+            lastName: 'last-name-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ lastName: 'last-name-value' }));
+    });
+
+    it('should transform with first name', () => {
+        const input: PatientCriteriaEntry = {
+            firstName: 'first-name-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ firstName: 'first-name-value' }));
+    });
+
+    it('should transform with gender', () => {
+        const input: PatientCriteriaEntry = {
+            gender: { name: 'Female', label: 'Female', value: 'F' },
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ gender: 'F' }));
+    });
+
+    it('should transform with patient id', () => {
+        const input: PatientCriteriaEntry = {
+            id: 'id-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ id: 'id-value' }));
+    });
+});
+
+describe('when the PatientCriteria contains Address criteria', () => {
+    it('should transform with Street address', () => {
+        const input: PatientCriteriaEntry = {
+            address: 'address-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ address: 'address-value' }));
+    });
+
+    it('should transform with City', () => {
+        const input: PatientCriteriaEntry = {
+            city: 'city-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ city: 'city-value' }));
+    });
+
+    it('should transform with State', () => {
+        const input: PatientCriteriaEntry = {
+            state: { name: 'State', label: 'State', value: 'state-value' },
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ state: 'state-value' }));
+    });
+
+    it('should transform with Zip', () => {
+        const input: PatientCriteriaEntry = {
+            zip: 1051,
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ zip: '1051' }));
+    });
+});
+
+describe('when the PatientCriteria contains Contact criteria', () => {
+    it('should transform with phone number', () => {
+        const input: PatientCriteriaEntry = {
+            phoneNumber: 'phone-number-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ phoneNumber: 'phone-number-value' }));
+    });
+
+    it('should transform with email', () => {
+        const input: PatientCriteriaEntry = {
+            email: 'email-value',
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ email: 'email-value' }));
+    });
+});
+
+describe('when the PatientCriteria contains Race / Ethnicity criteria', () => {
+    it('should transform with race', () => {
+        const input: PatientCriteriaEntry = {
+            race: { name: 'Race', label: 'Race', value: 'race-value' },
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ race: 'race-value' }));
+    });
+
+    it('should transform with ethnicity', () => {
+        const input: PatientCriteriaEntry = {
+            ethnicity: { name: 'Ethnicity', label: 'Ethnicity', value: 'ethnicity-value' },
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(expect.objectContaining({ ethnicity: 'ethnicity-value' }));
+    });
+});
+
+describe('when the PatientCriteria contains Identification criteria', () => {
+    it('should transform with identification', () => {
+        const input: PatientCriteriaEntry = {
+            identification: 'identification-value',
+            identificationType: {
+                name: 'Identification Type',
+                label: 'Identification Type',
+                value: 'identification-type-value'
+            },
+            status: []
+        };
+
+        const actual = transform(input);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                identification: expect.objectContaining({
+                    identificationNumber: 'identification-value',
+                    identificationType: 'identification-type-value'
+                })
+            })
+        );
+    });
+});

--- a/apps/modernization-ui/src/apps/search/patient/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/patient/transformer.ts
@@ -1,9 +1,9 @@
 import { RecordStatus, PersonFilter, IdentificationCriteria } from 'generated/graphql/schema';
 
 import { asValue, asValues } from 'options/selectable';
-import { PatientCriteria } from './criteria';
+import { PatientCriteriaEntry } from './criteria';
 
-const resolveIdentification = (data: PatientCriteria): IdentificationCriteria | undefined =>
+const resolveIdentification = (data: PatientCriteriaEntry): IdentificationCriteria | undefined =>
     data.identification && data.identificationType
         ? {
               identificationNumber: data.identification,
@@ -11,7 +11,7 @@ const resolveIdentification = (data: PatientCriteria): IdentificationCriteria | 
           }
         : undefined;
 
-export const transform = (data: PatientCriteria): PersonFilter => {
+export const transform = (data: PatientCriteriaEntry): PersonFilter => {
     return {
         ...data,
         recordStatus: asValues(data.status) as RecordStatus[],

--- a/apps/modernization-ui/src/apps/search/patient/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/patient/transformer.ts
@@ -12,14 +12,22 @@ const resolveIdentification = (data: PatientCriteriaEntry): IdentificationCriter
         : undefined;
 
 export const transform = (data: PatientCriteriaEntry): PersonFilter => {
+    const { disableSoundex, lastName, firstName, id, address, city, phoneNumber, email, ...remaining } = data;
     return {
-        ...data,
-        recordStatus: asValues(data.status) as RecordStatus[],
-        gender: asValue(data.gender),
-        state: asValue(data.state),
-        zip: data.zip ? String(data.zip) : undefined,
-        race: asValue(data.race),
-        ethnicity: asValue(data.ethnicity),
-        identification: resolveIdentification(data)
+        disableSoundex,
+        lastName,
+        firstName,
+        id,
+        address,
+        city,
+        phoneNumber,
+        email,
+        recordStatus: asValues(remaining.status) as RecordStatus[],
+        gender: asValue(remaining.gender),
+        state: asValue(remaining.state),
+        zip: remaining.zip ? String(remaining.zip) : undefined,
+        race: asValue(remaining.race),
+        ethnicity: asValue(remaining.ethnicity),
+        identification: resolveIdentification(remaining)
     };
 };

--- a/apps/modernization-ui/src/apps/search/patient/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/patient/transformer.ts
@@ -1,0 +1,25 @@
+import { RecordStatus, PersonFilter, IdentificationCriteria } from 'generated/graphql/schema';
+
+import { asValue, asValues } from 'options/selectable';
+import { PatientCriteria } from './criteria';
+
+const resolveIdentification = (data: PatientCriteria): IdentificationCriteria | undefined =>
+    data.identification && data.identificationType
+        ? {
+              identificationNumber: data.identification,
+              identificationType: data.identificationType.value
+          }
+        : undefined;
+
+export const transform = (data: PatientCriteria): PersonFilter => {
+    return {
+        ...data,
+        recordStatus: asValues(data.status) as RecordStatus[],
+        gender: asValue(data.gender),
+        state: asValue(data.state),
+        zip: data.zip ? String(data.zip) : undefined,
+        race: asValue(data.race),
+        ethnicity: asValue(data.ethnicity),
+        identification: resolveIdentification(data)
+    };
+};

--- a/apps/modernization-ui/src/apps/search/patient/usePatientSearch.ts
+++ b/apps/modernization-ui/src/apps/search/patient/usePatientSearch.ts
@@ -1,0 +1,26 @@
+import { PatientSearchResult, PersonFilter, useFindPatientsByFilterLazyQuery } from 'generated/graphql/schema';
+import { Page } from 'page';
+import { transform } from './transformer';
+import { PatientCriteriaEntry } from './criteria';
+import { Interaction, useSearchAPI } from '../useSearchAPI';
+
+const usePatientSearch = (): Interaction<PatientCriteriaEntry, PatientSearchResult> => {
+    const [fetch] = useFindPatientsByFilterLazyQuery();
+
+    const resolver = (parameters: PersonFilter, page: Page) =>
+        fetch({
+            variables: {
+                filter: parameters,
+                page: {
+                    pageNumber: page.current - 1,
+                    pageSize: page.pageSize
+                }
+            }
+        }).then((response) => response.data?.findPatientsByFilter);
+
+    const api = useSearchAPI({ transformer: transform, resolver });
+
+    return api;
+};
+
+export { usePatientSearch };

--- a/apps/modernization-ui/src/apps/search/patient/usePatientSearch.ts
+++ b/apps/modernization-ui/src/apps/search/patient/usePatientSearch.ts
@@ -12,11 +12,16 @@ const usePatientSearch = (): Interaction<PatientCriteriaEntry, PatientSearchResu
             variables: {
                 filter: parameters,
                 page: {
-                    pageNumber: page.current - 1,
+                    pageNumber: page.current,
                     pageSize: page.pageSize
                 }
             }
-        }).then((response) => response.data?.findPatientsByFilter);
+        }).then((response) => {
+            if (response.error) {
+                throw new Error(response.error.message);
+            }
+            return response.data?.findPatientsByFilter;
+        });
 
     const api = useSearchAPI({ transformer: transform, resolver });
 

--- a/apps/modernization-ui/src/apps/search/useSearch.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.spec.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { Settings, useSearchAPI } from './useSearchAPI';
-import { SearchProvider } from './useSearch';
+import { Settings, useSearch } from './useSearch';
+import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 
 type Criteria = { name: string };
 type APIParameters = { search: string };
@@ -10,7 +10,7 @@ type Result = { label: string; value: string };
 
 const wrapper = ({ children }: { children: ReactNode }) => (
     <MemoryRouter>
-        <SearchProvider>{children}</SearchProvider>
+        <SearchResultDisplayProvider>{children}</SearchResultDisplayProvider>
     </MemoryRouter>
 );
 
@@ -23,15 +23,12 @@ const setup = (props?: Partial<Settings<Criteria, APIParameters, Result>>) => {
     const resultResolver = props?.resultResolver ?? defaultResultResolver;
     const termResolver = props?.termResolver ?? defaultTermResolver;
 
-    return renderHook(
-        () => useSearchAPI<Criteria, APIParameters, Result>({ transformer, resultResolver, termResolver }),
-        {
-            wrapper
-        }
-    );
+    return renderHook(() => useSearch<Criteria, APIParameters, Result>({ transformer, resultResolver, termResolver }), {
+        wrapper
+    });
 };
 
-describe('when searching using useSearchAPI', () => {
+describe('when searching using useSearch', () => {
     it('should default to waiting without any results', () => {
         const { result } = setup();
 
@@ -107,11 +104,7 @@ describe('when searching using useSearchAPI', () => {
 
         expect(termResolver).toHaveBeenCalledWith({ name: 'name-value' });
 
-        expect(resultResolver).toHaveBeenCalledWith(
-            expect.objectContaining({ search: 'name-value' }),
-            expect.anything(),
-            undefined
-        );
+        expect(resultResolver).toHaveBeenCalledWith(expect.objectContaining({ parameters: { search: 'name-value' } }));
 
         expect(result.current.results?.terms).toEqual(
             expect.arrayContaining([{ source: 'mock-source', name: 'Mocked', value: 'mock' }])

--- a/apps/modernization-ui/src/apps/search/useSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.tsx
@@ -64,8 +64,8 @@ type Props = {
 
 const SearchProvider = ({ sorting, paging, children }: Props) => {
     return (
-        <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? true : sorting.appendToUrl}>
-            <PageProvider {...paging} appendToUrl={paging?.appendToUrl === undefined ? true : paging.appendToUrl}>
+        <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? false : sorting.appendToUrl}>
+            <PageProvider {...paging} appendToUrl={paging?.appendToUrl === undefined ? false : paging.appendToUrl}>
                 <InternalSearchProvider>{children}</InternalSearchProvider>
             </PageProvider>
         </SortingProvider>
@@ -79,11 +79,12 @@ const InternalSearchProvider = ({ children }: { children: ReactNode }) => {
 
     const reset = () => dispatch({ type: 'reset' });
     const search = () => dispatch({ type: 'search' });
+    const results = state.status === 'completed' ? state.results : emptyResults;
 
     const value = {
         status: state.status,
         view: state.view,
-        results: state.status === 'completed' ? state.results : emptyResults,
+        results,
         reset,
         search,
         complete

--- a/apps/modernization-ui/src/apps/search/useSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.tsx
@@ -75,13 +75,18 @@ const SearchProvider = ({ sorting, paging, children }: Props) => {
 const InternalSearchProvider = ({ children }: { children: ReactNode }) => {
     const [state, dispatch] = useReducer(reducer, initial);
 
+    const complete = (terms: Term[], total: number) => dispatch({ type: 'complete', terms, total });
+
+    const reset = () => dispatch({ type: 'reset' });
+    const search = () => dispatch({ type: 'search' });
+
     const value = {
         status: state.status,
         view: state.view,
         results: state.status === 'completed' ? state.results : emptyResults,
-        reset: () => dispatch({ type: 'reset' }),
-        search: () => dispatch({ type: 'search' }),
-        complete: (terms: Term[], total: number) => dispatch({ type: 'complete', terms, total })
+        reset,
+        search,
+        complete
     };
 
     return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;

--- a/apps/modernization-ui/src/apps/search/useSearchAPI.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchAPI.spec.tsx
@@ -1,0 +1,84 @@
+import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Settings, useSearchAPI } from './useSearchAPI';
+import { SearchProvider } from './useSearch';
+
+type Criteria = { name: string };
+type APIParameters = { search: string };
+type Result = { label: string; value: string };
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter>
+        <SearchProvider>{children}</SearchProvider>
+    </MemoryRouter>
+);
+
+const setup = (props?: Partial<Settings<Criteria, APIParameters, Result>>) => {
+    const defaultTransformer = (criteria: Criteria) => ({ search: criteria.name });
+    const defaultResolver = () => Promise.resolve({ total: 0, content: [], page: 0 });
+
+    const transformer = props?.transformer ?? defaultTransformer;
+    const resolver = props?.resolver ?? defaultResolver;
+
+    return renderHook(() => useSearchAPI<Criteria, APIParameters, Result>({ transformer, resolver }), {
+        wrapper
+    });
+};
+
+describe('when searching for patients with usePatientSearch', () => {
+    it('should default to waiting without any results', () => {
+        const { result } = setup();
+
+        expect(result.current.results).toBeUndefined();
+        expect(result.current.status).toEqual('waiting');
+    });
+
+    it('should change to status to completed when search results have been resolved', async () => {
+        const { result } = setup();
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        expect(result.current.status).toEqual('completed');
+    });
+
+    it('should change to status to waiting when reset after completed', async () => {
+        const { result } = setup();
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        await act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toEqual('waiting');
+    });
+
+    it('should change to status to error when search produces an error', async () => {
+        const { result } = setup({ resolver: () => Promise.reject(new Error('there has been an error')) });
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        expect(result.current.status).toEqual('error');
+    });
+
+    it('should change to status to waiting when reset after error', async () => {
+        const { result } = setup({ resolver: () => Promise.reject(new Error()) });
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        await act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toEqual('waiting');
+    });
+});

--- a/apps/modernization-ui/src/apps/search/useSearchAPI.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchAPI.spec.tsx
@@ -16,17 +16,22 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 
 const setup = (props?: Partial<Settings<Criteria, APIParameters, Result>>) => {
     const defaultTransformer = (criteria: Criteria) => ({ search: criteria.name });
-    const defaultResolver = () => Promise.resolve({ total: 0, content: [], page: 0 });
+    const defaultResultResolver = () => Promise.resolve({ total: 0, content: [], page: 0 });
+    const defaultTermResolver = () => [];
 
     const transformer = props?.transformer ?? defaultTransformer;
-    const resolver = props?.resolver ?? defaultResolver;
+    const resultResolver = props?.resultResolver ?? defaultResultResolver;
+    const termResolver = props?.termResolver ?? defaultTermResolver;
 
-    return renderHook(() => useSearchAPI<Criteria, APIParameters, Result>({ transformer, resolver }), {
-        wrapper
-    });
+    return renderHook(
+        () => useSearchAPI<Criteria, APIParameters, Result>({ transformer, resultResolver, termResolver }),
+        {
+            wrapper
+        }
+    );
 };
 
-describe('when searching for patients with usePatientSearch', () => {
+describe('when searching using useSearchAPI', () => {
     it('should default to waiting without any results', () => {
         const { result } = setup();
 
@@ -51,7 +56,7 @@ describe('when searching for patients with usePatientSearch', () => {
             result.current.search({ name: 'name-value' });
         });
 
-        await act(() => {
+        act(() => {
             result.current.reset();
         });
 
@@ -59,7 +64,7 @@ describe('when searching for patients with usePatientSearch', () => {
     });
 
     it('should change to status to error when search produces an error', async () => {
-        const { result } = setup({ resolver: () => Promise.reject(new Error('there has been an error')) });
+        const { result } = setup({ resultResolver: () => Promise.reject(new Error('there has been an error')) });
 
         await act(async () => {
             result.current.search({ name: 'name-value' });
@@ -69,16 +74,47 @@ describe('when searching for patients with usePatientSearch', () => {
     });
 
     it('should change to status to waiting when reset after error', async () => {
-        const { result } = setup({ resolver: () => Promise.reject(new Error()) });
+        const { result } = setup({ resultResolver: () => Promise.reject(new Error()) });
 
         await act(async () => {
             result.current.search({ name: 'name-value' });
         });
 
-        await act(() => {
+        act(() => {
             result.current.reset();
         });
 
         expect(result.current.status).toEqual('waiting');
+    });
+
+    it('should use the resolvers for searching', async () => {
+        const transformer = jest.fn(() => ({ search: 'name-value' }));
+
+        const terms = [{ source: 'mock-source', name: 'Mocked', value: 'mock' }];
+
+        const termResolver = jest.fn(() => terms);
+
+        const resovled = { total: 0, content: [], page: 0 };
+        const resultResolver = jest.fn(() => Promise.resolve(resovled));
+
+        const { result } = setup({ transformer, resultResolver, termResolver });
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        expect(transformer).toHaveBeenCalledWith({ name: 'name-value' });
+
+        expect(termResolver).toHaveBeenCalledWith({ name: 'name-value' });
+
+        expect(resultResolver).toHaveBeenCalledWith(
+            expect.objectContaining({ search: 'name-value' }),
+            expect.anything(),
+            undefined
+        );
+
+        expect(result.current.results?.terms).toEqual(
+            expect.arrayContaining([{ source: 'mock-source', name: 'Mocked', value: 'mock' }])
+        );
     });
 });

--- a/apps/modernization-ui/src/apps/search/useSearchAPI.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchAPI.ts
@@ -1,0 +1,123 @@
+import { useEffect, useReducer } from 'react';
+import { Page, Status as PageStatus, usePage } from 'page';
+import { Sorting, useSorting } from 'sorting';
+
+type PagedResult<R> = {
+    total: number;
+    page?: number;
+    content: R[];
+};
+
+type Waiting = { status: 'waiting' };
+
+type Requesting<C> = { status: 'requesting'; criteria: C };
+
+type Searching<A> = { status: 'searching'; parameters: A };
+
+type Completed<A, R> = { status: 'completed'; found: PagedResult<R>; parameters: A };
+
+type Failed = { status: 'error'; reason: string };
+
+type State<C, A, R> = Waiting | Requesting<C> | Searching<A> | Completed<A, R> | Failed;
+
+type Action<C, A, R> =
+    | { type: 'reset' }
+    | { type: 'refresh' }
+    | { type: 'request'; criteria: C }
+    | { type: 'search'; parameters: A }
+    | { type: 'complete'; found: PagedResult<R>; parameters: A }
+    | { type: 'error'; reason: string };
+
+const reducer = <C, A, R>(current: State<C, A, R>, action: Action<C, A, R>): State<C, A, R> => {
+    console.log('[current]', current, '[action]', action);
+
+    if (action.type === 'request') {
+        return { status: 'requesting', criteria: action.criteria };
+    } else if (action.type === 'search') {
+        return { status: 'searching', parameters: action.parameters };
+    } else if (action.type === 'complete' && current.status === 'searching') {
+        return { ...current, status: 'completed', found: action.found };
+    } else if (action.type === 'refresh' && current.status === 'completed') {
+        return { status: 'searching', parameters: current.parameters };
+    } else if (action.type === 'error') {
+        return { status: 'error', reason: action.reason };
+    } else if (action.type === 'reset') {
+        return { status: 'waiting' };
+    }
+    return current;
+};
+
+type ResultHandler<R> = (result: PagedResult<R>) => void;
+
+const orElseEmptyResult =
+    <R>(handler: ResultHandler<R>) =>
+    (result?: PagedResult<R>) => {
+        const ensured = result ?? { total: 0, content: [] };
+        handler(ensured);
+    };
+
+type Interaction<C, R> = {
+    status: 'waiting' | 'loading' | 'completed' | 'error';
+    results?: PagedResult<R>;
+    error?: string;
+    reset: () => void;
+    search: (criteria: C) => void;
+};
+
+type Settings<C, A, R> = {
+    transformer: (criteria: C) => A;
+    resolver: (parameters: A, page: Page, sorting: Sorting) => Promise<PagedResult<R> | undefined>;
+};
+
+const useSearchAPI = <C, A, R>({ transformer, resolver }: Settings<C, A, R>): Interaction<C, R> => {
+    const { page, ready } = usePage();
+    const { sorting } = useSorting();
+
+    const [state, dispatch] = useReducer(reducer<C, A, R>, { status: 'waiting' });
+
+    const handleComplete = (page: Page, parameters: A) => (result: PagedResult<R>) => {
+        const number = page.current - 1;
+        dispatch({ type: 'complete', found: { ...result, page: number }, parameters });
+        ready(result.total, number);
+    };
+
+    const handleError = (error: Error) => {
+        dispatch({ type: 'error', reason: error.message });
+    };
+
+    useEffect(() => {
+        console.log('change', state);
+
+        if (state.status === 'requesting') {
+            const parameters = transformer(state.criteria);
+            dispatch({ type: 'search', parameters });
+        } else if (state.status === 'searching') {
+            resolver(state.parameters, page, sorting).then(
+                orElseEmptyResult(handleComplete(page, state.parameters)),
+                handleError
+            );
+        }
+    }, [state.status]);
+
+    useEffect(() => {
+        if (page.status == PageStatus.Requested) {
+            dispatch({ type: 'refresh' });
+        }
+    }, [page.status, dispatch]);
+
+    const isLoading = state.status === 'searching' || state.status === 'requesting';
+
+    const reset = () => dispatch({ type: 'reset' });
+    const search = (criteria: C) => dispatch({ type: 'request', criteria });
+
+    return {
+        status: isLoading ? 'loading' : state.status,
+        results: state.status === 'completed' ? state.found : undefined,
+        error: state.status === 'error' ? state.reason : undefined,
+        reset,
+        search
+    };
+};
+
+export type { Settings, PagedResult, Interaction };
+export { useSearchAPI };

--- a/apps/modernization-ui/src/apps/search/useSearchAPI.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchAPI.ts
@@ -95,7 +95,7 @@ const useSearchAPI = <C, A, R>({ transformer, resultResolver, termResolver }: Se
         if (isLoading) {
             searchResults.search();
         } else if (state.status === 'completed') {
-            searchResults.complete(state.results.terms, state.results.total);
+            searchResults.complete(state.results.terms);
         } else if (state.status === 'waiting') {
             firstPage();
             searchResults.reset();

--- a/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
@@ -55,7 +55,7 @@ type Props = {
     paging?: PagingSettings;
 };
 
-const SearchProvider = ({ sorting, paging, children }: Props) => {
+const SearchResultDisplayProvider = ({ sorting, paging, children }: Props) => {
     return (
         <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? false : sorting.appendToUrl}>
             <PageProvider {...paging} appendToUrl={paging?.appendToUrl === undefined ? false : paging.appendToUrl}>
@@ -86,11 +86,11 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
     return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;
 };
 
-const useSearch = () => {
+const useSearchResultDisplay = () => {
     const context = useContext(SearchContext);
 
     if (context === undefined) {
-        throw new Error('useSearch must be used within a SearchProvider');
+        throw new Error('useSearchResultDisplay must be used within a SearchResultDisplayProvider');
     }
 
     return context;
@@ -98,4 +98,4 @@ const useSearch = () => {
 
 export type { Term, View };
 
-export { SearchProvider, useSearch };
+export { SearchResultDisplayProvider, useSearchResultDisplay };

--- a/apps/modernization-ui/src/options/selectable.spec.ts
+++ b/apps/modernization-ui/src/options/selectable.spec.ts
@@ -2,31 +2,31 @@ import { asValue, asValues } from './selectable';
 
 describe('when getting the value of a Selectable', () => {
     it('should return the value of the selectable', () => {
-        const actual = asValue({ name: 'name', value: 'value' });
+        const actual = asValue({ name: 'name', value: 'value', label: 'label' });
 
         expect(actual).toEqual('value');
     });
 
-    it('should return null when given null', () => {
+    it('should return undefined when given null', () => {
         const actual = asValue(null);
 
-        expect(actual).toBeNull();
+        expect(actual).toBeUndefined();
     });
 
-    it('should return null when given undefined', () => {
+    it('should return undefined when given undefined', () => {
         const actual = asValue(undefined);
 
-        expect(actual).toBeNull();
+        expect(actual).toBeUndefined();
     });
 });
 
 describe('when getting the value of multiple Selectables', () => {
     it('should return the values of each Selectable', () => {
         const actual = asValues([
-            { name: 'name-one', value: 'value-one' },
-            { name: 'name-two', value: 'value-two' },
-            { name: 'name-three', value: 'value-three' },
-            { name: 'name-four', value: 'value-four' }
+            { name: 'name-one', value: 'value-one', label: 'label-one' },
+            { name: 'name-two', value: 'value-two', label: 'label-two' },
+            { name: 'name-three', value: 'value-three', label: 'label-three' },
+            { name: 'name-four', value: 'value-four', label: 'label-four' }
         ]);
 
         expect(actual).toEqual(expect.arrayContaining(['value-one', 'value-two', 'value-three', 'value-four']));

--- a/apps/modernization-ui/src/options/selectable.ts
+++ b/apps/modernization-ui/src/options/selectable.ts
@@ -10,13 +10,18 @@ type Selectable = {
 
 export type { Selectable };
 
-type HasValue = { value: string | number; name: string };
-
-function asValue(selectable: HasValue | null | undefined): string | number | null {
-    return selectable?.value || null;
+/* eslint-disable no-redeclare */
+function asValue(selectable: Selectable): string;
+function asValue(selectable: null | undefined): undefined;
+function asValue(selectable: Selectable | null | undefined): undefined;
+function asValue(selectable: Selectable | null | undefined) {
+    return selectable?.value || undefined;
 }
 
-function asValues(selectables: HasValue[] | undefined): (string | number | null)[] | undefined {
+/* eslint-disable no-redeclare */
+function asValues(selectables: undefined): undefined;
+function asValues(selectables: Selectable[]): string[];
+function asValues(selectables: Selectable[] | undefined): string[] | undefined {
     return selectables && selectables.map((m) => asValue(m));
 }
 export { asValue, asValues };


### PR DESCRIPTION
## Description

Creates a standard way of interaction with Search API's using Patient Search as the first example.   The `useSearch` hook relies on the `usePage` and `useSorting` hooks for pagination and sorting.  The search results display state is updated when a search is performed.  

- Renames the `useSearch` hook to `useSearchResultDisplay`
- Adds a new hook `useSearch` to handle interactions with the search API's
- Adds the `usePatientSearch` hook to define how `useSearch` interacts with the Patient Search API
- Adds a term resolver for displaying the criteria used to search for patients
- Adds draft components for viewing a list of search results

## Tickets

* [CNFT1-2473](https://cdc-nbs.atlassian.net/browse/CNFT1-2473)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2473]: https://cdc-nbs.atlassian.net/browse/CNFT1-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ