### PR TITLE
Fix docker-compose -> docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To learn more about the build process view the cdc-sandbox [README](cdc-sandbox/
 2. Start the database and Elasticsearch containers
 
     ```sh
-    docker-compose up -d nbs-mssql elasticsearch
+    docker compose up -d nbs-mssql elasticsearch
     ```
 3. Navigate to the root directory
 

--- a/apps/modernization-api/README.md
+++ b/apps/modernization-api/README.md
@@ -22,7 +22,7 @@ Prior to running tests the `cdc-sandbox/test-db/` image must be built. To build 
 the `cdc-sandbox` directory.
 
 ```sh
-docker-compose up test-db -d
+docker compose up test-db -d
 ```
 
 To run all tests:

--- a/apps/question-bank/README.md
+++ b/apps/question-bank/README.md
@@ -16,7 +16,7 @@ in
 the `cdc-sandbox` directory.
 
 ```sh
-docker-compose build nbs-mssql
+docker compose build nbs-mssql
 ```
 
 To run all tests:

--- a/cdc-sandbox/build_classic.sh
+++ b/cdc-sandbox/build_classic.sh
@@ -12,7 +12,7 @@ git clone -b $CLASSIC_VERSION git@github.com:cdcent/NEDSSDev.git $CLASSIC_PATH
 
 # Build and deploy database and wildfly containers
 echo "Building SQL Server database and WildFly"
-docker-compose -f $BASE/docker-compose.yml up nbs-mssql wildfly --build -d
+docker compose -f $BASE/docker-compose.yml up nbs-mssql wildfly --build -d
 
 # Cleanup 
 rm -rf $CLASSIC_PATH

--- a/cdc-sandbox/build_classic.sh
+++ b/cdc-sandbox/build_classic.sh
@@ -12,7 +12,7 @@ git clone -b $CLASSIC_VERSION git@github.com:cdcent/NEDSSDev.git $CLASSIC_PATH
 
 # Build and deploy database and wildfly containers
 echo "Building SQL Server database and WildFly"
-docker compose -f $BASE/docker compose.yml up nbs-mssql wildfly --build -d
+docker compose -f $BASE/docker-compose.yml up nbs-mssql wildfly --build -d
 
 # Cleanup 
 rm -rf $CLASSIC_PATH

--- a/cdc-sandbox/build_classic.sh
+++ b/cdc-sandbox/build_classic.sh
@@ -12,7 +12,7 @@ git clone -b $CLASSIC_VERSION git@github.com:cdcent/NEDSSDev.git $CLASSIC_PATH
 
 # Build and deploy database and wildfly containers
 echo "Building SQL Server database and WildFly"
-docker compose -f $BASE/docker-compose.yml up nbs-mssql wildfly --build -d
+docker compose -f $BASE/docker compose.yml up nbs-mssql wildfly --build -d
 
 # Cleanup 
 rm -rf $CLASSIC_PATH

--- a/cdc-sandbox/build_modernized.sh
+++ b/cdc-sandbox/build_modernized.sh
@@ -5,17 +5,17 @@ BASE="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Start ES and the proxy
 echo "Starting elasticsearch reverse-proxy"
-docker-compose -f $BASE/docker-compose.yml up elasticsearch --build -d
+docker compose -f $BASE/docker-compose.yml up elasticsearch --build -d
 
 MODERNIZED_PATH=$BASE/../
 
 # Start of modernization-api initializes the elasticserach indices 
 echo "Starting modernized application services"
-docker-compose -f $MODERNIZED_PATH/docker-compose.yml  up --build -d
+docker compose -f $MODERNIZED_PATH/docker-compose.yml  up --build -d
 
 # NiFi handles synchronizing data between nbs-mssql and elasticsearch
 echo "Starting NiFi"
-docker-compose -f $BASE/docker-compose.yml up nifi --build -d
+docker compose -f $BASE/docker-compose.yml up nifi --build -d
 
 # Process complete
 echo "**** Modernized application startup complete ****"

--- a/cdc-sandbox/doc/build.md
+++ b/cdc-sandbox/doc/build.md
@@ -41,7 +41,7 @@ git clone -b NBS_6.0.15 git@github.com:cdcent/NEDSSDev.git
 
 From the `cdc-sanbox` directory, execute
 ```shell
-docker-compose up wildfly
+docker compose up wildfly
 ```
 
 The docker build will copy the output of `build.sh` (located in the dist folder) as well as the [pagemanagement](../../pagemanagement/) files into the container. In a normal windows installation the pagemanagement files are generated as follows:
@@ -56,7 +56,7 @@ In docker however, the unzip step fails. For this reason we manually copy the fi
 ## Build MSSQL Database Container Image
 
 ```shell
-docker-compose build nbs-mssql
+docker compose build nbs-mssql
 ```
 
 ## Clean Docker Environment
@@ -65,7 +65,7 @@ To start over and create all the Docker images from scratch again, run the
 following command in this project directory.
 
 ```shell
-docker-compose down
+docker compose down
 ```
 
 The Docker volume named "nbs-mssql-data" will not be removed automatically.
@@ -114,8 +114,8 @@ To build Elasticsearch and Kibana open your command prompt, navigate to the dire
 Configuration settings for **Elasticsearch** can be found at the external link [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html). Configuration settings for **Kibana** can be found at the external link [here](https://www.elastic.co/guide/en/kibana/8.4/settings.html).
 
 ```
-docker-compose up -d elasticsearch
-docker-compose up -d kibana
+docker compose up -d elasticsearch
+docker compose up -d kibana
 ```
 
 Once the containers are up you can access the Kibana home page as follows:
@@ -129,7 +129,7 @@ http://localhost:5601
 ### Running Traefik
 
 ```bash
-docker-compose up -d reverse-proxy
+docker compose up -d reverse-proxy
 ```
 
 ### Requirements
@@ -178,7 +178,7 @@ This configuration snippet defines a `router` that will catch requests matching 
 1. Starting NiFi (run in the cdc-sandbox directory):
 
 ```sh
-docker-compose up nifi -d
+docker compose up nifi -d
 ```
 
 ## Kafka
@@ -200,7 +200,7 @@ cd cdc-sandbox/kafka
 
 2. Launch kafka Docker container environment. If you are on an ARM Environment you may use (docker-compose-arm64v8.yml) if you experience any performance issues but regular script should work fine.
 ```
-docker-compose  -f docker-compose.yml up -d
+docker compose  -f docker-compose.yml up -d
 ```
 
 * Note: To create a topic you can open Zookeeper CLI and find the commands online. You can also open Kafka-UI in


### PR DESCRIPTION
## Description

Newer version of docker no longer supports `docker-compose` as this was deprecated in the migration to Go.

https://docs.docker.com/compose/migrate/