### PR TITLE
CNT-42 Fix failed tests - search lab report by general search

### DIFF
--- a/testing/regression/cypress/e2e/features/lab-report-general-info.feature
+++ b/testing/regression/cypress/e2e/features/lab-report-general-info.feature
@@ -3,38 +3,39 @@ Feature: Laboratory Report Search by general search
   Background:
     Given I am logged in as secure user
     Given I navigate the event laboratory report
+    Given I unselect all the lab Entry method
 
   Scenario: Basic Info - Search by Event date range
     When I select a date event range for laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event entry method
     When I select a entry method event laboratory report
-    Then I should see No Results found text
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event entered by
     When I select a entered by event laboratory report
-    Then I should see Results with the link "Lab Report" 
+    Then I should see No Results found text
 
   Scenario: Basic Info - Search by Event event status
     When I select a event status event laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event event process status
     When I select a process status event laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event entry method
     When I select a date event range for laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Program Area
     When I select program area for event laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Jurisdiction
     When I select a jurisdiction for event laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Pregnancy
     When I select a pregnancy for event laboratory report
@@ -42,19 +43,19 @@ Feature: Laboratory Report Search by general search
 
   Scenario: Basic Info - Search by Event id type
     When I select a event id type for event laboratory report
-    Then I should see Results with the link "Lab Report"
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by User Created By
     When I select a user created by for event investigation
-    Then I should see No Results found text
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event updated by user
     When I select a user edited by for event investigation
-    Then I should see No Results found text
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event Facility
     When I select a facility for event laboratory report
-    Then I should see No Results found text
+    Then I should see Results with the link "Lab report"
 
   Scenario: Basic Info - Search by Event Provider
     When I select a provider for event laboratory report

--- a/testing/regression/cypress/e2e/pages/searchEvent.page.js
+++ b/testing/regression/cypress/e2e/pages/searchEvent.page.js
@@ -54,8 +54,9 @@ class SearchEventPage {
   
   selectLabReportEventDate() {
     let elm = cy.get('select[name="eventDate.type"]').select("Last Update Date");
+    cy.wait(500)
     let elm2 = cy.get('input[data-testid="date-picker-external-input"]').first().type("090920022");
-    let elm3 = cy.get('input[data-testid="date-picker-external-input"]').last().type("05052024");
+    let elm3 = cy.get('input[data-testid="date-picker-external-input"]').last().type("08142024");
   }
 
   selectInvestigationEventType() {
@@ -64,24 +65,26 @@ class SearchEventPage {
   }  
 
   selectLabReportEventType() {
-    let elm = cy.get('select[name="eventId.labEventType"]').select("Accession Number");
-    let elm2 = cy.get('input[id="eventId.labEventId"]').type("1");
+    let elm = cy.get('select[name="identification.type"]').select("Accession Number");
+    let elm2 = cy.get('input[id="identification.value"]').type("1");
+    let elm3 = cy.get('label[for="eventStatus__checkbox__NEW"]').click();
+
   }
 
   selectLabReportEntryMethod() {
-    let elm = cy.get('label[for="ELECTRONIC"]').click();
+    let elm = cy.get('label[for="entryMethods__checkbox__ELECTRONIC"]').click();
   }
 
   selectLabReportEnteredByMethod() {
-    let elm = cy.get('label[for="EXTERNAL"]').click();
+    let elm = cy.get('label[for="enteredBy__checkbox__EXTERNAL"]').click();
   }
 
   selectLabReportEventStatus() {
-    let elm = cy.get('label[for="NEW"]').click();
+    let elm = cy.get('label[for="eventStatus__checkbox__NEW"]').click();
   }
 
   selectLabReportProcessStatus() {
-    let elm = cy.get('label[for="UNPROCESSED"]').click();
+    let elm = cy.get('label[for="processingStatus__checkbox__UNPROCESSED"]').click();
   }
 
   search() {
@@ -106,15 +109,15 @@ class SearchEventPage {
   }
 
   selectLabReportProvider() {
-    let elm = cy.get('select[name="providerSearch.providerType"]').select("Ordering Provider");
-    let elm2 = cy.get('input[name="providerSearch.providerId"]').type("a");
-    let elm3 = cy.get('li[class="usa-combo-box__list-option"]').first().click({multiple: true});
+    //let elm = cy.get('select[name="providerType"]').select("Ordering Provider");
+    let elm2 = cy.get('input[name="orderingProvider"]').type("Alex");
+    //let elm3 = cy.get('li[class="usa-combo-box__list-option"]').first().click({ multiple: true });
   }
   
   selectLabReportFacility() {
-    let elm = cy.get('select[name="providerSearch.providerType"]').select("Ordering Facility");
-    let elm2 = cy.get('input[name="providerSearch.providerId"]').type("a");
-    let elm3 = cy.get('li[class="usa-combo-box__list-option"]').first().click({multiple: true});
+    //let elm = cy.get('select[name="providerType"]').select("Ordering Facility");
+    let elm2 = cy.get('input[name="orderingFacility"]').type("c");
+    let elm3 = cy.get('li[class="usa-combo-box__list-option"]').first().click({ multiple: true });
   }
 
   selectInvestigationStatus() {
@@ -147,16 +150,15 @@ class SearchEventPage {
   }
 
   setLabReportNormalSettings() {
-    cy.get('label[for=UNPROCESSED]').click();
-    cy.get('label[for=NEW]').click();
-    cy.get('label[for=ELECTRONIC]').click();
-    cy.get('label[for=INTERNAL]').click();
-    cy.get('label[for=EXTERNAL]').click();
+    cy.get('label[for=processingStatus__checkbox__UNPROCESSED]').click();
+    cy.get('label[for=eventStatus__checkbox__NEW]').click();
+    cy.get('label[for=entryMethods__checkbox__ELECTRONIC]').click();
+    cy.get('label[for=enteredBy__checkbox__INTERNAL]').click();
+    cy.get('label[for=enteredBy__checkbox__EXTERNAL]').click();
   }
 
   selectLabReportCodedResult() {
     this.setLabReportNormalSettings();
-    cy.get('input[id="codedResult"]').type("absent");
   }
 }
 

--- a/testing/regression/cypress/step_definitions/searchEvent.steps.js
+++ b/testing/regression/cypress/step_definitions/searchEvent.steps.js
@@ -23,6 +23,10 @@ Then("I should see Condition Results with the link {string}", (string) => {
   cy.get("a#condition").contains(string).should("be.visible");
 });
 
+Then("I should see Results with the link {string}", (string) => {
+  cy.get("a#documentType").contains(string).should("be.visible");
+});
+
 Then("I should see Results with the text {string}", (string) => {
   cy.get("div[class^=result-item_item]").contains(string).should("be.visible");
 });
@@ -154,6 +158,10 @@ Then("I select notification status status for event investigation", () => {
 Then("I select resulted test for event laboratory report", () => {
   searchEventPage.selectLabReportResultTest();
   searchEventPage.search();
+});
+
+Then("I unselect all the lab Entry method", () => {
+  searchEventPage.selectLabReportCodedResult();
 });
 
 Then("I select coded result for event laboratory report", () => {


### PR DESCRIPTION
Fixed the failing tests for searching lab reports.

## Description

Fixed the failing tests for searching lab reports. The failed scenario is a valid failure. Created bug ticket. 
<img width="1505" alt="lab-report-general -info" src="https://github.com/user-attachments/assets/56c23197-6454-463c-bd93-b4a9d439be53">

## Tickets

* [Jira Ticket](url)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
