### PR TITLE
adding keypress listener triggering onSearch in search layout

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useState, useEffect } from 'react';
 import { Button } from 'components/button';
 import { Term, useSearchResultDisplay } from 'apps/search';
 import { SearchLanding } from './landing';
@@ -44,6 +44,19 @@ const SearchLayout = ({
     const {
         page: { total }
     } = usePage();
+
+    const handleKeyPress = (event: { key: string }) => {
+        if (event.key === 'Enter') {
+            onSearch();
+        }
+    };
+
+    useEffect(() => {
+        document.addEventListener('keypress', handleKeyPress);
+        return () => {
+            document.removeEventListener('keypress', handleKeyPress);
+        };
+    }, [onSearch]);
 
     return (
         <section className={styles.search}>


### PR DESCRIPTION
## Description

Using "enter or return" key press on keyboard to trigger search in new search forms

## Tickets

* [CNFT1-2853](https://cdc-nbs.atlassian.net/browse/CNFT1-2853)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2853]: https://cdc-nbs.atlassian.net/browse/CNFT1-2853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ