### PR TITLE
CNFT1-2770 API: Create Extended patient data entry form for Phone/email

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/NewPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/NewPatient.java
@@ -7,7 +7,8 @@ public record NewPatient(
     Instant asOf,
     String comment,
     List<Name> names,
-    List<Address> addresses) {
+    List<Address> addresses,
+    List<Phone> phones) {
 }
 
 
@@ -37,5 +38,18 @@ record Address(
     String county,
     String censusTract,
     String country,
+    String comment) {
+}
+
+
+record Phone(
+    Instant asOf,
+    String type,
+    String use,
+    String countryCode,
+    String number,
+    String extension,
+    String email,
+    String url,
     String comment) {
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/PatientCreateController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/PatientCreateController.java
@@ -18,6 +18,8 @@ import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
 import gov.cdc.nbs.patient.profile.address.change.NewPatientAddressInput;
 import gov.cdc.nbs.patient.profile.address.change.PatientAddressChangeService;
+import gov.cdc.nbs.patient.profile.phone.change.NewPatientPhoneInput;
+import gov.cdc.nbs.patient.profile.phone.change.PatientPhoneChangeService;
 import gov.cdc.nbs.patient.profile.names.change.NewPatientNameInput;
 import gov.cdc.nbs.patient.profile.names.change.PatientNameChangeService;
 
@@ -31,11 +33,13 @@ public class PatientCreateController {
       final PatientCreator creator,
       final PatientNameChangeService nameService,
       final PatientAddressChangeService addressService,
+      final PatientPhoneChangeService phoneService,
       final PatientIndexer indexer) {
     this.clock = clock;
     this.creator = creator;
     this.nameService = nameService;
     this.addressService = addressService;
+    this.phoneService = phoneService;
     this.indexer = indexer;
   }
 
@@ -44,6 +48,7 @@ public class PatientCreateController {
   private final PatientIndexer indexer;
   private final PatientNameChangeService nameService;
   private final PatientAddressChangeService addressService;
+  private final PatientPhoneChangeService phoneService;
 
   @PostMapping()
   @ResponseStatus(HttpStatus.CREATED)
@@ -90,7 +95,24 @@ public class PatientCreateController {
         addressService.add(context, newPatientAddressInput);
       });
     }
+    if (newPatient.phones() != null) {
+      newPatient.phones().forEach(phone -> {
+        NewPatientPhoneInput newPatientPhoneInput = new NewPatientPhoneInput(
+            created.id(),
+            phone.asOf(),
+            phone.type(),
+            phone.use(),
+            phone.countryCode(),
+            phone.number(),
+            phone.extension(),
+            phone.email(),
+            phone.url(),
+            phone.comment());
+        phoneService.add(context, newPatientPhoneInput);
+      });
+    }
     this.indexer.index(created.id());
     return created;
   }
 }
+

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/phone/change/PatientPhoneChangeService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/phone/change/PatientPhoneChangeService.java
@@ -8,40 +8,37 @@ import gov.cdc.nbs.patient.profile.PatientProfileService;
 import org.springframework.stereotype.Component;
 
 @Component
-class PatientPhoneChangeService {
+public class PatientPhoneChangeService {
 
   private final IdGeneratorService generator;
   private final PatientProfileService service;
 
   public PatientPhoneChangeService(
       final IdGeneratorService generator,
-      final PatientProfileService service
-  ) {
+      final PatientProfileService service) {
     this.generator = generator;
     this.service = service;
   }
 
-  PatientPhoneAdded add(final RequestContext context, final NewPatientPhoneInput input) {
+  public PatientPhoneAdded add(final RequestContext context, final NewPatientPhoneInput input) {
     return service.with(
-            input.patient(),
-            found -> found.add(
-                new PatientCommand.AddPhone(
-                    input.patient(),
-                    generateNbsId(),
-                    input.type(),
-                    input.use(),
-                    input.asOf(),
-                    input.countryCode(),
-                    input.number(),
-                    input.extension(),
-                    input.email(),
-                    input.url(),
-                    input.comment(),
-                    context.requestedBy(),
-                    context.requestedAt()
-                )
-            )
-        ).map(added -> new PatientPhoneAdded(input.patient(), added.getId().getLocatorUid()))
+        input.patient(),
+        found -> found.add(
+            new PatientCommand.AddPhone(
+                input.patient(),
+                generateNbsId(),
+                input.type(),
+                input.use(),
+                input.asOf(),
+                input.countryCode(),
+                input.number(),
+                input.extension(),
+                input.email(),
+                input.url(),
+                input.comment(),
+                context.requestedBy(),
+                context.requestedAt())))
+        .map(added -> new PatientPhoneAdded(input.patient(), added.getId().getLocatorUid()))
         .orElseThrow(() -> new PatientNotFoundException(input.patient()));
   }
 
@@ -65,9 +62,7 @@ class PatientPhoneChangeService {
             input.url(),
             input.comment(),
             context.requestedBy(),
-            context.requestedAt()
-        )
-    ));
+            context.requestedAt())));
 
   }
 
@@ -78,8 +73,6 @@ class PatientPhoneChangeService {
             input.patient(),
             input.id(),
             context.requestedBy(),
-            context.requestedAt()
-        )
-    ));
+            context.requestedAt())));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/PatientCreateSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/PatientCreateSteps.java
@@ -106,10 +106,10 @@ public class PatientCreateSteps {
         RandomUtil.getRandomDateInPast(),
         "type-value",
         "use-value",
-        "country-code",
-        "number",
-        "extension",
         null,
+        null,
+        null,
+        "email",
         "url",
         "comment")));
     this.input.active(newPatient);
@@ -121,12 +121,12 @@ public class PatientCreateSteps {
         RandomUtil.getRandomDateInPast(),
         "type-value",
         "use-value",
+        "country-code",
+        "number",
+        "extension",
         null,
-        null,
-        null,
-        "email",
-        null,
-        null)));
+        "url",
+        "comment")));
     this.input.active(newPatient);
 
   }
@@ -190,6 +190,7 @@ public class PatientCreateSteps {
     assertThat(actualElp)
         .returns(expected.asOf(), TeleEntityLocatorParticipation::getAsOfDate);
     assertThat(actualLocator)
+        .returns(expected.url(), TeleLocator::getUrlAddress)
         .returns(expected.email(), TeleLocator::getEmailAddress);
   }
 
@@ -203,6 +204,7 @@ public class PatientCreateSteps {
         .returns(expected.asOf(), TeleEntityLocatorParticipation::getAsOfDate);
     assertThat(actualLocator)
         .returns(expected.number(), TeleLocator::getPhoneNbrTxt)
+        .returns(expected.countryCode(), TeleLocator::getCntryCd)
         .returns(expected.url(), TeleLocator::getUrlAddress)
         .returns(expected.extension(), TeleLocator::getExtensionTxt);
   }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/PatientCreateSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/PatientCreateSteps.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.patient.profile;
 
 import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.entity.odse.TeleEntityLocatorParticipation;
+import gov.cdc.nbs.entity.odse.TeleLocator;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.repository.PersonRepository;
 import gov.cdc.nbs.support.util.RandomUtil;
@@ -59,7 +61,7 @@ public class PatientCreateSteps {
 
   @Given("I am adding a new patient with comments")
   public void i_am_adding_a_new_patient() {
-    NewPatient newPatient = new NewPatient(RandomUtil.getRandomDateInPast(), "abc", null, null);
+    NewPatient newPatient = new NewPatient(RandomUtil.getRandomDateInPast(), "abc", null, null, null);
     this.input.active(newPatient);
   }
 
@@ -75,7 +77,7 @@ public class PatientCreateSteps {
         faker.name().lastName(),
         faker.name().lastName(),
         "JR",
-        "BS")), null);
+        "BS")), null, null);
     this.input.active(newPatient);
   }
 
@@ -93,7 +95,38 @@ public class PatientCreateSteps {
         RandomUtil.getRandomString(),
         RandomUtil.getRandomString(10),
         RandomUtil.country(),
-        RandomUtil.getRandomString())));
+        RandomUtil.getRandomString())), null);
+    this.input.active(newPatient);
+
+  }
+
+  @Given("I am adding a new patient with emails")
+  public void i_am_adding_a_new_patient_with_emails() {
+    NewPatient newPatient = new NewPatient(null, null, null, null, Arrays.asList(new Phone(
+        RandomUtil.getRandomDateInPast(),
+        "type-value",
+        "use-value",
+        "country-code",
+        "number",
+        "extension",
+        null,
+        "url",
+        "comment")));
+    this.input.active(newPatient);
+  }
+
+  @Given("I am adding a new patient with phones")
+  public void i_am_adding_a_new_patient_with_phones() {
+    NewPatient newPatient = new NewPatient(null, null, null, null, Arrays.asList(new Phone(
+        RandomUtil.getRandomDateInPast(),
+        "type-value",
+        "use-value",
+        null,
+        null,
+        null,
+        "email",
+        null,
+        null)));
     this.input.active(newPatient);
 
   }
@@ -147,4 +180,31 @@ public class PatientCreateSteps {
     assertThat(accessDeniedException)
         .hasMessageContaining("Access Denied");
   }
+
+  @Then("the patient created has the entered emails")
+  public void the_patient_created_has_the_entered_emails() {
+    TeleEntityLocatorParticipation actualElp = patient.active().phoneNumbers().getFirst();
+    TeleLocator actualLocator = patient.active().phoneNumbers().getFirst().getLocator();
+    Phone expected = this.input.active().phones().getFirst();
+
+    assertThat(actualElp)
+        .returns(expected.asOf(), TeleEntityLocatorParticipation::getAsOfDate);
+    assertThat(actualLocator)
+        .returns(expected.email(), TeleLocator::getEmailAddress);
+  }
+
+  @Then("the patient created has the entered phones")
+  public void the_patient_created_has_the_entered_phones() {
+    TeleEntityLocatorParticipation actualElp = patient.active().phoneNumbers().getFirst();
+    TeleLocator actualLocator = patient.active().phoneNumbers().getFirst().getLocator();
+    Phone expected = this.input.active().phones().getFirst();
+
+    assertThat(actualElp)
+        .returns(expected.asOf(), TeleEntityLocatorParticipation::getAsOfDate);
+    assertThat(actualLocator)
+        .returns(expected.number(), TeleLocator::getPhoneNbrTxt)
+        .returns(expected.url(), TeleLocator::getUrlAddress)
+        .returns(expected.extension(), TeleLocator::getExtensionTxt);
+  }
 }
+

--- a/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileCreate.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/PatientProfileCreate.feature
@@ -38,3 +38,19 @@ Feature: Patient Profile create
     And I am adding a new patient with comments
     When I send a create patient request
     Then I am unable to create a patient
+
+  Scenario: I can create a patient with emails
+    Given I am logged into NBS
+    And I have the authorities: "FIND-PATIENT,ADD-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+    And I am adding a new patient with emails
+    When I send a create patient request
+    Then the patient is created
+    And the patient created has the entered emails
+
+  Scenario: I can create a patient with phones
+    Given I am logged into NBS
+    And I have the authorities: "FIND-PATIENT,ADD-PATIENT" for the jurisdiction: "ALL" and program area: "STD"
+    And I am adding a new patient with phones
+    When I send a create patient request
+    Then the patient is created
+    And the patient created has the entered phones


### PR DESCRIPTION
## Description

Build on https://github.com/CDCgov/NEDSS-Modernization/pull/1660 and expand the requestbody to include Phones (and emails). Use the existing service to add phones once the patient is created.

## Tickets

* [CNFT1-2770](https://cdc-nbs.atlassian.net/browse/CNFT1-2770)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2770]: https://cdc-nbs.atlassian.net/browse/CNFT1-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ