### PR TITLE
CNFT1-2888 List view headings color

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/list/result-item.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/list/result-item.module.scss
@@ -16,7 +16,7 @@
         font-weight: 600;
         letter-spacing: 0.02031rem;
         text-transform: uppercase;
-        color: colors.$base;
+        color: colors.$base-darkest;
     }
     p {
         margin-top: 0;

--- a/apps/modernization-ui/src/apps/search/layout/result/list/result-item.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/list/result-item.module.scss
@@ -16,7 +16,7 @@
         font-weight: 600;
         letter-spacing: 0.02031rem;
         text-transform: uppercase;
-        color: colors.$base-darkest;
+        color: colors.$base-dark;
     }
     p {
         margin-top: 0;

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.module.scss
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.module.scss
@@ -19,7 +19,7 @@
         }
 
         label {
-            color: colors.$base;
+            color: colors.$base-darkest;
             font-size: 0.8125rem;
             font-weight: 600;
             letter-spacing: 0.02031rem;

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.module.scss
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.module.scss
@@ -19,7 +19,7 @@
         }
 
         label {
-            color: colors.$base-darkest;
+            color: colors.$base-dark;
             font-size: 0.8125rem;
             font-weight: 600;
             letter-spacing: 0.02031rem;


### PR DESCRIPTION
## Description

Search result list view headings should be base-darkest.
<img width="642" alt="image" src="https://github.com/user-attachments/assets/b9cf6442-43a7-47e9-827c-aa1bbddb6e81">

## Tickets

* [CNFT1-2888](https://cdc-nbs.atlassian.net/browse/CNFT1-2888)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2888]: https://cdc-nbs.atlassian.net/browse/CNFT1-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ