### PR TITLE
[CNFT1-2829] Investigations Search Result link to investigation

### DIFF
--- a/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/InvestigationSearch.tsx
@@ -8,6 +8,8 @@ import { Investigation } from 'generated/graphql/schema';
 import { InvestigationSearchResultListItem } from './result/list';
 import { SearchCriteriaProvider } from 'providers/SearchCriteriaContext';
 import { Term, useSearchResultDisplay } from '../useSearchResultDisplay';
+import { useConceptOptions } from 'options/concepts';
+import { findByValue } from 'options';
 
 const InvestigationSearch = () => {
     const form = useForm<InvestigationFilterEntry, Partial<InvestigationFilterEntry>>({
@@ -43,10 +45,11 @@ const InvestigationSearch = () => {
             }
             search(form.getValues());
         } else {
-            form.reset();
             reset();
         }
     };
+
+    const { options: notificationStatus } = useConceptOptions('REC_STAT', { lazy: false });
 
     return (
         <SearchCriteriaProvider>
@@ -57,7 +60,12 @@ const InvestigationSearch = () => {
                     resultsAsList={() => (
                         <SearchResultList<Investigation>
                             results={results?.content ?? []}
-                            render={(result) => <InvestigationSearchResultListItem result={result} />}
+                            render={(result) => (
+                                <InvestigationSearchResultListItem
+                                    result={result}
+                                    notificationStatusResolver={findByValue(notificationStatus)}
+                                />
+                            )}
                         />
                     )}
                     resultsAsTable={() => <div>result table</div>}

--- a/apps/modernization-ui/src/apps/search/investigation/result/list/InvestigationSearchResultListItem.module.scss
+++ b/apps/modernization-ui/src/apps/search/investigation/result/list/InvestigationSearchResultListItem.module.scss
@@ -1,44 +1,11 @@
 @use 'styles/colors';
 
-.listItem {
-    display: flex;
-    flex-direction: row;
-    padding: 0.75rem 1rem;
-    justify-content: space-between;
+.status {
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.125rem;
 
-    .listItemBox {
-        flex: 1;
-        max-width: 25%;
+    background-color: colors.$open;
+    color: colors.$base-white;
 
-        .listItemData {
-            &:first-of-type {
-                margin-bottom: 0.25rem;
-            }
-        }
-
-        label {
-            color: colors.$base;
-            /* H5 */
-            font-size: 0.8125rem;
-            font-weight: 600;
-            letter-spacing: 0.02031rem;
-            text-transform: uppercase;
-            margin-right: 0.5rem;
-        }
-        .value {
-            color: colors.$base-darkest;
-            font-size: 0.875rem;
-            font-weight: 400;
-        }
-        .name {
-            color: colors.$primary;
-        }
-
-        .open {
-            background-color: colors.$open;
-            padding: 0.125rem 0.5rem;
-            color: colors.$base-white;
-            border-radius: 0.125rem;
-        }
-    }
+    width: fit-content;
 }

--- a/apps/modernization-ui/src/apps/search/investigation/result/list/InvestigationSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/result/list/InvestigationSearchResultListItem.spec.tsx
@@ -1,0 +1,275 @@
+import { Investigation } from 'generated/graphql/schema';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { InvestigationSearchResultListItem } from './InvestigationSearchResultListItem';
+
+describe('when showing an investigation search results', () => {
+    it('should display the patient ID', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            personParticipations: [
+                {
+                    shortId: 797,
+                    personCd: 'PAT',
+                    typeCd: 'SubjOfPHC'
+                }
+            ]
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Patient ID')).toBeInTheDocument();
+        expect(getByText('797')).toBeInTheDocument();
+    });
+
+    it('should display the patient legal name', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            personParticipations: [
+                {
+                    personCd: 'PAT',
+                    typeCd: 'SubjOfPHC',
+                    firstName: 'legal-first-name',
+                    lastName: 'legal-last-name'
+                }
+            ]
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Legal name')).toBeInTheDocument();
+        expect(getByText('legal-first-name legal-last-name')).toBeInTheDocument();
+    });
+
+    it('should display the patient date of birth when present', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            personParticipations: [
+                {
+                    personCd: 'PAT',
+                    typeCd: 'SubjOfPHC',
+                    birthTime: '1976-12-01'
+                }
+            ]
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Date of birth')).toBeInTheDocument();
+        expect(getByText('12/01/1976')).toBeInTheDocument();
+    });
+
+    it('should display the patient gender when present', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            personParticipations: [
+                {
+                    personCd: 'PAT',
+                    typeCd: 'SubjOfPHC',
+                    currSexCd: 'F'
+                }
+            ]
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Sex')).toBeInTheDocument();
+        expect(getByText('F')).toBeInTheDocument();
+    });
+
+    it('should display the condition under investigation', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            id: '1063',
+            cdDescTxt: 'investigated-condition',
+            localId: 'local-id-value',
+            personParticipations: []
+        };
+
+        const { getByText, debug } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        debug();
+
+        expect(getByText('Condition')).toBeInTheDocument();
+        expect(getByText('investigated-condition')).toBeInTheDocument();
+        expect(getByText('local-id-value')).toBeInTheDocument();
+    });
+
+    it('should display the investigation start date', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            addTime: '2023-07-21T15:21:03.770Z',
+            personParticipations: []
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Start date')).toBeInTheDocument();
+        expect(getByText('07/21/2023')).toBeInTheDocument();
+    });
+
+    it('should display the Jurisdiction', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            jurisdictionCodeDescTxt: 'jurisdication name',
+            personParticipations: []
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Jurisdiction')).toBeInTheDocument();
+        expect(getByText('jurisdication name')).toBeInTheDocument();
+    });
+
+    it('should display the investigator', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            personParticipations: [
+                {
+                    typeCd: 'InvestgrOfPHC',
+                    personCd: 'PRV',
+                    firstName: 'investigator-first-name',
+                    lastName: 'investigator-last-name'
+                }
+            ]
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Investigator')).toBeInTheDocument();
+        expect(getByText('investigator-first-name investigator-last-name')).toBeInTheDocument();
+    });
+
+    it('should display the open investigation status', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            investigationStatusCd: 'O',
+            personParticipations: []
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Status')).toBeInTheDocument();
+        expect(getByText('OPEN')).toBeInTheDocument();
+    });
+
+    it('should display the closed investigation status', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            investigationStatusCd: 'C',
+            personParticipations: []
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Status')).toBeInTheDocument();
+        expect(getByText('CLOSED')).toBeInTheDocument();
+    });
+
+    it('should display the notification status when present', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            notificationRecordStatusCd: 'notification-status',
+            personParticipations: []
+        };
+
+        const notificationStatusResolver = jest.fn();
+        notificationStatusResolver.mockReturnValue({
+            value: 'notification-status',
+            name: 'notification-status-display',
+            label: 'notification-status-display'
+        });
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={notificationStatusResolver}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Notification')).toBeInTheDocument();
+        expect(getByText('notification-status-display')).toBeInTheDocument();
+
+        expect(notificationStatusResolver).toBeCalledWith('notification-status');
+    });
+
+    it('should display the provided notification status unknown value is given', () => {
+        const result: Investigation = {
+            relevance: 63.1,
+            notificationRecordStatusCd: 'unknown-value',
+            personParticipations: []
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <InvestigationSearchResultListItem
+                    result={result}
+                    notificationStatusResolver={jest.fn()}></InvestigationSearchResultListItem>
+            </MemoryRouter>
+        );
+
+        expect(getByText('Notification')).toBeInTheDocument();
+        expect(getByText('unknown-value')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/apps/search/investigation/result/list/InvestigationSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/result/list/InvestigationSearchResultListItem.tsx
@@ -1,151 +1,94 @@
-import styles from './InvestigationSearchResultListItem.module.scss';
 import { Link } from 'react-router-dom';
 import { Investigation, InvestigationPersonParticipation } from 'generated/graphql/schema';
-import { NoData } from 'components/NoData';
+import { internalizeDate } from 'date';
+import { ClassicLink } from 'classic';
+import { Result, ResultItem, ResultItemGroup } from 'apps/search/layout/result/list';
+
+import styles from './InvestigationSearchResultListItem.module.scss';
+import { SelectableResolver } from 'options';
+
+const getPatient = (investigation: Investigation): InvestigationPersonParticipation | undefined | null => {
+    return investigation.personParticipations?.find((p) => p?.typeCd === 'SubjOfPHC');
+};
+
+const getInvestigatorName = (investigation: Investigation): string | undefined => {
+    const provider = investigation.personParticipations?.find((p) => p?.typeCd === 'InvestgrOfPHC');
+    if (provider) {
+        return `${provider.firstName} ${provider.lastName}`;
+    } else {
+        return undefined;
+    }
+};
 
 type Props = {
     result: Investigation;
+    notificationStatusResolver: SelectableResolver;
 };
 
-const InvestigationSearchResultListItem = ({ result }: Props) => {
-    const getPatient = (investigation: Investigation): InvestigationPersonParticipation | undefined | null => {
-        return investigation.personParticipations?.find((p) => p?.typeCd === 'SubjOfPHC');
-    };
-
+const InvestigationSearchResultListItem = ({ result, notificationStatusResolver }: Props) => {
     const patient = getPatient(result);
     const firstName = patient?.firstName ?? '';
     const lastName = patient?.lastName ?? '';
     const legalName = firstName && lastName ? `${firstName} ${lastName}` : 'No data';
 
-    const getInvestigatorName = (investigation: Investigation): string | undefined => {
-        const provider = investigation.personParticipations?.find((p) => p?.typeCd === 'InvestgrOfPHC');
-        if (provider) {
-            return `${provider.firstName} ${provider.lastName}`;
-        } else {
-            return undefined;
-        }
-    };
-
-    const getInvestigationStatusString = (investigation: Investigation): string => {
-        switch (investigation.investigationStatusCd) {
-            case 'O':
-                return 'OPEN';
-            case 'C':
-                return 'CLOSED';
-            default:
-                return investigation.investigationStatusCd ?? 'No Data';
-        }
-    };
+    const getInvestigationStatusString = (investigation: Investigation): string =>
+        investigation.investigationStatusCd === 'C' ? 'CLOSED' : 'OPEN';
 
     return (
-        <div className={styles.listItem}>
-            <div className={styles.listItemBox}>
-                <div className={styles.listItemData}>
-                    <label htmlFor="legalName" className={styles.listItemLabel}>
-                        LEGAL NAME
-                    </label>
-                    <br />
-                    <Link
-                        id="legalName"
-                        className={`${styles.value}, ${styles.name}`}
-                        to={`/patient-profile/${patient?.shortId}/summary`}>
+        <Result>
+            <ResultItemGroup>
+                <ResultItem label="Legal name" orientation="vertical">
+                    <Link id="legalName" to={`/patient-profile/${patient?.shortId}/summary`}>
                         {legalName}
                     </Link>
-                </div>
-
-                <div className={styles.listItemData}>
-                    <label htmlFor="dob">Date of birth</label>
-                    <span id="dob" className={styles.value}>
-                        {patient?.birthTime ?? <NoData />}
-                    </span>
-                </div>
-
-                <div className={styles.listItemData}>
-                    <label htmlFor="sex">SEX</label>
-                    <span id="sex" className={styles.value}>
-                        {patient?.currSexCd ?? 'No data'}
-                    </span>
-                </div>
-
-                <div className={styles.listItemData}>
-                    <label htmlFor="patientId" className={styles.listItemLabel}>
-                        Patient ID
-                    </label>
-                    <span id="patientId" className={styles.value}>
-                        {patient?.shortId ?? <NoData />}
-                    </span>
-                </div>
-            </div>
-
-            <div className={styles.listItemBox}>
-                <div className={styles.listItemData}>
-                    <label htmlFor="condition">Condition</label>
-                    <br />
-                    <Link
+                </ResultItem>
+                <ResultItem label="Date of birth">{internalizeDate(patient?.birthTime)}</ResultItem>
+                <ResultItem label="Sex">{patient?.currSexCd}</ResultItem>
+                <ResultItem label="Patient ID">{patient?.shortId}</ResultItem>
+            </ResultItemGroup>
+            <ResultItemGroup>
+                <ResultItem label="Condition" orientation="vertical">
+                    <ClassicLink
                         id="condition"
-                        className={`${styles.value}, ${styles.name}`}
-                        to={`/nbs/api/profile/${patient?.personParentUid}/investigation/${result.id}`}>
+                        url={`/nbs/api/profile/${patient?.personParentUid}/investigation/${result.id}`}>
                         {result.cdDescTxt}
-                    </Link>
-                    <br />
-                    <span>{result.localId}</span>
-                </div>
-
-                <div className={styles.listItemData}>
-                    <label htmlFor="startDate">Start Date</label>
-                    <br />
-                    <span id="startDate" className={styles.value}>
-                        {result.addTime ?? <NoData />}
-                    </span>
-                </div>
-            </div>
-
-            <div className={styles.listItemBox}>
-                <div className={styles.listItemData}>
-                    <label htmlFor="jurisdiction" className={styles.listItemLabel}>
-                        Jurisdiction
-                    </label>
-                    <br />
-                    <span id="jurisdiction" className={styles.value}>
-                        {result.jurisdictionCodeDescTxt ?? <NoData />}
-                    </span>
-                </div>
-                <div className={styles.listItemData}>
-                    <label htmlFor="investigator" className={styles.listItemLabel}>
-                        Investigator
-                    </label>
-                    <br />
-                    <span id="investigator" className={styles.value}>
-                        {getInvestigatorName(result) ?? <NoData />}
-                    </span>
-                </div>
-            </div>
-
-            <div className={styles.listItemBox}>
-                <div className={styles.listItemData}>
-                    <label htmlFor="status" className={styles.listItemLabel}>
-                        STATUS
-                    </label>
-                    <br />
-                    <span
-                        className={`${styles.value} ${result.investigationStatusCd == 'O' ? styles.open : ''}`}
-                        id="status">
-                        {getInvestigationStatusString(result) ?? <NoData />}
-                    </span>
-                </div>
-
-                <div className={styles.listItemData}>
-                    <label htmlFor="notification" className={styles.listItemLabel}>
-                        NOTIFICATION
-                    </label>
-                    <br />
-                    <span className={styles.value} id="notification">
-                        {result.notificationRecordStatusCd ?? <NoData />}
-                    </span>
-                </div>
-            </div>
-        </div>
+                    </ClassicLink>
+                    {result.localId}
+                </ResultItem>
+                <ResultItem label="Start date" orientation="vertical">
+                    {internalizeDate(result.addTime)}
+                </ResultItem>
+            </ResultItemGroup>
+            <ResultItemGroup>
+                <ResultItem label="Jurisdiction" orientation="vertical">
+                    {result.jurisdictionCodeDescTxt}
+                </ResultItem>
+                <ResultItem label="Investigator" orientation="vertical">
+                    {getInvestigatorName(result)}
+                </ResultItem>
+            </ResultItemGroup>
+            <ResultItemGroup>
+                <ResultItem label="Status" orientation="vertical">
+                    <StatusBadge>{getInvestigationStatusString(result)}</StatusBadge>
+                </ResultItem>
+                <ResultItem label="Notification" orientation="vertical">
+                    {(result.notificationRecordStatusCd &&
+                        notificationStatusResolver(result.notificationRecordStatusCd)?.name) ||
+                        result.notificationRecordStatusCd}
+                </ResultItem>
+            </ResultItemGroup>
+        </Result>
     );
 };
+
+type StatusBadgeProps = {
+    children?: string;
+};
+
+const StatusBadge = ({ children }: StatusBadgeProps) => (
+    <span className={styles.status} id="status">
+        {children}
+    </span>
+);
 
 export { InvestigationSearchResultListItem };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/list/LaboratoryReportSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/list/LaboratoryReportSearchResultListItem.spec.tsx
@@ -17,7 +17,7 @@ const expectedResult: LabReport = {
         {
             shortId: 123,
             personCd: '123',
-            birthTime: '05-05-1995',
+            birthTime: '1995-05-07',
             currSexCd: 'Male',
             firstName: 'Jon',
             lastName: 'Doe',
@@ -48,7 +48,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
                     <LaboratoryReportSearchResultListItem result={expectedResult} jurisdictionResolver={jest.fn()} />
                 </MemoryRouter>
             );
-            expect(getByText(expectedResult.personParticipations[0].birthTime)).toBeInTheDocument();
+            expect(getByText('05/07/1995')).toBeInTheDocument();
         });
     });
 

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/list/LaboratoryReportSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/list/LaboratoryReportSearchResultListItem.tsx
@@ -44,7 +44,7 @@ const LaboratoryReportSearchResultListItem = ({ result, jurisdictionResolver }: 
                         {legalName}
                     </Link>
                 </ResultItem>
-                <ResultItem label="Date of birth">{patient?.birthTime}</ResultItem>
+                <ResultItem label="Date of birth">{internalizeDate(patient?.birthTime)}</ResultItem>
                 <ResultItem label="Sex">{patient?.currSexCd}</ResultItem>
                 <ResultItem label="Patient ID">{patient?.shortId}</ResultItem>
             </ResultItemGroup>

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
@@ -1,13 +1,13 @@
 .terms {
     display: flex;
     align-items: center;
+    outline: none !important;
+
     .term {
         align-items: center;
         display: flex;
         flex-wrap: wrap;
     }
-
-    outline: none !important;
 
     h2 {
         display: flex;


### PR DESCRIPTION
## Description

Changes the `Link` to a `ClassicLink` in the Investigation Search Result Item component so that the user can click to navigate to the Investigation.

- Refactors the `InvestigationSearchResultListItem` to use the standardized search result components `Result`, `ResultItemGroup`, and `ResultItem`.
- Adds unit tests for `InvestigationSearchResultListItem`

## Tickets

* [CNFT1-2829](https://cdc-nbs.atlassian.net/browse/CNFT1-2829)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2829]: https://cdc-nbs.atlassian.net/browse/CNFT1-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ