### PR TITLE
CNFT1-2736 Fix search with special characters

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaQueryResolver.java
@@ -130,7 +130,7 @@ class PatientSearchCriteriaQueryResolver {
                                                   nested -> nested.path(NAMES)
                                                       .scoreMode(ChildScoreMode.Avg)
                                                       .query(
-                                                          nonPrimary -> nonPrimary.queryString(
+                                                          nonPrimary -> nonPrimary.simpleQueryString(
                                                               queryString -> queryString
                                                                   .fields("name.firstNm")
                                                                   .query(WildCards.startsWith(name))
@@ -183,7 +183,7 @@ class PatientSearchCriteriaQueryResolver {
                           nested -> nested.path(NAMES)
                               .scoreMode(ChildScoreMode.Avg)
                               .query(
-                                  query -> query.queryString(
+                                  query -> query.simpleQueryString(
                                       nonPrimary -> nonPrimary
                                           .fields("name.lastNm")
                                           .query(WildCards.startsWith(name))
@@ -233,8 +233,8 @@ class PatientSearchCriteriaQueryResolver {
               nested -> nested.path(EMAILS)
                   .scoreMode(ChildScoreMode.Avg)
                   .query(
-                      query -> query.queryString(
-                          queryString -> queryString.defaultField("email.emailAddress")
+                      query -> query.simpleQueryString(
+                          queryString -> queryString.fields("email.emailAddress")
                               .defaultOperator(Operator.And)
                               .query(email)))));
     }
@@ -312,8 +312,8 @@ class PatientSearchCriteriaQueryResolver {
               nested -> nested.path(ADDRESSES)
                   .scoreMode(ChildScoreMode.Avg)
                   .query(
-                      query -> query.queryString(
-                          queryString -> queryString.defaultField("address.streetAddr1")
+                      query -> query.simpleQueryString(
+                          queryString -> queryString.fields("address.streetAddr1")
                               .defaultOperator(Operator.And)
                               .query(WildCards.startsWith(result))))));
     }
@@ -331,8 +331,8 @@ class PatientSearchCriteriaQueryResolver {
               nested -> nested.path(ADDRESSES)
                   .scoreMode(ChildScoreMode.Avg)
                   .query(
-                      query -> query.queryString(
-                          queryString -> queryString.defaultField("address.city")
+                      query -> query.simpleQueryString(
+                          queryString -> queryString.fields("address.city")
                               .defaultOperator(Operator.And)
                               .query(WildCards.startsWith(city))))));
     }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -305,3 +305,37 @@ Feature: Patient Search
     When I search for patients
     Then the search results have a patient with a "first name" equal to "Liam"
 
+  Scenario: I can find a patient by last name using special characters without an error 
+    Given the patient has the "legal" name "Sam" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a "last name" equal to "Sm~th"
+    When I search for patients
+    Then there are 1 patient search results
+
+  Scenario: I can find a patient by first name using special characters without an error 
+    Given the patient has the "legal" name "Sam" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a "first name" equal to "S~m"
+    When I search for patients
+    Then there are 1 patient search results
+
+  Scenario: I can find a patient by address using special characters without an error 
+    Given the patient has an "address" of "123 Way"
+    And patients are available for search
+    And I add the patient criteria for a "address" equal to "123 W~y"
+    When I search for patients
+    Then there are 0 patient search results
+
+  Scenario: I can find a patient by email using special characters without an error 
+    Given the patient has an "email address" of "email@test.com"
+    And patients are available for search
+    And I add the patient criteria for a "email address" equal to "email~test.com"
+    When I search for patients
+    Then there are 1 patient search results
+
+  Scenario: I can find a patient by city using special characters without an error 
+    Given the patient has an "city" of "acity"
+    And patients are available for search
+    And I add the patient criteria for a "city" equal to "a~ity"
+    When I search for patients
+    Then there are 0 patient search results


### PR DESCRIPTION
## Description

The story was written for last name with tilde.  Behind the scenes search uses `queryString` for 5 different searches: last name, first name, city, address, email.  Tilde is a special character used in advanced searches for fuzzy searching.  We have 2 options.  We can modify the input to make sure it's valid for special searches or switch to `simpleQueryString` (suggested by @adamloup-enquizit ) which is more forgiving with special characters.  This is the easiest path to fix this and we fix all the instances where it is used (5 total).  The test cases simply prove the searches don't blow up with a tilde (as they did previously) but are somewhat undefined (meaning sometimes they return matches searching with tildes and sometimes they don't depending on if the advanced search is syntactically valid).  The elasticsearch reserved characters are: `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`

## Tickets

* [CNFT1-2736](https://cdc-nbs.atlassian.net/browse/CNFT1-2736)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2736]: https://cdc-nbs.atlassian.net/browse/CNFT1-2736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ