### PR TITLE
[CNFT1-2875] multi-select styles

### DIFF
--- a/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.scss
+++ b/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.scss
@@ -1,6 +1,12 @@
 @use 'styles/colors';
 @use 'styles/components';
 
+.multi-select {
+    border-width: 1px;
+    border-style: solid;
+    border-color: colors.$base-dark;
+}
+
 .multi-select-selection__indicator {
     height: 1.25rem;
     width: 1.25rem;
@@ -9,11 +15,8 @@
 }
 
 .multi-select__control {
-    height: unset;
-    min-height: unset !important;
-    max-height: 2.5rem;
-    border-radius: 0 !important;
-    border-color: colors.$base-dark !important;
+    // height: unset;
+    // min-height: unset !important;
 
     .multi-select__indicator {
         color: colors.$base-darker !important;
@@ -58,11 +61,9 @@
 }
 
 .multi-select__compact {
-    @extend %compact-input;
+    @extend %compact;
 
     .multi-select__control {
-        max-height: 2rem;
-
         .multi-select__value-container {
             padding: 0 !important;
 

--- a/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.tsx
+++ b/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.tsx
@@ -3,9 +3,8 @@ import ReactSelect, { MultiValue } from 'react-select';
 import { mapNonNull } from 'utils';
 import { Selectable, asSelectable, asValue as asSelectableValue } from 'options';
 import { EntryWrapper } from 'components/Entry';
-import { CheckboxOption } from 'design-system/select/multi';
 
-import { theme } from 'design-system/select/multi/theme';
+import { theme, styles, CheckboxOption } from 'design-system/select/multi';
 
 import './MultiSelectInput.scss';
 
@@ -79,11 +78,13 @@ export const MultiSelectInput = ({
             error={error}>
             <ReactSelect<Selectable, true>
                 theme={theme}
+                styles={styles}
                 isMulti
                 id={id}
                 name={name}
                 value={selectedOptions}
                 placeholder={placeholder}
+                className={'multi-select'}
                 classNamePrefix="multi-select"
                 hideSelectedOptions={false}
                 closeMenuOnSelect={false}

--- a/apps/modernization-ui/src/design-system/autocomplete/multi/AutocompleteMulti.tsx
+++ b/apps/modernization-ui/src/design-system/autocomplete/multi/AutocompleteMulti.tsx
@@ -1,41 +1,17 @@
-import { FocusEventHandler, useState } from 'react';
-import { MultiValue, components } from 'react-select';
+import { useState } from 'react';
+import { MultiValue } from 'react-select';
 import AsyncSelect from 'react-select/async';
-import { EntryWrapper, Orientation, Sizing } from 'components/Entry';
+import { EntryWrapper } from 'components/Entry';
 import { Selectable, asValue as asSelectableValue } from 'options';
 
 import { AutocompleteOptionsResolver } from 'options/autocompete';
 
-import { theme } from 'design-system/select/multi/theme';
-
-const CheckedOption = (props: any) => {
-    return (
-        <div>
-            <components.Option {...props}>
-                <input type="checkbox" checked={props.isSelected} readOnly /> <label>{props.label}</label>
-            </components.Option>
-        </div>
-    );
-};
+import { styles, theme, CheckboxOption } from 'design-system/select/multi';
+import { MultiSelectProps } from 'design-system/select';
 
 const asSelectableDisplay = (selectable: Selectable) => selectable.name;
 
-export type AutocompleteMultiProps = {
-    id: string;
-    name: string;
-    label: string;
-    placeholder?: string;
-    disabled?: boolean;
-    options?: Selectable[];
-    value?: Selectable[];
-    onBlur?: FocusEventHandler<HTMLInputElement>;
-    onChange?: (value: Selectable[]) => void;
-    orientation?: Orientation;
-    sizing?: Sizing;
-    error?: string;
-    required?: boolean;
-    asValue?: (selectable: Selectable) => string;
-    asDisplay?: (selectable: Selectable) => string;
+export type AutocompleteMultiProps = MultiSelectProps & {
     resolver: AutocompleteOptionsResolver;
 };
 
@@ -85,6 +61,7 @@ const AutocompleteMulti = ({
             error={error}>
             <AsyncSelect<Selectable, true>
                 theme={theme}
+                styles={styles}
                 isMulti
                 id={id}
                 name={name}
@@ -101,7 +78,7 @@ const AutocompleteMulti = ({
                 onBlur={onBlur}
                 loadOptions={(criteria: string) => resolver(criteria)}
                 defaultOptions={options}
-                components={{ Option: CheckedOption }}
+                components={{ Option: CheckboxOption }}
                 getOptionValue={asValue}
                 getOptionLabel={asDisplay}
             />

--- a/apps/modernization-ui/src/design-system/checkbox/Checkbox.tsx
+++ b/apps/modernization-ui/src/design-system/checkbox/Checkbox.tsx
@@ -14,7 +14,6 @@ const Checkbox = ({ id, label, className, selected = false, onChange, ...inputPr
     return (
         <div className={classNames(styles.checkbox, className)} aria-checked={selected}>
             <input
-                className={styles.input}
                 id={id}
                 type="checkbox"
                 checked={selected}

--- a/apps/modernization-ui/src/design-system/checkbox/checkbox.module.scss
+++ b/apps/modernization-ui/src/design-system/checkbox/checkbox.module.scss
@@ -17,6 +17,9 @@
         line-height: 1.25rem;
         user-select: none;
 
+        width: auto;
+        display: inline-block;
+
         &::before {
             content: ' ';
             display: block;

--- a/apps/modernization-ui/src/design-system/select/multi/MultiSelect.tsx
+++ b/apps/modernization-ui/src/design-system/select/multi/MultiSelect.tsx
@@ -4,7 +4,7 @@ import { EntryWrapper, Orientation, Sizing } from 'components/Entry';
 import { Selectable, asValue as asSelectableValue } from 'options';
 import classNames from 'classnames';
 
-import { theme } from 'design-system/select/multi/theme';
+import { styles, theme } from 'design-system/select/multi';
 import { CheckboxOption } from './CheckboxOption';
 
 type MultiSelectProps = {
@@ -66,6 +66,7 @@ export const MultiSelect = ({
             error={error}>
             <Select<Selectable, true>
                 theme={theme}
+                styles={styles}
                 isMulti
                 id={id}
                 name={name}
@@ -75,7 +76,7 @@ export const MultiSelect = ({
                 onBlur={onBlur}
                 placeholder={placeholder}
                 isDisabled={disabled}
-                className={classNames({ 'multi-select__compact': sizing === 'compact' })}
+                className={classNames('multi-select', { 'multi-select__compact': sizing === 'compact' })}
                 classNamePrefix="multi-select"
                 hideSelectedOptions={false}
                 closeMenuOnSelect={false}

--- a/apps/modernization-ui/src/design-system/select/multi/design.ts
+++ b/apps/modernization-ui/src/design-system/select/multi/design.ts
@@ -1,0 +1,20 @@
+import { Theme } from 'react-select';
+import { CSSObjectWithLabel } from 'react-select';
+
+const theme = (existing: Theme) => ({
+    ...existing,
+    borderRadius: 2,
+    colors: { ...existing.colors, primary: '#d9e8f6' }
+});
+
+const styles = {
+    control: (baseStyles: CSSObjectWithLabel) => ({
+        ...baseStyles,
+        borderStyle: 'none',
+        boxShadow: 'none',
+        minHeight: 'unset',
+        height: 'unset'
+    })
+};
+
+export { theme, styles };

--- a/apps/modernization-ui/src/design-system/select/multi/index.ts
+++ b/apps/modernization-ui/src/design-system/select/multi/index.ts
@@ -1,2 +1,2 @@
-export { theme } from './theme';
+export { theme, styles } from './design';
 export { CheckboxOption } from './CheckboxOption';

--- a/apps/modernization-ui/src/design-system/select/multi/theme.ts
+++ b/apps/modernization-ui/src/design-system/select/multi/theme.ts
@@ -1,9 +1,0 @@
-import { Theme } from 'react-select';
-
-const theme = (existing: Theme) => ({
-    ...existing,
-    borderRadius: 2,
-    colors: { ...existing.colors, primary: '#d9e8f6' }
-});
-
-export { theme };


### PR DESCRIPTION
## Description

I'm not sure what the bug was referring to however, I've fixed the styling issue with options that have long names and ensure that the input box expands correctly in compact mode.

## Tickets

* [CNFT1-2875](https://cdc-nbs.atlassian.net/browse/CNFT1-2875)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2875]: https://cdc-nbs.atlassian.net/browse/CNFT1-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ