### PR TITLE
adding localStorage.getItem(defaultSearchView) as View

### DIFF
--- a/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResultDisplay.tsx
@@ -54,6 +54,7 @@ const reducer = (current: State, action: Action): State => {
             return { ...current, status: 'noInput' };
         }
         case 'setView': {
+            localStorage.setItem('defaultSearchView', action.view);
             return { ...current, view: action.view };
         }
         default:

--- a/apps/modernization-ui/src/apps/search/useSearchSettings.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchSettings.ts
@@ -14,6 +14,7 @@ const defaults: SearchSettings = {
 
 const useSearchSettings = (): SearchSettings => {
     const [settings, setSettings] = useState<SearchSettings>(defaults);
+    const defaultView = localStorage.getItem('defaultSearchView') as View;
 
     const {
         features: { search }
@@ -21,7 +22,7 @@ const useSearchSettings = (): SearchSettings => {
 
     useEffect(() => {
         if (search.view.table.enabled) {
-            setSettings((current) => ({ ...current, defaultView: 'table', allowToggle: true }));
+            setSettings((current) => ({ ...current, defaultView: defaultView || 'table', allowToggle: true }));
         }
     }, [search.view.table.enabled]);
     return settings;


### PR DESCRIPTION
## Description
saving search view type- list or table”, so that its easy for data search.
Whenever user changes the preference, Save the search preference in local Browser storage. 
## Tickets

* [CNFT1-2556](https://cdc-nbs.atlassian.net/browse/CNFT1-2556)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2556]: https://cdc-nbs.atlassian.net/browse/CNFT1-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ