### PR TITLE
[CNFT1-2851] Laboratory report search results table view

### DIFF
--- a/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/LaboratoryReportSearch.tsx
@@ -11,6 +11,7 @@ import { LaboratoryReportSearchResultListItem } from './result/list';
 import { LaboratoryReportSearchCriteria } from './LaboratoryReportSearchCriteria';
 import { SearchCriteriaProvider } from 'providers/SearchCriteriaContext';
 import { useJurisdictionOptions } from 'options/jurisdictions';
+import { LaboratoryReportSearchResultsTable } from './result/table/LaboratoryReportSearchResultsTable';
 
 const LaboratoryReportSearch = () => {
     const form = useForm<LabReportFilterEntry, Partial<LabReportFilterEntry>>({
@@ -72,7 +73,12 @@ const LaboratoryReportSearch = () => {
                             )}
                         />
                     )}
-                    resultsAsTable={() => <div>result table</div>}
+                    resultsAsTable={() => (
+                        <LaboratoryReportSearchResultsTable
+                            results={results?.content ?? []}
+                            jurisdictionResolver={findById}
+                        />
+                    )}
                     searchEnabled={form.formState.isValid}
                     onSearch={form.handleSubmit(search)}
                     onClear={reset}

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/index.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/index.ts
@@ -1,0 +1,1 @@
+export * from './laboratoryReportResult';

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/laboratoryReportResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/laboratoryReportResult.spec.tsx
@@ -1,0 +1,230 @@
+import { LabReport } from 'generated/graphql/schema';
+import {
+    getAssociatedInvestigations,
+    getDescription,
+    getOrderingProviderName,
+    getPatient,
+    getPatientName,
+    getReportingFacility
+} from './laboratoryReportResult';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('when displaying a Laboratory Search Result', () => {
+    it('should resolve the patient when present', () => {
+        const result: LabReport = {
+            __typename: 'LabReport',
+            addTime: '2015-09-22',
+            associatedInvestigations: [],
+            id: 'id-value',
+            jurisdictionCd: 1063,
+            localId: 'local-id-value',
+            observations: [],
+            organizationParticipations: [],
+            personParticipations: [
+                {
+                    __typename: 'LabReportPersonParticipation',
+                    birthTime: '1979-05-19',
+                    currSexCd: 'M',
+                    typeCd: 'PATSBJ',
+                    firstName: 'patient-first-name',
+                    lastName: 'patient-last-name',
+                    personCd: 'PAT',
+                    personParentUid: 349,
+                    shortId: 919
+                },
+                {
+                    __typename: 'LabReportPersonParticipation',
+                    birthTime: '2001-11-17',
+                    currSexCd: 'F',
+                    typeCd: 'ORD',
+                    firstName: 'provider-first-name',
+                    lastName: 'provider-last-name',
+                    personCd: 'PRV',
+                    personParentUid: 503,
+                    shortId: 571
+                }
+            ],
+            relevance: 1
+        };
+
+        const actual = getPatient(result);
+
+        expect(actual).toEqual(expect.objectContaining({ shortId: 919 }));
+    });
+
+    it('should resolve the patient name when present', () => {
+        const result: LabReport = {
+            __typename: 'LabReport',
+            addTime: '2015-09-22',
+            associatedInvestigations: [],
+            id: 'id-value',
+            jurisdictionCd: 1063,
+            localId: 'local-id-value',
+            observations: [],
+            organizationParticipations: [],
+            personParticipations: [
+                {
+                    __typename: 'LabReportPersonParticipation',
+                    birthTime: '1979-05-19',
+                    currSexCd: 'M',
+                    typeCd: 'PATSBJ',
+                    firstName: 'patient-first-name',
+                    lastName: 'patient-last-name',
+                    personCd: 'PAT',
+                    personParentUid: 349,
+                    shortId: 919
+                },
+                {
+                    __typename: 'LabReportPersonParticipation',
+                    birthTime: '2001-11-17',
+                    currSexCd: 'F',
+                    typeCd: 'ORD',
+                    firstName: 'provider-first-name',
+                    lastName: 'provider-last-name',
+                    personCd: 'PRV',
+                    personParentUid: 503,
+                    shortId: 571
+                }
+            ],
+            relevance: 1
+        };
+
+        const { getByRole } = render(<MemoryRouter>{getPatientName(result)}</MemoryRouter>);
+
+        const actual = getByRole('link', { name: 'patient-first-name patient-last-name' });
+
+        expect(actual).toHaveAttribute('href', '/patient-profile/919');
+    });
+
+    it('should resolve the Ordering Provider when present', () => {
+        const result: LabReport = {
+            __typename: 'LabReport',
+            addTime: '2015-09-22',
+            associatedInvestigations: [],
+            id: 'id-value',
+            jurisdictionCd: 1063,
+            localId: 'local-id-value',
+            observations: [],
+            organizationParticipations: [],
+            personParticipations: [
+                {
+                    __typename: 'LabReportPersonParticipation',
+                    birthTime: '1979-05-19',
+                    currSexCd: 'M',
+                    typeCd: 'PATSBJ',
+                    firstName: 'patient-first-name',
+                    lastName: 'patient-last-name',
+                    personCd: 'PAT',
+                    personParentUid: 349,
+                    shortId: 919
+                },
+                {
+                    __typename: 'LabReportPersonParticipation',
+                    birthTime: '2001-11-17',
+                    currSexCd: 'F',
+                    typeCd: 'ORD',
+                    firstName: 'provider-first-name',
+                    lastName: 'provider-last-name',
+                    personCd: 'PRV',
+                    personParentUid: 503,
+                    shortId: 571
+                }
+            ],
+            relevance: 1
+        };
+
+        const actual = getOrderingProviderName(result);
+
+        expect(actual).toEqual('provider-first-name provider-last-name');
+    });
+
+    it('should resolve the Reporting Facility when present', () => {
+        const result: LabReport = {
+            __typename: 'LabReport',
+            addTime: '2015-09-22',
+            associatedInvestigations: [],
+            id: 'id-value',
+            jurisdictionCd: 1063,
+            localId: 'local-id-value',
+            observations: [],
+            organizationParticipations: [
+                {
+                    __typename: 'LabReportOrganizationParticipation',
+                    typeCd: 'AUT',
+                    name: 'ordering-facility-value'
+                }
+            ],
+            personParticipations: [],
+            relevance: 1
+        };
+
+        const actual = getReportingFacility(result);
+
+        expect(actual).toEqual('ordering-facility-value');
+    });
+
+    it('should resolve the description when lab results are present', () => {
+        const result: LabReport = {
+            __typename: 'LabReport',
+            addTime: '2015-09-22',
+            associatedInvestigations: [],
+            id: 'id-value',
+            jurisdictionCd: 1063,
+            localId: 'local-id-value',
+            observations: [
+                {
+                    __typename: 'Observation',
+                    cdDescTxt: 'No Information Given',
+                    statusCd: null,
+                    altCd: null,
+                    displayName: null
+                },
+                {
+                    __typename: 'Observation',
+                    cdDescTxt: 'lab-test-name',
+                    altCd: 'lab-test-code',
+                    displayName: 'lab-test-value'
+                }
+            ],
+            organizationParticipations: [],
+            personParticipations: [],
+            relevance: 1
+        };
+
+        const actual = getDescription(result);
+
+        expect(actual).toEqual('lab-test-name = lab-test-value');
+    });
+
+    it('should resolve associated investigations when present', () => {
+        const result: LabReport = {
+            __typename: 'LabReport',
+            addTime: '2015-09-22',
+            associatedInvestigations: [
+                {
+                    __typename: 'AssociatedInvestigation',
+                    cdDescTxt: 'condition-one-name',
+                    localId: 'condition-one-local'
+                },
+                {
+                    __typename: 'AssociatedInvestigation',
+                    cdDescTxt: 'condition-two-name',
+                    localId: 'condition-two-local'
+                }
+            ],
+            id: 'id-value',
+            jurisdictionCd: 1063,
+            localId: 'local-id-value',
+            observations: [],
+            organizationParticipations: [],
+            personParticipations: [],
+            relevance: 1
+        };
+
+        const actual = getAssociatedInvestigations(result);
+
+        expect(actual).toEqual(expect.stringContaining('condition-one-local\ncondition-one-name'));
+        expect(actual).toEqual(expect.stringContaining('condition-two-local\ncondition-two-name'));
+    });
+});

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/laboratoryReportResult.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/laboratoryReportResult.tsx
@@ -1,0 +1,47 @@
+import { LabReport, LabReportPersonParticipation } from 'generated/graphql/schema';
+import { displayName } from 'name';
+import { Link } from 'react-router-dom';
+
+const getPatient = (labReport: LabReport): LabReportPersonParticipation | undefined | null => {
+    return labReport.personParticipations?.find((p) => p?.typeCd === 'PATSBJ');
+};
+
+const getPatientName = (labReport: LabReport) => {
+    const patient = getPatient(labReport);
+
+    return (
+        <Link to={`/patient-profile/${patient?.shortId}`}>
+            {(patient && displayName('short')({ first: patient.firstName, last: patient.lastName })) || 'No Data'}
+        </Link>
+    );
+};
+
+const getOrderingProviderName = (labReport: LabReport): string | undefined => {
+    const provider = labReport.personParticipations.find((p) => p.typeCd === 'ORD' && p.personCd === 'PRV');
+
+    return provider && displayName('short')({ first: provider.firstName, last: provider.lastName });
+};
+
+const getReportingFacility = (labReport: LabReport): string | undefined => {
+    return labReport.organizationParticipations.find((o) => o?.typeCd === 'AUT')?.name;
+};
+
+const getDescription = (labReport: LabReport): string | undefined => {
+    const observation = labReport.observations?.find((o) => o?.altCd && o?.displayName && o?.cdDescTxt);
+
+    return observation && `${observation.cdDescTxt} = ${observation.displayName}`;
+};
+
+const getAssociatedInvestigations = (labReport: LabReport) =>
+    labReport.associatedInvestigations
+        ?.map((investigation) => `${investigation?.localId}\n${investigation?.cdDescTxt}\n`)
+        .join('\n');
+
+export {
+    getPatient,
+    getPatientName,
+    getOrderingProviderName,
+    getReportingFacility,
+    getDescription,
+    getAssociatedInvestigations
+};

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.spec.tsx
@@ -1,0 +1,146 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { LabReport } from 'generated/graphql/schema';
+import { LaboratoryReportSearchResultsTable } from './LaboratoryReportSearchResultsTable';
+import { Selectable } from 'options';
+import { Column } from 'design-system/table';
+
+const mockRegister = jest.fn();
+
+jest.mock('design-system/table/preferences', () => ({
+    useColumnPreferences: () => ({ register: mockRegister, apply: (columns: Column<LabReport>[]) => columns })
+}));
+
+const Wrapper = ({
+    results,
+    jurisdictionResolver = jest.fn()
+}: {
+    results: LabReport[];
+    jurisdictionResolver?: (value: string) => Selectable | undefined;
+}) => {
+    return (
+        <MemoryRouter>
+            <LaboratoryReportSearchResultsTable results={results} jurisdictionResolver={jurisdictionResolver} />
+        </MemoryRouter>
+    );
+};
+
+describe('When a Laboratory Report search result is viewed in a table', () => {
+    it('should register default columns', () => {
+        render(<Wrapper results={[]} />);
+
+        expect(mockRegister).toBeCalled();
+    });
+
+    it('should display column headers', () => {
+        const { getAllByRole } = render(<Wrapper results={[]} />);
+
+        const columns = getAllByRole('columnheader');
+
+        expect(columns[0]).toHaveTextContent('Legal name');
+        expect(columns[1]).toHaveTextContent('Date of birth');
+        expect(columns[2]).toHaveTextContent('Sex');
+        expect(columns[3]).toHaveTextContent('Patient ID');
+        expect(columns[4]).toHaveTextContent('Document type');
+        expect(columns[5]).toHaveTextContent('Date received');
+        expect(columns[6]).toHaveTextContent('Description');
+        expect(columns[7]).toHaveTextContent('Reporting facility');
+        expect(columns[8]).toHaveTextContent('Ordering provider');
+        expect(columns[9]).toHaveTextContent('Jurisdiction');
+        expect(columns[10]).toHaveTextContent('Associated with');
+        expect(columns[11]).toHaveTextContent('Local ID');
+    });
+
+    it('should display column content', () => {
+        const result: LabReport[] = [
+            {
+                __typename: 'LabReport',
+                addTime: '2015-09-22',
+                associatedInvestigations: [
+                    {
+                        __typename: 'AssociatedInvestigation',
+                        cdDescTxt: 'Bacterial Vaginosis',
+                        localId: 'CAS10001001GA01'
+                    },
+                    {
+                        __typename: 'AssociatedInvestigation',
+                        cdDescTxt: 'Bacterial Vaginosis',
+                        localId: 'CAS10001001GA01'
+                    }
+                ],
+                id: '10000013',
+                jurisdictionCd: 130006,
+                localId: 'CAS10000000GA01',
+                observations: [
+                    {
+                        __typename: 'Observation',
+                        cdDescTxt: 'No Information Given',
+                        statusCd: null,
+                        altCd: null,
+                        displayName: null
+                    },
+                    {
+                        __typename: 'Observation',
+                        cdDescTxt: '11-Desoxycortisol',
+                        statusCd: null,
+                        altCd: '1657-6',
+                        displayName: 'abnormal'
+                    }
+                ],
+                organizationParticipations: [
+                    {
+                        __typename: 'LabReportOrganizationParticipation',
+                        typeCd: 'AUT',
+                        name: 'Emory University Hospital'
+                    }
+                ],
+                personParticipations: [
+                    {
+                        __typename: 'LabReportPersonParticipation',
+                        birthTime: '1990-01-01',
+                        currSexCd: 'M',
+                        typeCd: 'PATSBJ',
+                        firstName: 'Surma',
+                        lastName: 'Singh',
+                        personCd: 'PAT',
+                        personParentUid: 10000001,
+                        shortId: 63000
+                    },
+                    {
+                        __typename: 'LabReportPersonParticipation',
+                        birthTime: '1990-01-01',
+                        currSexCd: 'M',
+                        typeCd: 'ORD',
+                        firstName: 'John',
+                        lastName: 'Henry',
+                        personCd: 'PRV',
+                        personParentUid: 10000001,
+                        shortId: 63000
+                    }
+                ],
+                relevance: 1
+            }
+        ];
+
+        const jurisdictionResolver = jest.fn();
+
+        jurisdictionResolver.mockReturnValue({ name: 'Gwinnett County' });
+
+        const { container } = render(<Wrapper results={result} jurisdictionResolver={jurisdictionResolver} />);
+        const columns = container.getElementsByTagName('td');
+        expect(columns[0]).toHaveTextContent('Surma Singh');
+        expect(columns[1]).toHaveTextContent('01/01/1990');
+        expect(columns[2]).toHaveTextContent('M');
+        expect(columns[3]).toHaveTextContent('63000');
+        expect(columns[4]).toHaveTextContent('Lab report');
+        expect(columns[5]).toHaveTextContent('09/22/2015');
+        expect(columns[6]).toHaveTextContent('11-Desoxycortisol = abnormal');
+        expect(columns[7]).toHaveTextContent('Emory University Hospital');
+        expect(columns[8]).toHaveTextContent('John Henry');
+        expect(columns[9]).toHaveTextContent('Gwinnett County');
+        expect(columns[10]).toHaveTextContent('Bacterial Vaginosis');
+        expect(columns[11]).toHaveTextContent('CAS10000000GA01');
+
+        expect(jurisdictionResolver).toHaveBeenCalledWith('130006');
+    });
+});

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.tsx
@@ -1,0 +1,140 @@
+import { useEffect } from 'react';
+import { LabReport } from 'generated/graphql/schema';
+import { Column, DataTable } from 'design-system/table';
+import { ColumnPreference, useColumnPreferences } from 'design-system/table/preferences';
+import { internalizeDate } from 'date';
+import { ClassicLink } from 'classic';
+import { Selectable } from 'options';
+import {
+    getPatient,
+    getOrderingProviderName,
+    getReportingFacility,
+    getDescription,
+    getAssociatedInvestigations,
+    getPatientName
+} from 'apps/search/laboratory-report/result';
+
+const LEGAL_NAME = { id: 'lastNm', name: 'Legal name' };
+const DATE_OF_BIRTH = { id: 'birthTime', name: 'Date of birth' };
+const SEX = { id: 'sex', name: 'Sex' };
+const PATIENT_ID = { id: 'id', name: 'Patient ID' };
+
+const DOCUMENT_TYPE = { id: 'documentType', name: 'Document type' };
+const DATE_RECEIVED = { id: 'dateReceived', name: 'Date received' };
+const DESCRIPTION = { id: 'description', name: 'Description' };
+const REPORTING_FACILITY = { id: 'reportingFacility', name: 'Reporting facility' };
+const ORDERING_PROVIDER = { id: 'orderingProvider', name: 'Ordering provider' };
+const JURSIDICTION = { id: 'jurisdiction', name: 'Jurisdiction' };
+const ASSOCIATED_WITH = { id: 'associatedWith', name: 'Associated with' };
+const LOCAL_ID = { id: 'localId', name: 'Local ID' };
+
+const preferences: ColumnPreference[] = [
+    { ...LEGAL_NAME },
+    { ...DATE_OF_BIRTH },
+    { ...SEX },
+    { ...PATIENT_ID },
+    { ...DOCUMENT_TYPE, moveable: true, toggleable: true },
+    { ...DATE_RECEIVED, moveable: true, toggleable: true },
+    { ...DESCRIPTION, moveable: true, toggleable: true },
+    { ...REPORTING_FACILITY, moveable: true, toggleable: true },
+    { ...ORDERING_PROVIDER, moveable: true, toggleable: true },
+    { ...JURSIDICTION, moveable: true, toggleable: true },
+    { ...ASSOCIATED_WITH, moveable: true, toggleable: true },
+    { ...LOCAL_ID, moveable: true, toggleable: true }
+];
+
+type Props = {
+    results: LabReport[];
+    jurisdictionResolver: (value: string) => Selectable | undefined;
+};
+
+const LaboratoryReportSearchResultsTable = ({ results, jurisdictionResolver }: Props) => {
+    const { apply, register } = useColumnPreferences();
+    const columns: Column<LabReport>[] = [
+        {
+            ...LEGAL_NAME,
+            fixed: true,
+            sortable: true,
+            render: getPatientName
+        },
+        {
+            ...DATE_OF_BIRTH,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return internalizeDate(patient?.birthTime);
+            }
+        },
+        {
+            ...SEX,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return patient?.currSexCd;
+            }
+        },
+        {
+            ...PATIENT_ID,
+            sortable: true,
+            render: (row) => {
+                const patient = getPatient(row);
+                return patient?.shortId;
+            }
+        },
+        {
+            ...DOCUMENT_TYPE,
+            render: (row) => {
+                const patient = getPatient(row);
+                return (
+                    <ClassicLink
+                        id="condition"
+                        url={`/nbs/api/profile/${patient?.personParentUid}/report/lab/${row.id}`}>
+                        Lab report
+                    </ClassicLink>
+                );
+            }
+        },
+        {
+            ...DATE_RECEIVED,
+            render: (row) => {
+                return internalizeDate(row.addTime);
+            }
+        },
+        {
+            ...DESCRIPTION,
+            render: (row) => {
+                return getDescription(row);
+            }
+        },
+        {
+            ...REPORTING_FACILITY,
+            render: getReportingFacility
+        },
+        {
+            ...ORDERING_PROVIDER,
+            render: getOrderingProviderName
+        },
+        {
+            ...JURSIDICTION,
+            render: (row) => jurisdictionResolver(String(row.jurisdictionCd))?.name
+        },
+        {
+            ...ASSOCIATED_WITH,
+            render: getAssociatedInvestigations
+        },
+        {
+            ...LOCAL_ID,
+            render: (row) => {
+                return row.localId;
+            }
+        }
+    ];
+
+    useEffect(() => {
+        register('LabReports', preferences);
+    }, []);
+
+    return <DataTable<LabReport> id="laboratory-report-search-results" columns={apply(columns)} data={results} />;
+};
+
+export { LaboratoryReportSearchResultsTable };

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/table/index.ts
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/table/index.ts
@@ -1,0 +1,1 @@
+export { LaboratoryReportSearchResultsTable } from './LaboratoryReportSearchResultsTable';


### PR DESCRIPTION
## Description

Adds Laboratory Report Search results table view.  

![image](https://github.com/user-attachments/assets/b55e83da-4b76-487a-9927-f847d5abe5bf)
 
_Note:_ The duplicate associated investigation is coming from the API

## Tickets

* [CNFT1-2851](https://cdc-nbs.atlassian.net/browse/CNFT1-2851)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2851]: https://cdc-nbs.atlassian.net/browse/CNFT1-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ