### PR TITLE
adding no data indicator on ui for when id types no data

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
@@ -208,4 +208,24 @@ describe('PatientSearchResultListItem', () => {
         expect(getByText('identification-two-type')).toBeInTheDocument();
         expect(getByText('identification-two-value')).toBeInTheDocument();
     });
+
+    it('should render "ID Types" label when there are no identifications', () => {
+        const patient: PatientSearchResult = {
+            patient: 829,
+            shortId: 653,
+            status: 'status-value',
+            addresses: [],
+            phones: [],
+            emails: [],
+            names: [],
+            identification: []
+        };
+
+        const { getByText } = render(
+            <MemoryRouter>
+                <PatientSearchResultListItem result={patient}/>
+            </MemoryRouter>
+        );
+        expect(getByText('ID Types')).toBeInTheDocument();
+    });
 });

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
@@ -46,6 +46,7 @@ const PatientSearchResultListItem = ({ result }: Props) => (
                     {id.value}
                 </ResultItem>
             ))}
+            {!result.identification.length && <ResultItem label="ID Types" orientation="vertical"></ResultItem>}
         </ResultItemGroup>
     </Result>
 );


### PR DESCRIPTION
## Description

adding no data indicator on ui for when id types no data displayed on the list view for patient search 

## Tickets

* [CNFT1-3051](https://cdc-nbs.atlassian.net/browse/CNFT1-3051)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3051]: https://cdc-nbs.atlassian.net/browse/CNFT1-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ