### PR TITLE
CNT-42 Fix failed automation tests - lab report criteria search

### DIFF
--- a/testing/regression/cypress/e2e/features/lab-report-criteria.feature
+++ b/testing/regression/cypress/e2e/features/lab-report-criteria.feature
@@ -10,4 +10,4 @@ Feature: Lab Report Search by criteria
 
   Scenario: Basic Info - Search by Coded result/organism
     When I select coded result for event laboratory report
-    Then I should see Results with the link "Lab Report" 
+    Then I should see Results with the link "Lab report" 

--- a/testing/regression/cypress/e2e/pages/searchEvent.page.js
+++ b/testing/regression/cypress/e2e/pages/searchEvent.page.js
@@ -3,7 +3,12 @@ class SearchEventPage {
     cy.get('a[href*="search/investigations"]').click();
     cy.wait(500);
   }
-
+  expandLabReportCriteria() {
+    cy.get('svg[aria-label="Collapse General search"]').first().click()
+    cy.get('svg[aria-label="Expand Lab report criteria"]').first().click()
+    cy.wait(500);
+  }
+   
   clickEventLabReport() {
     cy.get('a[href*="search/lab-reports"]').click();
     cy.wait(500);
@@ -146,7 +151,6 @@ class SearchEventPage {
 
   selectLabReportResultTest() {
     this.setLabReportNormalSettings();
-    cy.get('input[id="resultedTest"]').type("Lead");
   }
 
   setLabReportNormalSettings() {

--- a/testing/regression/cypress/step_definitions/searchEvent.steps.js
+++ b/testing/regression/cypress/step_definitions/searchEvent.steps.js
@@ -157,6 +157,9 @@ Then("I select notification status status for event investigation", () => {
 
 Then("I select resulted test for event laboratory report", () => {
   searchEventPage.selectLabReportResultTest();
+  searchEventPage.expandLabReportCriteria();
+  cy.get('input[id="resultedTest"]').type("LEAD");
+  cy.get('.usa-combo-box__list-option').eq(1).click();
   searchEventPage.search();
 });
 
@@ -166,5 +169,8 @@ Then("I unselect all the lab Entry method", () => {
 
 Then("I select coded result for event laboratory report", () => {
   searchEventPage.selectLabReportCodedResult();
+  searchEventPage.expandLabReportCriteria();
+  cy.get('input[id="codedResult"]').type("abnormal");
+  cy.get('.usa-combo-box__list-option').eq(0).click();
   searchEventPage.search();
 });


### PR DESCRIPTION
Fixed searching for lab reports by criteria section.

## Description

Fixed searching for lab reports by criteria section.

<img width="1505" alt="lab-report-criteria" src="https://github.com/user-attachments/assets/c9d90eee-5e12-4152-807a-4d259b267956">

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-42)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
