### PR TITLE
[CNFT1-2599] "Login to NBS demo site" link in same tab

### DIFF
--- a/apps/modernization-ui/src/apps/landing/SignIn/SignIn.tsx
+++ b/apps/modernization-ui/src/apps/landing/SignIn/SignIn.tsx
@@ -1,10 +1,11 @@
+import { useEffect } from 'react';
 import { Button } from '@trussworks/react-uswds';
 import classNames from 'classnames';
-import styles from './signIn.module.scss';
-import { LinkButton } from 'components/button';
 import { AlertBanner } from 'alert';
+import { LinkButton } from 'components/button';
 import { useSkipLink } from 'SkipLink/SkipLinkContext';
-import { useEffect } from 'react';
+
+import styles from './signIn.module.scss';
 
 export type SignInProps = {
     handleWelcomeEvent?: (value: string) => void;
@@ -28,16 +29,12 @@ export const SignIn = ({ handleWelcomeEvent }: SignInProps) => {
                     </p>
                 </AlertBanner>
             </div>
-            <LinkButton id="login" href="/nbs/login" type="solid" className="margin-top-2">
+            <LinkButton id="login" href="/nbs/login" type="solid" className={styles['sign-in']} target="_self">
                 Login to NBS demo site
             </LinkButton>
-            <div className={classNames(styles.signUpDemoText)}>
+            <div className={classNames(styles.participation)}>
                 Want to participate?
-                <Button
-                    onClick={() => handleWelcomeEvent?.('signUp')}
-                    type="button"
-                    unstyled
-                    className={classNames(styles.signUpButton)}>
+                <Button onClick={() => handleWelcomeEvent?.('signUp')} type="button" unstyled>
                     Sign up for demo access
                 </Button>
             </div>

--- a/apps/modernization-ui/src/apps/landing/SignIn/signIn.module.scss
+++ b/apps/modernization-ui/src/apps/landing/SignIn/signIn.module.scss
@@ -14,7 +14,12 @@
     }
 }
 
-.signUpDemoText {
+.sign-in {
+    margin-top: 1rem;
+    line-height: 1.25rem;
+}
+
+.participation {
     display: flex;
     gap: 0.5rem;
     justify-content: flex-start;
@@ -24,7 +29,7 @@
     border-bottom: 1px solid colors.$base-lighter;
     margin-top: 1rem;
 
-    .signUpButton {
+    button {
         font-size: 14px;
         padding: 0;
         text-decoration: none;


### PR DESCRIPTION
## Description

Sets the target of the "Login to NBS demo site" button to _self to ensure that the user stays in the same tab.

## Tickets

* [CNFT1-2599](https://cdc-nbs.atlassian.net/browse/CNFT1-2599)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2599]: https://cdc-nbs.atlassian.net/browse/CNFT1-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ