### PR TITLE
[CNFT1-2943] Allows for partial searches of coded results and resulted tests in Lab Report searches

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/LabReportFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/LabReportFilter.java
@@ -143,6 +143,16 @@ public final class LabReportFilter implements EventFilter {
     REPORTING_FACILITY
   }
 
+  public LabReportFilter withResultedTest(final String resultedTest) {
+    this.resultedTest = resultedTest;
+    return this;
+  }
+
+  public LabReportFilter withCodedResult(final String codedResult) {
+    this.codedResult = codedResult;
+    return this;
+  }
+
   public LabReportFilter withEventStatus(final EventStatus status) {
     this.eventStatus.add(status);
     return this;
@@ -231,13 +241,13 @@ public final class LabReportFilter implements EventFilter {
         : Optional.empty();
   }
 
-  public Optional<String> resultedTest() {
+  public Optional<String> withResultedTest() {
     return (this.resultedTest == null || this.resultedTest.isEmpty())
         ? Optional.empty()
         : Optional.of(this.resultedTest);
   }
 
-  public Optional<String> codedResult() {
+  public Optional<String> withCodedResult() {
     return (this.codedResult == null || this.codedResult.isEmpty())
         ? Optional.empty()
         : Optional.of(this.codedResult);

--- a/apps/modernization-api/src/main/resources/search/lab-report/lab-report.index.json
+++ b/apps/modernization-api/src/main/resources/search/lab-report/lab-report.index.json
@@ -189,10 +189,22 @@
             "type": "keyword"
           },
           "cd_desc_txt": {
-            "type": "keyword"
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           },
           "display_name": {
-            "type": "keyword"
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           },
           "domain_cd_st_1": {
             "type": "keyword"

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/test/CodedResultedTestMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/test/CodedResultedTestMother.java
@@ -23,23 +23,28 @@ public class CodedResultedTestMother {
         'OBS',
         'EVN'
       );
-      
+     
       insert into Observation(
         observation_uid,
         ctrl_cd_display_form,
         obs_domain_cd_st_1,
         cd,
+        cd_desc_txt,
         version_ctrl_nbr,
         shared_ind
-      ) values (
+      )
+      select
         :identifier,
         'LabReport',
         'Result',
-        :test,
+        lab_test_cd,
+        lab_test_desc_txt,
         1,
         'N'
-      );
-            
+      from [NBS_SRTE]..[Lab_test]
+      where lab_test_cd = :test
+     ;
+     
        insert into Act_relationship(
         source_act_uid,
         source_class_cd,
@@ -53,16 +58,21 @@ public class CodedResultedTestMother {
         'OBS',
         'COMP'
       );
-            
+     
       insert into Obs_value_coded (
         observation_uid,
-        code
-      ) values (
+        code,
+        display_name
+      )
+      select
         :identifier,
-        :result
-      );
-            
-      """;
+        lab_result_cd,
+        lab_result_desc_txt
+      from [NBS_SRTE]..[Lab_result]
+      where lab_result_cd = :result
+      and laboratory_id = 'DEFAULT'
+     ;
+     """;
 
 
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/LabReportFilterTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/LabReportFilterTest.java
@@ -42,7 +42,7 @@ class LabReportFilterTest {
 
     filter.setResultedTest("");
 
-    assertThat(filter.resultedTest()).isEmpty();
+    assertThat(filter.withResultedTest()).isEmpty();
   }
 
   @Test
@@ -51,6 +51,6 @@ class LabReportFilterTest {
 
     filter.setCodedResult("");
 
-    assertThat(filter.codedResult()).isEmpty();
+    assertThat(filter.withCodedResult()).isEmpty();
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaSteps.java
@@ -89,6 +89,16 @@ public class LabReportSearchCriteriaSteps {
             provider -> criteria.setOrderingProviderId(provider.identifier())));
   }
 
+  @Given("I want to find lab reports with test results for {string}")
+  public void i_want_to_find_lab_reports_with_test_results_for(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withResultedTest(value));
+  }
+
+  @Given("I want to find lab reports with the coded result {string}")
+  public void i_want_to_find_lab_reports_with_the_coded_result(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withCodedResult(value));
+  }
+
   @Given("I add the lab report criteria for {string}")
   public void i_add_the_lab_report_criteria_for(final String field) {
     this.activeCriteria.active(current -> applyCriteria(current, field));
@@ -158,18 +168,18 @@ public class LabReportSearchCriteriaSteps {
       case "processing status" -> processingStatus().map(List::of).ifPresent(filter::setProcessingStatus);
 
       case "ordering facility" -> orderingFacility().map(
-          provider -> providerSearch(
-              LabReportFilter.ProviderType.ORDERING_FACILITY,
-              provider))
+              provider -> providerSearch(
+                  LabReportFilter.ProviderType.ORDERING_FACILITY,
+                  provider))
           .ifPresent(filter::setProviderSearch);
 
       case "ordering facility new api" -> orderingFacility()
           .ifPresent(filter::setOrderingLabId);
 
       case "reporting facility" -> reportingFacility().map(
-          provider -> providerSearch(
-              LabReportFilter.ProviderType.REPORTING_FACILITY,
-              provider))
+              provider -> providerSearch(
+                  LabReportFilter.ProviderType.REPORTING_FACILITY,
+                  provider))
           .ifPresent(filter::setProviderSearch);
 
       case "reporting facility new api" -> reportingFacility()

--- a/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.feature
@@ -17,7 +17,6 @@ Feature: Lab Report Search
     And the lab report was filled by "307947"
     And the lab report was received on 08/11/2017
     And the lab report has not been processed
-    And the lab report has an Acid-Fast Stain test with a coded result of abnormal
     And lab reports are available for search
     And I am searching for the Lab Report
 
@@ -133,7 +132,27 @@ Feature: Lab Report Search
     And I want to find lab reports ordered by the provider using the new api
     When I search for lab reports
     Then the Lab Report search results contain the lab report
-    And there is only one lab report search result    
+    And there is only one lab report search result
+
+  Scenario: I can search for Lab Reports with a specific resulted test
+    Given the patient has a lab report
+    And the lab report has an Acid-Fast Stain test with a coded result of abnormal
+    And the lab report is available for search
+    And I am searching for the Lab Report
+    And I want to find lab reports with test results for "Aci"
+    When I search for lab reports
+    Then the Lab Report search results contain the lab report
+    And there is only one lab report search result
+
+  Scenario: I can search for Lab Reports with a specific coded result
+    Given the patient has a lab report
+    And the lab report has an Aldolase test with a coded result of above threshold
+    And the lab report is available for search
+    And I am searching for the Lab Report
+    And I want to find lab reports with the coded result "abo"
+    When I search for lab reports
+    Then the Lab Report search results contain the lab report
+    And there is only one lab report search result
 
   Scenario Outline: I can search for Lab Reports
     Given I add the lab report criteria for "<field>"
@@ -158,8 +177,6 @@ Feature: Lab Report Search
       | Ordering Facility new api      |
       | Reporting Facility             |
       | Reporting Facility new api     |
-      | resulted test                  |
-      | coded result                   |
 
 
   Scenario Outline: I can find a lab report by many fields in the laboratory report
@@ -187,6 +204,4 @@ Feature: Lab Report Search
       | Ordering Facility new api      | jurisdiction  | lab id       |
       | Reporting Facility             | jurisdiction  | lab id       |
       | Reporting Facility new api     | jurisdiction  | lab id       |
-      | resulted test                  | jurisdiction  | lab id       |
-      | coded result                   | jurisdiction  | lab id       |
       | patient id                     | resulted test | lab id       |


### PR DESCRIPTION
## Description

Allows searching for Laboratory Reports using partial text searches on coded results and resulted tests.

_Note: This PR contains mapping changes and requires a re-indexing of Elasticsearch_

## Tickets

* [CNFT1-2943](https://cdc-nbs.atlassian.net/browse/CNFT1-2943)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
