### PR TITLE
Fixing search terms chips exceeding height spilling over results 

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -36,10 +36,6 @@ const SearchResults = ({ children, onRemoveTerm }: Props) => {
         return () => window.removeEventListener('resize', updateContentHeight);
     }, []);
 
-    useEffect(() => {
-        updateContentHeight();
-    }, [terms]);
-
     return (
         <div className={styles.results}>
             <div ref={headerRef}>

--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { Term, useSearchResultDisplay } from 'apps/search';
 import { SearchResultsHeader } from './header/SearchResultsHeader';
 import styles from './search-results.module.scss';
@@ -17,17 +17,44 @@ const SearchResults = ({ children, onRemoveTerm }: Props) => {
 
     const { view, terms } = useSearchResultDisplay();
 
+    const headerRef = useRef<HTMLDivElement>(null);
+    const paginationRef = useRef<HTMLDivElement>(null);
+    const [contentHeight, setContentHeight] = useState<string>('auto');
+
+    const updateContentHeight = () => {
+        requestAnimationFrame(() => {
+            const headerHeight = headerRef.current?.offsetHeight || 0;
+            const paginationHeight = paginationRef.current?.offsetHeight || 0;
+            setContentHeight(`calc(100% - ${headerHeight}px - ${paginationHeight}px)`);
+        });
+    };
+
+    useEffect(() => {
+        updateContentHeight();
+        window.addEventListener('resize', updateContentHeight);
+
+        return () => window.removeEventListener('resize', updateContentHeight);
+    }, []);
+
+    useEffect(() => {
+        updateContentHeight();
+    }, [terms]);
+
     return (
         <div className={styles.results}>
-            <SearchResultsHeader
-                onRemoveTerm={onRemoveTerm}
-                className={styles.header}
-                view={view}
-                total={total}
-                terms={terms}
-            />
-            <main className={styles.content}>{children}</main>
-            <div className={styles.pagination}>
+            <div ref={headerRef}>
+                <SearchResultsHeader
+                    className={styles.header}
+                    onRemoveTerm={onRemoveTerm}
+                    view={view}
+                    total={total}
+                    terms={terms}
+                />
+            </div>
+            <main className={styles.content} style={{ height: contentHeight }}>
+                {children}
+            </main>
+            <div ref={paginationRef} className={styles.pagination}>
                 <Pagination />
             </div>
         </div>

--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/search-results-options.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/search-results-options.module.scss
@@ -1,6 +1,6 @@
 .options {
     display: flex;
-    align-self: center;
+    align-self: flex-start;
     align-items: center;
     gap: 0.5rem;
 }

--- a/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
@@ -1,10 +1,10 @@
 @use 'styles/borders';
 
 .header {
-    padding: 1rem;
+    padding: 0.25rem 1rem;
     display: flex;
 
     @extend %thin-bottom;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
 }

--- a/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
@@ -1,7 +1,7 @@
 @use 'styles/borders';
 
 .header {
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
     display: flex;
 
     @extend %thin-bottom;

--- a/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/search-results-header.module.scss
@@ -1,7 +1,7 @@
 @use 'styles/borders';
 
 .header {
-    padding: 0.25rem 1rem;
+    padding: 0.5rem 1rem;
     display: flex;
 
     @extend %thin-bottom;

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -23,8 +23,8 @@ const SearchTerms = ({ total, terms, onRemoveTerm }: Props) => {
 
     return (
         <div className={styles.terms} tabIndex={0} id="resultsCount" aria-label={total + ' Results have been found'}>
-            <h2>{total} results for:</h2>
             <div className={styles.term}>
+                <h2>{total} results for:</h2>
                 {terms.map((term, index) => (
                     <Chip key={index} name={term.title} value={term.name} handleClose={() => onRemoveTerm(term)} />
                 ))}

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
@@ -1,6 +1,7 @@
 .terms {
     display: flex;
     align-items: center;
+    align-self: center;
     outline: none !important;
 
     .term {

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
@@ -12,6 +12,6 @@
     h2 {
         display: flex;
         white-space: nowrap;
-        margin: 0;
+        margin: 0 0 0.25rem 0;
     }
 }

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/search-terms.module.scss
@@ -8,11 +8,12 @@
         align-items: center;
         display: flex;
         flex-wrap: wrap;
+        gap: 0.5rem;
     }
 
     h2 {
         display: flex;
         white-space: nowrap;
-        margin: 0 0 0.25rem 0;
+        margin: 0;
     }
 }

--- a/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/search-results.module.scss
@@ -4,11 +4,7 @@ $pagination-height: 4.75rem;
 .results {
     height: 100%;
     .header {
-        height: #{$header-height};
-    }
-
-    .content {
-        height: calc(100% - #{$header-height} - #{$pagination-height});
+        min-height: #{$header-height};
     }
 
     .pagination {

--- a/apps/modernization-ui/src/design-system/chips/chip.module.scss
+++ b/apps/modernization-ui/src/design-system/chips/chip.module.scss
@@ -1,7 +1,6 @@
 @use 'styles/colors';
 
 .chip-container {
-    margin: 0 0 0.1rem 0.25rem;
     padding: 0.25rem;
     font-size: 0.75rem;
     background-color: colors.$primary-lighter;


### PR DESCRIPTION
## Description

Fixing chips issue in search pages using useRef and use state to control height dynamically 

## Tickets

* [CNFT1-2925](https://cdc-nbs.atlassian.net/browse/CNFT1-2925)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2925]: https://cdc-nbs.atlassian.net/browse/CNFT1-2925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ