### PR TITLE
adding .gov instead of .org for cdc website

### DIFF
--- a/apps/modernization-ui/src/apps/landing/SignUp/SignUp.tsx
+++ b/apps/modernization-ui/src/apps/landing/SignUp/SignUp.tsx
@@ -31,7 +31,7 @@ const SignUp = () => {
                 <p>
                     Upon approval, you will receive an email with login details and the demo site address. If you
                     haven't received it within 24 hours, please let us know by emailing{' '}
-                    <a href="mailto:nbs@cdc.org">nbs@cdc.gov</a>
+                    <a href="mailto:nbs@cdc.gov">nbs@cdc.gov</a>
                 </p>
                 <div className={styles.form}>
                     <Controller

--- a/apps/modernization-ui/src/apps/landing/SignUp/useSignUp.ts
+++ b/apps/modernization-ui/src/apps/landing/SignUp/useSignUp.ts
@@ -2,7 +2,7 @@ const body = (requester: string) =>
     encodeURI(`A user with the email address ${requester} is requesting access to the NBS7 Demo site.`);
 
 const template = {
-    recipient: encodeURI('nbs@cdc.org'),
+    recipient: encodeURI('nbs@cdc.gov'),
     subject: encodeURI('Requesting access to NBS7 Demo site'),
     body
 };


### PR DESCRIPTION
## Description

fixing url email domain name is changed correctly but clicking the email link is showing .org still

## Tickets

* [CNFT1-2758](https://cdc-nbs.atlassian.net/browse/CNFT1-2758)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2758]: https://cdc-nbs.atlassian.net/browse/CNFT1-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ