### PR TITLE
[CNT-45] - Preview and publish - View page details and edit

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
@@ -189,7 +189,7 @@ const PreviewPageContent = () => {
                                     Create new draft
                                 </Button>
                             ) : (
-                                <ModalToggleButton modalRef={publishDraftRef} type="button">
+                                <ModalToggleButton modalRef={publishDraftRef} type="button" data-testid="publishBtn">
                                     Publish
                                 </ModalToggleButton>
                             )}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PublishPage/PublishPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PublishPage/PublishPage.tsx
@@ -133,6 +133,7 @@ export const PublishPage = ({ modalRef, onPublishing }: Props) => {
                 </ModalToggleButton>
                 <Button
                     type="submit"
+                    data-testid="publishBtnOnPublishPageModal"
                     disabled={
                         !publishForm.formState.isValid ||
                         !(conditions?.length && conditions.filter((c) => c.name).length)

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/information/PageInformation.tsx
@@ -67,7 +67,10 @@ const PageInformation = () => {
             <li className={activeTab == 'Details' ? styles.active : ''} onClick={() => setActiveTab('Details')}>
                 Details
             </li>
-            <li className={activeTab == 'History' ? styles.active : ''} onClick={() => setActiveTab('History')}>
+            <li
+                className={activeTab == 'History' ? styles.active : ''}
+                data-testid="historyTab"
+                onClick={() => setActiveTab('History')}>
                 History
             </li>
         </ul>
@@ -125,7 +128,12 @@ const PageInformation = () => {
                     </div>
                     <div className={styles.detailsContainer}>
                         <footer>
-                            <Button type="button" outline onClick={handleViewPage} className={styles.icon}>
+                            <Button
+                                type="button"
+                                outline
+                                onClick={handleViewPage}
+                                className={styles.icon}
+                                data-testid="EditViewPageDetails">
                                 {isEditable ? <Icon.Edit /> : <Icon.Visibility />}
                                 {isEditable ? 'Edit page details' : 'View page details'}
                             </Button>
@@ -133,7 +141,7 @@ const PageInformation = () => {
                     </div>
                 </div>
             ) : (
-                <div className={styles.content}>
+                <div className={styles.content} data-testid="historyTabContent">
                     <div className={styles.historyContent}>
                         {pageHistory?.map((pageData, index) => (
                             <div className={styles.versionBlock} key={index}>

--- a/testing/regression/cypress/e2e/features/preview-page/previewPage.feature
+++ b/testing/regression/cypress/e2e/features/preview-page/previewPage.feature
@@ -43,7 +43,7 @@ Feature: Page Builder - User can view Preview Page here.
       | Create new draft | Button |
 
   Scenario Outline: Verify the data elements in the preview page header buttons when page status is published with draft
-    When User navigates to Preview Page and page status is Published with Draft
+    When user is at Preview page - Page info section with page under Draft or Published with Draft status
     Then Below buttons will displays in preview page "<Content>" "<Type>"
     Examples:
       | Content          | Type   |
@@ -54,4 +54,25 @@ Feature: Page Builder - User can view Preview Page here.
       | Clone            | Icon   |
       | Print            | Icon   |
       | Publish          | Button |
+
+  Scenario: Preview Page - Page Info - View Page details and Edit
+    Given user is at Preview page - Page info section with page under Draft or Published with Draft status
+    When clicks on Edit Page details in preview page
+    Then verify user is navigated to Page details page with prepopulated data
+    Then verify Conditions is required and editable field
+    Then verify user can remove add the conditions
+    And verify Page name is required field and already prefilled
+    And verify user can update Page name with max characters 50
+    Then verify Event Type is required and uneditable field
+    And verify Reporting Mechanism is required and editable field
+    Then verify user can select another option from reporting mechanism dropdown
+    And verify Page description is optional field
+    And verify maximum allowed characters are 2000 in Page description
+    Then verify Data mart name is optional field and may display exiting data mart name
+    And verify maximum allowed characters are 50 for datamart name
+    When click on Cancel in page details page
+    Then verify user is brought back to Preview page with correct status on top right
+    And verify no changes are made to page
+    When click on Save changes in  page details page
+    Then verify user navigates to pre-preview page with success message You have successfully saved you changes
 

--- a/testing/regression/cypress/e2e/pages/preview-page/previewPage.page.js
+++ b/testing/regression/cypress/e2e/pages/preview-page/previewPage.page.js
@@ -20,7 +20,9 @@ class PreviewPagePage {
     navigateToPreviewPageWithStatusInitialDraft() {
         cy.visit('/page-builder/pages');
         cy.wait(2000);
-         cy.get("table[data-testid=table]").eq(0).find("tbody tr").each(($tr, index) => {
+        cy.get('#range-toggle').select('100')
+        cy.wait(5000);
+        cy.get("table[data-testid=table]").eq(0).find("tbody tr").each(($tr, index) => {
             if($tr.find("td").eq(3).text() === "Initial Draft") {
                 cy.get('table.pageLibraryTable tbody tr td a').eq(index).click();
                 return false
@@ -31,35 +33,245 @@ class PreviewPagePage {
     navigateToPreviewPageWithStatusPublished() {
         cy.visit('/page-builder/pages');
         cy.wait(2000);
+        cy.get('#range-toggle').select('100')
+        cy.wait(5000);
         let isExist = false;
-        const findOne = () => {
-            cy.get("table[data-testid=table]").eq(0).find("tbody tr").each(($tr, index) => {
-                cy.log('xox-$tr.find("td").eq(3).text()' + $tr.find("td").eq(3).text())
-                if($tr.find("td").eq(3).text() === "Published") {
-                    isExist = true;
-                    cy.get('table.pageLibraryTable tbody tr td a').eq(index).click();
-                    return false
-                }
-            });
-         }
-        findOne();
-        if(!isExist) {
-            cy.get("th .usa-button.usa-button--unstyled").eq(2).click();
-            cy.wait(2000);
-             cy.get('table.pageLibraryTable tbody tr td a').eq(2).click();
-        }
+        cy.get("table[data-testid=table]").eq(0).find("tbody tr").each(($tr, index) => {
+            if($tr.find("td").eq(3).text() === "Published") {
+                isExist = true;
+                cy.get('table.pageLibraryTable tbody tr td a').eq(index).click();
+                return false
+            }
+        });
     }
 
     navigateToPreviewPageWithStatusPublishedWithDraft() {
         cy.visit('/page-builder/pages');
         cy.wait(2000);
-         cy.get("table[data-testid=table]").eq(0).find("tbody tr").each(($tr, index) => {
+        cy.get('#range-toggle').select('100')
+        cy.wait(5000);
+        cy.get("table[data-testid=table]").eq(0).find("tbody tr").each(($tr, index) => {
             if($tr.find("td").eq(3).text() === "Published with Draft") {
                 cy.get('table.pageLibraryTable tbody tr td a').eq(index).click();
                 return false
             }
         });
     }
+
+    clickOnEditPageDetails() {
+        cy.get('[data-testid="EditViewPageDetails"]').click()
+    }
+
+    checkNavigatedToPageDetails() {
+        cy.contains('Page Details')
+    }
+
+    checkConditionsField() {
+        cy.get('.multi-select__input-container').eq(0).click()
+    }
+
+    checkRemoveOrAddConditions() {
+        cy.get('.multi-select__menu').eq(0).click()
+        cy.get('.multi-select__input-container').eq(0).click()
+    }
+
+    checkPageNameField() {
+        cy.get('#name').click()
+    }
+
+    checkPageNameFieldMaxLength() {
+        cy.get('#name')
+            .invoke('text')
+            .then((text) => {
+                if(text) {
+                    expect(text.length).to.be.lessThan(50)
+                }
+            })
+    }
+
+    checkEventTypeField() {
+        cy.get('[data-testid="dropdown"]').should('be.disabled')
+    }
+
+    checkReportingMechanismField() {
+        cy.get('#messageMappingGuide').should('be.exist')
+    }
+
+    selectAnotherOptionFromReportingMechanism() {
+        cy.get('#messageMappingGuide').select(2)
+    }
+
+    checkPageDescriptionField() {
+        cy.get('#description').should('be.exist')
+    }
+
+    checkPageDescriptionFieldMaxLength() {
+        cy.get('#description')
+            .invoke('text')
+            .then((text) => {
+                if(text) {
+                    expect(text.length).to.be.lessThan(2000)
+                }
+            })
+    }
+
+    checkDatamartNameField() {
+        cy.get('#datamart').should('be.exist')
+    }
+
+    checkDatamartNameFieldMaxField() {
+        cy.get('#datamart')
+            .invoke('text')
+            .then((text) => {
+                if(text) {
+                    expect(text.length).to.be.lessThan(2000)
+                }
+            })
+    }
+
+    clickCancelBtnPageDetailsPage() {
+        cy.contains('Cancel').click()
+    }
+
+    checkNavigatedBackToPreviewPage() {
+        cy.contains('Page Details')
+    }
+
+    checkChangesOnPreviewPage() {
+        cy.contains('Page information')
+    }
+
+    clickSaveChangesBtnPageDetailsPage() {
+        this.clickOnEditPageDetails()
+        cy.get('#name').type('test')
+        cy.contains('Save').click()
+    }
+
+    checkSuccessMessage() {
+        cy.wait(2000)
+        cy.contains('successfully')
+    }
+
+    checkChangesOnPreviewPageStatusType() {
+        cy.contains('PREVIEWING:')
+    }
+
+    checkEditDraftPage() {
+        cy.contains('Edit draft')
+    }
+
+    clickOnMetadataBtn() {
+        this.clickCancelBtnPageDetailsPage()
+        cy.contains('Metadata').click()
+    }
+
+    clickOnHistoryTab() {
+        cy.get('[data-testid="historyTab"]').click()
+    }
+
+    checkHistoryInfo(info) {
+         cy.get('[data-testid="historyTabContent"]')
+            .invoke('text')
+            .then((text) => {
+                if (text.includes(info)) {
+                    cy.contains(info);
+                }
+            })
+    }
+
+    userSeeOnlyTenRows() {
+        cy.get('[data-testid="historyTabContent"]')
+            .invoke('text')
+            .then((text) => {
+                if (text.includes(10)) {
+                    cy.contains(10);
+                }
+            })
+    }
+
+    checkRowOptionsAvailable() {
+        cy.get('[data-testid="historyTabContent"]')
+            .invoke('text')
+            .then((text) => {
+                if (text.includes(20)) {
+                    cy.contains(20);
+                }
+            })
+    }
+
+    clickCreateNewPageButton() {
+        cy.visit('/page-builder/pages');
+        cy.get(".createNewPageButton").eq(0).click()
+    }
+    userViewsEventTypeField() {
+        cy.get("#eventType")
+    }
+
+    selectEventType(type) {
+        cy.wait(2000)
+        if(type) {
+            cy.get("#eventType").select(type)
+        } else {
+            cy.get("#eventType").select("INV")
+        }
+    }
+
+    viewTextOnPage(text) {
+        cy.contains(text)
+    }
+
+    selectCondition() {
+        this.selectEventType()
+        cy.get("#conditionIds").click()
+        cy.get('#conditionIds .multi-select__option input[type="checkbox"]').eq(0).click()
+    }
+
+    selectPageName() {
+        cy.get('#name').click({ force: true })
+        const newPageName = Math.random().toString(36).substring(2, 8);
+        cy.get('#name').type(`New page test ${newPageName}`)
+    }
+
+    selectTemplate() {
+        cy.get('#templateId').find('option').eq(1).then((option) => {
+            cy.get('#templateId').select(option.attr('value'))
+        })
+    }
+
+    selectReportingMechanism() {
+        cy.get('#messageMappingGuide').find('option').eq(1).then((option) => {
+            cy.get('#messageMappingGuide').select(option.attr('value'))
+        })
+    }
+    enterPageDescription() {
+        cy.get("#pageDescription").type("This page is for diagnosis")
+    }
+
+    clickCreatePageButton() {
+        cy.get('.createPage').eq(0).click()
+        cy.wait(4000)
+    }
+
+    clickPreviewAfterNewlyCreatedPage() {
+        cy.contains('Preview').click();
+    }
+
+    clickPublishBtn() {
+        cy.get('[data-testid="publishBtn"]').eq(0).click();
+
+    }
+
+    clickPublishBtnOnPublishPage() {
+        cy.wait(2000)
+        cy.get('#notes').type('Version note test', { force: true });
+        cy.get('[data-testid="publishBtnOnPublishPageModal"]').click({ force: true });
+    }
+
+    viewTextOnPageForStatus(text) {
+        cy.wait(2000)
+        cy.contains(text)
+    }
+
 }
 
 export const previewPagePage = new PreviewPagePage()

--- a/testing/regression/cypress/step_definitions/preview-page/previewPage.steps.js
+++ b/testing/regression/cypress/step_definitions/preview-page/previewPage.steps.js
@@ -17,3 +17,83 @@ Then("User navigates to Preview Page and page status is Published", () => {
     previewPagePage.navigateToPreviewPageWithStatusPublished();
 });
 
+Then("user is at Preview page - Page info section with page under Draft or Published with Draft status", () => {
+    previewPagePage.navigateToPreviewPageWithStatusInitialDraft();
+});
+
+Then("clicks on Edit Page details in preview page", () => {
+    previewPagePage.clickOnEditPageDetails();
+});
+
+Then("verify user is navigated to Page details page with prepopulated data", () => {
+    previewPagePage.checkNavigatedToPageDetails();
+});
+
+Then("verify Conditions is required and editable field", () => {
+    previewPagePage.checkConditionsField();
+});
+
+Then("verify user can remove add the conditions", () => {
+    previewPagePage.checkRemoveOrAddConditions();
+});
+
+Then("verify Page name is required field and already prefilled", () => {
+    previewPagePage.checkPageNameField();
+});
+
+Then("verify user can update Page name with max characters 50", () => {
+    previewPagePage.checkPageNameFieldMaxLength();
+});
+
+Then("verify Event Type is required and uneditable field", () => {
+    previewPagePage.checkEventTypeField();
+});
+
+Then("verify Reporting Mechanism is required and editable field", () => {
+    previewPagePage.checkReportingMechanismField();
+});
+
+Then("verify user can select another option from reporting mechanism dropdown", () => {
+    previewPagePage.selectAnotherOptionFromReportingMechanism();
+});
+
+Then("verify Page description is optional field", () => {
+    previewPagePage.checkPageDescriptionField();
+});
+
+Then("verify maximum allowed characters are 2000 in Page description", () => {
+    previewPagePage.checkPageDescriptionFieldMaxLength();
+});
+
+Then("verify Data mart name is optional field and may display exiting data mart name", () => {
+    previewPagePage.checkDatamartNameField();
+});
+
+Then("verify maximum allowed characters are 50 for datamart name", () => {
+    previewPagePage.checkDatamartNameFieldMaxField();
+});
+
+Then("click on Cancel in page details page", () => {
+    previewPagePage.clickCancelBtnPageDetailsPage();
+});
+
+Then("verify user is brought back to Preview page with correct status on top right", () => {
+    previewPagePage.checkNavigatedBackToPreviewPage();
+});
+
+Then("verify no changes are made to page", () => {
+    previewPagePage.checkChangesOnPreviewPageStatusType();
+});
+
+Then("click on Save changes in  page details page", () => {
+    previewPagePage.clickSaveChangesBtnPageDetailsPage();
+});
+
+Then("verify user navigates to pre-preview page with success message You have successfully saved you changes", () => {
+    previewPagePage.checkSuccessMessage();
+});
+
+Then("click on Close button in page details page", () => {
+    previewPagePage.clickCloseBtnPageDetailsPage();
+});
+


### PR DESCRIPTION
## Description

Added end to end test case for preview and publish page has View page details and edit [CNFT2-1978](https://cdc-nbs.atlassian.net/browse/CNFT2-1978)
<img width="1504" alt="Screenshot 2024-07-26 at 10 35 37 AM" src="https://github.com/user-attachments/assets/48c7eb6a-7b0f-4f33-8ad1-320cc8b52152">

## Tickets

* [CNT-45](https://cdc-nbs.atlassian.net/browse/CNT-45)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT2-1978]: https://cdc-nbs.atlassian.net/browse/CNFT2-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNT-45]: https://cdc-nbs.atlassian.net/browse/CNT-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ