### PR TITLE
[CNFT1-2892] fixes criteria to exclude patients from providers list

### DIFF
--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/providers/autocomplete/ProviderOptionResolver.java
@@ -5,7 +5,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ProviderOptionResolver extends SQLBasedOptionResolver {
+class ProviderOptionResolver extends SQLBasedOptionResolver {
 
   private static final String QUERY = """
       with [user]([value], [name], [quickCode]) AS (
@@ -23,7 +23,7 @@ public class ProviderOptionResolver extends SQLBasedOptionResolver {
                 [quick_code].entity_uid = [provider].person_uid
             and [quick_code].type_cd='QEC'
           where   [provider].cd='PRV'
-              and [provider].electronic_ind is null or [provider].electronic_ind <> 'Y'
+              and ([provider].electronic_ind is null or [provider].electronic_ind <> 'Y')
       )
       select
           [value],
@@ -38,7 +38,7 @@ public class ProviderOptionResolver extends SQLBasedOptionResolver {
       fetch next :limit rows only
       """;
 
-  public ProviderOptionResolver(final NamedParameterJdbcTemplate template) {
+  ProviderOptionResolver(final NamedParameterJdbcTemplate template) {
     super(QUERY, template);
   }
 }


### PR DESCRIPTION
## Description

Parenthesis were missing from the criteria that excludes electronic providers that was causing patients to be load in the provider list.

## Tickets

* [CNFT1-2892](https://cdc-nbs.atlassian.net/browse/CNFT1-2892)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2892]: https://cdc-nbs.atlassian.net/browse/CNFT1-2892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ