### PR TITLE
Adds the cipher dependency to JRE

### DIFF
--- a/apps/modernization-api/Dockerfile
+++ b/apps/modernization-api/Dockerfile
@@ -37,19 +37,19 @@ RUN gradle :modernization-api:buildNeeded -x test --no-daemon
 RUN jar xf apps/modernization-api/build/libs/modernization-api.jar
 
 RUN jdeps --ignore-missing-deps -q  \
-    --recursive  \
-    --multi-release 21  \
-    --print-module-deps  \
-    --class-path 'BOOT-INF/lib/*'  \
-    apps/modernization-api/build/libs/modernization-api.jar > deps.info
+  --recursive  \
+  --multi-release 21  \
+  --print-module-deps  \
+  --class-path 'BOOT-INF/lib/*'  \
+  apps/modernization-api/build/libs/modernization-api.jar > deps.info
 
 RUN jlink \
-    --add-modules $(cat deps.info) \
-    --strip-debug \
-    --compress 2 \
-    --no-header-files \
-    --no-man-pages \
-    --output modernization-api/runtime
+  --add-modules $(cat deps.info),jdk.crypto.cryptoki \
+  --strip-debug \
+  --compress 2 \
+  --no-header-files \
+  --no-man-pages \
+  --output modernization-api/runtime
 
 FROM redhat/ubi9-micro:latest
 

--- a/apps/question-bank/Dockerfile
+++ b/apps/question-bank/Dockerfile
@@ -19,19 +19,19 @@ RUN gradle :question-bank:buildNeeded -x test --no-daemon
 RUN jar xf apps/question-bank/build/libs/question-bank.jar
 
 RUN jdeps --ignore-missing-deps -q  \
-    --recursive  \
-    --multi-release 21  \
-    --print-module-deps  \
-    --class-path 'BOOT-INF/lib/*'  \
-    apps/question-bank/build/libs/question-bank.jar > deps.info
+  --recursive  \
+  --multi-release 21  \
+  --print-module-deps  \
+  --class-path 'BOOT-INF/lib/*'  \
+  apps/question-bank/build/libs/question-bank.jar > deps.info
 
 RUN jlink \
-    --add-modules $(cat deps.info) \
-    --strip-debug \
-    --compress 2 \
-    --no-header-files \
-    --no-man-pages \
-    --output page-builder/runtime
+  --add-modules $(cat deps.info),jdk.crypto.cryptoki \
+  --strip-debug \
+  --compress 2 \
+  --no-header-files \
+  --no-man-pages \
+  --output page-builder/runtime
 
 FROM redhat/ubi9-micro:latest
 


### PR DESCRIPTION
## Description

Add additional SSL Cipher support to modernization-api and question-bank docker containers in the same manner as it was added to the nbs-gateway here:
https://github.com/CDCgov/NEDSS-Modernization/pull/1583