### PR TITLE
Add jdk.crypto.cryptoki module to ensure cipher availability" (#1583)

### DIFF
--- a/apps/nbs-gateway/Dockerfile
+++ b/apps/nbs-gateway/Dockerfile
@@ -14,19 +14,19 @@ RUN gradle :nbs-gateway:build -x test --no-daemon
 
 RUN jar xf apps/nbs-gateway/build/libs/nbs-gateway.jar
 RUN jdeps --ignore-missing-deps -q  \
-    --recursive  \
-    --multi-release 21  \
-    --print-module-deps  \
-    --class-path 'BOOT-INF/lib/*'  \
-    apps/nbs-gateway/build/libs/nbs-gateway.jar > deps.info
+  --recursive  \
+  --multi-release 21  \
+  --print-module-deps  \
+  --class-path 'BOOT-INF/lib/*'  \
+  apps/nbs-gateway/build/libs/nbs-gateway.jar > deps.info
 
 RUN jlink \
-    --add-modules $(cat deps.info) \
-    --strip-debug \
-    --compress 2 \
-    --no-header-files \
-    --no-man-pages \
-    --output gateway/runtime
+  --add-modules $(cat deps.info),jdk.crypto.cryptoki \
+  --strip-debug \
+  --compress 2 \
+  --no-header-files \
+  --no-man-pages \
+  --output gateway/runtime
 
 FROM redhat/ubi9-micro:latest
 


### PR DESCRIPTION
## Description

Adds the [nbs-gateway fix](https://github.com/CDCgov/NEDSS-Modernization/pull/1583) to the 7.5.0 release branch.