### PR TITLE
CNFT1-2482 API: Investigation search Reporting provider

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/InvestigationFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/InvestigationFilter.java
@@ -32,8 +32,8 @@ public final class InvestigationFilter implements EventFilter {
   private List<CaseStatus> caseStatuses = new ArrayList<>();
   private List<NotificationStatus> notificationStatuses = new ArrayList<>();
   private List<ProcessingStatus> processingStatuses = new ArrayList<>();
-  private Long reportingFacilityId;
-  private Long reportingProviderId;
+  private String reportingFacilityId;
+  private String reportingProviderId;
 
   @Data
   @AllArgsConstructor
@@ -277,7 +277,7 @@ public final class InvestigationFilter implements EventFilter {
 
   public Optional<Long> reportingFacility() {
     if (this.reportingFacilityId != null) {
-      return Optional.of(this.reportingFacilityId);
+      return Optional.of(Long.parseLong(this.reportingFacilityId));
     }
     return (this.providerFacilitySearch != null
         && this.providerFacilitySearch.getEntityType() == ReportingEntityType.FACILITY)
@@ -287,7 +287,7 @@ public final class InvestigationFilter implements EventFilter {
 
   public Optional<Long> reportingProvider() {
     if (this.reportingProviderId != null) {
-      return Optional.of(this.reportingProviderId);
+      return Optional.of(Long.parseLong(this.reportingProviderId));
     }
     return (this.providerFacilitySearch != null
         && this.providerFacilitySearch.getEntityType() == ReportingEntityType.PROVIDER)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/InvestigationFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/InvestigationFilter.java
@@ -33,7 +33,7 @@ public final class InvestigationFilter implements EventFilter {
   private List<NotificationStatus> notificationStatuses = new ArrayList<>();
   private List<ProcessingStatus> processingStatuses = new ArrayList<>();
   private Long reportingFacilityId;
-
+  private Long reportingProviderId;
 
   @Data
   @AllArgsConstructor
@@ -286,6 +286,9 @@ public final class InvestigationFilter implements EventFilter {
   }
 
   public Optional<Long> reportingProvider() {
+    if (this.reportingProviderId != null) {
+      return Optional.of(this.reportingProviderId);
+    }
     return (this.providerFacilitySearch != null
         && this.providerFacilitySearch.getEntityType() == ReportingEntityType.PROVIDER)
             ? Optional.of(this.providerFacilitySearch.getId())

--- a/apps/modernization-api/src/main/resources/graphql/investigation.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/investigation.graphqls
@@ -50,8 +50,8 @@ input InvestigationFilter {
   caseStatuses: [CaseStatus!]
   notificationStatuses: [NotificationStatus]
   processingStatuses: [ProcessingStatus]
-  reportingFacilityId: ID
-  reportingProviderId: ID
+  reportingFacilityId: String
+  reportingProviderId: String
 }
 
 input EventId {

--- a/apps/modernization-api/src/main/resources/graphql/investigation.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/investigation.graphqls
@@ -51,6 +51,7 @@ input InvestigationFilter {
   notificationStatuses: [NotificationStatus]
   processingStatuses: [ProcessingStatus]
   reportingFacilityId: ID
+  reportingProviderId: ID
 }
 
 input EventId {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationSearchCriteriaSteps.java
@@ -288,7 +288,7 @@ public class InvestigationSearchCriteriaSteps {
   @Given("I want to find investigations reported by the {organization} facility using the new api")
   public void i_want_to_find_investigations_reported_by_the_organization_using_the_new_api(final long organization) {
     this.activeCriteria.maybeActive().ifPresent(
-        criteria -> criteria.setReportingFacilityId(organization));
+        criteria -> criteria.setReportingFacilityId(String.valueOf(organization)));
   }
 
   @Given("I want to find investigations reported by the provider")
@@ -303,7 +303,7 @@ public class InvestigationSearchCriteriaSteps {
   @Given("I want to find investigations reported by the provider using the new api")
   public void i_want_to_find_investigations_reported_by_the_provider_using_the_new_api() {
     this.activeCriteria.maybeActive().ifPresent(
-        criteria -> criteria.setReportingProviderId(this.activeProvider.active().identifier()));
+        criteria -> criteria.setReportingProviderId(String.valueOf(this.activeProvider.active().identifier())));
   }
 
   @Given("I want to find investigations related to the {outbreak} outbreak")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/investigation/InvestigationSearchCriteriaSteps.java
@@ -300,6 +300,12 @@ public class InvestigationSearchCriteriaSteps {
                 this.activeProvider.active().identifier())));
   }
 
+  @Given("I want to find investigations reported by the provider using the new api")
+  public void i_want_to_find_investigations_reported_by_the_provider_using_the_new_api() {
+    this.activeCriteria.maybeActive().ifPresent(
+        criteria -> criteria.setReportingProviderId(this.activeProvider.active().identifier()));
+  }
+
   @Given("I want to find investigations related to the {outbreak} outbreak")
   public void i_want_to_find_investigations_related_to_the_outbreak(final String outbreak) {
     this.activeCriteria.maybeActive().ifPresent(

--- a/apps/modernization-api/src/test/resources/features/search/investigation/InvestigationSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/search/investigation/InvestigationSearch.feature
@@ -294,7 +294,16 @@ Feature: Investigation search
     Then the Investigation search results contain the Investigation
     And there is only one investigation search result
 
-    Scenario: I can search for Investigations related to an outbreak
+  Scenario: I can search for Investigations reported by a specific provider using the new api
+    Given there is a provider named "Robin" "Buckley"
+    And the investigation was reported by the provider
+    And the investigation is available for search
+    And I want to find investigations reported by the provider using the new api
+    When I search for investigations
+    Then the Investigation search results contain the Investigation
+    And there is only one investigation search result
+
+  Scenario: I can search for Investigations related to an outbreak
       Given "Peanuts at Fratelli's Restaurant" caused an outbreak
       And the investigation is related to the Peanuts at Fratelli's Restaurant outbreak
       And the investigation is available for search

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -283,8 +283,8 @@ export type InvestigationFilter = {
   processingStatuses?: InputMaybe<Array<InputMaybe<ProcessingStatus>>>;
   programAreas?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   providerFacilitySearch?: InputMaybe<ProviderFacilitySearch>;
-  reportingFacilityId?: InputMaybe<Scalars['ID']['input']>;
-  reportingProviderId?: InputMaybe<Scalars['ID']['input']>;
+  reportingFacilityId?: InputMaybe<Scalars['String']['input']>;
+  reportingProviderId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InvestigationPersonParticipation = {

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -284,6 +284,7 @@ export type InvestigationFilter = {
   programAreas?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   providerFacilitySearch?: InputMaybe<ProviderFacilitySearch>;
   reportingFacilityId?: InputMaybe<Scalars['ID']['input']>;
+  reportingProviderId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type InvestigationPersonParticipation = {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -136,8 +136,8 @@ input InvestigationFilter {
   caseStatuses: [CaseStatus!]
   notificationStatuses: [NotificationStatus]
   processingStatuses: [ProcessingStatus]
-  reportingFacilityId: ID
-  reportingProviderId: ID
+  reportingFacilityId: String
+  reportingProviderId: String
 }
 
 input EventId {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -137,6 +137,7 @@ input InvestigationFilter {
   notificationStatuses: [NotificationStatus]
   processingStatuses: [ProcessingStatus]
   reportingFacilityId: ID
+  reportingProviderId: ID
 }
 
 input EventId {


### PR DESCRIPTION
## Description

Make new API backwards compatible with old by adding optional `reportingProviderId` to `InvestigationFilter`. This allows us to use these criteria together vs previously you could only select one.

## Tickets

* [CNFT1-2482](https://cdc-nbs.atlassian.net/browse/CNFT1-2482)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2482]: https://cdc-nbs.atlassian.net/browse/CNFT1-2482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ