### PR TITLE
CNFT1-2480 API: Lab search API- Reporting facility

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/LabReportFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/LabReportFilter.java
@@ -29,6 +29,7 @@ public final class LabReportFilter implements EventFilter {
   private LabReportProviderSearch providerSearch;
   private Long orderingLabId;
   private Long orderingProviderId;
+  private Long reportingLabId;
   private String resultedTest;
   private String codedResult;
 
@@ -206,6 +207,9 @@ public final class LabReportFilter implements EventFilter {
   }
 
   public Optional<Long> reportingFacility() {
+    if (this.reportingLabId != null) {
+      return Optional.of(this.reportingLabId);
+    }
     return (this.providerSearch != null && this.providerSearch.getProviderType() == ProviderType.REPORTING_FACILITY)
         ? Optional.of(this.providerSearch.getProviderId())
         : Optional.empty();

--- a/apps/modernization-api/src/main/resources/graphql/labReport.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/labReport.graphqls
@@ -73,6 +73,7 @@ input LabReportFilter {
   codedResult: String
   orderingLabId: ID
   orderingProviderId: ID
+  reportingLabId: ID
 }
 
 input LabReportEventId {

--- a/apps/modernization-api/src/main/resources/graphql/patient-lab-report.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-lab-report.graphqls
@@ -26,6 +26,7 @@ input PatientLabReportFilter {
   codedResult: String
   orderingLabId: ID
   orderingProviderId: ID
+  reportingLabId: ID
 }
 
 type PatientLabReport {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
@@ -172,6 +172,9 @@ public class LabReportSearchCriteriaSteps {
               provider))
           .ifPresent(filter::setProviderSearch);
 
+      case "reporting facility new api" -> reportingFacility()
+          .ifPresent(filter::setReportingLabId);
+
       case "resulted test" -> tests().map(SearchableLabReport.LabTest::name)
           .ifPresent(filter::setResultedTest);
 

--- a/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
@@ -157,6 +157,7 @@ Feature: Lab Report Search
       | Ordering Facility              |
       | Ordering Facility new api      |
       | Reporting Facility             |
+      | Reporting Facility new api     |
       | resulted test                  |
       | coded result                   |
 
@@ -185,6 +186,7 @@ Feature: Lab Report Search
       | Ordering Facility              | jurisdiction  | lab id       |
       | Ordering Facility new api      | jurisdiction  | lab id       |
       | Reporting Facility             | jurisdiction  | lab id       |
+      | Reporting Facility new api     | jurisdiction  | lab id       |
       | resulted test                  | jurisdiction  | lab id       |
       | coded result                   | jurisdiction  | lab id       |
       | patient id                     | resulted test | lab id       |

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -363,6 +363,7 @@ export type LabReportFilter = {
   processingStatus?: InputMaybe<Array<InputMaybe<LaboratoryReportStatus>>>;
   programAreas?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   providerSearch?: InputMaybe<LabReportProviderSearch>;
+  reportingLabId?: InputMaybe<Scalars['ID']['input']>;
   resultedTest?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1140,6 +1141,7 @@ export type PatientLabReportFilter = {
   processingStatus?: InputMaybe<Array<InputMaybe<LaboratoryReportStatus>>>;
   programAreas?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   providerSearch?: InputMaybe<LabReportProviderSearch>;
+  reportingLabId?: InputMaybe<Scalars['ID']['input']>;
   resultedTest?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -310,6 +310,7 @@ input LabReportFilter {
   codedResult: String
   orderingLabId: ID
   orderingProviderId: ID
+  reportingLabId: ID
 }
 
 input LabReportEventId {
@@ -586,6 +587,7 @@ input PatientLabReportFilter {
   codedResult: String
   orderingLabId: ID
   orderingProviderId: ID
+  reportingLabId: ID
 }
 
 type PatientLabReport {


### PR DESCRIPTION
## Description

Make new API backwards compatible with old by adding optional `reportingLabId` to `LabReportFilter`.  This allows us to use these criteria together vs previously you could only select one.

## Tickets

* [CNFT1-2480](https://cdc-nbs.atlassian.net/browse/CNFT1-2480)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2480]: https://cdc-nbs.atlassian.net/browse/CNFT1-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ