### PR TITLE
view more/less button bugs fixed

### DIFF
--- a/apps/modernization-ui/src/components/button/Button.module.scss
+++ b/apps/modernization-ui/src/components/button/Button.module.scss
@@ -1,5 +1,21 @@
 @forward 'styles/buttons';
+@use 'styles/colors';
 
 .button-component {
     margin: 0 !important;
+}
+
+.unpadded {
+    background: none !important;
+    border: none;
+    padding: 0 !important;
+    // text-decoration: underline;
+    cursor: pointer;
+    color: colors.$primary !important;
+    text-align: left !important;
+    height: unset !important;
+    font-size: .875rem;
+    font-weight: 0;
+    line-height: 162%;
+    font-style: normal;
 }

--- a/apps/modernization-ui/src/components/button/Button.tsx
+++ b/apps/modernization-ui/src/components/button/Button.tsx
@@ -12,6 +12,7 @@ type Props = {
     disabled?: boolean;
     type?: 'button' | 'submit' | 'reset';
     unstyled?: boolean;
+    unpadded?: boolean;
     labelPosition?: 'left' | 'right';
     onClick?: () => void;
 } & JSX.IntrinsicElements['button'];
@@ -20,6 +21,7 @@ const Button = ({
     className,
     type = 'button',
     icon,
+    unpadded,
     children,
     outline = false,
     destructive = false,
@@ -30,7 +32,8 @@ const Button = ({
     const isIconOnly = icon && !children;
     const classesAarray = classNames(className, {
         [styles.destructive]: destructive,
-        [styles.icon]: icon
+        [styles.icon]: icon,
+        [styles.unpadded]: unpadded
     });
 
     return (

--- a/apps/modernization-ui/src/design-system/table/DataTableRow.tsx
+++ b/apps/modernization-ui/src/design-system/table/DataTableRow.tsx
@@ -28,7 +28,10 @@ export const DataTableRow = <V,>({ columns, row, index }: Props<V>) => {
                             [styles.sorted]: isSorting
                         })}>
                         {column.render(row, index) ? (
-                            <HeightConstrained rowConstraint={constraint} onChange={setConstraint}>
+                            <HeightConstrained
+                                rowConstraint={constraint}
+                                onChange={setConstraint}
+                                name={column.name.toLowerCase()}>
                                 {column.render(row, index)}
                             </HeightConstrained>
                         ) : (

--- a/apps/modernization-ui/src/design-system/table/HeightConstrained.tsx
+++ b/apps/modernization-ui/src/design-system/table/HeightConstrained.tsx
@@ -6,12 +6,13 @@ import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 type Props = {
     children: ReactNode;
     rowConstraint: Constraint;
+    name: string;
     onChange: (value: Constraint) => void;
 };
 
 export type Constraint = 'bounded' | 'unbounded' | 'acceptable';
 
-export const HeightConstrained = ({ children, onChange, rowConstraint }: Props) => {
+export const HeightConstrained = ({ children, onChange, rowConstraint, name }: Props) => {
     const measureRef = useRef<HTMLTableRowElement | null>(null);
     const [constraint, setConstraint] = useState<Constraint>('acceptable');
     const matchesRow = useMemo(() => constraint === rowConstraint, [constraint, rowConstraint]);
@@ -39,12 +40,20 @@ export const HeightConstrained = ({ children, onChange, rowConstraint }: Props) 
                 {children}
             </div>
             {constraint === 'bounded' && matchesRow && (
-                <Button aria-label="view more" unpadded className={styles.button} onClick={() => onChange('unbounded')}>
+                <Button
+                    aria-label={`view more ` + name}
+                    unpadded
+                    className={styles.button}
+                    onClick={() => onChange('unbounded')}>
                     View more
                 </Button>
             )}
             {constraint === 'bounded' && rowConstraint === 'unbounded' && (
-                <Button aria-label="view less" unpadded className={styles.button} onClick={() => onChange('bounded')}>
+                <Button
+                    aria-label={`view less ` + name}
+                    unpadded
+                    className={styles.button}
+                    onClick={() => onChange('bounded')}>
                     View less
                 </Button>
             )}

--- a/apps/modernization-ui/src/design-system/table/HeightConstrained.tsx
+++ b/apps/modernization-ui/src/design-system/table/HeightConstrained.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import styles from './height-constrained.module.scss';
-import { Button } from 'components/button';
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 type Props = {
@@ -39,14 +38,15 @@ export const HeightConstrained = ({ children, onChange, rowConstraint }: Props) 
                 {children}
             </div>
             {constraint === 'bounded' && matchesRow && (
-                <Button aria-label="view more" unstyled className={styles.button} onClick={() => onChange('unbounded')}>
+                <a aria-label="view more" className={styles.button} onClick={() => onChange('unbounded')}>
                     View more
-                </Button>
+                </a>
             )}
+
             {constraint === 'bounded' && rowConstraint === 'unbounded' && (
-                <Button aria-label="view less" unstyled className={styles.button} onClick={() => onChange('bounded')}>
+                <a aria-label="view less" className={styles.button} onClick={() => onChange('bounded')}>
                     View less
-                </Button>
+                </a>
             )}
         </>
     );

--- a/apps/modernization-ui/src/design-system/table/HeightConstrained.tsx
+++ b/apps/modernization-ui/src/design-system/table/HeightConstrained.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import styles from './height-constrained.module.scss';
+import { Button } from 'components/button';
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 type Props = {
@@ -38,15 +39,14 @@ export const HeightConstrained = ({ children, onChange, rowConstraint }: Props) 
                 {children}
             </div>
             {constraint === 'bounded' && matchesRow && (
-                <a aria-label="view more" className={styles.button} onClick={() => onChange('unbounded')}>
+                <Button aria-label="view more" unpadded className={styles.button} onClick={() => onChange('unbounded')}>
                     View more
-                </a>
+                </Button>
             )}
-
             {constraint === 'bounded' && rowConstraint === 'unbounded' && (
-                <a aria-label="view less" className={styles.button} onClick={() => onChange('bounded')}>
+                <Button aria-label="view less" unpadded className={styles.button} onClick={() => onChange('bounded')}>
                     View less
-                </a>
+                </Button>
             )}
         </>
     );

--- a/apps/modernization-ui/src/design-system/table/height-constrained.module.scss
+++ b/apps/modernization-ui/src/design-system/table/height-constrained.module.scss
@@ -9,6 +9,6 @@
     padding: 0 !important;
     margin-left: auto !important;
     width: 9ch !important;
-    float: right;
     text-decoration: unset !important;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Description

3 bugs with View more/less button:
1. Aligned button to the left
2. Changed it to a link and not a button
3. Also changed the aria label to have for example: 'view more address' or 'view more phone' or 'view less address'

<img width="379" alt="Screenshot 2024-08-27 at 4 23 30 PM" src="https://github.com/user-attachments/assets/62f7d404-4412-442e-a177-74ebcee8f2e6">


## Tickets

* [CNFT1-2955](https://cdc-nbs.atlassian.net/browse/CNFT1-2955)
* [CNFT1-2953](https://cdc-nbs.atlassian.net/browse/CNFT1-2953)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2955]: https://cdc-nbs.atlassian.net/browse/CNFT1-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-2953]: https://cdc-nbs.atlassian.net/browse/CNFT1-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ