### PR TITLE
Pagebuilder workflow fix

### DIFF
--- a/.github/workflows/Build-and-deploy-modernization-api.yaml
+++ b/.github/workflows/Build-and-deploy-modernization-api.yaml
@@ -1,5 +1,6 @@
 name: Build and Deploy modernization-api image
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/Build-and-deploy-modernization-api.yaml
+++ b/.github/workflows/Build-and-deploy-modernization-api.yaml
@@ -1,6 +1,5 @@
 name: Build and Deploy modernization-api image
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/Build-and-deploy-page-builder-api.yaml
+++ b/.github/workflows/Build-and-deploy-page-builder-api.yaml
@@ -17,6 +17,7 @@ jobs:
       PASSED_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD}}
+      PARAMETER_SECRET: ${{secrets.PARAMETER_SECRET}}
       TOKEN_SECRET: ${{secrets.TOKEN_SECRET}}
   call-build-microservice-container-workflow:
     name: Build Container

--- a/.github/workflows/Build-and-deploy-page-builder-api.yaml
+++ b/.github/workflows/Build-and-deploy-page-builder-api.yaml
@@ -1,6 +1,5 @@
 name: Build and Deploy page-builder-api image
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/Build-and-deploy-page-builder-api.yaml
+++ b/.github/workflows/Build-and-deploy-page-builder-api.yaml
@@ -1,5 +1,6 @@
 name: Build and Deploy page-builder-api image
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -16,13 +16,13 @@ on:
         required: true
       DATABASE_PASSWORD:
         description: "Secret named DATABASE_PASSWORD that references the test database container default password"
-        required: false
+        required: true
       TOKEN_SECRET:
         description: "Secret named TOKEN_SECRET that references a default JWT token key"
-        required: false
+        required: true
       PARAMETER_SECRET:
         description: "Secret named PARAMETER_SECRET that references a default key for encrypting search parameters"
-        required: false
+        required: true
   pull_request:
     paths:
       - "apps/**"


### PR DESCRIPTION
## Description

The sonar workflow runs all tests regardless of the api being updated. Due to this, the `PARAMETER_SECRET` is in fact required for the pagebuilder workflow.

1. Resets params to required in sonar since they are actually required for each container
2. Adds `PARAMETER_SECRET` to page builder workflow