### PR TITLE
[CNFT1-2973] Investigation add time to started on

### DIFF
--- a/apps/modernization-ui/src/apps/search/investigation/result/table/InvestigationSearchResultsTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/result/table/InvestigationSearchResultsTable.spec.tsx
@@ -152,7 +152,7 @@ describe('When InvestigationSearchResultsTable renders', () => {
         const results: Investigation[] = [
             {
                 relevance: 1,
-                addTime: '2015-09-22',
+                startedOn: '2015-09-22',
                 personParticipations: []
             }
         ];

--- a/apps/modernization-ui/src/apps/search/investigation/result/table/InvestigationSearchResultsTable.tsx
+++ b/apps/modernization-ui/src/apps/search/investigation/result/table/InvestigationSearchResultsTable.tsx
@@ -55,7 +55,7 @@ const columns = (notificationStatusResolver: SelectableResolver): Column<Investi
     {
         ...START_DATE,
         sortable: true,
-        render: (row) => internalizeDate(row.addTime)
+        render: (row) => internalizeDate(row.startedOn)
     },
     {
         ...JURSIDICTION,


### PR DESCRIPTION
## Description

Changes the investigation start date value from `addTime` to `startedOn` so that the displayed results would match the chosen sort.

![image](https://github.com/user-attachments/assets/51417d63-88b5-4828-bd38-f041a259d4ee)


## Tickets

* [CNFT1-2973](https://cdc-nbs.atlassian.net/browse/CNFT1-2973)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2973]: https://cdc-nbs.atlassian.net/browse/CNFT1-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ