### PR TITLE
[CNFT1-2518] Ensures last change time is set for Address update

### DIFF
--- a/apps/modernization-api/build.gradle
+++ b/apps/modernization-api/build.gradle
@@ -23,6 +23,7 @@ bootJar {
 
 dependencies {
 
+    implementation(project(':audit'))
     implementation(project(':accumulation'))
     implementation(project(':database-entities'))
     implementation(project(':event-schema'))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/PatientAddressFinder.java
@@ -63,7 +63,7 @@ class PatientAddressFinder {
         )
         .join(this.tables.address()).on(
             this.tables.address().id.eq(this.tables.locators().id.locatorUid),
-            this.tables.address().recordStatusCd.eq(ACTIVE_CODE)
+            this.tables.address().recordStatus.recordStatusCd.eq(ACTIVE_CODE)
         )
         .join(this.tables.type()).on(
             this.tables.type().id.codeSetNm.eq(POSTAL_TYPE_CODE_SET),

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/phone/PatientPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/phone/PatientPhoneFinder.java
@@ -59,7 +59,7 @@ class PatientPhoneFinder {
         )
         .join(this.tables.phoneNumber()).on(
             this.tables.phoneNumber().id.eq(this.tables.locators().id.locatorUid),
-            this.tables.phoneNumber().recordStatusCd.eq(ACTIVE_CODE)
+            this.tables.phoneNumber().recordStatus.recordStatusCd.eq(ACTIVE_CODE)
         )
         .join(this.tables.type()).on(
             this.tables.type().id.codeSetNm.eq(PHONE_TYPE_CODE_SET),

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientCreateAssertions.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientCreateAssertions.java
@@ -91,7 +91,7 @@ public class PatientCreateAssertions {
             .extracting(TeleEntityLocatorParticipation::getLocator)
             .returns(phone.getNumber(), TeleLocator::getPhoneNbrTxt)
             .returns(phone.getExtension(), TeleLocator::getExtensionTxt)
-            .returns("ACTIVE", TeleLocator::getRecordStatusCd)
+            .returns("ACTIVE", locator -> locator.recordStatus().status())
             ;
     }
 
@@ -111,7 +111,7 @@ public class PatientCreateAssertions {
             .returns("H", TeleEntityLocatorParticipation::getUseCd)
             .extracting(TeleEntityLocatorParticipation::getLocator)
             .returns(email, TeleLocator::getEmailAddress)
-            .returns("ACTIVE", TeleLocator::getRecordStatusCd)
+            .returns("ACTIVE", locator -> locator.recordStatus().status())
             ;
     }
 

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Locator.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Locator.java
@@ -1,58 +1,39 @@
 package gov.cdc.nbs.entity.odse;
 
+import gov.cdc.nbs.audit.Audit;
+import gov.cdc.nbs.audit.RecordStatus;
 import gov.cdc.nbs.patient.PatientCommand;
-
-import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.MappedSuperclass;
-import java.time.Instant;
 
 @MappedSuperclass
 public abstract class Locator {
 
-    @Column(name = "add_reason_cd", length = 80)
-    private String addReasonCd;
+  @Embedded
+  private Audit audit;
 
-    @Column(name = "add_time")
-    private Instant addTime;
+  @Embedded
+  private RecordStatus recordStatus;
 
-    @Column(name = "add_user_id")
-    private Long addUserId;
+  protected Locator() {
 
-    @Column(name = "last_chg_reason_cd", length = 20)
-    private String lastChgReasonCd;
+  }
 
-    @Column(name = "last_chg_time")
-    private Instant lastChgTime;
+  protected Locator(final PatientCommand command) {
+    this.audit = new Audit(command.requester(), command.requestedOn());
+    this.recordStatus = new RecordStatus(command.requestedOn());
+  }
 
-    @Column(name = "last_chg_user_id")
-    private Long lastChgUserId;
+  protected void changed(final PatientCommand command) {
+    this.audit.changed(command.requester(), command.requestedOn());
+  }
 
-    @Column(name = "record_status_cd", length = 20)
-    private String recordStatusCd;
+  public Audit audit() {
+    return audit;
+  }
 
-    @Column(name = "record_status_time")
-    private Instant recordStatusTime;
+  public RecordStatus recordStatus() {
+    return recordStatus;
+  }
 
-    protected Locator() {
-
-    }
-
-    protected Locator(final PatientCommand command) {
-        this.addUserId = command.requester();
-        this.addTime = command.requestedOn();
-
-        this.lastChgTime = command.requestedOn();
-        this.lastChgUserId = command.requester();
-
-        this.recordStatusCd = "ACTIVE";
-        this.recordStatusTime = command.requestedOn();
-    }
-
-    public String getRecordStatusCd() {
-        return recordStatusCd;
-    }
-
-    public void setRecordStatusCd(String recordStatusCd) {
-        this.recordStatusCd = recordStatusCd;
-    }
 }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
@@ -1,12 +1,16 @@
 package gov.cdc.nbs.entity.odse;
 
 import gov.cdc.nbs.entity.enums.RecordStatus;
-import gov.cdc.nbs.patient.PatientPostalLocatorHistoryListener;
 import gov.cdc.nbs.patient.PatientCommand;
-
-import jakarta.persistence.*;
-
-import java.util.Objects;
+import gov.cdc.nbs.patient.PatientPostalLocatorHistoryListener;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
 
 @Entity
 @DiscriminatorValue(PostalEntityLocatorParticipation.POSTAL_CLASS_CODE)

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
@@ -6,6 +6,8 @@ import gov.cdc.nbs.patient.PatientCommand;
 
 import jakarta.persistence.*;
 
+import java.util.Objects;
+
 @Entity
 @DiscriminatorValue(PostalEntityLocatorParticipation.POSTAL_CLASS_CODE)
 @EntityListeners(PatientPostalLocatorHistoryListener.class)
@@ -65,13 +67,14 @@ public class PostalEntityLocatorParticipation extends EntityLocatorParticipation
     }
 
     public void update(final PatientCommand.UpdateAddress update) {
+
         this.asOfDate = update.asOf();
         this.cd = update.type();
         this.useCd = update.use();
         this.locatorDescTxt = update.comments();
-        this.locator.update(update);
-
         changed(update);
+
+        this.locator.update(update);
     }
 
     public void delete(final PatientCommand.DeleteAddress deleted) {

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalLocator.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalLocator.java
@@ -2,14 +2,14 @@ package gov.cdc.nbs.entity.odse;
 
 import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.patient.PatientCommand;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.Objects;
 
 @AllArgsConstructor
@@ -118,6 +118,8 @@ public class PostalLocator extends Locator {
         this.stateCd = birth.state();
         this.cntyCd = birth.county();
         this.cntryCd = birth.country();
+
+        changed(birth);
     }
 
     public void update(final PatientCommand.UpdateMortality mortality) {
@@ -132,6 +134,8 @@ public class PostalLocator extends Locator {
             this.cntyCd = null;
             this.cntryCd = null;
         }
+
+        changed(mortality);
     }
 
     public void update(final PatientCommand.UpdateAddress update) {
@@ -143,6 +147,8 @@ public class PostalLocator extends Locator {
         this.cntyCd = update.county();
         this.cntryCd = update.country();
         this.censusTract = update.censusTract();
+
+        changed(update);
     }
 
     @Override

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -603,6 +603,8 @@ class PersonTest {
                 .returns("Zip", PostalLocator::getZipCd)
                 .returns("country-code", PostalLocator::getCntryCd)
                 .returns("Census Tract", PostalLocator::getCensusTract)
+                .returns(171L, locator -> locator.audit().changed().changedBy())
+                .returns(Instant.parse("2020-03-04T00:00:00Z"), locator -> locator.audit().changed().changedOn())
         );
 
   }


### PR DESCRIPTION
## Description

The `last_chg_time` was not being set when a Patient's address was updated.

## Tickets

* [CNFT1-2518](https://cdc-nbs.atlassian.net/browse/CNFT1-2518)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2518]: https://cdc-nbs.atlassian.net/browse/CNFT1-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ