### PR TITLE
adding form and sidebar placeholders and administrative ui

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
@@ -1,7 +1,39 @@
+import { Button, Grid } from '@trussworks/react-uswds';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Form } from 'react-router-dom';
+import Administrative from './administrative/Administrative';
+import styles from './extended.module.scss';
+import classNames from 'classnames';
+
 export const AddPatientExtended = () => {
+    const methods = useForm({
+        mode: 'onBlur'
+    });
+
     return (
-        <div>
-            <h2>New patient</h2>
-        </div>
+        <Grid row>
+            <Grid col={3} className={styles.sidebar}>
+                Sidebar
+            </Grid>
+            <Grid col={9}>
+                <FormProvider {...methods}>
+                    <Form autoComplete="off">
+                        <Grid row className={styles['page-title-bar']}>
+                            <div className={classNames(styles.flexBox, 'flex-justify width-full')}>
+                                <h1>New patient</h1>
+                                <Button type={'submit'}>Save changes</Button>
+                            </div>
+                        </Grid>
+                        <div>
+                            <Grid row className={classNames('padding-3')}>
+                                <Grid col={9}>
+                                    <Administrative title="Administrative" id={'section-Administrative'} />
+                                </Grid>
+                            </Grid>
+                        </div>
+                    </Form>
+                </FormProvider>
+            </Grid>
+        </Grid>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/administrative/Administrative.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/administrative/Administrative.tsx
@@ -1,0 +1,62 @@
+import { ErrorMessage, Grid, Label, Textarea } from '@trussworks/react-uswds';
+import FormCard from 'components/FormCard/FormCard';
+import { Controller, useFormContext } from 'react-hook-form';
+import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
+import { maxLengthRule } from 'validation/entry';
+import classNames from 'classnames';
+import styles from '../extended.module.scss';
+
+export default function Administrative({ id, title }: { id?: string; title?: string }) {
+    const { control } = useFormContext();
+    return (
+        <FormCard id={id} title={title}>
+            <Grid col={12} className="padding-3">
+                <Grid row className={styles.flexBox}>
+                    <Grid col={4}>
+                        <Label className={classNames({ required: true })} htmlFor={'asOf'}>
+                            Administrative Information as of
+                        </Label>
+                    </Grid>
+                    <Grid col={4}>
+                        <Controller
+                            rules={{
+                                required: { value: true, message: 'This field is required' }
+                            }}
+                            control={control}
+                            name="asOf"
+                            render={({ field: { onChange, value, name }, fieldState: { error } }) => (
+                                <DatePickerInput
+                                    defaultValue={value}
+                                    onChange={onChange}
+                                    name={name}
+                                    disableFutureDates
+                                    errorMessage={error?.message}
+                                />
+                            )}
+                        />
+                    </Grid>
+                </Grid>
+                <Grid row className={styles.flexBox}>
+                    <Grid col={4}>
+                        <Label htmlFor={'comments'}>General Comments</Label>
+                    </Grid>
+                    <Grid col={4}>
+                        <Controller
+                            control={control}
+                            name="comments"
+                            rules={maxLengthRule(2000)}
+                            render={({ field: { onChange, name, onBlur }, fieldState: { error } }) => (
+                                <>
+                                    <Textarea onChange={onChange} onBlur={onBlur} name={name} id={name} />
+                                    {error?.message && (
+                                        <ErrorMessage id={error?.message}>{error?.message}</ErrorMessage>
+                                    )}
+                                </>
+                            )}
+                        />
+                    </Grid>
+                </Grid>
+            </Grid>
+        </FormCard>
+    );
+}

--- a/apps/modernization-ui/src/apps/patient/add/extended/extended.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/extended/extended.module.scss
@@ -1,0 +1,23 @@
+@use 'styles/colors';
+
+.sidebar {
+    background: colors.$base-white;
+    border-right: 1px solid colors.$base-lightest;
+}
+
+.page-title-bar {
+    background: colors.$base-white;
+    min-height: 78px;
+    font-family: sans-serif;
+    padding: 0 1.5rem;
+    border-bottom: 1px solid colors.$base-lightest;
+}
+
+.flexBox {
+    display: flex;
+    align-items: center;
+
+    label {
+        font-weight: 600;
+    }
+}


### PR DESCRIPTION
## Description

UI: Create Extended patient data entry form for Administrative section
added form and sidebar placeholders in order to style administrative ui within the extended data page, these could be modified later
## Tickets

* [CNFT1-2749](https://cdc-nbs.atlassian.net/browse/CNFT1-2749)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2749]: https://cdc-nbs.atlassian.net/browse/CNFT1-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ