### PR TITLE
adding type check for condition for field to populate and fixing spel…

### DIFF
--- a/apps/modernization-ui/src/apps/search/laboratory-report/GeneralFields.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/GeneralFields.tsx
@@ -143,7 +143,7 @@ export const GeneralFields = ({ form }: LabReportGeneralFieldProps) => {
                 )}
             />
 
-            {watch.identification?.value ? (
+            {watch.identification?.type?.value ? (
                 <Controller
                     control={form.control}
                     name="identification.value"

--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -52,7 +52,7 @@ const NEW_STATUS = asSelectable('NEW', 'New');
 const eventStatusTypes: Selectable[] = [NEW_STATUS, asSelectable('UPDATE', 'Update')];
 
 const identificationTypes: Selectable[] = [
-    asSelectable('ACCESSION_NUMBER', 'Asccession Number'),
+    asSelectable('ACCESSION_NUMBER', 'Accession Number'),
     asSelectable('LAB_ID', 'Lab Id')
 ];
 

--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -52,7 +52,7 @@ const NEW_STATUS = asSelectable('NEW', 'New');
 const eventStatusTypes: Selectable[] = [NEW_STATUS, asSelectable('UPDATE', 'Update')];
 
 const identificationTypes: Selectable[] = [
-    asSelectable('ACCESSION_NUMBER', 'Assecsion Number'),
+    asSelectable('ACCESSION_NUMBER', 'Assession Number'),
     asSelectable('LAB_ID', 'Lab Id')
 ];
 

--- a/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/labReportFormTypes.ts
@@ -52,7 +52,7 @@ const NEW_STATUS = asSelectable('NEW', 'New');
 const eventStatusTypes: Selectable[] = [NEW_STATUS, asSelectable('UPDATE', 'Update')];
 
 const identificationTypes: Selectable[] = [
-    asSelectable('ACCESSION_NUMBER', 'Assession Number'),
+    asSelectable('ACCESSION_NUMBER', 'Asccession Number'),
     asSelectable('LAB_ID', 'Lab Id')
 ];
 


### PR DESCRIPTION
(Lab reports) Missing input field for Event ID when selecting an option from drop-down box

## Description

Selecting Accession Number or Lab ID does not invoke the Event id input field for entry.

Also, fixed the spelling of Assecsion to Assession 

## Tickets

* [CNFT1-2713](https://cdc-nbs.atlassian.net/browse/CNFT1-2713)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2713]: https://cdc-nbs.atlassian.net/browse/CNFT1-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ