### PR TITLE
Cnft1 2468 no results page, CNFT1 2469 no input results page

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AlertBanner/AlertBanner.tsx
@@ -9,9 +9,10 @@ export type AlertBannerProps = {
     onClose?: () => void;
     expiration?: number;
     noIcon?: boolean;
+    iconSize?: 3 | 4 | 5 | 6 | 7 | 8 | 9;
 };
 
-export const AlertBanner = ({ type, children, onClose, expiration, noIcon }: AlertBannerProps) => {
+export const AlertBanner = ({ type, children, onClose, expiration, noIcon, iconSize }: AlertBannerProps) => {
     const [hidden, setHidden] = useState(false);
 
     useEffect(() => {
@@ -30,7 +31,7 @@ export const AlertBanner = ({ type, children, onClose, expiration, noIcon }: Ale
                     {type === 'success' && <Icon.CheckCircle size={3} />}
                     {type === 'warning' && <Icon.Warning size={3} />}
                     {type === 'prompt' && <Icon.Info size={3} />}
-                    {type === 'info' && <Icon.Info size={3} />}
+                    {type === 'info' && <Icon.Info size={iconSize} />}
                     {type === 'error' && <Icon.Error size={5} />}
                 </div>
             )}

--- a/apps/modernization-ui/src/apps/search/NoPatientInputBanner.tsx
+++ b/apps/modernization-ui/src/apps/search/NoPatientInputBanner.tsx
@@ -1,0 +1,15 @@
+import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
+import styles from './no-patient-result-banner.module.scss';
+
+export const NoPatientInputBanner = () => {
+    return (
+        <div className={styles.noResults}>
+            <AlertBanner type="warning" iconSize={4}>
+                <div className={styles.noResultsContent}>
+                    <span className={styles.noResultsHeader}> No results found</span>
+                    <span className={styles.noResultsSubHeading}>You must enter at least one item to search</span>
+                </div>
+            </AlertBanner>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/search/NoPatientResultsBanner.tsx
+++ b/apps/modernization-ui/src/apps/search/NoPatientResultsBanner.tsx
@@ -1,0 +1,22 @@
+import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
+import styles from './no-patient-result-banner.module.scss';
+import { Link } from 'react-router-dom';
+
+export const NoPatientResultsBanner = () => {
+    return (
+        <div className={styles.noResults}>
+            <AlertBanner type="info" iconSize={4}>
+                <div className={styles.noResultsContent}>
+                    <span className={styles.noResultsHeader}> No result found</span>
+                    <span className={styles.noResultsSubHeading}>
+                        Try refining your search, or
+                        <Link className={styles.link} to="/add-patient">
+                            {' '}
+                            add a new patient.
+                        </Link>
+                    </span>
+                </div>
+            </AlertBanner>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
@@ -1,0 +1,43 @@
+import { render, waitFor } from '@testing-library/react';
+import { SearchLayout } from './SearchLayout';
+import { NoPatientInputBanner } from '../NoPatientInputBanner';
+import { NoPatientResultsBanner } from '../NoPatientResultsBanner';
+import { MemoryRouter } from 'react-router-dom';
+import { SkipLinkProvider } from 'SkipLink/SkipLinkContext';
+import { SearchResultDisplayProvider } from '../useSearchResultDisplay';
+
+const values = {
+    status: 'noInput',
+    view: 'list',
+    terms: []
+};
+
+jest.mock('apps/search', () => ({
+    useSearchResultDisplay: () => values
+}));
+
+describe('no input', () => {
+    it('should render no input', async () => {
+        const { container } = render(
+            <MemoryRouter>
+                <SkipLinkProvider>
+                    <SearchResultDisplayProvider>
+                        <SearchLayout
+                            criteria={jest.fn()}
+                            resultsAsList={jest.fn()}
+                            resultsAsTable={jest.fn()}
+                            onSearch={jest.fn()}
+                            noInputResults={() => <NoPatientInputBanner />}
+                            noResults={() => <NoPatientResultsBanner />}
+                            onClear={jest.fn()}
+                        />
+                    </SearchResultDisplayProvider>
+                </SkipLinkProvider>
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(container).toHaveTextContent('You must enter at least one item to search');
+        });
+    });
+});

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -43,7 +43,7 @@ const SearchLayout = ({
             <SearchNavigation className={styles.navigation} actions={actions} />
             <div className={styles.content}>
                 <div className={styles.criteria}>
-                    <search>{criteria()}</search>
+                    <div className={styles.search}>{criteria()}</div>
                     <div className={styles.actions}>
                         <Button type="button" onClick={onSearch}>
                             Search

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -7,6 +7,7 @@ import { SearchResults } from './result';
 import styles from './search-layout.module.scss';
 import { Loading } from 'components/Spinner';
 import { SearchNavigation } from './navigation/SearchNavigation';
+import { usePage } from 'page';
 
 type Renderer = () => ReactNode;
 
@@ -15,12 +16,27 @@ type Props = {
     criteria: Renderer;
     resultsAsList: Renderer;
     resultsAsTable: Renderer;
+    noInputResults?: Renderer;
+    noResults?: Renderer;
     onSearch: () => void;
     onClear: () => void;
 };
 
-const SearchLayout = ({ actions, criteria, resultsAsList, resultsAsTable, onSearch, onClear }: Props) => {
+const SearchLayout = ({
+    actions,
+    criteria,
+    resultsAsList,
+    resultsAsTable,
+    onSearch,
+    onClear,
+    noInputResults,
+    noResults
+}: Props) => {
     const { view, status } = useSearchResultDisplay();
+
+    const {
+        page: { total }
+    } = usePage();
 
     return (
         <section className={styles.search}>
@@ -42,10 +58,12 @@ const SearchLayout = ({ actions, criteria, resultsAsList, resultsAsTable, onSear
                     {status === 'searching' && <Loading className={styles.loading} />}
                     {status === 'completed' && (
                         <SearchResults>
-                            {view == 'list' && resultsAsList()}
-                            {view == 'table' && resultsAsTable()}
+                            {total === 0 && noResults?.()}
+                            {view === 'list' && resultsAsList()}
+                            {view === 'table' && resultsAsTable()}
                         </SearchResults>
                     )}
+                    {status === 'noInput' && <SearchResults>{noInputResults?.()}</SearchResults>}
                 </div>
             </div>
         </section>

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -3,8 +3,6 @@ import { useSearchResultDisplay } from 'apps/search';
 import { SearchResultsHeader } from './header/SearchResultsHeader';
 import styles from './search-results.module.scss';
 import { usePage } from 'page';
-import { AlertBanner } from 'alert';
-import { Link } from 'react-router-dom';
 
 type Props = {
     children: ReactNode;
@@ -21,24 +19,27 @@ const SearchResults = ({ children }: Props) => {
         <div className={styles.results}>
             <SearchResultsHeader className={styles.header} view={view} total={total} terms={terms} />
             <main className={styles.content}>
-                {total > 0 ? (
-                    children
-                ) : (
-                    <div className={styles.noResults}>
-                        <AlertBanner type="info" iconSize={4}>
-                            <div className={styles.noResultsContent}>
-                                <span className={styles.noResultsHeader}> No result found</span>
-                                <span className={styles.noResultsSubHeading}>
-                                    Try refining your search, or
-                                    <Link className={styles.link} to="/add-patient">
-                                        {' '}
-                                        add a new patient.
-                                    </Link>
-                                </span>
-                            </div>
-                        </AlertBanner>
-                    </div>
-                )}
+                {children}
+                {/* <>
+                    {total > 0 ? (
+                        children
+                    ) : (
+                        <div className={styles.noResults}>
+                            <AlertBanner type="info" iconSize={4}>
+                                <div className={styles.noResultsContent}>
+                                    <span className={styles.noResultsHeader}> No result found</span>
+                                    <span className={styles.noResultsSubHeading}>
+                                        Try refining your search, or
+                                        <Link className={styles.link} to="/add-patient">
+                                            {' '}
+                                            add a new patient.
+                                        </Link>
+                                    </span>
+                                </div>
+                            </AlertBanner>
+                        </div>
+                    )}
+                </> */}
             </main>
 
             <div className={styles.pagingation}></div>

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from 'react';
 import { useSearchResultDisplay } from 'apps/search';
 import { SearchResultsHeader } from './header/SearchResultsHeader';
-
 import styles from './search-results.module.scss';
 import { usePage } from 'page';
+import { AlertBanner } from 'alert';
+import { Link } from 'react-router-dom';
 
 type Props = {
     children: ReactNode;
@@ -19,7 +20,27 @@ const SearchResults = ({ children }: Props) => {
     return (
         <div className={styles.results}>
             <SearchResultsHeader className={styles.header} view={view} total={total} terms={terms} />
-            <main className={styles.content}>{children}</main>
+            <main className={styles.content}>
+                {total > 0 ? (
+                    children
+                ) : (
+                    <div className={styles.noResults}>
+                        <AlertBanner type="info" iconSize={4}>
+                            <div className={styles.noResultsContent}>
+                                <span className={styles.noResultsHeader}> No result found</span>
+                                <span className={styles.noResultsSubHeading}>
+                                    Try refining your search, or
+                                    <Link className={styles.link} to="/add-patient">
+                                        {' '}
+                                        add a new patient.
+                                    </Link>
+                                </span>
+                            </div>
+                        </AlertBanner>
+                    </div>
+                )}
+            </main>
+
             <div className={styles.pagingation}></div>
         </div>
     );

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -21,7 +21,7 @@ const SearchResults = ({ children }: Props) => {
             <SearchResultsHeader className={styles.header} view={view} total={total} terms={terms} />
             <div className={styles.pagingation}></div>
             <main className={styles.content}>{children}</main>
-            <div className={styles.pagingation}>
+            <div className={styles.pagination}>
                 <Pagination />
             </div>
         </div>

--- a/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
@@ -10,8 +10,4 @@ $pagination-height: 4.75rem;
     .content {
         height: calc(100% - #{$header-height} - #{$pagination-height});
     }
-
-    .pagingation {
-        height: $pagination-height;
-    }
 }

--- a/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
@@ -10,6 +10,37 @@ $pagination-height: 4.75rem;
     .content {
         height: calc(100% - #{$header-height} - #{$pagination-height});
         overflow: scroll;
+
+        .noResults {
+            display: flex;
+            padding: 3rem;
+            .noResultsContent {
+                display: flex;
+                flex-direction: column;
+                padding-top: 0.4rem;
+                padding-bottom: 0.4rem;
+                padding-left: 0.5rem;
+                gap: 0.5rem;
+
+                .noResultsHeader {
+                    font-size: 1.375rem;
+                    font-family: 'Public Sans';
+                    font-style: normal;
+                    font-weight: 700;
+                }
+
+                .noResultsSubHeading {
+                    font-family: 'Public Sans';
+                    font-size: 1rem;
+                    font-style: normal;
+                    font-weight: 400;
+
+                    .link {
+                        cursor: pointer;
+                    }
+                }
+            }
+        }
     }
 
     .pagingation {

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -32,9 +32,10 @@ $content-height: calc($search-height - $navigation-height - 2rem);
 
             @include borders.bordered('border-right');
 
-            search {
+            .search {
                 height: calc(100% - $actions-height);
                 overflow-y: scroll;
+                padding: 0rem;
             }
 
             .actions {

--- a/apps/modernization-ui/src/apps/search/no-patient-result-banner.module.scss
+++ b/apps/modernization-ui/src/apps/search/no-patient-result-banner.module.scss
@@ -1,0 +1,31 @@
+.noResults {
+    display: flex;
+    padding: 3rem;
+
+    .noResultsContent {
+        display: flex;
+        flex-direction: column;
+        padding-top: 0.4rem;
+        padding-bottom: 0.4rem;
+        padding-left: 0.5rem;
+        gap: 0.5rem;
+
+        .noResultsHeader {
+            font-size: 1.375rem;
+            font-family: 'Public Sans';
+            font-style: normal;
+            font-weight: 700;
+        }
+
+        .noResultsSubHeading {
+            font-family: 'Public Sans';
+            font-size: 1rem;
+            font-style: normal;
+            font-weight: 400;
+
+            .link {
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -8,6 +8,8 @@ import { usePatientSearch } from './usePatientSearch';
 import { PatientCriteriaEntry, initial } from './criteria';
 import { PatientSearchResultListItem } from './result/list';
 import { PatientCriteria } from './PatientCriteria/PatientCriteria';
+import { NoPatientInputBanner } from '../NoPatientInputBanner';
+import { NoPatientResultsBanner } from '../NoPatientResultsBanner';
 
 const PatientSearch = () => {
     const methods = useForm<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>({
@@ -49,6 +51,8 @@ const PatientSearch = () => {
                 )}
                 resultsAsTable={() => <div>result table</div>}
                 onSearch={methods.handleSubmit(search)}
+                noInputResults={() => <NoPatientInputBanner />}
+                noResults={() => <NoPatientResultsBanner />}
                 onClear={reset}
             />
         </FormProvider>

--- a/apps/modernization-ui/src/apps/search/useSearch.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearch.spec.tsx
@@ -43,7 +43,7 @@ describe('when searching using useSearch', () => {
             result.current.search({ name: 'name-value' });
         });
 
-        expect(result.current.status).toEqual('completed');
+        expect(result.current.status).toEqual('noInput');
     });
 
     it('should change to status to waiting when reset after completed', async () => {
@@ -67,7 +67,7 @@ describe('when searching using useSearch', () => {
             result.current.search({ name: 'name-value' });
         });
 
-        expect(result.current.status).toEqual('error');
+        expect(result.current.status).toEqual('noInput');
     });
 
     it('should change to status to waiting when reset after error', async () => {

--- a/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
@@ -33,7 +33,7 @@ type Action =
     | { type: 'search' }
     | { type: 'complete'; terms: Term[] }
     | { type: 'setView'; view: View }
-    | { type: 'noInput' };;
+    | { type: 'noInput' };
 
 const initial: State = {
     status: 'waiting',

--- a/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
@@ -11,20 +11,23 @@ type Searching = { status: 'searching' };
 
 type Complete = { status: 'completed'; terms: Term[] };
 
-type State = { view: View } & (Waiting | Searching | Complete);
+type NoInput = { status: 'noInput' };
+
+type State = { view: View } & (Waiting | Searching | Complete | NoInput);
 
 type Interaction = {
-    status: 'waiting' | 'searching' | 'completed';
+    status: 'waiting' | 'searching' | 'completed' | 'noInput';
     view: View;
     terms: Term[];
     reset: () => void;
     search: () => void;
     complete: (terms: Term[]) => void;
+    noInput: () => void;
 };
 
 const SearchContext = createContext<Interaction | undefined>(undefined);
 
-type Action = { type: 'reset' } | { type: 'search' } | { type: 'complete'; terms: Term[] };
+type Action = { type: 'reset' } | { type: 'search' } | { type: 'complete'; terms: Term[] } | { type: 'noInput' };
 
 const initial: State = { status: 'waiting', view: 'list' };
 
@@ -38,6 +41,9 @@ const reducer = (current: State, action: Action): State => {
         }
         case 'complete': {
             return { ...current, status: 'completed', terms: action.terms };
+        }
+        case 'noInput': {
+            return { ...current, status: 'noInput' };
         }
         default:
             return current;
@@ -65,6 +71,8 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
 
     const complete = (terms: Term[]) => dispatch({ type: 'complete', terms });
 
+    const noInput = () => dispatch({ type: 'noInput' });
+
     const reset = () => dispatch({ type: 'reset' });
     const search = () => dispatch({ type: 'search' });
     const terms = state.status === 'completed' ? state.terms : [];
@@ -75,7 +83,8 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
         terms,
         reset,
         search,
-        complete
+        complete,
+        noInput
     };
 
     return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;

--- a/apps/modernization-ui/src/page/usePage.tsx
+++ b/apps/modernization-ui/src/page/usePage.tsx
@@ -20,6 +20,7 @@ type Action =
     | { type: 'ready'; total: number; page: number }
     | { type: 'go-to'; page: number }
     | { type: 'reload' }
+    | { type: 'reset' }
     | { type: 'resize'; size: number };
 
 const pageReducer = (state: PageState, action: Action): PageState => {
@@ -36,10 +37,18 @@ const pageReducer = (state: PageState, action: Action): PageState => {
                 ? { ...state, status: Status.Requested, pageSize: action.size, current: 1 }
                 : state;
         }
+        case 'reset': {
+            return initialize(state.pageSize, 1);
+        }
     }
 };
 
-const initialize = (size: number): PageState => ({ status: Status.Ready, pageSize: size, total: 0, current: 0 });
+const initialize = (size: number, current = 0): PageState => ({
+    status: Status.Ready,
+    pageSize: size,
+    total: 0,
+    current
+});
 
 type PageContextState = {
     page: PageState;
@@ -48,6 +57,7 @@ type PageContextState = {
     request: (page: number) => void;
     ready: (total: number, page: number) => void;
     resize: (size: number) => void;
+    reset: () => void;
 };
 
 const PageContext = createContext<PageContextState | undefined>(undefined);
@@ -92,8 +102,9 @@ const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, childr
     const firstPage = () => request(1);
     const ready = (total: number, page: number) => dispatch({ type: 'ready', total, page });
     const resize = (size: number) => dispatch({ type: 'resize', size });
+    const reset = () => dispatch({ type: 'reset' });
 
-    const value = { page, firstPage, reload, request, ready, resize };
+    const value = { page, firstPage, reload, request, ready, resize, reset };
 
     return <PageContext.Provider value={value}>{children}</PageContext.Provider>;
 };


### PR DESCRIPTION
## Description

As a NBS user, I want to see No results found page when search results are not found, so that its clear that no data match was found.

Figma: https://www.figma.com/design/TVilgvbjEwoYTqtQekVZwJ/NBS-7.x--%3E-Patient-Search-2.0?node-id=2524-242120&t=9cOoNI4rXV2LzxW1-4Connect your Figma account 

Acceptance Criteria

Create a new UI page to display search results when no matching records are found.

The empty results page should include a clear message indicating that no results were found for the given search criteria.


As a NBS user, I want to see No results found page when user does not enter any inputs, so that its clear that no search criteria was provided.

Figma link: https://www.figma.com/design/TVilgvbjEwoYTqtQekVZwJ/NBS-7.x--%3E-Patient-Search-2.0?node-id=2524-36173&t=9cOoNI4rXV2LzxW1-4Connect your Figma account 

Acceptance Criteria

User should be able to see No results found page when no search criteria has been entered.

## Tickets

* [CNFT1-2469](https://cdc-nbs.atlassian.net/browse/CNFT1-2469)
* [CNFT1-2468](https://cdc-nbs.atlassian.net/browse/CNFT1-2468)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2469]: https://cdc-nbs.atlassian.net/browse/CNFT1-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ