### PR TITLE
[FIX] Patient sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# local environment set up
 application-local.yml
-
-# merged .graphqls files used in code generation
-ui/src/generated/schema.graphqls
+local.env

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSortResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSortResolver.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static gov.cdc.nbs.search.SearchSorting.asSortOption;
 import static gov.cdc.nbs.search.SearchSorting.asSortOrder;
@@ -18,31 +19,34 @@ class PatientSearchCriteriaSortResolver {
   List<SortOptions> resolve(final Pageable pageable) {
     return pageable.getSort()
         .stream()
-        .map(this::asOption)
+        .flatMap(this::asOption)
         .toList();
   }
 
-  private SortOptions asOption(final Sort.Order sorting) {
+  private Stream<SortOptions> asOption(final Sort.Order sorting) {
     SortOrder order = asSortOrder(sorting.getDirection());
 
-    return switch (sorting.getProperty()) {
-      case ADDRESS -> asSortOption(ADDRESS, "address.streetAddr1.keyword", order);
-      case "birthTime" -> asSortOption("birth_time", order);
-      case "city" -> asSortOption(ADDRESS, "address.city.keyword", order);
-      case "county" -> asSortOption(ADDRESS, "address.cntyText.keyword", order);
-      case "country" -> asSortOption(ADDRESS, "address.cntryText.keyword", order);
-      case "email" -> asSortOption("email", "email.emailAddress.keyword", order);
-      case "firstNm" -> asSortOption("name", "name.firstNm.keyword", order);
-      case "id" -> asSortOption("patient", order);
-      case "identification" -> asSortOption("entity_id", "entity_id.rootExtensionTxt.keyword", order);
-      case "lastNm" -> asSortOption("name", "name.lastNm.keyword", order);
-      case "phoneNumber" -> asSortOption("phone", "phone.telephoneNbr.keyword", order);
-      case "relevance" -> asSortOption("_score", order);
-      case "state" -> asSortOption(ADDRESS, "address.stateText.keyword", order);
-      case "sex" -> asSortOption("curr_sex_cd", order);
-      case "zip" -> asSortOption(ADDRESS, "address.zip.keyword", order);
-      // local_id :
-      default -> asSortOption(sorting.getProperty(), order);
+    return switch (sorting.getProperty().toLowerCase()) {
+      case "patientid" -> Stream.of(asSortOption("local_id", order));
+      case "legalname" -> Stream.of(
+          asSortOption("name", "name.lastNm.keyword", order),
+          asSortOption("name", "name.firstNm.keyword", order)
+      );
+      case "lastnm" -> Stream.of(asSortOption("name", "name.lastNm.keyword", order));
+      case "firstnm" -> Stream.of(asSortOption("name", "name.firstNm.keyword", order));
+      case ADDRESS -> Stream.of(asSortOption(ADDRESS, "address.streetAddr1.keyword", order));
+      case "birthtime", "birthday" -> Stream.of(asSortOption("birth_time", order));
+      case "city" -> Stream.of(asSortOption(ADDRESS, "address.city.keyword", order));
+      case "county" -> Stream.of(asSortOption(ADDRESS, "address.cntyText.keyword", order));
+      case "country" -> Stream.of(asSortOption(ADDRESS, "address.cntryText.keyword", order));
+      case "email" -> Stream.of(asSortOption("email", "email.emailAddress.keyword", order));
+      case "id" -> Stream.of(asSortOption("patient", order));
+      case "identification" -> Stream.of(asSortOption("entity_id", "entity_id.rootExtensionTxt.keyword", order));
+      case "phonenumber" -> Stream.of(asSortOption("phone", "phone.telephoneNbr.keyword", order));
+      case "state" -> Stream.of(asSortOption(ADDRESS, "address.stateText.keyword", order));
+      case "sex" -> Stream.of(asSortOption("curr_sex_cd", order));
+      case "zip" -> Stream.of(asSortOption(ADDRESS, "address.zip.keyword", order));
+      default -> Stream.of(asSortOption("_score", order));
     };
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/RunCucumber.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/RunCucumber.java
@@ -30,7 +30,7 @@ import static io.cucumber.junit.platform.engine.Constants.*;
 @CucumberContextConfiguration
 @SpringBootTest
 @Import(PatientLocalIdentifierGeneratorTestConfiguration.class)
-@ActiveProfiles({"default", "test"})
+@ActiveProfiles({"default", "test", "local"})
 @AutoConfigureMockMvc
 @Testcontainers
 @EmbeddedNbsDatabase

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchSortingSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchSortingSteps.java
@@ -18,9 +18,11 @@ public class PatientSearchSortingSteps {
     Sort.Direction sortDirection = direction.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
 
     String field = switch (sortBy.toLowerCase()) {
+      case "local_id", "patient id" -> "patientid";
       case "birthday" -> "birthTime";
       case "first name" -> "firstNm";
       case "last name" -> "lastNm";
+      case "legal name" -> "legalName";
       case "phone" -> "phoneNumber";
       default -> sortBy.toLowerCase();
     };

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
@@ -45,7 +45,8 @@ public class PatientSearchVerificationSteps {
   public void search_result_n_has_a_x_of_y(
       final int position,
       final String field,
-      final String value) throws Exception {
+      final String value
+  ) throws Exception {
 
     int index = position - 1;
 
@@ -118,7 +119,7 @@ public class PatientSearchVerificationSteps {
           "$.data.findPatientsByFilter.content[%s].identification[*].value",
           position
       );
-      case "local id" -> jsonPath("$.data.findPatientsByFilter.content[%s].shortId", position);
+      case "patientid", "patient id", "short id" -> jsonPath("$.data.findPatientsByFilter.content[%s].shortId", position);
       default -> throw new AssertionError("Unexpected property check %s".formatted(field));
     };
   }
@@ -126,7 +127,7 @@ public class PatientSearchVerificationSteps {
   private Matcher<?> matchingValue(final String field, final String value) {
     return switch (field.toLowerCase()) {
       case "birthday", "sex" -> equalTo(value);
-      case "local id" -> equalTo(Integer.parseInt(value));
+      case "patientid","patient id", "short id" -> equalTo(Integer.parseInt(value));
       case "status" -> hasItem(PatientStatusCriteriaResolver.resolve(value).name());
       default -> hasItem(value);
     };

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.sorting.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.sorting.feature
@@ -32,6 +32,38 @@ Feature: Patient Search Sorting
     And search result 2 has a "birthday" of "1987-01-15"
     And search result 3 has a "birthday" of "1974-05-29"
 
+  Scenario: I can find the most relevant patient when sorting by legal name  ascending
+    Given the patient has the "legal" name "Wanda" "Maximoff"
+    And I have another patient
+    And the patient has the "legal" name "Helen" "Cho"
+    And I have another patient
+    And the patient has the "legal" name "Pietro" "Maximoff"
+    And patients are available for search
+    And I want patients sorted by "legal name" "asc"
+    When I search for patients
+    Then search result 1 has a "first name" of "Helen"
+    And search result 1 has a "last name" of "Cho"
+    And search result 2 has a "first name" of "Pietro"
+    And search result 2 has a "last name" of "Maximoff"
+    And search result 3 has a "first name" of "Wanda"
+    And search result 3 has a "last name" of "Maximoff"
+
+  Scenario: I can find the most relevant patient when sorting by legal name descending
+    Given the patient has the "legal" name "Wanda" "Maximoff"
+    And I have another patient
+    And the patient has the "legal" name "Helen" "Cho"
+    And I have another patient
+    And the patient has the "legal" name "Pietro" "Maximoff"
+    And patients are available for search
+    And I want patients sorted by "last name" "desc"
+    When I search for patients
+    Then search result 1 has a "first name" of "Wanda"
+    And search result 1 has a "last name" of "Maximoff"
+    And search result 2 has a "first name" of "Pietro"
+    And search result 2 has a "last name" of "Maximoff"
+    And search result 3 has a "first name" of "Helen"
+    And search result 3 has a "last name" of "Cho"
+
   Scenario: I can find the most relevant patient when sorting by last name  ascending
     Given the patient has the "legal" name "Timothy" "Jackson"
     And I have another patient
@@ -281,9 +313,9 @@ Feature: Patient Search Sorting
     And patients are available for search
     And I want patients sorted by "local_id" "asc"
     When I search for patients
-    Then search result 1 has an "local id" of "120"
-    And search result 2 has an "local id" of "220"
-    And search result 3 has an "local id" of "320"
+    Then search result 1 has a "patient id" of "120"
+    And search result 2 has a "patient id" of "220"
+    And search result 3 has a "patient id" of "320"
 
   Scenario: I can find the most relevant patient when sorting by local id descending
     Given the patient has an "local id" of "PSN10000120GA01"
@@ -292,11 +324,11 @@ Feature: Patient Search Sorting
     And I have another patient
     And the patient has an "local id" of "PSN10000220GA01"
     And patients are available for search
-    And I want patients sorted by "local_id" "desc"
+    And I want patients sorted by "patient id" "desc"
     When I search for patients
-    Then search result 1 has an "local id" of "320"
-    And search result 2 has an "local id" of "220"
-    And search result 3 has an "local id" of "120"
+    Then search result 1 has a "patient id" of "320"
+    And search result 2 has a "patient id" of "220"
+    And search result 3 has a "patient id" of "120"
 
   Scenario: I can find the most relevant patient when sorting by state ascending
     Given the patient has a "state" of "01"


### PR DESCRIPTION
## Description

The recent changes to sorting broke a few of the sorting options on Patient Search. 

- Add support for sorting by `patientid` and `legalname` in Patient Search to match Investigation and Laboratory Search.
- Makes the `local` profile active for tests. 


