### PR TITLE
[CNFT1-2943] coded results autocomplete api

### DIFF
--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -31,6 +31,7 @@ export type { Smarty } from './models/Smarty';
 export type { Table } from './models/Table';
 export type { View } from './models/View';
 
+export { CodedResultOptionsService } from './services/CodedResultOptionsService';
 export { ConceptOptionsService } from './services/ConceptOptionsService';
 export { ConditionOptionsService } from './services/ConditionOptionsService';
 export { ConfigurationControllerService } from './services/ConfigurationControllerService';

--- a/apps/modernization-ui/src/generated/services/CodedResultOptionsService.ts
+++ b/apps/modernization-ui/src/generated/services/CodedResultOptionsService.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Option } from '../models/Option';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class CodedResultOptionsService {
+    /**
+     * NBS Coded result Option Autocomplete
+     * Provides options from Local or SNOMED coded results that have a name or code matching a criteria.
+     * @returns Option OK
+     * @throws ApiError
+     */
+    public static codedResultAutocomplete({
+        criteria,
+        limit = 15,
+    }: {
+        criteria: string,
+        limit?: number,
+    }): CancelablePromise<Array<Option>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/options/coded-result/search',
+            query: {
+                'criteria': criteria,
+                'limit': limit,
+            },
+        });
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-springBoot = '3.3.1'
-spring-security = '6.3.0'
+springBoot = '3.3.3'
+spring-security = '6.3.3'
 jackson = '2.17.1'
 queryDSL = '5.1.0'
 spring-kafka = '3.2.0'
@@ -10,16 +10,16 @@ assertj = '3.25.3'
 testcontainers = '1.19.8'
 
 [libraries]
-guava = { module = 'com.google.guava:guava', version = '33.2.0-jre' }
+guava = { module = 'com.google.guava:guava', version = '33.3.0-jre' }
 springBoot = { module = 'org.springframework.boot:spring-boot-starter', version.ref = 'springBoot' }
 springBoot-jdbc = { module = 'org.springframework.boot:spring-boot-starter-jdbc', version.ref = 'springBoot' }
 springBoot-jpa = { module = 'org.springframework.boot:spring-boot-starter-data-jpa', version.ref = 'springBoot' }
 springBoot-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'springBoot' }
-graphql = { module = 'com.graphql-java:graphql-java', version = '20.8' }
+graphql = { module = 'com.graphql-java:graphql-java', version = '20.9' }
 springBoot-graphql = { module = 'org.springframework.boot:spring-boot-starter-graphql', version.ref = 'springBoot' }
 spring-kafka = { module = 'org.springframework.kafka:spring-kafka', version.ref = 'spring-kafka' }
 spring-kafka-test = { module = 'org.springframework.kafka:spring-kafka-test', version.ref = 'spring-kafka' }
-elasticsearch-java = { module = 'co.elastic.clients:elasticsearch-java', version = '7.17.16' }
+elasticsearch-java = { module = 'co.elastic.clients:elasticsearch-java', version = '7.17.23' }
 parsson = { module = 'org.eclipse.parsson:parsson', version = '1.1.5' }
 spring-test = { module = 'org.springframework.boot:spring-boot-starter-test', version.ref = 'springBoot' }
 spring-security = { module = 'org.springframework.boot:spring-boot-starter-security', version.ref = 'springBoot' }
@@ -28,16 +28,16 @@ spring-security-web = { module = 'org.springframework.security:spring-security-w
 spring-security-oauth2-resource-server = { module = 'org.springframework.security:spring-security-oauth2-resource-server', version.ref = 'spring-security' }
 spring-security-oauth2-jose = { module = 'org.springframework.security:spring-security-oauth2-jose', version.ref = 'spring-security' }
 spring-security-test = { module = 'org.springframework.security:spring-security-test', version.ref = 'spring-security' }
-open-api = { module = 'org.springdoc:springdoc-openapi-starter-webmvc-ui', version = '2.4.0' }
+open-api = { module = 'org.springdoc:springdoc-openapi-starter-webmvc-ui', version = '2.6.0' }
 spring-validation = { module = 'org.springframework.boot:spring-boot-starter-validation', version.ref = 'springBoot' }
 jackson-core = { module = 'com.fasterxml.jackson.core:jackson-core', version.ref = 'jackson' }
 jackson-datatype-jsr310 = { module = 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310', version.ref = 'jackson' }
 queryDSL-apt = { module = 'com.querydsl:querydsl-apt', version.ref = 'queryDSL' }
 queryDSL-jpa = { module = 'com.querydsl:querydsl-jpa', version.ref = 'queryDSL' }
-lombok = { module = 'org.projectlombok:lombok', version = '1.18.32' }
+lombok = { module = 'org.projectlombok:lombok', version = '1.18.34' }
 mssql-jdbc = { module = 'com.microsoft.sqlserver:mssql-jdbc', version = '12.4.2.jre11' }
 java-jwt = { module = 'com.auth0:java-jwt', version = '4.4.0' }
-itextpdf = { module = 'com.itextpdf:itextpdf', version = '5.5.13.3' }
+itextpdf = { module = 'com.itextpdf:itextpdf', version = '5.5.13.4' }
 assertj-core = { module = 'org.assertj:assertj-core', version.ref = 'assertj' }
 mockito = { module = 'org.mockito:mockito-core', version = '5.12.0' }
 testcontainers = { module = 'org.testcontainers:testcontainers', version.ref = 'testcontainers' }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultOptionAutocompleteController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultOptionAutocompleteController.java
@@ -1,0 +1,35 @@
+package gov.cdc.nbs.option.coded.result.autocomplete;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+@RequestMapping("nbs/api/options/coded-result/search")
+class CodedResultOptionAutocompleteController {
+
+  private final CodedResultOptionResolver resolver;
+
+  CodedResultOptionAutocompleteController(final CodedResultOptionResolver finder) {
+    this.resolver = finder;
+  }
+
+  @Operation(
+      operationId = "coded-result-autocomplete",
+      summary = "NBS Coded result Option Autocomplete",
+      description = "Provides options from Local or SNOMED coded results that have a name or code matching a criteria.",
+      tags = "CodedResultOptions")
+  @GetMapping
+  Collection<Option> complete(
+      @RequestParam final String criteria,
+      @RequestParam(defaultValue = "15") final int limit
+  ) {
+    return this.resolver.resolve(criteria, limit);
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultOptionResolver.java
@@ -1,0 +1,49 @@
+package gov.cdc.nbs.option.coded.result.autocomplete;
+
+import gov.cdc.nbs.option.jdbc.autocomplete.SQLBasedOptionResolver;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class CodedResultOptionResolver extends SQLBasedOptionResolver {
+  private static final String QUERY =
+      """
+          with [coded_test]([value], [name]) as (
+                select
+                    lab_result_cd,
+                    lab_result_desc_txt
+                from
+                    [NBS_SRTE].[dbo].[Lab_result]
+                where organism_name_ind = 'N'
+                and (
+                            lab_result_desc_txt like :criteria
+                        or  lab_result_desc_txt like :prefixCriteria
+                        or  lab_result_cd like :criteria
+                    )
+                union
+                select
+                    snomed_cd,
+                    snomed_desc_txt
+                from
+                    [NBS_SRTE].[dbo].[Snomed_code]
+                where   snomed_desc_txt like :criteria
+                    or snomed_desc_txt like :prefixCriteria
+                    or  snomed_cd like :criteria
+          )
+          select
+              [value],
+              [name],
+              row_number() over( order by [name])
+          from [coded_test]
+
+          order by
+              [name]
+
+          offset 0 rows
+          fetch next :limit rows only
+          """;
+
+  CodedResultOptionResolver(final NamedParameterJdbcTemplate template) {
+    super(QUERY, template);
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/CodedResultOptionMother.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/CodedResultOptionMother.java
@@ -1,0 +1,86 @@
+package gov.cdc.nbs.option.coded.result;
+
+import io.cucumber.spring.ScenarioScope;
+import jakarta.annotation.PreDestroy;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@ScenarioScope
+class CodedResultOptionMother {
+
+  private static final String DELETE_LOCAL = """
+      delete from NBS_SRTE.dbo.Lab_result where laboratory_id = 'LAB_TESTING'
+      """;
+
+  private static final String DELETE_SNOMED_CODE = """
+      delete from NBS_SRTE.dbo.Snomed_code where source_version_id = '4_TESTING'
+      """;
+
+  private static final String CREATE_LOCAL =
+      """
+      insert into NBS_SRTE.dbo.Lab_coding_system(laboratory_id) SELECT 'LAB_TESTING' WHERE NOT EXISTS (SELECT * FROM NBS_SRTE.dbo.Lab_coding_system WHERE laboratory_id='LAB_TESTING');
+      insert into NBS_SRTE.dbo.Lab_result(lab_result_cd,laboratory_id,lab_result_desc_txt,organism_name_ind) values (:code, 'LAB_TESTING', :name,'N');
+      """;
+
+  private static final String CREATE_SNOMED_CODE =
+      """
+      insert into NBS_SRTE.dbo.Snomed_code(snomed_cd, snomed_desc_txt, source_concept_id, source_version_id) values (:code, :name, :code, '4_TESTING');
+      """;
+
+  private final NamedParameterJdbcTemplate template;
+
+  CodedResultOptionMother(final JdbcTemplate template) {
+    this.template = new NamedParameterJdbcTemplate(template);
+  }
+
+  @PreDestroy
+  void reset() {
+    Map<String, List<String>> parameters = Map.of();
+
+    template.execute(
+        DELETE_LOCAL,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+    template.execute(
+        DELETE_SNOMED_CODE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate);
+
+  }
+
+  void createSNOMED(final String code, final String name) {
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "code", code,
+        "name", name
+    );
+
+    template.execute(
+        CREATE_SNOMED_CODE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate
+    );
+  }
+
+  void createLocal(final String code, final String name) {
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "code", code,
+        "name", name
+    );
+
+    template.execute(
+        CREATE_LOCAL,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate
+    );
+
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/CodedResultOptionSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/CodedResultOptionSteps.java
@@ -1,0 +1,22 @@
+package gov.cdc.nbs.option.coded.result;
+
+import io.cucumber.java.en.Given;
+
+public class CodedResultOptionSteps {
+
+  private final CodedResultOptionMother mother;
+
+  CodedResultOptionSteps(final CodedResultOptionMother mother) {
+    this.mother = mother;
+  }
+
+  @Given("there is a SNOMED coded result for {string} {string}")
+  public void there_is_a_SNOMED_coded_result(final String code, final String value) {
+    mother.createSNOMED(code, value);
+  }
+
+  @Given("there is a local coded result for {string} {string}")
+  public void there_is_a_local_coded_result(final String code, final String value) {
+    mother.createLocal(code, value);
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultAutocompleteRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultAutocompleteRequester.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.coded.result.autocomplete;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+class CodedResultAutocompleteRequester {
+
+  private final MockMvc mvc;
+
+  CodedResultAutocompleteRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions complete(final String criteria) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/coded-result/search")
+            .param("criteria", criteria))
+        .andDo(print());
+  }
+
+  ResultActions complete(final String criteria, final int limit) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/coded-result/search")
+            .param("criteria", criteria)
+            .param("limit", String.valueOf(limit)))
+        .andDo(print());
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultAutocompleteSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/coded/result/autocomplete/CodedResultAutocompleteSteps.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.coded.result.autocomplete;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class CodedResultAutocompleteSteps {
+
+  private final CodedResultAutocompleteRequester request;
+  private final Active<ResultActions> response;
+
+  CodedResultAutocompleteSteps(
+      final CodedResultAutocompleteRequester request,
+      final Active<ResultActions> response
+  ) {
+    this.request = request;
+    this.response = response;
+  }
+
+  @When("I am trying to find coded results that start with {string}")
+  public void i_am_trying_to_find_coded_results_that_start_with(final String criteria) throws Exception {
+    response.active(request.complete(criteria));
+  }
+
+  @When("I am trying to find at most {int} coded result(s) that start with {string}")
+  public void i_am_trying_to_find_n_coded_results_that_start_with(
+      final int limit,
+      final String criteria
+  ) throws Exception {
+    response.active(request.complete(criteria, limit));
+  }
+
+}

--- a/libs/options-api/src/test/resources/features/coded-result/CodedResultOptions.feature
+++ b/libs/options-api/src/test/resources/features/coded-result/CodedResultOptions.feature
@@ -1,0 +1,18 @@
+Feature: Coded Result Options REST API
+
+  Background:
+    Given there is a SNOMED coded result for "prefix1code1a" "name1"
+    And there is a local coded result for "prefix1code1b" "name2"
+    And there is a SNOMED coded result for "prefix2code2a" "name3"
+    And there is a local coded result for "prefix2code2b" "name4"
+    And there is a SNOMED coded result for "prefix3code2a" "prefix1 name3"
+    And there is a local coded result for "prefix3code2b" "prefix1 name4"
+
+  Scenario: I can find specific coded result
+    When I am trying to find coded results that start with "prefix1"
+    Then there are options available
+    And the option named "name1" is included
+    And the option named "name2" is included
+    And the option named "prefix1 name3" is included
+    And the option named "prefix1 name4" is included
+    And there are 4 options included


### PR DESCRIPTION
## Description

Adds the `/nbs/api/options/coded-result/search` endpoint that allows autocompletion of Local and SNOMED coded results.  

- The `CodedResultOptionsService.codedResultAutocomplete` client has been generated. 

## Tickets

* [CNFT1-2943](https://cdc-nbs.atlassian.net/browse/CNFT1-2943)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2943]: https://cdc-nbs.atlassian.net/browse/CNFT1-2943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ