### PR TITLE
[CNFT1-2852] Ensures that the email input is present.

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.spec.ts
@@ -73,7 +73,7 @@ describe('when addind a new patient from a patient search', () => {
         expect(actual).toEqual(expect.objectContaining({ homePhone: 'phone-number-value' }));
     });
 
-    it('should populate the email address that was searched for as the home phone', () => {
+    it('should populate the email address that was searched for', () => {
         const critiera = { email: 'email-value' };
 
         const actual = asNewPatientEntry(critiera);
@@ -81,6 +81,18 @@ describe('when addind a new patient from a patient search', () => {
         expect(actual).toEqual(
             expect.objectContaining({
                 emailAddresses: expect.arrayContaining([expect.objectContaining({ email: 'email-value' })])
+            })
+        );
+    });
+
+    it('should default the email address when it was not searched for', () => {
+        const critiera = {};
+
+        const actual = asNewPatientEntry(critiera);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                emailAddresses: expect.arrayContaining([expect.objectContaining({ email: '' })])
             })
         );
     });

--- a/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.ts
@@ -18,7 +18,7 @@ const resolveIdentification = (entry: Identification): IdentificationEntry[] =>
 
 const resolveRace = (entry: RaceEthnicity): string[] => (entry.race ? [asValue(entry.race)] : []);
 
-const resolveEmail = (entry: Contact): EmailEntry[] => (entry.email ? [{ email: entry.email }] : []);
+const resolveEmail = (entry: Contact): EmailEntry[] => [{ email: entry.email || '' }];
 
 const asNewPatientEntry = (criteria: Partial<PatientCriteriaEntry>): NewPatientEntry => {
     return {


### PR DESCRIPTION
## Description

The new patient form is driven by an object, when coming from a search without an email address there was no initial email object created to make the email input show up.  The `asNewPatientEntry` function was changed to ensure that an email address is present in the array to make the input show up.

## Tickets

* [CNFT1-2852](https://cdc-nbs.atlassian.net/browse/CNFT1-2852)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2852]: https://cdc-nbs.atlassian.net/browse/CNFT1-2852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ