### PR TITLE
Clear county when state value is cleared. Hook error fix

### DIFF
--- a/apps/modernization-ui/src/apps/patient/profile/sexBirth/BirthAndGenderEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/sexBirth/BirthAndGenderEntryFields.tsx
@@ -22,10 +22,10 @@ export const BirthAndGenderEntryFields = () => {
 
     const coded = usePatientSexBirthCodedValues();
 
-    const { counties } = useCountyCodedValues(selectedState ?? '');
+    const { counties } = useCountyCodedValues(selectedState);
 
     useEffect(() => {
-        if (selectedState == null || selectedState == undefined || selectedState == '') {
+        if (!selectedState) {
             setValue('birth.county', '');
         }
     }, [selectedState]);

--- a/apps/modernization-ui/src/apps/patient/profile/sexBirth/BirthAndGenderEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/sexBirth/BirthAndGenderEntryFields.tsx
@@ -3,8 +3,8 @@ import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { Input } from 'components/FormInputs/Input';
 import { SelectInput } from 'components/FormInputs/SelectInput';
 import { calculateAge } from 'date';
-import { CountiesCodedValues, useCountyCodedValues } from 'location';
-import { useMemo } from 'react';
+import { useCountyCodedValues } from 'location';
+import { useEffect, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
 import { BirthAndGenderEntry } from './BirthAndGenderEntry';
@@ -13,20 +13,22 @@ import { usePatientSexBirthCodedValues } from './usePatientSexBirthCodedValues';
 const UNKNOWN_GENDER = 'U';
 
 export const BirthAndGenderEntryFields = () => {
-    const { control } = useFormContext<BirthAndGenderEntry>();
+    const { control, setValue } = useFormContext<BirthAndGenderEntry>();
     const currentBirthday = useWatch({ control, name: 'birth.bornOn' });
-
     const age = useMemo(() => calculateAge(currentBirthday), [currentBirthday]);
-
     const selectedCurrentGender = useWatch({ control, name: 'gender.current' });
-
     const selectedState = useWatch({ control, name: 'birth.state' });
-
     const selectedMultipleBirth = useWatch({ control, name: 'birth.multipleBirth' });
 
     const coded = usePatientSexBirthCodedValues();
 
-    const byState: CountiesCodedValues = selectedState ? useCountyCodedValues(selectedState) : { counties: [] };
+    const { counties } = useCountyCodedValues(selectedState ?? '');
+
+    useEffect(() => {
+        if (selectedState == null || selectedState == undefined || selectedState == '') {
+            setValue('birth.county', '');
+        }
+    }, [selectedState]);
 
     return (
         <section>
@@ -244,7 +246,7 @@ export const BirthAndGenderEntryFields = () => {
                         id={name}
                         name={name}
                         htmlFor={name}
-                        options={byState.counties}
+                        options={counties}
                     />
                 )}
             />

--- a/apps/modernization-ui/src/location/useCountyCodedValues.ts
+++ b/apps/modernization-ui/src/location/useCountyCodedValues.ts
@@ -30,7 +30,7 @@ type CountiesCodedValues = {
     counties: GroupedCodedValue[];
 };
 
-const useCountyCodedValues = (state?: string | undefined) => {
+const useCountyCodedValues = (state?: string | undefined | null) => {
     const [coded, setCoded] = useState<CountiesCodedValues>(initial);
 
     const [getCodedValues] = useCodedValueQuery({ onCompleted: setCoded });


### PR DESCRIPTION
## Description

Changing the `state` value of the `Sex & birth` form was causing an error triggering a redirection. There was also an issue with the county value persisting when deselecting the state. 

## Tickets

* [CNFT1-2980](https://cdc-nbs.atlassian.net/browse/CNFT1-2980)

## Error
![image](https://github.com/user-attachments/assets/d9a60c81-aabd-4e20-8893-ab80f94a4be1)

## Demo with fix
![birthsexstate](https://github.com/user-attachments/assets/8cfaa46d-7245-4f44-a21e-ec374b0a9732)



## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2980]: https://cdc-nbs.atlassian.net/browse/CNFT1-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ