### PR TITLE
Add event id field when event id type is selected

### DIFF
--- a/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.spec.tsx
@@ -122,13 +122,13 @@ describe('GeneralSearchFields', () => {
             });
         });
 
-        it('should not display event id', async () => {
+        it('should not display event id', () => {
             const { queryByLabelText } = render(<InvestigationFormWithFields />);
             const eventIdField = queryByLabelText('Event ID');
             expect(eventIdField).toBeNull();
         });
 
-        it('should display event id once event id type is selected', async () => {
+        it('should display event id once event id type is selected', () => {
             const { getByLabelText } = render(<InvestigationFormWithFields />);
 
             const eventTypeField = getByLabelText('Event ID type');

--- a/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.spec.tsx
@@ -129,12 +129,12 @@ describe('GeneralSearchFields', () => {
         });
 
         it('should display event id once event id type is selected', () => {
-            const { getByLabelText } = render(<InvestigationFormWithFields />);
+            const { getByLabelText, queryByLabelText } = render(<InvestigationFormWithFields />);
 
             const eventTypeField = getByLabelText('Event ID type');
             userEvent.selectOptions(eventTypeField, 'ABCS_CASE_ID');
 
-            const eventIdField = screen.queryByLabelText('Event ID');
+            const eventIdField = queryByLabelText('Event ID');
             expect(eventIdField).toBeInTheDocument();
         });
     });

--- a/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.spec.tsx
@@ -37,7 +37,7 @@ const InvestigationFormWithFields = () => {
 describe('GeneralSearchFields', () => {
     describe('Pregnancy Status', () => {
         it('should contain default selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const preg = screen.getByTestId('pregnancyStatus');
@@ -47,7 +47,7 @@ describe('GeneralSearchFields', () => {
         });
 
         it('should update the selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('pregnancyStatus');
@@ -59,7 +59,7 @@ describe('GeneralSearchFields', () => {
 
     describe('Event ID Type', () => {
         it('should contain default selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('identification.type');
@@ -69,7 +69,7 @@ describe('GeneralSearchFields', () => {
         });
 
         it('should update the selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('identification.type');
@@ -81,7 +81,7 @@ describe('GeneralSearchFields', () => {
 
     describe('Event Date Type', () => {
         it('should contain default selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('eventDate.type');
@@ -91,7 +91,7 @@ describe('GeneralSearchFields', () => {
         });
 
         it('should update the selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('eventDate.type');
@@ -103,7 +103,7 @@ describe('GeneralSearchFields', () => {
 
     describe('Reporting Facility type', () => {
         it('should contain default selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('reportingFacility');
@@ -113,13 +113,29 @@ describe('GeneralSearchFields', () => {
         });
 
         it('should update the selection', async () => {
-            const { container } = render(<InvestigationFormWithFields />);
+            render(<InvestigationFormWithFields />);
 
             await waitFor(() => {
                 const element = screen.getByTestId('reportingFacility');
                 userEvent.selectOptions(element, 'Reporting Facility');
                 expect(element).toHaveTextContent('Reporting Facility');
             });
+        });
+
+        it('should not display event id', async () => {
+            const { queryByLabelText } = render(<InvestigationFormWithFields />);
+            const eventIdField = queryByLabelText('Event ID');
+            expect(eventIdField).toBeNull();
+        });
+
+        it('should display event id once event id type is selected', async () => {
+            const { getByLabelText } = render(<InvestigationFormWithFields />);
+
+            const eventTypeField = getByLabelText('Event ID type');
+            userEvent.selectOptions(eventTypeField, 'ABCS_CASE_ID');
+
+            const eventIdField = screen.queryByLabelText('Event ID');
+            expect(eventIdField).toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.tsx
@@ -1,3 +1,11 @@
+import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
+import { Input } from 'components/FormInputs/Input';
+import { MultiSelect, SingleSelect } from 'design-system/select';
+import { PregnancyStatus } from 'generated/graphql/schema';
+import { FacilityAutocomplete } from 'options/autocompete/FacilityAutocomplete';
+import { ProviderAutocomplete } from 'options/autocompete/ProviderAutocomplete';
+import { UserAutocomplete } from 'options/autocompete/UserAutocomplete';
+import { SearchCriteriaContext } from 'providers/SearchCriteriaContext';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import {
     InvestigationFilterEntry,
@@ -5,15 +13,6 @@ import {
     entityOptions,
     investigationEventTypeOptions
 } from './InvestigationFormTypes';
-import { PregnancyStatus } from 'generated/graphql/schema';
-import { MultiSelect, SingleSelect } from 'design-system/select';
-import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
-import { SearchCriteriaContext } from 'providers/SearchCriteriaContext';
-import { ProviderAutocomplete } from 'options/autocompete/ProviderAutocomplete';
-import { ErrorMessage } from '@trussworks/react-uswds';
-import { FacilityAutocomplete } from 'options/autocompete/FacilityAutocomplete';
-import { UserAutocomplete } from 'options/autocompete/UserAutocomplete';
-import { Input } from 'components/FormInputs/Input';
 
 const GeneralSearchFields = () => {
     const form = useFormContext<InvestigationFilterEntry, Partial<InvestigationFilterEntry>>();
@@ -254,10 +253,8 @@ const GeneralSearchFields = () => {
                                         onChange={onChange}
                                         required={true}
                                         onBlur={onBlur}
+                                        error={error?.message}
                                     />
-                                    {error && (
-                                        <ErrorMessage id={`provider-error-message`}>{error?.message}</ErrorMessage>
-                                    )}
                                 </>
                             )}
                         />
@@ -280,10 +277,8 @@ const GeneralSearchFields = () => {
                                         onChange={(e) => onChange(e?.value)}
                                         required={true}
                                         onBlur={onBlur}
+                                        error={error?.message}
                                     />
-                                    {error && (
-                                        <ErrorMessage id={`facility-error-message`}>{error?.message}</ErrorMessage>
-                                    )}
                                 </>
                             )}
                         />

--- a/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/GeneralSearchFields.tsx
@@ -13,6 +13,7 @@ import { ProviderAutocomplete } from 'options/autocompete/ProviderAutocomplete';
 import { ErrorMessage } from '@trussworks/react-uswds';
 import { FacilityAutocomplete } from 'options/autocompete/FacilityAutocomplete';
 import { UserAutocomplete } from 'options/autocompete/UserAutocomplete';
+import { Input } from 'components/FormInputs/Input';
 
 const GeneralSearchFields = () => {
     const form = useFormContext<InvestigationFilterEntry, Partial<InvestigationFilterEntry>>();
@@ -109,7 +110,7 @@ const GeneralSearchFields = () => {
                         render={({ field: { name, value, onChange } }) => (
                             <SingleSelect
                                 name={name}
-                                label="Event id type"
+                                label="Event ID type"
                                 data-testid={name}
                                 id={name}
                                 value={value}
@@ -118,6 +119,30 @@ const GeneralSearchFields = () => {
                             />
                         )}
                     />
+
+                    {watch.identification?.type && (
+                        <Controller
+                            control={form.control}
+                            name="identification.value"
+                            rules={{
+                                required: { value: true, message: 'Event Id is required' }
+                            }}
+                            render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                                <Input
+                                    onBlur={onBlur}
+                                    onChange={onChange}
+                                    defaultValue={value}
+                                    type="text"
+                                    label="Event ID"
+                                    name={name}
+                                    htmlFor={name}
+                                    id={name}
+                                    error={error?.message}
+                                    required
+                                />
+                            )}
+                        />
+                    )}
 
                     <Controller
                         control={form.control}
@@ -230,7 +255,9 @@ const GeneralSearchFields = () => {
                                         required={true}
                                         onBlur={onBlur}
                                     />
-                                    {error && <ErrorMessage id={`${error}-message`}>{error?.message}</ErrorMessage>}
+                                    {error && (
+                                        <ErrorMessage id={`provider-error-message`}>{error?.message}</ErrorMessage>
+                                    )}
                                 </>
                             )}
                         />
@@ -254,7 +281,9 @@ const GeneralSearchFields = () => {
                                         required={true}
                                         onBlur={onBlur}
                                     />
-                                    {error && <ErrorMessage id={`${error}-message`}>{error?.message}</ErrorMessage>}
+                                    {error && (
+                                        <ErrorMessage id={`facility-error-message`}>{error?.message}</ErrorMessage>
+                                    )}
                                 </>
                             )}
                         />

--- a/apps/modernization-ui/src/design-system/autocomplete/single/Autocomplete.tsx
+++ b/apps/modernization-ui/src/design-system/autocomplete/single/Autocomplete.tsx
@@ -37,6 +37,7 @@ const Autocomplete = ({
     const suggestionRef = useRef<HTMLUListElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
+    // setting to empty string prevents error: A component is changing an uncontrolled input to be controlled
     const [entered, setEntered] = useState(value?.name ?? '');
 
     const { options, suggest, reset } = useSelectableAutocomplete({ resolver, criteria: entered });

--- a/apps/modernization-ui/src/design-system/autocomplete/single/Autocomplete.tsx
+++ b/apps/modernization-ui/src/design-system/autocomplete/single/Autocomplete.tsx
@@ -37,7 +37,7 @@ const Autocomplete = ({
     const suggestionRef = useRef<HTMLUListElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const [entered, setEntered] = useState(value?.name);
+    const [entered, setEntered] = useState(value?.name ?? '');
 
     const { options, suggest, reset } = useSelectableAutocomplete({ resolver, criteria: entered });
 


### PR DESCRIPTION
## Description

Displays the `Event ID` field when an `Event ID type` is selected. Matching the behavior of search v1, `Event ID` is required if an `Event ID type` is selected.


### No selection
![image](https://github.com/user-attachments/assets/bafa507e-0376-4eda-9616-753b97a314e8)

### Event ID type selected
![image](https://github.com/user-attachments/assets/09d121e2-2deb-4a64-84c4-a811fc354084)


## Tickets

* [CNFT1-2760](https://cdc-nbs.atlassian.net/browse/CNFT1-2760)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2760]: https://cdc-nbs.atlassian.net/browse/CNFT1-2760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ