### PR TITLE
CNFT1-2928 API: Update Lab Search API to include Resulted Test Data

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResult.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResult.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.event.search.labreport;
 
 import java.time.LocalDate;
 import java.util.List;
+import gov.cdc.nbs.patient.documentsrequiringreview.detail.LabTestSummary;
 
 record LabReportSearchResult(
     Double relevance,
@@ -12,39 +13,36 @@ record LabReportSearchResult(
     List<PersonParticipation> personParticipations,
     List<OrganizationParticipation> organizationParticipations,
     List<Observation> observations,
-    List<AssociatedInvestigation> associatedInvestigations
-) {
+    List<AssociatedInvestigation> associatedInvestigations,
+    LabTestSummary labTestSummary) {
 
   record PersonParticipation(
-     LocalDate birthTime,
-     String currSexCd,
-     String typeCd,
-     String firstName,
-     String lastName,
-     String personCd,
-     long personParentUid,
-     String local
-  ){}
+      LocalDate birthTime,
+      String currSexCd,
+      String typeCd,
+      String firstName,
+      String lastName,
+      String personCd,
+      long personParentUid,
+      String local) {
+  }
 
   record OrganizationParticipation(
       String typeCd,
-      String name
-  ) {
+      String name) {
 
   }
 
   record Observation(
-    String cdDescTxt,
-    String altCd,
-    String displayName
-  ) {
+      String cdDescTxt,
+      String altCd,
+      String displayName) {
 
   }
 
   record AssociatedInvestigation(
-    String cdDescTxt,
-    String localId
-  ) {
+      String cdDescTxt,
+      String localId) {
 
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResult.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResult.java
@@ -14,7 +14,7 @@ record LabReportSearchResult(
     List<OrganizationParticipation> organizationParticipations,
     List<Observation> observations,
     List<AssociatedInvestigation> associatedInvestigations,
-    LabTestSummary labTestSummary) {
+    List<LabTestSummary> labTestSummaries) {
 
   record PersonParticipation(
       LocalDate birthTime,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverter.java
@@ -42,7 +42,7 @@ class LabReportSearchResultConverter {
         organizationParticipations,
         observations,
         associatedInvestigations,
-        labTestSummaries.isEmpty() ? null : labTestSummaries.getFirst());
+        labTestSummaries == null || labTestSummaries.isEmpty() ? null : labTestSummaries.getFirst());
   }
 
   private static LabReportSearchResult.PersonParticipation asPerson(final SearchableLabReport.Person person) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverter.java
@@ -1,13 +1,14 @@
 package gov.cdc.nbs.event.search.labreport;
 
 import gov.cdc.nbs.event.search.RelevanceResolver;
-
+import gov.cdc.nbs.patient.documentsrequiringreview.detail.LabTestSummary;
 import java.util.Collections;
 import java.util.List;
 
 class LabReportSearchResultConverter {
 
-  static LabReportSearchResult convert(final SearchableLabReport searchable, final Double score) {
+  static LabReportSearchResult convert(final SearchableLabReport searchable, final Double score,
+      final LabTestSummaryFinder labTestSummaryFinder) {
 
     double relevance = RelevanceResolver.resolve(score);
 
@@ -28,6 +29,9 @@ class LabReportSearchResultConverter {
     List<LabReportSearchResult.AssociatedInvestigation> associatedInvestigations =
         asAssociatedInvestigations(searchable.associated());
 
+    List<LabTestSummary> labTestSummaries =
+        labTestSummaryFinder == null ? null : labTestSummaryFinder.find(searchable.identifier());
+
     return new LabReportSearchResult(
         relevance,
         String.valueOf(searchable.identifier()),
@@ -37,8 +41,8 @@ class LabReportSearchResultConverter {
         personParticipations,
         organizationParticipations,
         observations,
-        associatedInvestigations
-    );
+        associatedInvestigations,
+        labTestSummaries.isEmpty() ? null : labTestSummaries.getFirst());
   }
 
   private static LabReportSearchResult.PersonParticipation asPerson(final SearchableLabReport.Person person) {
@@ -56,13 +60,11 @@ class LabReportSearchResultConverter {
         patient.lastName(),
         patient.code(),
         patient.identifier(),
-        patient.local()
-    );
+        patient.local());
   }
 
   private static LabReportSearchResult.PersonParticipation asPerson(
-      final SearchableLabReport.Person.Provider provider
-  ) {
+      final SearchableLabReport.Person.Provider provider) {
     return new LabReportSearchResult.PersonParticipation(
         null,
         null,
@@ -71,44 +73,37 @@ class LabReportSearchResultConverter {
         provider.lastName(),
         provider.code(),
         provider.identifier(),
-        null
-    );
+        null);
   }
 
   private static LabReportSearchResult.OrganizationParticipation asOrganization(
-      final SearchableLabReport.Organization organization
-  ) {
+      final SearchableLabReport.Organization organization) {
     return new LabReportSearchResult.OrganizationParticipation(
         organization.type(),
-        organization.name()
-    );
+        organization.name());
   }
 
   private static LabReportSearchResult.Observation asObservation(final SearchableLabReport.LabTest test) {
     return new LabReportSearchResult.Observation(
         test.name(),
         test.alternative(),
-        test.result()
-    );
+        test.result());
   }
 
   private static List<LabReportSearchResult.AssociatedInvestigation> asAssociatedInvestigations(
-      final List<SearchableLabReport.Investigation> investigations
-  ) {
+      final List<SearchableLabReport.Investigation> investigations) {
     return investigations == null
         ? Collections.emptyList()
         : investigations.stream()
-        .map(LabReportSearchResultConverter::asAssociatedInvestigation)
-        .toList();
+            .map(LabReportSearchResultConverter::asAssociatedInvestigation)
+            .toList();
   }
 
   private static LabReportSearchResult.AssociatedInvestigation asAssociatedInvestigation(
-      final SearchableLabReport.Investigation investigation
-  ) {
+      final SearchableLabReport.Investigation investigation) {
     return new LabReportSearchResult.AssociatedInvestigation(
         investigation.condition(),
-        investigation.local()
-    );
+        investigation.local());
   }
 
   private LabReportSearchResultConverter() {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverter.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.event.search.labreport;
 
 import gov.cdc.nbs.event.search.RelevanceResolver;
 import gov.cdc.nbs.patient.documentsrequiringreview.detail.LabTestSummary;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,9 +30,6 @@ class LabReportSearchResultConverter {
     List<LabReportSearchResult.AssociatedInvestigation> associatedInvestigations =
         asAssociatedInvestigations(searchable.associated());
 
-    List<LabTestSummary> labTestSummaries =
-        labTestSummaryFinder == null ? null : labTestSummaryFinder.find(searchable.identifier());
-
     return new LabReportSearchResult(
         relevance,
         String.valueOf(searchable.identifier()),
@@ -42,7 +40,8 @@ class LabReportSearchResultConverter {
         organizationParticipations,
         observations,
         associatedInvestigations,
-        labTestSummaries == null || labTestSummaries.isEmpty() ? null : labTestSummaries.getFirst());
+        labTestSummaryFinder == null ? new ArrayList<LabTestSummary>()
+            : labTestSummaryFinder.find(searchable.identifier()));
   }
 
   private static LabReportSearchResult.PersonParticipation asPerson(final SearchableLabReport.Person person) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
@@ -54,6 +54,7 @@ public class LabTestSummaryFinder {
    * @return
    */
   public List<LabTestSummary> find(long observationUid) {
+    observationUid = 10054292;
     SqlParameterSource namedParameters = new MapSqlParameterSource(
         Map.of("observationUid", observationUid));
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
@@ -1,0 +1,66 @@
+package gov.cdc.nbs.event.search.labreport;
+
+import gov.cdc.nbs.patient.documentsrequiringreview.detail.LabTestSummary;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Component;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class LabTestSummaryFinder {
+  private static final String QUERY = """
+      select
+        lt.lab_test_desc_txt    as name,
+        cvg.code_short_desc_txt as status,
+        lr.lab_result_desc_txt  as coded_result,
+        ovn.numeric_value_1     as numeric_result,
+        ovn.high_range          as high,
+        ovn.low_range           as low,
+        ovn.numeric_unit_cd     as unit
+      from
+        NBS_SRTE..Lab_test lt
+        join observation o on lt.lab_test_cd = o.cd and o.obs_domain_cd_st_1 = 'Result'
+        join Obs_value_coded ovc on ovc.observation_uid = o.observation_uid
+        join NBS_SRTE..Lab_result lr on lr.lab_result_cd = ovc.code
+        join Obs_value_numeric ovn on ovn.observation_uid = o.observation_uid
+        left join NBS_SRTE..Code_value_general cvg on cvg.code = o.status_cd and cvg.code_set_nm = 'ACT_OBJ_ST'
+      where
+        lt.test_type_cd = 'R'
+        and o.observation_uid = :observationUid
+                                              """;
+
+  private final NamedParameterJdbcTemplate namedTemplate;
+
+  public LabTestSummaryFinder(
+      final NamedParameterJdbcTemplate template) {
+    this.namedTemplate = template;
+
+  }
+
+  /**
+   * @param observationUid
+   * @return
+   */
+  public List<LabTestSummary> find(long observationUid) {
+    SqlParameterSource namedParameters = new MapSqlParameterSource(
+        Map.of("observationUid", observationUid));
+
+    return namedTemplate.query(QUERY, namedParameters, new RowMapper<LabTestSummary>() {
+
+      @Override
+      public LabTestSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
+        // return new LabTestSummary("name", "status", "coded", new BigDecimal("1.0"), "high", "low", "unit");
+        return new LabTestSummary(rs.getString(1), rs.getString(2), rs.getString(3), rs.getBigDecimal(4),
+            rs.getString(5), rs.getString(6),
+            rs.getString(7));
+      }
+    });
+  }
+
+}
+

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
@@ -54,7 +54,6 @@ public class LabTestSummaryFinder {
    * @return
    */
   public List<LabTestSummary> find(long observationUid) {
-    observationUid = 10054292;
     SqlParameterSource namedParameters = new MapSqlParameterSource(
         Map.of("observationUid", observationUid));
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
@@ -1,13 +1,12 @@
 package gov.cdc.nbs.event.search.labreport;
 
 import gov.cdc.nbs.patient.documentsrequiringreview.detail.LabTestSummary;
+import gov.cdc.nbs.patient.documentsrequiringreview.detail.LabTestSummaryRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
@@ -35,11 +34,19 @@ public class LabTestSummaryFinder {
                                               """;
 
   private final NamedParameterJdbcTemplate namedTemplate;
+  private final RowMapper<LabTestSummary> mapper;
 
   public LabTestSummaryFinder(
       final NamedParameterJdbcTemplate template) {
+    this.mapper = new LabTestSummaryRowMapper(new LabTestSummaryRowMapper.Column(
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7));
     this.namedTemplate = template;
-
   }
 
   /**
@@ -50,15 +57,7 @@ public class LabTestSummaryFinder {
     SqlParameterSource namedParameters = new MapSqlParameterSource(
         Map.of("observationUid", observationUid));
 
-    return namedTemplate.query(QUERY, namedParameters, new RowMapper<LabTestSummary>() {
-
-      @Override
-      public LabTestSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
-        return new LabTestSummary(rs.getString(1), rs.getString(2), rs.getString(3), rs.getBigDecimal(4),
-            rs.getString(5), rs.getString(6),
-            rs.getString(7));
-      }
-    });
+    return namedTemplate.query(QUERY, namedParameters, mapper);
   }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
@@ -54,7 +54,6 @@ public class LabTestSummaryFinder {
 
       @Override
       public LabTestSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
-        // return new LabTestSummary("name", "status", "coded", new BigDecimal("1.0"), "high", "low", "unit");
         return new LabTestSummary(rs.getString(1), rs.getString(2), rs.getString(3), rs.getBigDecimal(4),
             rs.getString(5), rs.getString(6),
             rs.getString(7));

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabTestSummaryFinder.java
@@ -22,15 +22,21 @@ public class LabTestSummaryFinder {
         ovn.low_range           as low,
         ovn.numeric_unit_cd     as unit
       from
-        NBS_SRTE..Lab_test lt
-        join observation o on lt.lab_test_cd = o.cd and o.obs_domain_cd_st_1 = 'Result'
-        join Obs_value_coded ovc on ovc.observation_uid = o.observation_uid
+        Observation o1
+        join Act_relationship ar on
+          ar.target_act_uid = o1.observation_uid
+          and ar.type_cd = 'COMP'
+          and ar.source_class_cd = 'OBS'
+          and ar.target_class_cd = 'OBS'
+        join observation o2 on o2.observation_uid = ar.source_act_uid and o2.obs_domain_cd_st_1 = 'Result'
+        join NBS_SRTE..Lab_test lt on lt.lab_test_cd = o2.cd
+        join Obs_value_coded ovc on ovc.observation_uid = o2.observation_uid
         join NBS_SRTE..Lab_result lr on lr.lab_result_cd = ovc.code
-        join Obs_value_numeric ovn on ovn.observation_uid = o.observation_uid
-        left join NBS_SRTE..Code_value_general cvg on cvg.code = o.status_cd and cvg.code_set_nm = 'ACT_OBJ_ST'
+        join Obs_value_numeric ovn on ovn.observation_uid = o2.observation_uid
+        left join NBS_SRTE..Code_value_general cvg on cvg.code = o2.status_cd and cvg.code_set_nm = 'ACT_OBJ_ST'
       where
         lt.test_type_cd = 'R'
-        and o.observation_uid = :observationUid
+        and o1.observation_uid = :observationUid
                                               """;
 
   private final NamedParameterJdbcTemplate namedTemplate;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LabTestSummaryRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LabTestSummaryRowMapper.java
@@ -26,10 +26,6 @@ public class LabTestSummaryRowMapper implements RowMapper<LabTestSummary> {
 
   @Override
   public LabTestSummary mapRow(final ResultSet resultSet, final int rowNum) throws SQLException {
-    return map(resultSet);
-  }
-
-  public LabTestSummary map(final ResultSet resultSet) throws SQLException {
     String name = resultSet.getString(columns.name());
     String coded = resultSet.getString(columns.coded());
     String status = resultSet.getString(columns.status());

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LabTestSummaryRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LabTestSummaryRowMapper.java
@@ -3,8 +3,9 @@ package gov.cdc.nbs.patient.documentsrequiringreview.detail;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
 
-public class LabTestSummaryRowMapper {
+public class LabTestSummaryRowMapper implements RowMapper<LabTestSummary> {
 
   public record Column(
       int name,
@@ -13,8 +14,7 @@ public class LabTestSummaryRowMapper {
       int numeric,
       int high,
       int low,
-      int unit
-  ) {
+      int unit) {
   }
 
 
@@ -22,6 +22,11 @@ public class LabTestSummaryRowMapper {
 
   public LabTestSummaryRowMapper(final Column columns) {
     this.columns = columns;
+  }
+
+  @Override
+  public LabTestSummary mapRow(final ResultSet resultSet, final int rowNum) throws SQLException {
+    return map(resultSet);
   }
 
   public LabTestSummary map(final ResultSet resultSet) throws SQLException {
@@ -40,7 +45,6 @@ public class LabTestSummaryRowMapper {
         numeric,
         high,
         low,
-        unit
-    );
+        unit);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LaboratoryReportDetailRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LaboratoryReportDetailRowMapper.java
@@ -19,8 +19,7 @@ class LaboratoryReportDetailRowMapper implements RowMapper<DocumentRequiringRevi
       FacilityProvidersRowMapper.Column facilities,
       int electronic,
       int event,
-      LabTestSummaryRowMapper.Column tests
-  ) {
+      LabTestSummaryRowMapper.Column tests) {
   }
 
 
@@ -55,8 +54,7 @@ class LaboratoryReportDetailRowMapper implements RowMapper<DocumentRequiringRevi
         electronic,
         false,
         providers,
-        descriptions
-    );
+        descriptions);
   }
 
   private Instant maybeMap(final ResultSet resultSet, final int column) throws SQLException {
@@ -69,7 +67,7 @@ class LaboratoryReportDetailRowMapper implements RowMapper<DocumentRequiringRevi
   }
 
   private List<DocumentRequiringReview.Description> maybeMapTests(final ResultSet resultSet) throws SQLException {
-    LabTestSummary summary = this.labTestSummaryMapper.map(resultSet);
+    LabTestSummary summary = this.labTestSummaryMapper.mapRow(resultSet, 0);
 
     return LabTestSummaryDescriptionMapper.maybeMap(summary).map(List::of).orElse(Collections.emptyList());
   }

--- a/apps/modernization-api/src/main/resources/graphql/lab-report-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/lab-report-search.graphqls
@@ -88,6 +88,16 @@ type LabReportResults {
   size: Int!
 }
 
+type LabTestSummary {
+  name: String
+  status: String
+  coded: String
+  numeric: Float
+  high: String
+  low: String
+  unit: String
+}
+
 type LabReport {
   relevance: Float!
   id: String!
@@ -98,6 +108,7 @@ type LabReport {
   organizationParticipations: [LabReportOrganizationParticipation!]!
   observations: [Observation!]!
   associatedInvestigations: [AssociatedInvestigation!]!
+  labTestSummary: LabTestSummary
 }
 
 type LabReportPersonParticipation {

--- a/apps/modernization-api/src/main/resources/graphql/lab-report-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/lab-report-search.graphqls
@@ -108,7 +108,7 @@ type LabReport {
   organizationParticipations: [LabReportOrganizationParticipation!]!
   observations: [Observation!]!
   associatedInvestigations: [AssociatedInvestigation!]!
-  labTestSummaries: [LabTestSummary]!
+  labTestSummaries: [LabTestSummary!]!
 }
 
 type LabReportPersonParticipation {

--- a/apps/modernization-api/src/main/resources/graphql/lab-report-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/lab-report-search.graphqls
@@ -108,7 +108,7 @@ type LabReport {
   organizationParticipations: [LabReportOrganizationParticipation!]!
   observations: [Observation!]!
   associatedInvestigations: [AssociatedInvestigation!]!
-  labTestSummary: LabTestSummary
+  labTestSummaries: [LabTestSummary]!
 }
 
 type LabReportPersonParticipation {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverterTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/search/labreport/LabReportSearchResultConverterTest.java
@@ -29,36 +29,30 @@ class LabReportSearchResultConverterTest {
         LocalDate.of(
             2002,
             Month.FEBRUARY,
-            17
-        ),
+            17),
         LocalDate.of(
             2002,
             Month.MARCH,
-            19
-        ),
+            19),
         LocalDate.of(
             2003,
             Month.MAY,
-            23
-        ),
+            23),
         179L,
         LocalDate.of(
             2005,
             Month.JULY,
-            29
-        ),
+            29),
         857L,
         LocalDate.of(
             2007,
             Month.NOVEMBER,
-            2
-        ),
+            2),
         1,
         "status-value",
-        "entry-value"
-    );
+        "entry-value");
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, 101d);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, 101d, null);
 
     assertThat(converted.relevance()).isEqualTo(101f);
     assertThat(converted.id()).isEqualTo("1019");
@@ -76,7 +70,7 @@ class LabReportSearchResultConverterTest {
     when(searchable.associated()).thenReturn(Collections.emptyList());
     when(searchable.organizations()).thenReturn(Collections.emptyList());
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null, null);
 
     assertThat(converted.relevance()).isZero();
   }
@@ -99,12 +93,9 @@ class LabReportSearchResultConverterTest {
                 "first-name-one-value",
                 "last-name-one-value",
                 "gender-value",
-                LocalDate.of(2009, Month.NOVEMBER, 13)
-            )
-        )
-    );
+                LocalDate.of(2009, Month.NOVEMBER, 13))));
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null, null);
 
     assertThat(converted.personParticipations()).satisfiesExactly(
         actual -> assertAll(
@@ -115,9 +106,7 @@ class LabReportSearchResultConverterTest {
             () -> assertThat(actual.lastName()).isEqualTo("last-name-one-value"),
             () -> assertThat(actual.personCd()).isEqualTo("PAT"),
             () -> assertThat(actual.personParentUid()).isEqualTo(443L),
-            () -> assertThat(actual.local()).isEqualTo("local-one-value")
-        )
-    );
+            () -> assertThat(actual.local()).isEqualTo("local-one-value")));
   }
 
   @Test
@@ -135,12 +124,9 @@ class LabReportSearchResultConverterTest {
                 "type-two-value",
                 "subject-type-two-value",
                 "first-name-two-value",
-                "last-name-two-value"
-            )
-        )
-    );
+                "last-name-two-value")));
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null, null);
 
     assertThat(converted.personParticipations()).satisfiesExactly(
         actual -> assertAll(
@@ -151,9 +137,7 @@ class LabReportSearchResultConverterTest {
             () -> assertThat(actual.lastName()).isEqualTo("last-name-two-value"),
             () -> assertThat(actual.personCd()).isEqualTo("PRV"),
             () -> assertThat(actual.personParentUid()).isEqualTo(857L),
-            () -> assertThat(actual.local()).isNull()
-        )
-    );
+            () -> assertThat(actual.local()).isNull()));
   }
 
 
@@ -171,30 +155,23 @@ class LabReportSearchResultConverterTest {
                 787L,
                 "type-one-value",
                 "subject-type-one-value",
-                "name-one-value"
-            ),
+                "name-one-value"),
             new SearchableLabReport.Organization(
                 829L,
                 "type-two-value",
                 "subject-type-two-value",
-                "name-two-value"
-            )
-        )
-    );
+                "name-two-value")));
 
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null, null);
 
     assertThat(converted.organizationParticipations()).satisfiesExactly(
         actual -> assertAll(
             () -> assertThat(actual.typeCd()).isEqualTo("type-one-value"),
-            () -> assertThat(actual.name()).isEqualTo("name-one-value")
-        ),
+            () -> assertThat(actual.name()).isEqualTo("name-one-value")),
         actual -> assertAll(
             () -> assertThat(actual.typeCd()).isEqualTo("type-two-value"),
-            () -> assertThat(actual.name()).isEqualTo("name-two-value")
-        )
-    );
+            () -> assertThat(actual.name()).isEqualTo("name-two-value")));
   }
 
   @Test
@@ -212,31 +189,24 @@ class LabReportSearchResultConverterTest {
             new SearchableLabReport.LabTest(
                 "name-one-value",
                 "result-one-value",
-                "alternative-one-value"
-            ),
+                "alternative-one-value"),
             new SearchableLabReport.LabTest(
                 "name-two-value",
                 "result-two-value",
-                "alternative-two-value"
-            )
-        )
-    );
+                "alternative-two-value")));
 
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null, null);
 
     assertThat(converted.observations()).satisfiesExactly(
         actual -> assertAll(
             () -> assertThat(actual.cdDescTxt()).isEqualTo("name-one-value"),
             () -> assertThat(actual.altCd()).isEqualTo("alternative-one-value"),
-            () -> assertThat(actual.displayName()).isEqualTo("result-one-value")
-        ),
+            () -> assertThat(actual.displayName()).isEqualTo("result-one-value")),
         actual -> assertAll(
             () -> assertThat(actual.cdDescTxt()).isEqualTo("name-two-value"),
             () -> assertThat(actual.altCd()).isEqualTo("alternative-two-value"),
-            () -> assertThat(actual.displayName()).isEqualTo("result-two-value")
-        )
-    );
+            () -> assertThat(actual.displayName()).isEqualTo("result-two-value")));
   }
 
   @Test
@@ -247,7 +217,7 @@ class LabReportSearchResultConverterTest {
     when(searchable.organizations()).thenReturn(Collections.emptyList());
     when(searchable.tests()).thenReturn(Collections.emptyList());
 
-    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null);
+    LabReportSearchResult converted = LabReportSearchResultConverter.convert(searchable, null, null);
 
     assertThat(converted.associatedInvestigations()).isEmpty();
   }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LabTestSummaryRowMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/documentsrequiringreview/detail/LabTestSummaryRowMapperTest.java
@@ -23,7 +23,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.name()).isEqualTo("name-value");
     assertThat(mapped.coded()).isNull();
@@ -43,7 +43,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.coded()).isEqualTo("coded-value");
 
@@ -57,7 +57,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.numeric()).isEqualTo("739.53");
 
@@ -72,7 +72,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.high()).isEqualTo("high-value");
 
@@ -87,7 +87,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.low()).isEqualTo("low-value");
 
@@ -102,7 +102,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.unit()).isEqualTo("unit-value");
 
@@ -117,7 +117,7 @@ class LabTestSummaryRowMapperTest {
 
     LabTestSummaryRowMapper mapper = new LabTestSummaryRowMapper(columns);
 
-    LabTestSummary mapped = mapper.map(resultSet);
+    LabTestSummary mapped = mapper.mapRow(resultSet, 0);
 
     assertThat(mapped.status()).isEqualTo("status-value");
 

--- a/apps/modernization-ui/src/apps/search/event/components/LabReportSearch/LabReportResults.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/event/components/LabReportSearch/LabReportResults.spec.tsx
@@ -36,7 +36,8 @@ const labReports: [LabReport] = [
                 displayName: 'abnormal'
             }
         ],
-        associatedInvestigations: []
+        associatedInvestigations: [],
+        labTestSummaries: []
     }
 ];
 

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/laboratoryReportResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/laboratoryReportResult.spec.tsx
@@ -42,6 +42,7 @@ describe('when displaying a Laboratory Search Result', () => {
                     shortId: 571
                 }
             ],
+            labTestSummaries: [],
             relevance: 1
         };
 
@@ -84,6 +85,7 @@ describe('when displaying a Laboratory Search Result', () => {
                     shortId: 571
                 }
             ],
+            labTestSummaries: [],
             relevance: 1
         };
 
@@ -109,6 +111,7 @@ describe('when displaying a Laboratory Search Result', () => {
                 }
             ],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 1
         };
 
@@ -142,6 +145,7 @@ describe('when displaying a Laboratory Search Result', () => {
             ],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 1
         };
 
@@ -172,6 +176,7 @@ describe('when displaying a Laboratory Search Result', () => {
             observations: [],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 1
         };
 

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/list/LaboratoryReportSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/list/LaboratoryReportSearchResultListItem.spec.tsx
@@ -22,6 +22,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
                     typeCd: 'PATSBJ'
                 }
             ],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -52,6 +53,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
                     typeCd: 'PATSBJ'
                 }
             ],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -81,6 +83,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
                     typeCd: 'PATSBJ'
                 }
             ],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -110,6 +113,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
                     typeCd: 'PATSBJ'
                 }
             ],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -131,6 +135,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
             observations: [],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -152,6 +157,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
             observations: [],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -173,6 +179,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
             observations: [{ cdDescTxt: 'test description', altCd: 'alt-cd-vlalue', displayName: 'test display' }],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -196,6 +203,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
             observations: [],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 5
         };
 
@@ -220,6 +228,7 @@ describe('LaboratoryReportSearchResultListItem', () => {
             observations: [],
             organizationParticipations: [],
             personParticipations: [],
+            labTestSummaries: [],
             relevance: 5
         };
 

--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/table/LaboratoryReportSearchResultsTable.spec.tsx
@@ -110,6 +110,7 @@ describe('When a Laboratory Report search result is viewed in a table', () => {
                         shortId: 63000
                     }
                 ],
+                labTestSummaries: [],
                 relevance: 1
             }
         ];

--- a/apps/modernization-ui/src/generated/gql/queries/findLabReportsByFilter.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findLabReportsByFilter.gql
@@ -30,7 +30,7 @@ query findLabReportsByFilter($filter: LabReportFilter!, $page: SortablePage){
                 cdDescTxt
                 localId
             }
-            labTestSummary{
+            labTestSummaries{
                 name
                 status
                 coded

--- a/apps/modernization-ui/src/generated/gql/queries/findLabReportsByFilter.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findLabReportsByFilter.gql
@@ -30,6 +30,15 @@ query findLabReportsByFilter($filter: LabReportFilter!, $page: SortablePage){
                 cdDescTxt
                 localId
             }
+            labTestSummary{
+                name
+                status
+                coded
+                numeric
+                high
+                low
+                unit
+            }
         }
         total
         page

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -346,7 +346,7 @@ export type LabReport = {
   associatedInvestigations: Array<AssociatedInvestigation>;
   id: Scalars['String']['output'];
   jurisdictionCd: Scalars['Int']['output'];
-  labTestSummary?: Maybe<LabTestSummary>;
+  labTestSummaries: Array<Maybe<LabTestSummary>>;
   localId: Scalars['String']['output'];
   observations: Array<Observation>;
   organizationParticipations: Array<LabReportOrganizationParticipation>;
@@ -2470,7 +2470,7 @@ export type FindLabReportsByFilterQueryVariables = Exact<{
 }>;
 
 
-export type FindLabReportsByFilterQuery = { __typename?: 'Query', findLabReportsByFilter: { __typename?: 'LabReportResults', total: number, page: number, size: number, content: Array<{ __typename?: 'LabReport', relevance: number, id: string, jurisdictionCd: number, localId: string, addTime: any, personParticipations: Array<{ __typename?: 'LabReportPersonParticipation', birthTime?: any | null, currSexCd?: string | null, typeCd?: string | null, firstName?: string | null, lastName?: string | null, personCd: string, personParentUid?: number | null, shortId?: number | null }>, organizationParticipations: Array<{ __typename?: 'LabReportOrganizationParticipation', typeCd: string, name: string }>, observations: Array<{ __typename?: 'Observation', cdDescTxt?: string | null, statusCd?: string | null, altCd?: string | null, displayName?: string | null }>, associatedInvestigations: Array<{ __typename?: 'AssociatedInvestigation', cdDescTxt: string, localId: string }>, labTestSummary?: { __typename?: 'LabTestSummary', name?: string | null, status?: string | null, coded?: string | null, numeric?: number | null, high?: string | null, low?: string | null, unit?: string | null } | null }> } };
+export type FindLabReportsByFilterQuery = { __typename?: 'Query', findLabReportsByFilter: { __typename?: 'LabReportResults', total: number, page: number, size: number, content: Array<{ __typename?: 'LabReport', relevance: number, id: string, jurisdictionCd: number, localId: string, addTime: any, personParticipations: Array<{ __typename?: 'LabReportPersonParticipation', birthTime?: any | null, currSexCd?: string | null, typeCd?: string | null, firstName?: string | null, lastName?: string | null, personCd: string, personParentUid?: number | null, shortId?: number | null }>, organizationParticipations: Array<{ __typename?: 'LabReportOrganizationParticipation', typeCd: string, name: string }>, observations: Array<{ __typename?: 'Observation', cdDescTxt?: string | null, statusCd?: string | null, altCd?: string | null, displayName?: string | null }>, associatedInvestigations: Array<{ __typename?: 'AssociatedInvestigation', cdDescTxt: string, localId: string }>, labTestSummaries: Array<{ __typename?: 'LabTestSummary', name?: string | null, status?: string | null, coded?: string | null, numeric?: number | null, high?: string | null, low?: string | null, unit?: string | null } | null> }> } };
 
 export type FindLabReportsForPatientQueryVariables = Exact<{
   personUid: Scalars['Int']['input'];
@@ -4638,7 +4638,7 @@ export const FindLabReportsByFilterDocument = gql`
         cdDescTxt
         localId
       }
-      labTestSummary {
+      labTestSummaries {
         name
         status
         coded

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -346,7 +346,7 @@ export type LabReport = {
   associatedInvestigations: Array<AssociatedInvestigation>;
   id: Scalars['String']['output'];
   jurisdictionCd: Scalars['Int']['output'];
-  labTestSummaries: Array<Maybe<LabTestSummary>>;
+  labTestSummaries: Array<LabTestSummary>;
   localId: Scalars['String']['output'];
   observations: Array<Observation>;
   organizationParticipations: Array<LabReportOrganizationParticipation>;
@@ -2470,7 +2470,7 @@ export type FindLabReportsByFilterQueryVariables = Exact<{
 }>;
 
 
-export type FindLabReportsByFilterQuery = { __typename?: 'Query', findLabReportsByFilter: { __typename?: 'LabReportResults', total: number, page: number, size: number, content: Array<{ __typename?: 'LabReport', relevance: number, id: string, jurisdictionCd: number, localId: string, addTime: any, personParticipations: Array<{ __typename?: 'LabReportPersonParticipation', birthTime?: any | null, currSexCd?: string | null, typeCd?: string | null, firstName?: string | null, lastName?: string | null, personCd: string, personParentUid?: number | null, shortId?: number | null }>, organizationParticipations: Array<{ __typename?: 'LabReportOrganizationParticipation', typeCd: string, name: string }>, observations: Array<{ __typename?: 'Observation', cdDescTxt?: string | null, statusCd?: string | null, altCd?: string | null, displayName?: string | null }>, associatedInvestigations: Array<{ __typename?: 'AssociatedInvestigation', cdDescTxt: string, localId: string }>, labTestSummaries: Array<{ __typename?: 'LabTestSummary', name?: string | null, status?: string | null, coded?: string | null, numeric?: number | null, high?: string | null, low?: string | null, unit?: string | null } | null> }> } };
+export type FindLabReportsByFilterQuery = { __typename?: 'Query', findLabReportsByFilter: { __typename?: 'LabReportResults', total: number, page: number, size: number, content: Array<{ __typename?: 'LabReport', relevance: number, id: string, jurisdictionCd: number, localId: string, addTime: any, personParticipations: Array<{ __typename?: 'LabReportPersonParticipation', birthTime?: any | null, currSexCd?: string | null, typeCd?: string | null, firstName?: string | null, lastName?: string | null, personCd: string, personParentUid?: number | null, shortId?: number | null }>, organizationParticipations: Array<{ __typename?: 'LabReportOrganizationParticipation', typeCd: string, name: string }>, observations: Array<{ __typename?: 'Observation', cdDescTxt?: string | null, statusCd?: string | null, altCd?: string | null, displayName?: string | null }>, associatedInvestigations: Array<{ __typename?: 'AssociatedInvestigation', cdDescTxt: string, localId: string }>, labTestSummaries: Array<{ __typename?: 'LabTestSummary', name?: string | null, status?: string | null, coded?: string | null, numeric?: number | null, high?: string | null, low?: string | null, unit?: string | null }> }> } };
 
 export type FindLabReportsForPatientQueryVariables = Exact<{
   personUid: Scalars['Int']['input'];

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -346,6 +346,7 @@ export type LabReport = {
   associatedInvestigations: Array<AssociatedInvestigation>;
   id: Scalars['String']['output'];
   jurisdictionCd: Scalars['Int']['output'];
+  labTestSummary?: Maybe<LabTestSummary>;
   localId: Scalars['String']['output'];
   observations: Array<Observation>;
   organizationParticipations: Array<LabReportOrganizationParticipation>;
@@ -408,6 +409,17 @@ export type LabReportResults = {
   page: Scalars['Int']['output'];
   size: Scalars['Int']['output'];
   total: Scalars['Int']['output'];
+};
+
+export type LabTestSummary = {
+  __typename?: 'LabTestSummary';
+  coded?: Maybe<Scalars['String']['output']>;
+  high?: Maybe<Scalars['String']['output']>;
+  low?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  numeric?: Maybe<Scalars['Float']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
 };
 
 export type LaboratoryEventDateSearch = {
@@ -2458,7 +2470,7 @@ export type FindLabReportsByFilterQueryVariables = Exact<{
 }>;
 
 
-export type FindLabReportsByFilterQuery = { __typename?: 'Query', findLabReportsByFilter: { __typename?: 'LabReportResults', total: number, page: number, size: number, content: Array<{ __typename?: 'LabReport', relevance: number, id: string, jurisdictionCd: number, localId: string, addTime: any, personParticipations: Array<{ __typename?: 'LabReportPersonParticipation', birthTime?: any | null, currSexCd?: string | null, typeCd?: string | null, firstName?: string | null, lastName?: string | null, personCd: string, personParentUid?: number | null, shortId?: number | null }>, organizationParticipations: Array<{ __typename?: 'LabReportOrganizationParticipation', typeCd: string, name: string }>, observations: Array<{ __typename?: 'Observation', cdDescTxt?: string | null, statusCd?: string | null, altCd?: string | null, displayName?: string | null }>, associatedInvestigations: Array<{ __typename?: 'AssociatedInvestigation', cdDescTxt: string, localId: string }> }> } };
+export type FindLabReportsByFilterQuery = { __typename?: 'Query', findLabReportsByFilter: { __typename?: 'LabReportResults', total: number, page: number, size: number, content: Array<{ __typename?: 'LabReport', relevance: number, id: string, jurisdictionCd: number, localId: string, addTime: any, personParticipations: Array<{ __typename?: 'LabReportPersonParticipation', birthTime?: any | null, currSexCd?: string | null, typeCd?: string | null, firstName?: string | null, lastName?: string | null, personCd: string, personParentUid?: number | null, shortId?: number | null }>, organizationParticipations: Array<{ __typename?: 'LabReportOrganizationParticipation', typeCd: string, name: string }>, observations: Array<{ __typename?: 'Observation', cdDescTxt?: string | null, statusCd?: string | null, altCd?: string | null, displayName?: string | null }>, associatedInvestigations: Array<{ __typename?: 'AssociatedInvestigation', cdDescTxt: string, localId: string }>, labTestSummary?: { __typename?: 'LabTestSummary', name?: string | null, status?: string | null, coded?: string | null, numeric?: number | null, high?: string | null, low?: string | null, unit?: string | null } | null }> } };
 
 export type FindLabReportsForPatientQueryVariables = Exact<{
   personUid: Scalars['Int']['input'];
@@ -4625,6 +4637,15 @@ export const FindLabReportsByFilterDocument = gql`
       associatedInvestigations {
         cdDescTxt
         localId
+      }
+      labTestSummary {
+        name
+        status
+        coded
+        numeric
+        high
+        low
+        unit
       }
     }
     total

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -351,7 +351,7 @@ type LabReport {
   organizationParticipations: [LabReportOrganizationParticipation!]!
   observations: [Observation!]!
   associatedInvestigations: [AssociatedInvestigation!]!
-  labTestSummary: LabTestSummary
+  labTestSummaries: [LabTestSummary]!
 }
 
 type LabReportPersonParticipation {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -351,7 +351,7 @@ type LabReport {
   organizationParticipations: [LabReportOrganizationParticipation!]!
   observations: [Observation!]!
   associatedInvestigations: [AssociatedInvestigation!]!
-  labTestSummaries: [LabTestSummary]!
+  labTestSummaries: [LabTestSummary!]!
 }
 
 type LabReportPersonParticipation {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -331,6 +331,16 @@ type LabReportResults {
   size: Int!
 }
 
+type LabTestSummary {
+  name: String
+  status: String
+  coded: String
+  numeric: Float
+  high: String
+  low: String
+  unit: String
+}
+
 type LabReport {
   relevance: Float!
   id: String!
@@ -341,6 +351,7 @@ type LabReport {
   organizationParticipations: [LabReportOrganizationParticipation!]!
   observations: [Observation!]!
   associatedInvestigations: [AssociatedInvestigation!]!
+  labTestSummary: LabTestSummary
 }
 
 type LabReportPersonParticipation {


### PR DESCRIPTION
## Description

Create a `LabTestSummaryFinder` that finds resulted tests by observation_uid.  Do db lookup when converting the lab report results from elasticsearch and place the db fetched resulted tests into the labTestSummary field. Make old `LabTestSummaryRowMapper` implement `RowMapper<LabTestSummary>`.  Switch old calls from `map` to `mapRow`

## Tickets

* [CNFT1-2945](https://cdc-nbs.atlassian.net/browse/CNFT1-2945)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests

[CNFT1-2945]: https://cdc-nbs.atlassian.net/browse/CNFT1-2945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

```
{
    "data": {
        "findLabReportsByFilter": {
            "content": [
                {
                    "relevance": 1.0,
                    "id": "10055288",
                    "jurisdictionCd": 130006,
                    "localId": "OBS10002000GA01",
                    "addTime": "2024-03-01",
                    "personParticipations": [
                        {
                            "birthTime": "1990-01-01",
                            "currSexCd": "M",
                            "typeCd": "PATSBJ",
                            "firstName": "Surma",
                            "lastName": "Singh",
                            "personCd": "PAT",
                            "personParentUid": 10000001,
                            "shortId": 63000,
                            "__typename": "LabReportPersonParticipation"
                        }
                    ],
                    "organizationParticipations": [
                        {
                            "typeCd": "AUT",
                            "name": "CHOA - Scottish Rite",
                            "__typename": "LabReportOrganizationParticipation"
                        }
                    ],
                    "observations": [
                        {
                            "cdDescTxt": "No Information Given",
                            "statusCd": null,
                            "altCd": null,
                            "displayName": null,
                            "__typename": "Observation"
                        },
                        {
                            "cdDescTxt": "Bordetella pertussis Smear, by DFA",
                            "statusCd": null,
                            "altCd": "13916-2",
                            "displayName": "abnormal result",
                            "__typename": "Observation"
                        }
                    ],
                    "associatedInvestigations": [],
                    "labTestSummaries": [],
                    "__typename": "LabReport"
                },
                {
                    "relevance": 1.0,
                    "id": "10054288",
                    "jurisdictionCd": 130006,
                    "localId": "OBS10001000GA01",
                    "addTime": "2023-11-14",
                    "personParticipations": [
                        {
                            "birthTime": "1990-01-01",
                            "currSexCd": "M",
                            "typeCd": "PATSBJ",
                            "firstName": "Surma",
                            "lastName": "Singh",
                            "personCd": "PAT",
                            "personParentUid": 10000001,
                            "shortId": 63000,
                            "__typename": "LabReportPersonParticipation"
                        }
                    ],
                    "organizationParticipations": [
                        {
                            "typeCd": "AUT",
                            "name": "CHOA - Scottish Rite",
                            "__typename": "LabReportOrganizationParticipation"
                        }
                    ],
                    "observations": [
                        {
                            "cdDescTxt": "Patient Status at Specimen Collection",
                            "statusCd": null,
                            "altCd": null,
                            "displayName": "hospitalized",
                            "__typename": "Observation"
                        },
                        {
                            "cdDescTxt": "No Information Given",
                            "statusCd": null,
                            "altCd": null,
                            "displayName": null,
                            "__typename": "Observation"
                        },
                        {
                            "cdDescTxt": "Acid-Fast Stain",
                            "statusCd": null,
                            "altCd": "11545-1",
                            "displayName": "abnormal",
                            "__typename": "Observation"
                        }
                    ],
                    "associatedInvestigations": [],
                    "labTestSummaries": [
                        {
                            "name": "Acid-Fast Stain",
                            "status": "Final",
                            "coded": "abnormal",
                            "numeric": 2344.0,
                            "high": "2",
                            "low": "1",
                            "unit": "%",
                            "__typename": "LabTestSummary"
                        }
                    ],
                    "__typename": "LabReport"
                },
```