### PR TITLE
CNT-49 E2E testing from wait to Poll and Retry

### DIFF
--- a/testing/regression/cypress/e2e/hl7/elr-generate.feature
+++ b/testing/regression/cypress/e2e/hl7/elr-generate.feature
@@ -5,4 +5,3 @@ Feature: Generate ELR HL7
 
   Scenario: ID - Check Search after HL7 ELR is created
     When I Generate HL7 messages to api and mark as review
-    Then I check the ELR in search

--- a/testing/regression/cypress/e2e/pages/searchEvent.page.js
+++ b/testing/regression/cypress/e2e/pages/searchEvent.page.js
@@ -157,32 +157,6 @@ class SearchEventPage {
     this.setLabReportNormalSettings();
     cy.get('input[id="codedResult"]').type("absent");
   }
-
-  checkELR() {
-    let fakeSSN = Cypress.env().fakeSSN;
-    let fakeFullName = Cypress.env().fakeFullName;
-    function formatSSN(ssn) {
-      // Ensure the input is a string
-      const ssnString = ssn.toString();
-
-      // Extract parts of the SSN
-      const part1 = ssnString.slice(0, 3);
-      const part2 = ssnString.slice(3, 5);
-      const part3 = ssnString.slice(5, 9);
-
-      // Combine parts with dashes
-      const formattedSSN = `${part1}-${part2}-${part3}`;
-
-      return formattedSSN;
-    }
-
-    const formattedSSN = formatSSN(fakeSSN);
-    cy.contains(formattedSSN).scrollIntoView().should("be.visible");
-    cy.get("a").contains(fakeFullName).click({force: true});
-    cy.get("a").contains("Events").click({force: true});
-    cy.get("td").contains("Fulton County").scrollIntoView().should("be.visible");
-  }
-
 }
 
 export const searchEventPage = new SearchEventPage();


### PR DESCRIPTION
## Description

Change the E2E testing from wait to Poll and Retry .
<img width="1179" alt="Screenshot 2024-07-23 at 9 11 02 AM" src="https://github.com/user-attachments/assets/575f09a0-a655-4762-a802-62216fed89c7">


## Tickets

* [CNT-49](https://cdc-nbs.atlassian.net/browse/CNT-49)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNT-49]: https://cdc-nbs.atlassian.net/browse/CNT-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ