### PR TITLE
Code System Lookup Fix

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/CodeValueGeneralRepository.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/CodeValueGeneralRepository.java
@@ -10,14 +10,14 @@ import org.springframework.data.repository.query.Param;
 
 public interface CodeValueGeneralRepository extends JpaRepository<CodeValueGeneral, CodeValueGeneralId> {
 
-    @Query("SELECT cvg FROM CodeValueGeneral cvg WHERE cvg.id.code=:code")
-    Optional<CodeValueGeneral> findByCode(@Param("code") String code);
+  @Query("SELECT cvg FROM CodeValueGeneral cvg WHERE cvg.id.code=:code AND cvg.id.codeSetNm = 'CODE_SYSTEM'")
+  Optional<CodeValueGeneral> findCodeSystemByCode(@Param("code") String code);
 
-    Optional<CodeValueGeneral> findByIdCodeSetNmAndIdCode(String codesetName, String code);
+  Optional<CodeValueGeneral> findByIdCodeSetNmAndIdCode(String codesetName, String code);
 
-    List<CodeValueGeneral> findByIdCodeSetNm(String codeSetNm, Sort sort);
+  List<CodeValueGeneral> findByIdCodeSetNm(String codeSetNm, Sort sort);
 
-    @Modifying
-    @Query("DELETE from CodeValueGeneral c WHERE c.id.codeSetNm =:codesetNm")
-    void deleteAllByCodesetName(@Param("codesetNm") String codesetNm);
+  @Modifying
+  @Query("DELETE from CodeValueGeneral c WHERE c.id.codeSetNm =:codesetNm")
+  void deleteAllByCodesetName(@Param("codesetNm") String codesetNm);
 }

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionManagementUtil.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/question/QuestionManagementUtil.java
@@ -32,7 +32,7 @@ public class QuestionManagementUtil {
 
     public QuestionOid getQuestionOid(boolean includedInMessage, String codeSystem, CodeSet codeSet) {
         if (includedInMessage) {
-            return codeValueGeneralRepository.findByCode(
+            return codeValueGeneralRepository.findCodeSystemByCode(
                     codeSystem)
                 .stream()
                 .map(cvg -> new QuestionOid(

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionManagementUtilTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/question/QuestionManagementUtilTest.java
@@ -76,7 +76,7 @@ class QuestionManagementUtilTest {
     CodeValueGeneral cvg = new CodeValueGeneral();
     cvg.setCodeDescTxt("2.16.840.1.113883.12.78");
     cvg.setCodeShortDescTxt("Abnormal flags (HL7)");
-    when(codeValueGeneralRepository.findByCode(Mockito.anyString())).thenReturn(Optional.of(cvg));
+    when(codeValueGeneralRepository.findCodeSystemByCode(Mockito.anyString())).thenReturn(Optional.of(cvg));
 
     // when I generate the question oid
     QuestionOid oid = questionManagementUtil.getQuestionOid(true, "", CodeSet.LOCAL);
@@ -122,7 +122,7 @@ class QuestionManagementUtilTest {
   void should_throw_exception_failed_to_find_code_system() {
     // given a request with an invalid code_system
     CreateTextQuestionRequest request = QuestionRequestMother.localTextRequest();
-    when(codeValueGeneralRepository.findByCode(request.getMessagingInfo().codeSystem()))
+    when(codeValueGeneralRepository.findCodeSystemByCode(request.getMessagingInfo().codeSystem()))
         .thenReturn(Optional.empty());
 
     // when retrieving the question oid


### PR DESCRIPTION
## Description

A 500 server error is being thrown when attempting to create a new page builder question using the `SNOMED_CT_HL7` code system. This is due to there being multiple entries in the `code_value_general` with the `SNOMED_CT_HL7`  code.

This PR updates the query to specify the `code_value_general` `code_set_nm` along with the `code` to correctly select only 1 entry from the db.

## Tickets

*  TBD - awaiting bug creation

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
