### PR TITLE
[CNFT1-2813] ensures name ordering for home page search

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaMerger.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaMerger.java
@@ -1,0 +1,29 @@
+package gov.cdc.nbs.search.redirect.simple;
+
+import gov.cdc.nbs.option.Option;
+
+import java.time.LocalDate;
+
+class SimplePatientSearchCriteriaMerger {
+
+  static SimplePatientSearchCriteria merge(final SimplePatientSearchCriteria left,
+      final SimplePatientSearchCriteria right) {
+
+    String first = left.firstName() == null ? right.firstName() : left.firstName();
+    String last = left.lastName() == null ? right.lastName() : left.lastName();
+    String id = left.id() == null ? right.id() : left.id();
+    Option gender = left.gender() == null ? right.gender() : left.gender();
+    LocalDate dateOfBirth = left.dateOfBirth() == null ? right.dateOfBirth() : left.dateOfBirth();
+
+    return new SimplePatientSearchCriteria(
+        last,
+        first,
+        dateOfBirth,
+        gender,
+        id
+    );
+  }
+
+  private SimplePatientSearchCriteriaMerger(){}
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaResolver.java
@@ -50,7 +50,7 @@ class SimplePatientSearchCriteriaResolver {
             maybe(criteria, NBS_SEX).map(SimplePatientSearchCriteriaResolver::fromGender),
             maybe(criteria, NBS_ID).map(SimplePatientSearchCriteriaResolver::fromId)
         ).flatMap(Optional::stream)
-        .collect(accumulating(SimplePatientSearchCriteriaResolver::merge));
+        .collect(accumulating(SimplePatientSearchCriteriaMerger::merge));
   }
 
   private Optional<String> maybe(final Map<String, String> map, final String key) {
@@ -61,21 +61,5 @@ class SimplePatientSearchCriteriaResolver {
         : Optional.empty();
   }
 
-  private static SimplePatientSearchCriteria merge(final SimplePatientSearchCriteria left,
-      final SimplePatientSearchCriteria right) {
 
-    String first = left.firstName() == null ? right.firstName() : left.firstName();
-    String last = left.lastName() == null ? right.lastName() : left.lastName();
-    String id = left.id() == null ? right.id() : left.id();
-    Option gender = left.gender() == null ? right.gender() : left.gender();
-    LocalDate dateOfBirth = left.dateOfBirth() == null ? right.dateOfBirth() : left.dateOfBirth();
-
-    return new SimplePatientSearchCriteria(
-        first,
-        last,
-        dateOfBirth,
-        gender,
-        id
-    );
-  }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaMergerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaMergerTest.java
@@ -1,0 +1,70 @@
+package gov.cdc.nbs.search.redirect.simple;
+
+import gov.cdc.nbs.option.Option;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class SimplePatientSearchCriteriaMergerTest {
+
+  @Test
+  void should_merge_last_name_preferring_the_first_value() {
+
+    SimplePatientSearchCriteria actual = SimplePatientSearchCriteriaMerger.merge(
+        new SimplePatientSearchCriteria("first-last-name", null, null, null, null),
+        new SimplePatientSearchCriteria("second-last-name", null, null, null, null)
+    );
+
+    assertThat(actual.lastName()).isEqualTo("first-last-name");
+  }
+
+  @Test
+  void should_merge_first_name_preferring_the_first_value() {
+
+    SimplePatientSearchCriteria actual = SimplePatientSearchCriteriaMerger.merge(
+        new SimplePatientSearchCriteria(null, "first-first-name", null, null, null),
+        new SimplePatientSearchCriteria(null, "second-first-name", null, null, null)
+    );
+
+    assertThat(actual.firstName()).isEqualTo("first-first-name");
+  }
+
+  @Test
+  void should_merge_date_of_birth_preferring_the_first_value() {
+
+    SimplePatientSearchCriteria actual = SimplePatientSearchCriteriaMerger.merge(
+        new SimplePatientSearchCriteria(null, null, LocalDate.of(2014, Month.JULY, 13), null, null),
+        new SimplePatientSearchCriteria(null, null, LocalDate.of(2014, Month.FEBRUARY, 2), null, null)
+    );
+
+    assertThat(actual.dateOfBirth()).isEqualTo("2014-07-13");
+  }
+
+
+  @Test
+  void should_merge_gender_preferring_the_first_value() {
+
+    SimplePatientSearchCriteria actual = SimplePatientSearchCriteriaMerger.merge(
+        new SimplePatientSearchCriteria(null, null, null, new Option("first-gender"), null),
+        new SimplePatientSearchCriteria(null, null, null, new Option("second-gender"), null)
+    );
+
+    assertThat(actual.gender()).isEqualTo(new Option("first-gender"));
+  }
+
+
+  @Test
+  void should_merge_id_preferring_the_first_value() {
+
+    SimplePatientSearchCriteria actual = SimplePatientSearchCriteriaMerger.merge(
+        new SimplePatientSearchCriteria(null, null, null, null, "first-id-value"),
+        new SimplePatientSearchCriteria(null, null, null, null, "second-id-value")
+    );
+
+    assertThat(actual.id()).isEqualTo("first-id-value");
+  }
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/Option.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/Option.java
@@ -16,4 +16,8 @@ public record Option(
     this(value, name, name, 1);
   }
 
+  public Option(String value) {
+    this(value, value);
+  }
+
 }


### PR DESCRIPTION
## Description

Fixes the name ordering of searches from the home page.  A.K.A. This is why you don't skip the last 5% coverage.

## Tickets

* [CNFT1-2813](https://cdc-nbs.atlassian.net/browse/CNFT1-2813)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2813]: https://cdc-nbs.atlassian.net/browse/CNFT1-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ