### PR TITLE
CNFT1-2851 Lab reports search table

### DIFF
--- a/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
@@ -11,6 +11,7 @@ import { LaboratoryReportSearchResultListItem } from './result/list';
 import { LaboratoryReportSearchCriteria } from './LaboratoryReportSearchCriteria';
 import { SearchCriteriaProvider } from 'providers/SearchCriteriaContext';
 import { useJurisdictionOptions } from 'options/jurisdictions';
+import { LaboratoryReportSearchResultsTable } from './result/table/LaboratoryReportSearchResultsTable';
 
 const LaboratoryReportSearch = () => {
     const form = useForm<LabReportFilterEntry, Partial<LabReportFilterEntry>>({
@@ -72,7 +73,7 @@ const LaboratoryReportSearch = () => {
                             )}
                         />
                     )}
-                    resultsAsTable={() => <div>result table</div>}
+                    resultsAsTable={() => <LaboratoryReportSearchResultsTable results={results?.content ?? []} />}
                     searchEnabled={form.formState.isValid}
                     onSearch={form.handleSubmit(search)}
                     onClear={reset}

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.spec.tsx
@@ -1,0 +1,122 @@
+import { render, waitFor } from '@testing-library/react';
+import { LaboratoryReportSearchResultsTable } from './LaboratoryReportSearchResultsTable';
+import { useJurisdictionOptions } from 'options/jurisdictions';
+import { LabReport } from 'generated/graphql/schema';
+import { MemoryRouter } from 'react-router-dom';
+import { SearchResultDisplayProvider } from 'apps/search/useSearchResultDisplay';
+import { ColumnPreferenceProvider } from 'design-system/table/preferences';
+
+jest.mock('options/jurisdictions', () => ({
+    useJurisdictionOptions: jest.fn()
+}));
+
+describe('LaboratoryReportSearchResultsTable', () => {
+        const mockJurisdictions = [
+            { value: '130006', name: 'Jurisdiction 1' },
+            { value: '2', name: 'Jurisdiction 2' }
+        ];
+
+        (useJurisdictionOptions as jest.Mock).mockReturnValue({
+            all: mockJurisdictions
+        });
+
+        const results: LabReport[] = [{
+            "__typename": "LabReport",
+            "addTime": "2015-09-22",
+            "associatedInvestigations": [
+                {
+                    "__typename": "AssociatedInvestigation",
+                    "cdDescTxt": "Bacterial Vaginosis",
+                    "localId": "CAS10001001GA01"
+                },
+                {
+                    "__typename": "AssociatedInvestigation",
+                    "cdDescTxt": "Bacterial Vaginosis",
+                    "localId": "CAS10001001GA01"
+                }
+            ],
+            "id": "10000013",
+            "jurisdictionCd": 130006,
+            "localId": "CAS10000000GA01",
+            "observations": [
+                {
+                    "__typename": "Observation",
+                    "cdDescTxt": "No Information Given",
+                    "statusCd": null,
+                    "altCd": null,
+                    "displayName": null
+                },
+                {
+                    "__typename": "Observation",
+                    "cdDescTxt": "11-Desoxycortisol",
+                    "statusCd": null,
+                    "altCd": "1657-6",
+                    "displayName": "abnormal"
+                }
+            ],
+            "organizationParticipations": [
+                {
+                    "__typename": "LabReportOrganizationParticipation",
+                    "typeCd": "AUT",
+                    "name": "Emory University Hospital"
+                }
+            ],
+            "personParticipations": [
+                {
+                    "__typename": "LabReportPersonParticipation",
+                    "birthTime": "1990-01-01",
+                    "currSexCd": "M",
+                    "typeCd": "PATSBJ",
+                    "firstName": "Surma",
+                    "lastName": "Singh",
+                    "personCd": "PAT",
+                    "personParentUid": 10000001,
+                    "shortId": 63000
+                },
+                {
+                    "__typename": "LabReportPersonParticipation",
+                    "birthTime": "1990-01-01",
+                    "currSexCd": "M",
+                    "typeCd": "ORD",
+                    "firstName": "John",
+                    "lastName": "Henry",
+                    "personCd": "PRV",
+                    "personParentUid": 10000001,
+                    "shortId": 63000
+                }
+            ],
+            "relevance": 1
+        }];
+
+        const Wrapper = () => {
+            return (
+                <MemoryRouter>
+                    <SearchResultDisplayProvider>
+                        <ColumnPreferenceProvider>
+                            <LaboratoryReportSearchResultsTable results={results} />
+                        </ColumnPreferenceProvider>
+                    </SearchResultDisplayProvider>
+                </MemoryRouter>
+            );
+        };
+
+        const { container } = render(<Wrapper />);
+
+    it('displays table content', async () => {
+        await waitFor(() => {
+            const columns = container.getElementsByTagName('td');
+            expect(columns[0]).toHaveTextContent('Surma Singh');
+            expect(columns[1]).toHaveTextContent('01/01/1990');
+            expect(columns[2]).toHaveTextContent('M');
+            expect(columns[3]).toHaveTextContent('63000');
+            expect(columns[4]).toHaveTextContent('Lab report');
+            expect(columns[5]).toHaveTextContent('09/22/2015');
+            expect(columns[6]).toHaveTextContent('11-Desoxycortisol = abnormal');
+            expect(columns[7]).toHaveTextContent('Emory University Hospital');
+            expect(columns[8]).toHaveTextContent('John Henry');
+            expect(columns[9]).toHaveTextContent('Jurisdiction 1');
+            expect(columns[10]).toHaveTextContent('Bacterial Vaginosis');
+            expect(columns[11]).toHaveTextContent('CAS10000000GA01');
+        });
+    });
+});

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import { LabReport, LabReportPersonParticipation, LabReportOrganizationParticipation } from 'generated/graphql/schema';
+import { Column, DataTable } from 'design-system/table';
+import { ColumnPreference, useColumnPreferences } from 'design-system/table/preferences';
+import { internalizeDate } from 'date';
+import { ClassicLink } from 'classic';
+import { useJurisdictionOptions } from 'options/jurisdictions';
+import { Selectable } from 'options';
+
+const getPatient = (labReport: LabReport): LabReportPersonParticipation | undefined | null => {
+    return labReport.personParticipations?.find((p) => p?.typeCd === 'PATSBJ');
+};
+
+const getOrderingProviderName = (labReport: LabReport): string | undefined => {
+    const provider = labReport.personParticipations.find((p) => p.typeCd === 'ORD' && p.personCd === 'PRV');
+    if (provider) {
+        return `${provider.firstName} ${provider.lastName}`;
+    } else {
+        return undefined;
+    }
+};
+
+const getReportingFacility = (labReport: LabReport): LabReportOrganizationParticipation | undefined => {
+    return labReport.organizationParticipations.find((o) => o?.typeCd === 'AUT');
+};
+
+const getDescription = (labReport: LabReport): string | undefined => {
+    const observation = labReport.observations?.find((o) => o?.altCd && o?.displayName && o?.cdDescTxt);
+
+    return observation && `${observation.cdDescTxt} = ${observation.displayName}`;
+};
+
+const LEGAL_NAME = { id: 'lastNm', name: 'Legal name' };
+const DATE_OF_BIRTH = { id: 'birthTime', name: 'Date of birth' };
+const SEX = { id: 'sex', name: 'Sex' };
+const PATIENT_ID = { id: 'id', name: 'Patient ID' };
+
+const DOCUMENT_TYPE = { id: 'documentType', name: 'Document type' };
+const DATE_RECEIVED = { id: 'dateReceived', name: 'Date received' };
+const DESCRIPTION = { id: 'description', name: 'Description' };
+const REPORTING_FACILITY = { id: 'reportingFacility', name: 'Reporting facility' };
+const ORDERING_PROVIDER = { id: 'orderingProvider', name: 'Ordering provider' };
+const JURSIDICTION = { id: 'jurisdiction', name: 'Jurisdiction' };
+const ASSOCIATED_WITH = { id: 'associatedWith', name: 'Associated with' };
+const LOCAL_ID = { id: 'localId', name: 'Local ID' };
+
+const preferences: ColumnPreference[] = [
+    { ...LEGAL_NAME },
+    { ...DATE_OF_BIRTH },
+    { ...SEX },
+    { ...PATIENT_ID },
+    { ...DOCUMENT_TYPE, moveable: true, toggleable: true },
+    { ...DATE_RECEIVED, moveable: true, toggleable: true },
+    { ...DESCRIPTION, moveable: true, toggleable: true },
+    { ...REPORTING_FACILITY, moveable: true, toggleable: true },
+    { ...ORDERING_PROVIDER, moveable: true, toggleable: true },
+    { ...JURSIDICTION, moveable: true, toggleable: true },
+    { ...ASSOCIATED_WITH, moveable: true, toggleable: true },
+    { ...LOCAL_ID, moveable: true, toggleable: true }
+];
+
+type Props = {
+    results: LabReport[];
+};
+
+const LaboratoryReportSearchResultsTable = ({ results }: Props) => {
+    const { apply, register } = useColumnPreferences();
+    const { all } = useJurisdictionOptions();
+    const [allJurisdictions] = useState<Selectable[]>(all);
+    const columns: Column<LabReport>[] = [
+        {
+            ...LEGAL_NAME,
+            fixed: true,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return patient ? `${patient.firstName ?? ''} ${patient.lastName ?? ''}`.trim() || 'N/A' : 'N/A';
+            }
+        },
+        {
+            ...DATE_OF_BIRTH,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return internalizeDate(patient?.birthTime);
+            }
+        },
+        {
+            ...SEX,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return patient?.currSexCd;
+            }
+        },
+        {
+            ...PATIENT_ID,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return patient?.shortId;
+            }
+        },
+        {
+            ...DOCUMENT_TYPE,
+            render: (row) => {
+                const patient = getPatient(row);
+                return (
+                    <ClassicLink
+                        id="condition"
+                        url={`/nbs/api/profile/${patient?.personParentUid}/investigation/${row.id}`}>
+                        Lab report
+                    </ClassicLink>
+                );
+            }
+        },
+        {
+            ...DATE_RECEIVED,
+            render: (row) => {
+                return internalizeDate(row.addTime);
+            }
+        },
+        {
+            ...DESCRIPTION,
+            render: (row) => {
+                return getDescription(row);
+            }
+        },
+        {
+            ...REPORTING_FACILITY,
+            render: (row) => {
+                return getReportingFacility(row)?.name;
+            }
+        },
+        {
+            ...ORDERING_PROVIDER,
+            render: (row) => {
+                return getOrderingProviderName(row);
+            }
+        },
+        {
+            ...JURSIDICTION,
+            render: (row) => {
+                const jurisdiction = allJurisdictions.find(
+                    (jurisdiction) => jurisdiction.value === String(row.jurisdictionCd)
+                );
+                return jurisdiction ? jurisdiction.name : 'No Data';
+            }
+        },
+        {
+            ...ASSOCIATED_WITH,
+            render: (row) => {
+                return row.associatedInvestigations
+                    ?.map((investigation) => `${investigation?.localId}\n${investigation?.cdDescTxt}\n`)
+                    .join('\n');
+            }
+        },
+        {
+            ...LOCAL_ID,
+            render: (row) => {
+                return row.localId;
+            }
+        }
+    ];
+
+    useEffect(() => {
+        register('LabReports', preferences);
+    }, []);
+
+    return <DataTable<LabReport> id="laboratory-report-search-results" columns={apply(columns)} data={results} />;
+};
+
+export { LaboratoryReportSearchResultsTable };


### PR DESCRIPTION
## Description

Here we display the table view of Lab Report Search.
If my solution is unpopular, Adam has a branch that we can pull instead.

## Tickets

* [CNFT1-2851](https://cdc-nbs.atlassian.net/browse/CNFT1-2851)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2851]: https://cdc-nbs.atlassian.net/browse/CNFT1-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ