### PR TITLE
CNFT1-2478 CNFT1-2479 Lab Search API: ordering provider, facility

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/LabReportFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/LabReportFilter.java
@@ -27,6 +27,8 @@ public final class LabReportFilter implements EventFilter {
   private Long createdBy;
   private Long lastUpdatedBy;
   private LabReportProviderSearch providerSearch;
+  private Long orderingLabId;
+  private Long orderingProviderId;
   private String resultedTest;
   private String codedResult;
 
@@ -140,8 +142,7 @@ public final class LabReportFilter implements EventFilter {
   public Optional<LabReportEventId> accession() {
     if (this.eventId != null
         && this.eventId.getLabEventId() != null
-        && this.eventId.getLabEventType() == LaboratoryEventIdType.ACCESSION_NUMBER
-    ) {
+        && this.eventId.getLabEventType() == LaboratoryEventIdType.ACCESSION_NUMBER) {
       return Optional.of(this.eventId);
     }
     return Optional.empty();
@@ -150,8 +151,7 @@ public final class LabReportFilter implements EventFilter {
   public Optional<LabReportEventId> labId() {
     if (this.eventId != null
         && this.eventId.getLabEventId() != null
-        && this.eventId.getLabEventType() == LaboratoryEventIdType.LAB_ID
-    ) {
+        && this.eventId.getLabEventType() == LaboratoryEventIdType.LAB_ID) {
       return Optional.of(this.eventId);
     }
     return Optional.empty();
@@ -188,12 +188,18 @@ public final class LabReportFilter implements EventFilter {
   }
 
   public Optional<Long> orderingProvider() {
+    if (this.orderingProviderId != null) {
+      return Optional.of(this.orderingProviderId);
+    }
     return (this.providerSearch != null && this.providerSearch.getProviderType() == ProviderType.ORDERING_PROVIDER)
         ? Optional.of(this.providerSearch.getProviderId())
         : Optional.empty();
   }
 
   public Optional<Long> orderingFacility() {
+    if (this.orderingLabId != null) {
+      return Optional.of(this.orderingLabId);
+    }
     return (this.providerSearch != null && this.providerSearch.getProviderType() == ProviderType.ORDERING_FACILITY)
         ? Optional.of(this.providerSearch.getProviderId())
         : Optional.empty();

--- a/apps/modernization-api/src/main/resources/graphql/labReport.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/labReport.graphqls
@@ -55,7 +55,6 @@ enum LaboratoryReportStatus {
   UNPROCESSED
 }
 
-
 input LabReportFilter {
   patientId: Int
   programAreas: [String]
@@ -72,6 +71,8 @@ input LabReportFilter {
   providerSearch: LabReportProviderSearch
   resultedTest: String
   codedResult: String
+  orderingLabId: ID
+  orderingProviderId: ID
 }
 
 input LabReportEventId {

--- a/apps/modernization-api/src/main/resources/graphql/patient-lab-report.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-lab-report.graphqls
@@ -24,6 +24,8 @@ input PatientLabReportFilter {
   providerSearch: LabReportProviderSearch
   resultedTest: String
   codedResult: String
+  orderingLabId: ID
+  orderingProviderId: ID
 }
 
 type PatientLabReport {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
@@ -163,6 +163,9 @@ public class LabReportSearchCriteriaSteps {
               provider))
           .ifPresent(filter::setProviderSearch);
 
+      case "ordering facility new api" -> orderingFacility()
+          .ifPresent(filter::setOrderingLabId);
+
       case "reporting facility" -> reportingFacility().map(
           provider -> providerSearch(
               LabReportFilter.ProviderType.REPORTING_FACILITY,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
@@ -25,8 +25,7 @@ public class LabReportSearchCriteriaSteps {
       final Active<PatientIdentifier> patient,
       final Active<ProviderIdentifier> activeProvider,
       final Active<SearchableLabReport> searchableLabReport,
-      final Active<LabReportFilter> activeCriteria
-  ) {
+      final Active<LabReportFilter> activeCriteria) {
     this.patient = patient;
     this.activeProvider = activeProvider;
     this.searchableLabReport = searchableLabReport;
@@ -36,8 +35,7 @@ public class LabReportSearchCriteriaSteps {
   @Given("I want to find lab reports created by {user}")
   public void i_want_to_find_lab_reports_created_by(final ActiveUser user) {
     this.activeCriteria.maybeActive().ifPresent(
-        criteria -> criteria.setCreatedBy(user.id())
-    );
+        criteria -> criteria.setCreatedBy(user.id()));
   }
 
   @Given("I want to find lab reports created on {localDate}")
@@ -46,17 +44,13 @@ public class LabReportSearchCriteriaSteps {
         criteria -> criteria.setEventDate(
             eventDateSearch(
                 LabReportFilter.LabReportDateType.LAB_REPORT_CREATE_DATE,
-                on
-            )
-        )
-    );
+                on)));
   }
 
   @Given("I want to find lab reports updated by {user}")
   public void i_want_to_find_lab_reports_updated_by(final ActiveUser user) {
     this.activeCriteria.maybeActive().ifPresent(
-        criteria -> criteria.setLastUpdatedBy(user.id())
-    );
+        criteria -> criteria.setLastUpdatedBy(user.id()));
   }
 
   @Given("I want to find lab reports updated on {localDate}")
@@ -65,10 +59,7 @@ public class LabReportSearchCriteriaSteps {
         criteria -> criteria.setEventDate(
             eventDateSearch(
                 LabReportFilter.LabReportDateType.LAST_UPDATE_DATE,
-                on
-            )
-        )
-    );
+                on)));
   }
 
   @Given("I want to find new lab reports")
@@ -88,11 +79,14 @@ public class LabReportSearchCriteriaSteps {
             provider -> criteria.setProviderSearch(
                 providerSearch(
                     LabReportFilter.ProviderType.ORDERING_PROVIDER,
-                    provider.identifier()
-                )
-            )
-        )
-    );
+                    provider.identifier()))));
+  }
+
+  @Given("I want to find lab reports ordered by the provider using the new api")
+  public void i_want_to_find_lab_reports_ordered_by_the_provider_and_new_api() {
+    this.activeCriteria.maybeActive().ifPresent(
+        criteria -> this.activeProvider.maybeActive().ifPresent(
+            provider -> criteria.setOrderingProviderId(provider.identifier())));
   }
 
   @Given("I add the lab report criteria for {string}")
@@ -102,8 +96,7 @@ public class LabReportSearchCriteriaSteps {
 
   private LabReportFilter applyCriteria(
       final LabReportFilter filter,
-      final String field
-  ) {
+      final String field) {
     if (field == null || field.isEmpty()) {
       return filter;
     }
@@ -124,43 +117,37 @@ public class LabReportSearchCriteriaSteps {
 
       case "accession number" -> accession()
           .map(
-              filler ->
-                  eventId(
-                      LabReportFilter.LaboratoryEventIdType.ACCESSION_NUMBER,
-                      filler
-                  )
-          ).ifPresent(filter::setEventId);
+              filler -> eventId(
+                  LabReportFilter.LaboratoryEventIdType.ACCESSION_NUMBER,
+                  filler))
+          .ifPresent(filter::setEventId);
 
       case "lab id" -> this.searchableLabReport.maybeActive()
           .map(lab -> eventId(
-                  LabReportFilter.LaboratoryEventIdType.LAB_ID,
-                  lab.local()
-              )
-          ).ifPresent(filter::setEventId);
+              LabReportFilter.LaboratoryEventIdType.LAB_ID,
+              lab.local()))
+          .ifPresent(filter::setEventId);
 
       case "date of report" -> this.searchableLabReport.maybeActive()
           .map(
               lab -> eventDateSearch(
                   LabReportFilter.LabReportDateType.DATE_OF_REPORT,
-                  lab.reportedOn()
-              )
-          ).ifPresent(filter::setEventDate);
+                  lab.reportedOn()))
+          .ifPresent(filter::setEventDate);
 
       case "date received by public health" -> this.searchableLabReport.maybeActive()
           .map(
               lab -> eventDateSearch(
                   LabReportFilter.LabReportDateType.DATE_RECEIVED_BY_PUBLIC_HEALTH,
-                  lab.receivedOn()
-              )
-          ).ifPresent(filter::setEventDate);
+                  lab.receivedOn()))
+          .ifPresent(filter::setEventDate);
 
       case "date of specimen collection" -> this.searchableLabReport.maybeActive()
           .map(
               lab -> eventDateSearch(
                   LabReportFilter.LabReportDateType.DATE_OF_SPECIMEN_COLLECTION,
-                  lab.collectedOn()
-              )
-          ).ifPresent(filter::setEventDate);
+                  lab.collectedOn()))
+          .ifPresent(filter::setEventDate);
 
       case "entry method" -> {
         filter.setEntryMethods(List.of(LabReportFilter.EntryMethod.ELECTRONIC));
@@ -173,16 +160,14 @@ public class LabReportSearchCriteriaSteps {
       case "ordering facility" -> orderingFacility().map(
           provider -> providerSearch(
               LabReportFilter.ProviderType.ORDERING_FACILITY,
-              provider
-          )
-      ).ifPresent(filter::setProviderSearch);
+              provider))
+          .ifPresent(filter::setProviderSearch);
 
       case "reporting facility" -> reportingFacility().map(
           provider -> providerSearch(
               LabReportFilter.ProviderType.REPORTING_FACILITY,
-              provider
-          )
-      ).ifPresent(filter::setProviderSearch);
+              provider))
+          .ifPresent(filter::setProviderSearch);
 
       case "resulted test" -> tests().map(SearchableLabReport.LabTest::name)
           .ifPresent(filter::setResultedTest);
@@ -202,18 +187,15 @@ public class LabReportSearchCriteriaSteps {
 
   private LabReportFilter.LabReportEventId eventId(
       final LabReportFilter.LaboratoryEventIdType type,
-      final String value
-  ) {
+      final String value) {
     return new LabReportFilter.LabReportEventId(
         type,
-        value
-    );
+        value);
   }
 
   private LabReportFilter.LaboratoryEventDateSearch eventDateSearch(
       final LabReportFilter.LabReportDateType type,
-      final LocalDate from
-  ) {
+      final LocalDate from) {
     return new LabReportFilter.LaboratoryEventDateSearch(
         type,
         from.minusDays(5),
@@ -273,8 +255,7 @@ public class LabReportSearchCriteriaSteps {
 
   private LabReportFilter.LabReportProviderSearch providerSearch(
       final LabReportFilter.ProviderType type,
-      final long value
-  ) {
+      final long value) {
     return new LabReportFilter.LabReportProviderSearch(type, value);
   }
 }

--- a/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
@@ -155,6 +155,7 @@ Feature: Lab Report Search
       | entered by                     |
       | processing status              |
       | Ordering Facility              |
+      | Ordering Facility new api      |
       | Reporting Facility             |
       | resulted test                  |
       | coded result                   |
@@ -182,6 +183,7 @@ Feature: Lab Report Search
       | entered by                     | jurisdiction  | lab id       |
       | processing status              | jurisdiction  | lab id       |
       | Ordering Facility              | jurisdiction  | lab id       |
+      | Ordering Facility new api      | jurisdiction  | lab id       |
       | Reporting Facility             | jurisdiction  | lab id       |
       | resulted test                  | jurisdiction  | lab id       |
       | coded result                   | jurisdiction  | lab id       |

--- a/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
@@ -124,6 +124,17 @@ Feature: Lab Report Search
     Then the Lab Report search results contain the lab report
     And there is only one lab report search result
 
+  Scenario: I can search for Lab Reports ordered by a specific provider and the new api
+    Given the patient has a lab report
+    And there is a provider named "Emilio" "Lizardo"
+    And the lab report was ordered by the provider
+    And the lab report is available for search
+    And I am searching for the Lab Report
+    And I want to find lab reports ordered by the provider using the new api
+    When I search for lab reports
+    Then the Lab Report search results contain the lab report
+    And there is only one lab report search result    
+
   Scenario Outline: I can search for Lab Reports
     Given I add the lab report criteria for "<field>"
     When I search for lab reports

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -356,6 +356,8 @@ export type LabReportFilter = {
   eventStatus?: InputMaybe<Array<InputMaybe<EventStatus>>>;
   jurisdictions?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   lastUpdatedBy?: InputMaybe<Scalars['ID']['input']>;
+  orderingLabId?: InputMaybe<Scalars['ID']['input']>;
+  orderingProviderId?: InputMaybe<Scalars['ID']['input']>;
   patientId?: InputMaybe<Scalars['Int']['input']>;
   pregnancyStatus?: InputMaybe<PregnancyStatus>;
   processingStatus?: InputMaybe<Array<InputMaybe<LaboratoryReportStatus>>>;
@@ -1131,6 +1133,8 @@ export type PatientLabReportFilter = {
   eventStatus?: InputMaybe<Array<InputMaybe<EventStatus>>>;
   jurisdictions?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   lastUpdatedBy?: InputMaybe<Scalars['ID']['input']>;
+  orderingLabId?: InputMaybe<Scalars['ID']['input']>;
+  orderingProviderId?: InputMaybe<Scalars['ID']['input']>;
   patientId?: InputMaybe<Scalars['Int']['input']>;
   pregnancyStatus?: InputMaybe<PregnancyStatus>;
   processingStatus?: InputMaybe<Array<InputMaybe<LaboratoryReportStatus>>>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -292,7 +292,6 @@ enum LaboratoryReportStatus {
   UNPROCESSED
 }
 
-
 input LabReportFilter {
   patientId: Int
   programAreas: [String]
@@ -309,6 +308,8 @@ input LabReportFilter {
   providerSearch: LabReportProviderSearch
   resultedTest: String
   codedResult: String
+  orderingLabId: ID
+  orderingProviderId: ID
 }
 
 input LabReportEventId {
@@ -583,6 +584,8 @@ input PatientLabReportFilter {
   providerSearch: LabReportProviderSearch
   resultedTest: String
   codedResult: String
+  orderingLabId: ID
+  orderingProviderId: ID
 }
 
 type PatientLabReport {


### PR DESCRIPTION
## Description

Make new API backwards compatible with old by adding optional `orderingLabId` and `orderingProviderId` to `LabReportFilter`.  This allows us to use these criteria together vs previously you could only select one.

## Tickets

* [CNFT1-2478](https://cdc-nbs.atlassian.net/browse/CNFT1-2478)
* [CNFT1-2479](https://cdc-nbs.atlassian.net/browse/CNFT1-2479)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2478]: https://cdc-nbs.atlassian.net/browse/CNFT1-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNFT1-2479]: https://cdc-nbs.atlassian.net/browse/CNFT1-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ