### PR TITLE
Prevent submission of empty string for deceased value. Type form

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
@@ -128,7 +128,11 @@ const AddPatient = () => {
 
         handleSavePatient({
             variables: {
-                patient: payload
+                patient: {
+                    ...payload,
+                    // prevent value of '' being passed for deceased
+                    deceased: payload.deceased ? payload.deceased : undefined
+                }
             }
         }).then((result) => {
             if (result.data?.createPatient) {

--- a/apps/modernization-ui/src/apps/patient/add/otherInfoFields/OtherInfoFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/otherInfoFields/OtherInfoFields.tsx
@@ -1,13 +1,15 @@
-import { useMemo } from 'react';
 import { Grid } from '@trussworks/react-uswds';
-import { calculateAge } from 'date';
-import { CodedValue, Indicator } from 'coded';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { CodedValue } from 'coded';
 import FormCard from 'components/FormCard/FormCard';
-import { Input } from 'components/FormInputs/Input';
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
+import { Input } from 'components/FormInputs/Input';
 import { SelectInput } from 'components/FormInputs/SelectInput';
+import { calculateAge } from 'date';
+import { Deceased } from 'generated/graphql/schema';
+import { useMemo } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
+import { NewPatientEntry } from '../NewPatientEntry';
 
 type CodedValues = {
     deceased: CodedValue[];
@@ -17,8 +19,8 @@ type CodedValues = {
 
 type Props = { id: string; title: string; coded: CodedValues };
 
-export default function OtherInfoFields({ id, title, coded }: Props) {
-    const { control } = useFormContext();
+export default function OtherInfoFields({ id, title, coded }: Readonly<Props>) {
+    const { control } = useFormContext<NewPatientEntry>();
 
     const selectedDeceased = useWatch({ control, name: 'deceased' });
 
@@ -107,7 +109,7 @@ export default function OtherInfoFields({ id, title, coded }: Props) {
                         />
                     </Grid>
                 </Grid>
-                {selectedDeceased === Indicator.Yes && (
+                {selectedDeceased === Deceased.Y && (
                     <Grid row>
                         <Grid col={6}>
                             <Controller
@@ -120,7 +122,7 @@ export default function OtherInfoFields({ id, title, coded }: Props) {
                                         name={name}
                                         label="Date of death"
                                         disableFutureDates
-                                        disabled={selectedDeceased !== Indicator.Yes}
+                                        disabled={selectedDeceased !== Deceased.Y}
                                     />
                                 )}
                             />


### PR DESCRIPTION
## Description

Toggling `Is the patient deceased` to a value and then back to null causes an error on submission. This is due to the form value being set to an empty string: ''.

Changing this to undefined at time of submission resolves the issue.


### Before fix
![brokenDeceased](https://github.com/user-attachments/assets/89f5e591-d8c7-46b4-bd49-fe2a659079ff)


### After fix
![deceasedFix](https://github.com/user-attachments/assets/cf452e59-a3ba-4caf-8a6e-0191cb1c876d)

## Tickets

* [CNFT1-2845](https://cdc-nbs.atlassian.net/browse/CNFT1-2845)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2845]: https://cdc-nbs.atlassian.net/browse/CNFT1-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ