### PR TITLE
[CNFT1-2470] Actually collapsible criteria

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -70,7 +70,10 @@ const SearchLayout = ({
         <section className={styles.search}>
             <SearchNavigation className={styles.navigation} actions={actions} />
             <div className={styles.content}>
-                <CollapsiblePanel className={styles.criteria} ariaLabel="Search criteria">
+                <CollapsiblePanel
+                    className={styles.panel}
+                    contentClassName={styles.criteria}
+                    ariaLabel="Search criteria">
                     <div className={styles.inputs}>{criteria()}</div>
                     <div className={styles.actions}>
                         <Button type="button" onClick={onSearch} disabled={!searchEnabled}>

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -24,13 +24,16 @@ $content-height: calc($search-height - $navigation-height - 3rem);
 
         background-color: colors.$base-white;
 
+        overflow-y: clip;
+
         @include borders.bordered();
         @include borders.rounded();
 
-        .criteria {
-            flex-shrink: 0;
-            width: $criteria-width;
+        .panel {
+            --expanded-max-width: 320px;
+        }
 
+        .criteria {
             background-color: colors.$base-white;
 
             @include borders.bordered('border-right');
@@ -58,9 +61,7 @@ $content-height: calc($search-height - $navigation-height - 3rem);
 
         .results {
             flex-grow: 1;
-            width: calc(100% - $criteria-width);
-
-            z-index: 0;
+            min-width: calc(100% - $criteria-width);
         }
     }
 }

--- a/apps/modernization-ui/src/design-system/collapsible-panel/CollapsiblePanel.tsx
+++ b/apps/modernization-ui/src/design-system/collapsible-panel/CollapsiblePanel.tsx
@@ -8,17 +8,20 @@ type Props = {
     id?: string;
     children: ReactNode;
     className?: string;
+    contentClassName?: string;
     ariaLabel?: string;
 };
 
-const CollapsiblePanel = ({ children, id, className, ariaLabel }: Props) => {
+const CollapsiblePanel = ({ children, id, className, contentClassName, ariaLabel }: Props) => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
 
     return (
-        <div id={id} className={classNames(className, styles.collapsible, { [styles.collapsed]: collapsed })}>
-            <span className={styles.content} aria-hidden={collapsed}>
-                {children}
-            </span>
+        <div id={id} className={classNames(styles.collapsible, className, { [styles.collapsed]: collapsed })}>
+            <div className={styles.boundary}>
+                <div className={classNames(styles.content, contentClassName)} aria-hidden={collapsed}>
+                    {children}
+                </div>
+            </div>
             <button
                 type="button"
                 className={classNames(styles.control, { [styles.collapsed]: collapsed })}

--- a/apps/modernization-ui/src/design-system/collapsible-panel/collapsible-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/collapsible-panel/collapsible-panel.module.scss
@@ -4,6 +4,18 @@
 $control-height: 3rem;
 $control-width: 1.5rem;
 
+@mixin expanded($property) {
+    transition-duration: 0.25s;
+    transition-property: #{$property};
+    transition-timing-function: ease-out;
+}
+
+@mixin collapsed($property) {
+    transition-duration: 0.2s;
+    transition-property: #{$property};
+    transition-timing-function: ease-in;
+}
+
 .control {
     position: absolute;
     z-index: 1000;
@@ -19,6 +31,8 @@ $control-width: 1.5rem;
     top: calc(50% - #{$control-height});
 
     right: -($control-width / 2);
+
+    cursor: pointer;
 
     &:focus {
         outline: 0;
@@ -38,19 +52,34 @@ $control-width: 1.5rem;
 }
 
 .collapsible {
-    position: relative;
-    transition-duration: 0.25s;
-    transition-property: transform;
-    transition-timing-function: ease-out;
+    --expanded-max-width: 100%;
+    --collapsed-max-width: 0;
 
-    // overflow: clip;
+    position: relative;
+
+    @include expanded('width');
+    width: var(--expanded-max-width, 100%);
+
+    .boundary {
+        overflow: clip;
+    }
+
+    .content {
+        min-width: max-content;
+
+        position: relative;
+        @include expanded('left');
+        left: 0;
+    }
 
     &.collapsed {
-        transition-duration: 0.2s;
-        transition-timing-function: ease-in;
-        transform: translateX(-100%);
+        @include expanded('width');
+        width: var(--collapsed-max-width, 0);
 
         .content {
+            @include collapsed('left');
+            left: -100%;
+
             animation: collapsing 600ms forwards;
         }
     }


### PR DESCRIPTION
## Description

Makes the `CollapsiblePanel` slide to the left and give up previously occupied space.

![cnft1-2740](https://github.com/user-attachments/assets/3f746c82-479f-48b0-ab62-050ea8806cfc)


## Tickets

* [CNFT1-2470](https://cdc-nbs.atlassian.net/browse/CNFT1-2470)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2470]: https://cdc-nbs.atlassian.net/browse/CNFT1-2470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ