### PR TITLE
adding empty string logic into applyPatientIdentifierCriteria

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaQueryResolver.java
@@ -67,10 +67,14 @@ class PatientSearchCriteriaQueryResolver {
     if (criteria.getId() != null) {
       String shortOrLongIdStripped = criteria.getId().strip();
 
+      if (shortOrLongIdStripped.isEmpty()) {
+        return Optional.empty();
+      }
+
       if (Character.isDigit(shortOrLongIdStripped.charAt(0))) {
-        //  This may be a short id, resolve the local id and then search for it
+        // This may be a short id, resolve the local id and then search for it
         try {
-          long shortId = Long.parseLong(criteria.getId());
+          long shortId = Long.parseLong(shortOrLongIdStripped);
 
           String localId = resolver.resolve(shortId);
 
@@ -80,7 +84,7 @@ class PatientSearchCriteriaQueryResolver {
           // skip these criteria. it's not a short id or long id
         }
       } else {
-        return applyLocalId(criteria.getId());
+        return applyLocalId(shortOrLongIdStripped);
       }
     }
 
@@ -216,7 +220,6 @@ class PatientSearchCriteriaQueryResolver {
                       query -> query.wildcard(
                           wildcard -> wildcard.field("phone.telephoneNbr")
                               .value(WildCards.contains(number))))));
-
 
     }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -21,7 +21,8 @@ public class PatientSearchCriteriaSteps {
   @Given("I add the patient criteria for a(n) {string} equal to {string}")
   public void i_add_the_patient_criteria_for_a_field_that_is_value(
       final String field,
-      final String value) {
+      final String value
+  ) {
 
     if (field == null || field.isEmpty()) {
       return;
@@ -34,8 +35,10 @@ public class PatientSearchCriteriaSteps {
   private PatientFilter applyCriteria(
       final String field,
       final String value,
-      final PatientFilter criteria) {
+      final PatientFilter criteria
+  ) {
     switch (field.toLowerCase()) {
+      case "patient id" -> criteria.setId(value);
       case "first name" -> criteria.setFirstName(value);
       case "last name" -> criteria.setLastName(value);
       case "disable soundex" -> criteria.setDisableSoundex(value.equals("true"));

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
@@ -95,7 +95,7 @@ public class PatientSearchVerificationSteps {
       case "county" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].county", position);
       case "country" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].country", position);
       case "zip" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].zipcode", position);
-      case "gender" -> jsonPath("$.data.findPatientsByFilter.content[%s].gender", position);
+      case "gender", "sex" -> jsonPath("$.data.findPatientsByFilter.content[%s].gender", position);
       case "first name" -> jsonPath("$.data.findPatientsByFilter.content[%s].names[*].first", position);
       case "last name" -> jsonPath("$.data.findPatientsByFilter.content[%s].names[*].last", position);
       case "legal first name" -> jsonPath("$.data.findPatientsByFilter.content[%s].legalName.first", position);
@@ -104,15 +104,20 @@ public class PatientSearchVerificationSteps {
       case "legal name suffix" -> jsonPath("$.data.findPatientsByFilter.content[%s].legalName.suffix", position);
       case "phone number" -> jsonPath(
           "$.data.findPatientsByFilter.content[%s].phones[*]",
-          position);
+          position
+      );
       case "email", "email address" -> jsonPath(
           "$.data.findPatientsByFilter.content[%s].emails[*]",
-          position);
-      case "identification type" -> jsonPath("$.data.findPatientsByFilter.content[%s].identification[*].type",
-          position);
-      case "identification value" -> jsonPath("$.data.findPatientsByFilter.content[%s].identification[*].value",
-          position);
-      case "sex" -> jsonPath("$.data.findPatientsByFilter.content[%s].gender", position);
+          position
+      );
+      case "identification type" -> jsonPath(
+          "$.data.findPatientsByFilter.content[%s].identification[*].type",
+          position
+      );
+      case "identification value" -> jsonPath(
+          "$.data.findPatientsByFilter.content[%s].identification[*].value",
+          position
+      );
       case "local id" -> jsonPath("$.data.findPatientsByFilter.content[%s].shortId", position);
       default -> throw new AssertionError("Unexpected property check %s".formatted(field));
     };
@@ -120,8 +125,7 @@ public class PatientSearchVerificationSteps {
 
   private Matcher<?> matchingValue(final String field, final String value) {
     return switch (field.toLowerCase()) {
-      case "birthday" -> equalTo(value);
-      case "sex" -> equalTo(value);
+      case "birthday", "sex" -> equalTo(value);
       case "local id" -> equalTo(Integer.parseInt(value));
       case "status" -> hasItem(PatientStatusCriteriaResolver.resolve(value).name());
       default -> hasItem(value);
@@ -135,7 +139,7 @@ public class PatientSearchVerificationSteps {
             jsonPath(
                 "$.data.findPatientsByFilter.content[?(@.patient=='%s')]",
                 String.valueOf(this.patient.active().id()))
-                    .exists());
+                .exists());
   }
 
   @Then("the patient is not in the search result(s)")
@@ -145,7 +149,7 @@ public class PatientSearchVerificationSteps {
             jsonPath(
                 "$.data.findPatientsByFilter.content[?(@.patient=='%s')]",
                 String.valueOf(this.patient.active().id()))
-                    .doesNotExist());
+                .doesNotExist());
   }
 
   @Then("there is only one patient search result")

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -21,6 +21,12 @@ Feature: Patient Search
     Then the patient is in the search results
     And there is only one patient search result
 
+  Scenario: Patient search does not fail when the Patient ID is blank (BUG CNFT1-2861)
+    Given patients are available for search
+    And I add the patient criteria for a "Patient ID" equal to ""
+    When I search for patients
+    Then the patient is in the search results
+
   Scenario: I can find patients with active record status
     Given I have another patient
     And the patient is inactive

--- a/apps/modernization-api/src/test/resources/features/search/redirect/SimpleSearchRedirect.feature
+++ b/apps/modernization-api/src/test/resources/features/search/redirect/SimpleSearchRedirect.feature
@@ -38,7 +38,8 @@ Feature: Searching from the NBS home page
       | Accession Number ID | lab-reports    |
       | Lab ID              | lab-reports    |
 
-  Scenario: NBS home page search is not redirected a user is not logged in
+  Scenario: NBS home page search is not redirected when a user is not logged in
     Given I am not logged in
+    And I want a simple search for a "First name" of "Firstly"
     And I perform a search from the NBS Home screen
     Then I am not allowed due to insufficient permissions


### PR DESCRIPTION
## Description

adding empty string logic into applyPatientIdentifierCriteria.

## Tickets

* [CNFT1-2861](https://cdc-nbs.atlassian.net/browse/CNFT1-2861)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2861]: https://cdc-nbs.atlassian.net/browse/CNFT1-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ