### PR TITLE
[CNFT1-2807] Ensures that Return-Patient cookie is removed after use

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/redirect/incoming/ModernizedPatientProfileRedirect.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/redirect/incoming/ModernizedPatientProfileRedirect.java
@@ -26,9 +26,8 @@ public sealed interface ModernizedPatientProfileRedirect {
   static ResponseEntity<Void> redirectTo(final URI location) {
     return ResponseEntity.status(HttpStatus.SEE_OTHER)
         .location(location)
-        .headers(
-            ReturningPatientCookie.empty().apply()
-                .andThen(removeCookie(PatientActionCookie.empty().name())))
+        .headers(removeCookie(ReturningPatientCookie.empty().name()))
+        .headers(removeCookie(PatientActionCookie.empty().name()))
         .build();
   }
 

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/filter/RemoveCookieGatewayFilterFactory.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/filter/RemoveCookieGatewayFilterFactory.java
@@ -1,0 +1,74 @@
+package gov.cdc.nbs.gateway.filter;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * A {@link GatewayFilter} factory that will remove a cookie by adding a {@code Set-Cookie} header to the response with
+ * a blank value and max-age of zero.
+ *
+ * <pre>
+ * spring:
+ *   cloud:
+ *     gateway:
+ *       routes:
+ *         - id: remove-cookie
+ *           uri: https://example.org
+ *           predicates:
+ *             - Path=/
+ *           filters:
+ *             - RemoveCookie=Path, CookieName
+ * </pre>
+ * <p>
+ * This adds a {@code Set-Cookie} header with a value of {@code Cookie=parameter-value; Secure; HttpOnly}
+ */
+@Component
+public class RemoveCookieGatewayFilterFactory extends
+    AbstractGatewayFilterFactory<RemoveCookieGatewayFilterFactory.Config> {
+
+  public record Config(String path, String cookie) {
+  }
+
+  public RemoveCookieGatewayFilterFactory() {
+    super(Config.class);
+  }
+
+  @Override
+  public List<String> shortcutFieldOrder() {
+    return List.of("path", "cookie");
+  }
+
+
+  @Override
+  public GatewayFilter apply(final Config config) {
+    return ((exchange, chain) -> chain.filter(exchange)
+        .then(
+            Mono.fromRunnable(
+                () -> execute(config, exchange)
+            )
+        )
+    );
+  }
+
+  private void execute(final Config config, final ServerWebExchange exchange) {
+    exchange.getResponse().addCookie(create(config.path(), config.cookie()));
+  }
+
+
+  private ResponseCookie create(final String path, final String name) {
+    return ResponseCookie.from(name)
+        .path(path)
+        .sameSite("Strict")
+        .httpOnly(true)
+        .secure(true)
+        .maxAge(0)
+        .build();
+  }
+
+}

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/investigation/ViewInvestigationRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/investigation/ViewInvestigationRouteLocatorConfiguration.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.gateway.patient.profile.events.investigation;
 
 import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import gov.cdc.nbs.gateway.filter.RemoveCookieGatewayFilterFactory;
 import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory;
 import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory.Config;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -15,10 +16,16 @@ import java.util.List;
 
 /**
  * Adds the {@code Patient-Action} cookie to the response when the {@code routes.patient.profile.enabled} property is
- * {@code true} and any of the following criteria is satisfied;
+ * {@code true} and any of the following criteria is satisfied;  The {@code Return-Patient} cookie is also removed.
  *
  * <ul>
  *     <li>Path equal to {@code /nbs/MyProgramAreaInvestigations1.do}</li>*
+ *     <li>Query Parameter {@code publicHealthCaseUID} exists</li>
+ * </ul>
+ *
+ * <ul>
+ *     <li>Path equal to {@code /nbs/ViewFile1.do}</li>
+ *     <li>Query Parameter {@code ContextAction} equal to {@code }</li>
  *     <li>Query Parameter {@code publicHealthCaseUID} exists</li>
  * </ul>
  */
@@ -27,6 +34,12 @@ import java.util.List;
 class ViewInvestigationRouteLocatorConfiguration {
 
   private static final String IDENTIFIER_PARAMETER = "publicHealthCaseUID";
+  private static final Config ADD_PATIENT_ACTION_CONFIG = new Config(
+      IDENTIFIER_PARAMETER,
+      "Patient-Action"
+  );
+  private static final RemoveCookieGatewayFilterFactory.Config REMOVE_RETURN_PATIENT_CONFIG =
+      new RemoveCookieGatewayFilterFactory.Config("/nbs/", "Return-Patient");
 
   @Bean
   RouteLocator viewInvestigationActionCookie(
@@ -38,20 +51,34 @@ class ViewInvestigationRouteLocatorConfiguration {
     return builder
         .routes()
         .route(
-            "view-investigation-apply-patient-action-cookie",
+            "view-open-investigations-apply-patient-action-cookie",
             route -> route.path("/nbs/MyProgramAreaInvestigations1.do")
                 .and()
                 .query(IDENTIFIER_PARAMETER)
                 .filters(
-                    filter -> filter.filter(
-                            new RequestParameterToCookieGatewayFilterFactory()
-                                .apply(
-                                    new Config(
-                                        IDENTIFIER_PARAMETER,
-                                        "Patient-Action"
-                                    )
-                                )
+                    filter -> filter
+                        .filter(
+                            new RequestParameterToCookieGatewayFilterFactory().apply(ADD_PATIENT_ACTION_CONFIG)
                         )
+                        .filter(new RemoveCookieGatewayFilterFactory().apply(REMOVE_RETURN_PATIENT_CONFIG))
+                        .filters(defaults)
+                        .filter(classicFilter)
+                )
+                .uri(service.uri())
+        )
+        .route(
+            "view-investigation-apply-patient-action-cookie",
+            route -> route.path("/nbs/ViewFile1.do")
+                .and()
+                .query("ContextAction", "InvestigationIDOnSummary")
+                .and()
+                .query(IDENTIFIER_PARAMETER)
+                .filters(
+                    filter -> filter
+                        .filter(
+                            new RequestParameterToCookieGatewayFilterFactory().apply(ADD_PATIENT_ACTION_CONFIG)
+                        )
+                        .filter(new RemoveCookieGatewayFilterFactory().apply(REMOVE_RETURN_PATIENT_CONFIG))
                         .filters(defaults)
                         .filter(classicFilter)
                 )

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfiguration.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.gateway.patient.profile.events.observation;
 
 import gov.cdc.nbs.gateway.RouteOrdering;
 import gov.cdc.nbs.gateway.classic.NBSClassicService;
+import gov.cdc.nbs.gateway.filter.RemoveCookieGatewayFilterFactory;
 import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory;
 import gov.cdc.nbs.gateway.filter.RequestParameterToCookieGatewayFilterFactory.Config;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,7 +17,7 @@ import java.util.List;
 
 /**
  * Adds the {@code Patient-Action} cookie to the response when the {@code routes.patient.profile.enabled} property is
- * {@code true} and any of the following criteria is satisfied;
+ * {@code true} and any of the following criteria is satisfied;  The {@code Return-Patient} cookie is also removed.
  *
  * <ul>
  *     <li>Path equal to {@code /nbs/NewLabReview1.do.do}</li>*
@@ -28,6 +29,12 @@ import java.util.List;
 class ViewObservationRouteLocatorConfiguration {
 
   private static final String IDENTIFIER_PARAMETER = "observationUID";
+  private static final Config ADD_PATIENT_ACTION_CONFIG = new Config(
+      IDENTIFIER_PARAMETER,
+      "Patient-Action"
+  );
+  private static final RemoveCookieGatewayFilterFactory.Config REMOVE_RETURN_PATIENT_CONFIG =
+      new RemoveCookieGatewayFilterFactory.Config("/nbs/", "Return-Patient");
 
   @Bean
   RouteLocator viewObservationActionCookie(
@@ -46,15 +53,11 @@ class ViewObservationRouteLocatorConfiguration {
                 .and()
                 .query(IDENTIFIER_PARAMETER)
                 .filters(
-                    filter -> filter.filter(
-                            new RequestParameterToCookieGatewayFilterFactory()
-                                .apply(
-                                    new Config(
-                                        IDENTIFIER_PARAMETER,
-                                        "Patient-Action"
-                                    )
-                                )
+                    filter -> filter
+                        .filter(
+                            new RequestParameterToCookieGatewayFilterFactory().apply(ADD_PATIENT_ACTION_CONFIG)
                         )
+                        .filter(new RemoveCookieGatewayFilterFactory().apply(REMOVE_RETURN_PATIENT_CONFIG))
                         .filters(defaults)
                         .filter(classicFilter)
                 )

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/filter/RemoveCookieGatewayFilterFactoryTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/filter/RemoveCookieGatewayFilterFactoryTest.java
@@ -1,0 +1,53 @@
+package gov.cdc.nbs.gateway.filter;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "test.destination.uri=http://localhost:10000"
+    }
+)
+@DirtiesContext
+@ActiveProfiles(profiles = "remove-cookie-gateway-filter")
+class RemoveCookieGatewayFilterFactoryTest {
+
+  @RegisterExtension
+  static WireMockExtension test = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
+  @Autowired
+  WebTestClient client;
+
+  @Test
+  void should_remove_cookie() {
+    client.get()
+        .uri(
+            uri -> uri.path("/remove-cookie-test")
+                .build()
+        )
+        .exchange()
+        .expectHeader()
+        .value(
+            HttpHeaders.SET_COOKIE,
+            actual -> assertThat(actual)
+                .contains("Secure")
+                .containsIgnoringCase("HTTPOnly")
+                .contains("cookie-name=;")
+                .contains("Max-Age=0;")
+                .contains("Path=/path")
+        );
+  }
+}

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/events/investigation/ViewInvestigationRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/events/investigation/ViewInvestigationRouteLocatorConfigurationTest.java
@@ -10,40 +10,47 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
 
 @SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {
-                "nbs.gateway.classic=http://localhost:10000",
-                "nbs.gateway.patient.profile.enabled=true"
-        }
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "nbs.gateway.classic=http://localhost:10000",
+        "nbs.gateway.patient.profile.enabled=true"
+    }
 )
 class ViewInvestigationRouteLocatorConfigurationTest {
 
-    @RegisterExtension
-    static WireMockExtension classic = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(10000))
-            .build();
+  @RegisterExtension
+  static WireMockExtension classic = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
 
-    @Autowired
-    WebTestClient webClient;
+  @Autowired
+  WebTestClient webClient;
 
-    @Test
-    void should_add_Patient_Action_cookie_when_viewing_an_investigation() {
+  @Test
+  void should_add_Patient_Action_cookie_when_viewing_an_investigation() {
 
-        classic.stubFor(get(urlPathMatching("/nbs/MyProgramAreaInvestigations1.do\\\\?.*")).willReturn(ok()));
+    classic.stubFor(get(urlPathMatching("/nbs/MyProgramAreaInvestigations1.do\\\\?.*")).willReturn(ok()));
 
-        webClient
-                .get().uri(
-                        builder -> builder
-                                .path("/nbs/MyProgramAreaInvestigations1.do")
-                                .queryParam("ContextAction", "InvestigationID")
-                                .queryParam("publicHealthCaseUID", "7841")
-                                .build()
-                )
-                .exchange()
-                .expectHeader()
-                .value("Set-Cookie", containsString("Patient-Action=7841"));
+    webClient
+        .get().uri(
+            builder -> builder
+                .path("/nbs/MyProgramAreaInvestigations1.do")
+                .queryParam("ContextAction", "InvestigationID")
+                .queryParam("publicHealthCaseUID", "7841")
+                .build()
+        )
+        .exchange()
+        .expectHeader()
+        .values(
+            "Set-Cookie",
+            hasItems(
+                containsString("Patient-Action=7841;"),
+                containsString("Return-Patient=;")
+            )
+        );
 
-    }
+  }
 }

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/events/observation/ViewObservationRouteLocatorConfigurationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
 
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -43,7 +44,13 @@ class ViewObservationRouteLocatorConfigurationTest {
                 )
                 .exchange()
                 .expectHeader()
-                .value("Set-Cookie", containsString("Patient-Action=7841"));
+            .values(
+                "Set-Cookie",
+                hasItems(
+                    containsString("Patient-Action=7841;"),
+                    containsString("Return-Patient=;")
+                )
+            );
 
     }
 
@@ -62,7 +69,13 @@ class ViewObservationRouteLocatorConfigurationTest {
             )
             .exchange()
             .expectHeader()
-            .value("Set-Cookie", containsString("Patient-Action=7841"));
+            .values(
+                "Set-Cookie",
+                hasItems(
+                    containsString("Patient-Action=7841;"),
+                    containsString("Return-Patient=;")
+                )
+            );
 
     }
 }

--- a/apps/nbs-gateway/src/test/resources/application-remove-cookie-gateway-filter.yml
+++ b/apps/nbs-gateway/src/test/resources/application-remove-cookie-gateway-filter.yml
@@ -1,0 +1,10 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: remove-cookie-test
+          uri: ${test.destination.uri}
+          predicates:
+            - Path=/remove-cookie-test
+          filters:
+            - RemoveCookie=/path, cookie-name


### PR DESCRIPTION
## Description

The `Return-Patient` cookie was not being removed when routing back to the patient profile which was causing routing to go to the previous patient as the `Return-Patient` cookie has precedence over `Patient-Action`

## Tickets

* [CNFT1-2807](https://cdc-nbs.atlassian.net/browse/CNFT1-2807)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2807]: https://cdc-nbs.atlassian.net/browse/CNFT1-2807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ