### PR TITLE
CNFT1-2804 Refactor ButtonActionMenu

### DIFF
--- a/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/advancedSearch/AdvancedSearch.tsx
@@ -34,6 +34,7 @@ import { focusedTarget } from 'utils';
 import { TabNavigationEntry, TabNavigation } from 'components/TabNavigation/TabNavigation';
 import { OutOfTabOrder } from './components/OutOfTabOrder';
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
+import { Button } from 'components/button';
 
 export enum SEARCH_TYPE {
     PERSON = 'search',
@@ -354,14 +355,14 @@ export const AdvancedSearch = () => {
                 <Grid row className="page-title-bar bg-white">
                     <div className="width-full text-bold flex-row display-flex flex-align-center flex-justify">
                         <h1 className="advanced-search-title margin-0">Search</h1>
-                        <ButtonActionMenu
-                            label="Add new"
-                            items={[
-                                { label: 'Add new patient', action: handleAddNewPatientClick },
-                                { label: 'Add new lab report', action: handleAddNewLabReportClick }
-                            ]}
-                            disabled={!lastSearchType}
-                        />
+                        <ButtonActionMenu label="Add new" disabled={!lastSearchType}>
+                            <Button type="button" onClick={handleAddNewPatientClick}>
+                                Add new patient
+                            </Button>
+                            <Button type="button" onClick={handleAddNewLabReportClick}>
+                                Add new lab report
+                            </Button>
+                        </ButtonActionMenu>
                     </div>
                 </Grid>
                 <Grid row className="search-page-height">
@@ -418,55 +419,59 @@ export const AdvancedSearch = () => {
                             <div style={{ display: 'flex', alignItems: 'center' }}>
                                 <div className="button-group">
                                     {lastSearchType && !isNoResultsFound() && !isError() && !isLoading() && (
-                                        <ButtonActionMenu
-                                            label="Sort by"
-                                            items={[
-                                                {
-                                                    label: 'Closest match',
-                                                    action: () => {
+                                        <ButtonActionMenu label="Sort by">
+                                            <>
+                                                <Button
+                                                    type="button"
+                                                    onClick={() => {
                                                         setSort({
                                                             sortField: SortField.Relevance
                                                         });
-                                                    }
-                                                },
-                                                {
-                                                    label: 'Patient name (A-Z)',
-                                                    action: () => {
+                                                    }}>
+                                                    Closest match
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    onClick={() => {
                                                         setSort({
                                                             sortDirection: SortDirection.Asc,
                                                             sortField: SortField.LastNm
                                                         });
-                                                    }
-                                                },
-                                                {
-                                                    label: 'Patient name (Z-A)',
-                                                    action: () => {
+                                                    }}>
+                                                    Patient name (A-Z)
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    onClick={() => {
                                                         setSort({
                                                             sortDirection: SortDirection.Desc,
                                                             sortField: SortField.LastNm
                                                         });
-                                                    }
-                                                },
-                                                {
-                                                    label: 'Date of birth (Ascending)',
-                                                    action: () => {
+                                                    }}>
+                                                    Patient name (Z-A)
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    onClick={() => {
                                                         setSort({
                                                             sortDirection: SortDirection.Asc,
                                                             sortField: SortField.BirthTime
                                                         });
-                                                    }
-                                                },
-                                                {
-                                                    label: 'Date of birth (Descending)',
-                                                    action: () => {
+                                                    }}>
+                                                    Date of birth (Ascending)
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    onClick={() => {
                                                         setSort({
                                                             sortDirection: SortDirection.Desc,
                                                             sortField: SortField.BirthTime
                                                         });
-                                                    }
-                                                }
-                                            ]}
-                                        />
+                                                    }}>
+                                                    Date of birth (Descending)
+                                                </Button>
+                                            </>
+                                        </ButtonActionMenu>
                                     )}
                                 </div>
                             </div>

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/list/SearchResultsListOptions.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/list/SearchResultsListOptions.tsx
@@ -4,6 +4,7 @@ import styles from './search-results-list-options.module.scss';
 import { Direction, useSorting } from 'sorting';
 import { SortField } from 'generated/graphql/schema';
 import { useEffect } from 'react';
+import { Button } from 'components/button';
 
 type Props = {
     disabled?: boolean;
@@ -27,50 +28,50 @@ const SearchResultsListOptions = ({ disabled = false }: Props) => {
     }, []);
 
     return (
-        <ButtonActionMenu
-            className={styles.option}
-            outline
-            icon={<Icon.SortArrow />}
-            disabled={disabled}
-            items={[
-                {
-                    label: 'Closest match',
-                    action: () => {
+        <ButtonActionMenu className={styles.option} outline icon={<Icon.SortArrow />} disabled={disabled}>
+            <>
+                <Button
+                    type="button"
+                    onClick={() => {
                         sortBy(SortField.Relevance, Direction.Descending);
                         savePreferences(SortField.Relevance, Direction.Descending);
-                    }
-                },
-                {
-                    label: 'Patient name (A-Z)',
-                    action: () => {
+                    }}>
+                    Closest match
+                </Button>
+                <Button
+                    type="button"
+                    onClick={() => {
                         sortBy(SortField.LastNm, Direction.Ascending);
                         savePreferences(SortField.LastNm, Direction.Ascending);
-                    }
-                },
-                {
-                    label: 'Patient name (Z-A)',
-                    action: () => {
+                    }}>
+                    Patient name (A-Z)
+                </Button>
+                <Button
+                    type="button"
+                    onClick={() => {
                         sortBy(SortField.LastNm, Direction.Descending);
                         savePreferences(SortField.LastNm, Direction.Descending);
-                    }
-                },
-                {
-                    label: 'Date of birth (Ascending)',
-                    action: () => {
+                    }}>
+                    Patient name (Z-A)
+                </Button>
+                <Button
+                    type="button"
+                    onClick={() => {
                         sortBy(SortField.BirthTime, Direction.Ascending);
                         savePreferences(SortField.BirthTime, Direction.Ascending);
-                    }
-                },
-                {
-                    label: 'Date of birth (Descending)',
-                    action: () => {
+                    }}>
+                    Date of birth (Ascending)
+                </Button>
+                <Button
+                    type="button"
+                    onClick={() => {
                         sortBy(SortField.BirthTime, Direction.Descending);
                         savePreferences(SortField.BirthTime, Direction.Descending);
-                    }
-                }
-            ]}
-            label={''}
-        />
+                    }}>
+                    Date of birth (Descending)
+                </Button>
+            </>
+        </ButtonActionMenu>
     );
 };
 

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -13,6 +13,7 @@ import { NoPatientResultsBanner } from '../NoPatientResultsBanner';
 import { PatientSearchResultTable } from './result/table';
 import { NoInputBanner } from '../NoInputBanner';
 import { Term, useSearchResultDisplay } from '../useSearchResultDisplay';
+import { Button } from '@trussworks/react-uswds';
 
 const PatientSearch = () => {
     const navigate = useNavigate();
@@ -68,14 +69,16 @@ const PatientSearch = () => {
             <SearchLayout
                 onRemoveTerm={handleRemoveTerm}
                 actions={() => (
-                    <ButtonActionMenu
-                        label="Add new"
-                        items={[
-                            { label: 'Add new patient', action: handleAddNewPatientClick },
-                            { label: 'Add new lab report', action: handleAddNewLabReportClick }
-                        ]}
-                        disabled={total === 0}
-                    />
+                    <ButtonActionMenu label="Add new" disabled={total === 0}>
+                        <>
+                            <Button type="button" onClick={handleAddNewPatientClick}>
+                                Add new patient
+                            </Button>
+                            <Button type="button" onClick={handleAddNewLabReportClick}>
+                                Add new lab report
+                            </Button>
+                        </>
+                    </ButtonActionMenu>
                 )}
                 criteria={() => <PatientCriteria />}
                 resultsAsList={() => (

--- a/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.spec.tsx
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.spec.tsx
@@ -4,13 +4,12 @@ import { render } from "@testing-library/react";
 
 describe('When ButtonActionMenu renders', () => {
     const { container } = render(
-        <ButtonActionMenu
-            label="Add new"
-            items={[
-                { label: 'Add new patient', action: jest.fn() },
-                { label: 'Add new lab report', action: jest.fn() }
-            ]}
-        />
+        <ButtonActionMenu label="Add new">
+            <>
+                <Button type="button" onClick={() => jest.fn()}>Test this</Button>
+                <Button type="button" onClick={() =>jest.fn() }>Test that</Button>
+            </>
+        </ButtonActionMenu>
     );
     it('should not display menu', () => {
         expect(container.getElementsByClassName('menu')).toHaveLength(0);

--- a/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.tsx
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.tsx
@@ -4,21 +4,31 @@ import { Icon } from '@trussworks/react-uswds';
 import { Button } from 'components/button/Button';
 import classNames from 'classnames';
 
-type Action = {
-    label: string;
-    action: () => void;
-};
-
 type Props = {
-    label: string;
-    items: Action[];
+    label?: string;
     disabled?: boolean;
     icon?: ReactNode;
     outline?: boolean;
     className?: string;
+    labelPosition?: string;
+    menuTitle?: string;
+    menuAction?: () => void;
+    menuActionTitle?: string;
+    children: ReactNode;
 };
 
-export const ButtonActionMenu = ({ label, items, disabled, icon, outline, className }: Props) => {
+export const ButtonActionMenu = ({
+    label,
+    disabled,
+    icon,
+    outline,
+    className,
+    labelPosition,
+    menuTitle,
+    menuAction,
+    menuActionTitle,
+    children
+}: Props) => {
     const wrapperRef = useRef(null);
     const clickOutside = (ref: any) => {
         useEffect(() => {
@@ -45,19 +55,25 @@ export const ButtonActionMenu = ({ label, items, disabled, icon, outline, classN
                 className={classNames(styles.actionMenuButton, className, 'action-button')}
                 disabled={disabled}
                 outline={outline}
-                labelPosition="right"
+                labelPosition={labelPosition === 'left' ? 'left' : 'right'}
                 icon={icon ? icon : <Icon.ArrowDropDown size={4} />}>
-                {label}
+                {label ? label : ''}
             </Button>
             {open ? (
                 <div className={'menu ' + styles.menu}>
-                    {items.map((item, i) => {
-                        return (
-                            <Button key={i} type="button" onClick={item.action}>
-                                {item.label}
+                    {menuTitle ? (
+                        <div className={styles.menuHeader}>
+                            <h3>{menuTitle}</h3>
+                        </div>
+                    ) : null}
+                    <div className={styles.menuContent}>{children}</div>
+                    {menuAction ? (
+                        <div className={styles.menuFooter}>
+                            <Button type="button" onClick={menuAction}>
+                                {menuActionTitle}
                             </Button>
-                        );
-                    })}
+                        </div>
+                    ) : null}
                 </div>
             ) : null}
         </div>

--- a/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
@@ -5,8 +5,8 @@
     .actionMenuButton {
         padding: 0.375rem 1.25rem;
         line-height: 0;
-        svg {
-            margin: 0 -0.5rem;
+        span {
+            margin-right: 1rem;
         }
     }
     .menu {


### PR DESCRIPTION
## Description

Refactoring ButtonActionMenu to accept menu content as {children} to enable more custom content, such as drag-drop tiles.

## Tickets

* [CNFT1-2804](https://cdc-nbs.atlassian.net/browse/CNFT1-2804)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2804]: https://cdc-nbs.atlassian.net/browse/CNFT1-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ