### PR TITLE
[CNFT1-2940] Alternating colors for the active sort column

### DIFF
--- a/apps/modernization-ui/src/design-system/table/data-table.module.scss
+++ b/apps/modernization-ui/src/design-system/table/data-table.module.scss
@@ -55,13 +55,17 @@
             }
 
             &.sorted {
-                background-color: colors.$cool-accent-lighter !important;
+                background-color: colors.$cool-accent-lightest;
             }
         }
 
         tr:nth-child(odd) {
             td {
                 background-color: colors.$base-lightest;
+
+                &.sorted {
+                    background-color: colors.$cool-accent-lighter;
+                }
             }
         }
 

--- a/apps/modernization-ui/src/styles/_colors.scss
+++ b/apps/modernization-ui/src/styles/_colors.scss
@@ -23,6 +23,7 @@ $secondary-vivid: #e41d3d;
 $secondary-dark: #b51d09;
 $secondary-darker: #8b1303;
 
+$cool-accent-lightest: #f0f9fb;
 $cool-accent-lighter: #e1f3f8;
 $cool-accent-light: #97d4ea;
 $cool-accent: #00bde3;


### PR DESCRIPTION
## Description

Applies alternating background colors for the active sort column.

![image](https://github.com/user-attachments/assets/c40c5096-f45f-467a-bb98-e8e1597910bc)

## Tickets

* [CNFT1-2940](https://cdc-nbs.atlassian.net/browse/CNFT1-2940)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2940]: https://cdc-nbs.atlassian.net/browse/CNFT1-2940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ