### PR TITLE
[CNFT1-2995] Structure of the form and api request for the creation of a patient with extended data

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/api.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/api.ts
@@ -1,0 +1,39 @@
+import {
+    Administrative,
+    Name,
+    Address,
+    PhoneEmail,
+    Identification,
+    Race,
+    Ethnicity,
+    Sex,
+    Birth,
+    Mortality,
+    GeneralInformation
+} from 'apps/patient/data/api';
+import { Maybe } from 'utils';
+
+type NewPatient = {
+    administrative: Administrative;
+    names?: Name[];
+    addresses?: Address[];
+    phoneEmails?: PhoneEmail[];
+    identifications?: Identification[];
+    races?: Race[];
+    ethnicity?: Maybe<Ethnicity>;
+    birth?: Maybe<Birth>;
+    sex?: Maybe<Sex>;
+    mortality?: Maybe<Mortality>;
+    general?: Maybe<GeneralInformation>;
+};
+
+type CreatedPatient = {
+    id: number;
+    shortId: number;
+    name?: {
+        first?: string;
+        last?: string;
+    };
+};
+
+export type { NewPatient, CreatedPatient };

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -1,0 +1,29 @@
+import {
+    AdministrativeEntry,
+    NameEntry,
+    AddressEntry,
+    PhoneEmailEntry,
+    IdentificationEntry,
+    RaceEntry,
+    EthnicityEntry,
+    SexEntry,
+    BirthEntry,
+    MortalityEntry,
+    GeneralInformationEntry
+} from 'apps/patient/data/entry';
+
+type ExtendedNewPatientEntry = {
+    administrative: AdministrativeEntry;
+    names?: NameEntry[];
+    addresses?: AddressEntry[];
+    phoneEmail?: PhoneEmailEntry[];
+    identifications?: IdentificationEntry[];
+    races?: RaceEntry[];
+    ethnicity?: EthnicityEntry;
+    birth?: BirthEntry;
+    sex?: SexEntry;
+    mortality?: MortalityEntry;
+    general?: GeneralInformationEntry;
+};
+
+export type { ExtendedNewPatientEntry };

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -16,7 +16,7 @@ type ExtendedNewPatientEntry = {
     administrative: AdministrativeEntry;
     names?: NameEntry[];
     addresses?: AddressEntry[];
-    phoneEmail?: PhoneEmailEntry[];
+    phoneEmails?: PhoneEmailEntry[];
     identifications?: IdentificationEntry[];
     races?: RaceEntry[];
     ethnicity?: EthnicityEntry;

--- a/apps/modernization-ui/src/apps/patient/add/extended/index.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/index.ts
@@ -1,0 +1,2 @@
+export { AddPatientExtended } from './AddPatientExtended';
+export type { ExtendedNewPatientEntry } from './entry';

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -178,4 +178,22 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform mortality', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            mortality: {
+                asOf: '04/13/2017',
+                deceasedOn: '09/07/1976'
+            }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                mortality: expect.objectContaining({ deceasedOn: '09/07/1976' })
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -196,4 +196,22 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform general information', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            general: {
+                asOf: '04/13/2017',
+                comment: 'general-information'
+            }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                general: expect.objectContaining({ comment: 'general-information' })
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -1,0 +1,28 @@
+import { ExtendedNewPatientEntry } from './entry';
+import { transformer } from './transformer';
+
+describe('when transforming entered extended patient data', () => {
+    it('should transform administrative to a format accepted by the API', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017', comment: 'entered-value' }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'entered-value' } })
+        );
+    });
+
+    it('should transform names to a format accepted by the API', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            names: [
+                {
+                    asOf: '04/13/2017',
+                    type: { value: 'name-type-value', name: 'name-type-name' }
+                }
+            ]
+        };
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -102,4 +102,25 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform races', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            races: [
+                {
+                    asOf: '04/13/2017',
+                    race: { value: 'race-value', name: 'race-name' },
+                    detailed: []
+                }
+            ]
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                races: expect.arrayContaining([expect.objectContaining({ race: 'race-value' })])
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -79,4 +79,27 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform identifictions', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            identifications: [
+                {
+                    asOf: '04/13/2017',
+                    type: { value: 'identification-type-value', name: 'identification-type-name' },
+                    id: 'id-value'
+                }
+            ]
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                identifications: expect.arrayContaining([
+                    expect.objectContaining({ type: 'identification-type-value' })
+                ])
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -123,4 +123,23 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform ethnicity', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            ethnicity: {
+                asOf: '04/13/2017',
+                ethnicity: { value: 'ethnicity-value', name: 'ethnicity-name' },
+                detailed: []
+            }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                ethnicity: expect.objectContaining({ ethnicity: 'ethnicity-value' })
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -56,4 +56,27 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform phone and emails', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            phoneEmails: [
+                {
+                    asOf: '04/13/2017',
+                    type: { value: 'phone-email-type-value', name: 'phone-email-type-name' },
+                    use: { value: 'phone-email-use-value', name: 'phone-email-use-name' }
+                }
+            ]
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                phoneEmails: expect.arrayContaining([
+                    expect.objectContaining({ type: 'phone-email-type-value', use: 'phone-email-use-value' })
+                ])
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -14,7 +14,7 @@ describe('when transforming entered extended patient data', () => {
         );
     });
 
-    it('should transform names to a format accepted by the API', () => {
+    it('should transform names', () => {
         const entry: ExtendedNewPatientEntry = {
             administrative: { asOf: '04/13/2017' },
             names: [
@@ -24,5 +24,36 @@ describe('when transforming entered extended patient data', () => {
                 }
             ]
         };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                names: expect.arrayContaining([expect.objectContaining({ type: 'name-type-value' })])
+            })
+        );
+    });
+
+    it('should transform addresses', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            addresses: [
+                {
+                    asOf: '04/13/2017',
+                    type: { value: 'address-type-value', name: 'address-type-name' },
+                    use: { value: 'address-use-value', name: 'address-use-name' }
+                }
+            ]
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                addresses: expect.arrayContaining([
+                    expect.objectContaining({ type: 'address-type-value', use: 'address-use-value' })
+                ])
+            })
+        );
     });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -160,4 +160,22 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform birth', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            birth: {
+                asOf: '04/13/2017',
+                bornOn: '06/17/2003'
+            }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                birth: expect.objectContaining({ bornOn: '06/17/2003' })
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -142,4 +142,22 @@ describe('when transforming entered extended patient data', () => {
             })
         );
     });
+
+    it('should transform sex', () => {
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017' },
+            sex: {
+                asOf: '04/13/2017',
+                current: { value: 'current-sex-value', name: 'current-sex-name' }
+            }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                sex: expect.objectContaining({ current: 'current-sex-value' })
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,4 +1,4 @@
-import { asAdministrative, asName } from 'apps/patient/data';
+import { asAddress, asAdministrative, asName } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 import { Mapping } from 'utils';
@@ -14,12 +14,14 @@ const maybeMapAll =
         value ? value.map(mapping) : [];
 
 const asNames = maybeMapAll(asName);
+const asAddresses = maybeMapAll(asAddress);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
     const names = asNames(entry.names);
+    const addresses = asAddresses(entry.addresses);
 
-    return { administrative, names };
+    return { administrative, names, addresses };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,4 +1,4 @@
-import { asAddress, asAdministrative, asName } from 'apps/patient/data';
+import { asAddress, asAdministrative, asName, asPhoneEmail } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 import { Mapping } from 'utils';
@@ -15,13 +15,15 @@ const maybeMapAll =
 
 const asNames = maybeMapAll(asName);
 const asAddresses = maybeMapAll(asAddress);
+const asPhoneEmails = maybeMapAll(asPhoneEmail);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
     const names = asNames(entry.names);
     const addresses = asAddresses(entry.addresses);
+    const phoneEmails = asPhoneEmails(entry.phoneEmails);
 
-    return { administrative, names, addresses };
+    return { administrative, names, addresses, phoneEmails };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,4 +1,4 @@
-import { asAddress, asAdministrative, asName, asPhoneEmail } from 'apps/patient/data';
+import { asAddress, asAdministrative, asName, asPhoneEmail, asIdentification } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 import { Mapping } from 'utils';
@@ -16,14 +16,16 @@ const maybeMapAll =
 const asNames = maybeMapAll(asName);
 const asAddresses = maybeMapAll(asAddress);
 const asPhoneEmails = maybeMapAll(asPhoneEmail);
+const asIdentifications = maybeMapAll(asIdentification);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
     const names = asNames(entry.names);
     const addresses = asAddresses(entry.addresses);
     const phoneEmails = asPhoneEmails(entry.phoneEmails);
+    const identifications = asIdentifications(entry.identifications);
 
-    return { administrative, names, addresses, phoneEmails };
+    return { administrative, names, addresses, phoneEmails, identifications };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -5,7 +5,8 @@ import {
     asPhoneEmail,
     asIdentification,
     asRace,
-    asEthnicity
+    asEthnicity,
+    asSex
 } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
@@ -28,6 +29,7 @@ const asIdentifications = maybeMapAll(asIdentification);
 const asRaces = maybeMapAll(asRace);
 
 const maybeAsEthnicity = maybeMap(asEthnicity);
+const maybeAsSex = maybeMap(asSex);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
@@ -38,8 +40,9 @@ const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const races = asRaces(entry.races);
 
     const ethnicity = maybeAsEthnicity(entry.ethnicity);
+    const sex = maybeAsSex(entry.sex);
 
-    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity };
+    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity, sex };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,4 +1,4 @@
-import { asAddress, asAdministrative, asName, asPhoneEmail, asIdentification } from 'apps/patient/data';
+import { asAddress, asAdministrative, asName, asPhoneEmail, asIdentification, asRace } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 import { Mapping } from 'utils';
@@ -17,6 +17,7 @@ const asNames = maybeMapAll(asName);
 const asAddresses = maybeMapAll(asAddress);
 const asPhoneEmails = maybeMapAll(asPhoneEmail);
 const asIdentifications = maybeMapAll(asIdentification);
+const asRaces = maybeMapAll(asRace);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
@@ -24,8 +25,9 @@ const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const addresses = asAddresses(entry.addresses);
     const phoneEmails = asPhoneEmails(entry.phoneEmails);
     const identifications = asIdentifications(entry.identifications);
+    const races = asRaces(entry.races);
 
-    return { administrative, names, addresses, phoneEmails, identifications };
+    return { administrative, names, addresses, phoneEmails, identifications, races };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,4 +1,12 @@
-import { asAddress, asAdministrative, asName, asPhoneEmail, asIdentification, asRace } from 'apps/patient/data';
+import {
+    asAddress,
+    asAdministrative,
+    asName,
+    asPhoneEmail,
+    asIdentification,
+    asRace,
+    asEthnicity
+} from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 import { Mapping } from 'utils';
@@ -19,6 +27,8 @@ const asPhoneEmails = maybeMapAll(asPhoneEmail);
 const asIdentifications = maybeMapAll(asIdentification);
 const asRaces = maybeMapAll(asRace);
 
+const maybeAsEthnicity = maybeMap(asEthnicity);
+
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
     const names = asNames(entry.names);
@@ -27,7 +37,9 @@ const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const identifications = asIdentifications(entry.identifications);
     const races = asRaces(entry.races);
 
-    return { administrative, names, addresses, phoneEmails, identifications, races };
+    const ethnicity = maybeAsEthnicity(entry.ethnicity);
+
+    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,8 +1,9 @@
+import { asAdministrative } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
-    const { administrative } = entry;
+    const administrative = asAdministrative(entry.administrative);
 
     return { administrative };
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,0 +1,10 @@
+import { ExtendedNewPatientEntry } from './entry';
+import { Transformer } from './useAddExtendedPatient';
+
+const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
+    const { administrative } = entry;
+
+    return { administrative };
+};
+
+export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -8,11 +8,13 @@ import {
     asEthnicity,
     asSex,
     asBirth,
-    asMortality
+    asMortality,
+    asGeneral
 } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
 import { Mapping } from 'utils';
+import { NewPatient } from './api';
 
 const maybeMap =
     <R, S>(mapping: Mapping<R, S>) =>
@@ -34,8 +36,9 @@ const maybeAsEthnicity = maybeMap(asEthnicity);
 const maybeAsSex = maybeMap(asSex);
 const maybeBirth = maybeMap(asBirth);
 const maybeMortality = maybeMap(asMortality);
+const maybeGeneral = maybeMap(asGeneral);
 
-const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
+const transformer: Transformer = (entry: ExtendedNewPatientEntry): NewPatient => {
     const administrative = asAdministrative(entry.administrative);
     const names = asNames(entry.names);
     const addresses = asAddresses(entry.addresses);
@@ -47,8 +50,21 @@ const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const sex = maybeAsSex(entry.sex);
     const birth = maybeBirth(entry.birth);
     const mortality = maybeMortality(entry.mortality);
+    const general = maybeGeneral(entry.general);
 
-    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity, sex, birth, mortality };
+    return {
+        administrative,
+        names,
+        addresses,
+        phoneEmails,
+        identifications,
+        races,
+        ethnicity,
+        sex,
+        birth,
+        mortality,
+        general
+    };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -7,7 +7,8 @@ import {
     asRace,
     asEthnicity,
     asSex,
-    asBirth
+    asBirth,
+    asMortality
 } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
@@ -32,6 +33,7 @@ const asRaces = maybeMapAll(asRace);
 const maybeAsEthnicity = maybeMap(asEthnicity);
 const maybeAsSex = maybeMap(asSex);
 const maybeBirth = maybeMap(asBirth);
+const maybeMortality = maybeMap(asMortality);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
@@ -44,8 +46,9 @@ const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const ethnicity = maybeAsEthnicity(entry.ethnicity);
     const sex = maybeAsSex(entry.sex);
     const birth = maybeBirth(entry.birth);
+    const mortality = maybeMortality(entry.mortality);
 
-    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity, sex, birth };
+    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity, sex, birth, mortality };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,11 +1,25 @@
-import { asAdministrative } from 'apps/patient/data';
+import { asAdministrative, asName } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
+import { Mapping } from 'utils';
+
+const maybeMap =
+    <R, S>(mapping: Mapping<R, S>) =>
+    (value?: R): S | undefined =>
+        value ? mapping(value) : undefined;
+
+const maybeMapAll =
+    <R, S>(mapping: Mapping<R, S>) =>
+    (value?: R[]): S[] =>
+        value ? value.map(mapping) : [];
+
+const asNames = maybeMapAll(asName);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
+    const names = asNames(entry.names);
 
-    return { administrative };
+    return { administrative, names };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -6,7 +6,8 @@ import {
     asIdentification,
     asRace,
     asEthnicity,
-    asSex
+    asSex,
+    asBirth
 } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
 import { Transformer } from './useAddExtendedPatient';
@@ -30,6 +31,7 @@ const asRaces = maybeMapAll(asRace);
 
 const maybeAsEthnicity = maybeMap(asEthnicity);
 const maybeAsSex = maybeMap(asSex);
+const maybeBirth = maybeMap(asBirth);
 
 const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
     const administrative = asAdministrative(entry.administrative);
@@ -41,8 +43,9 @@ const transformer: Transformer = (entry: ExtendedNewPatientEntry) => {
 
     const ethnicity = maybeAsEthnicity(entry.ethnicity);
     const sex = maybeAsSex(entry.sex);
+    const birth = maybeBirth(entry.birth);
 
-    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity, sex };
+    return { administrative, names, addresses, phoneEmails, identifications, races, ethnicity, sex, birth };
 };
 
 export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.spec.ts
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Settings, useAddExtendedPatient } from './useAddExtendedPatient';
+import { ExtendedNewPatientEntry } from './entry';
+import { NewPatient } from './api';
+
+const setup = (settings?: Partial<Settings>) => {
+    const transformer = settings?.transformer ?? jest.fn();
+    const creator = settings?.creator ?? jest.fn();
+
+    return renderHook(() => useAddExtendedPatient({ transformer, creator }));
+};
+
+describe('when adding patients with extended data', () => {
+    it('should default to waiting', () => {
+        const { result } = setup();
+
+        expect(result.current.status).toEqual('waiting');
+    });
+
+    it('should transition to created when creation is completed', async () => {
+        const input: NewPatient = { administrative: { asOf: '04/13/2017', comment: 'transformed' } };
+
+        const transformer = jest.fn();
+
+        transformer.mockReturnValue(input);
+
+        const creator = jest.fn();
+
+        creator.mockResolvedValue({ id: 101, shortId: 691 });
+
+        const { result } = setup({ transformer, creator });
+
+        const entry: ExtendedNewPatientEntry = {
+            administrative: { asOf: '04/13/2017', comment: 'entered' }
+        };
+
+        await act(async () => {
+            result.current.create(entry);
+        });
+
+        expect(transformer).toHaveBeenCalledWith(
+            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'entered' } })
+        );
+
+        expect(creator).toHaveBeenCalledWith(
+            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'transformed' } })
+        );
+
+        expect(result.current.status).toEqual('created');
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { CreatedPatient, NewPatient } from './api';
+import { ExtendedNewPatientEntry } from './entry';
+
+type Step =
+    | { status: 'requesting'; entry: ExtendedNewPatientEntry }
+    | { status: 'creating'; input: NewPatient }
+    | { status: 'created'; created: CreatedPatient }
+    | { status: 'waiting' };
+
+type Action =
+    | { type: 'request'; entry: ExtendedNewPatientEntry }
+    | { type: 'create'; input: NewPatient }
+    | { type: 'complete'; created: CreatedPatient }
+    | { type: 'wait' };
+
+const initial: Step = { status: 'waiting' };
+
+const reducer = (current: Step, action: Action): Step => {
+    switch (action.type) {
+        case 'request': {
+            return { status: 'requesting', entry: action.entry };
+        }
+        case 'create': {
+            return { status: 'creating', input: action.input };
+        }
+        case 'complete': {
+            return { status: 'created', created: action.created };
+        }
+        default: {
+            return current;
+        }
+    }
+};
+
+type Transformer = (entry: ExtendedNewPatientEntry) => NewPatient;
+type Creator = (input: NewPatient) => Promise<CreatedPatient>;
+
+type Settings = {
+    transformer: Transformer;
+    creator: Creator;
+};
+
+type Working = {
+    status: 'waiting' | 'working';
+};
+
+type Created = {
+    status: 'created';
+    created: CreatedPatient;
+};
+
+type State = Working | Created;
+
+type Interaction = {
+    create: (entry: ExtendedNewPatientEntry) => void;
+};
+
+type Return = Interaction & State;
+
+const useAddExtendedPatient = ({ transformer, creator }: Settings): Return => {
+    const [step, dispatch] = useReducer(reducer, initial);
+
+    useEffect(() => {
+        if (step.status === 'requesting') {
+            const input = transformer(step.entry);
+            dispatch({ type: 'create', input });
+        } else if (step.status === 'creating') {
+            creator(step.input).then((created) => dispatch({ type: 'complete', created }));
+        }
+    }, [step.status, dispatch]);
+
+    const state: State = useMemo(() => evaluateState(step), [step]);
+
+    const create = useCallback((entry: ExtendedNewPatientEntry) => dispatch({ type: 'request', entry }), [dispatch]);
+
+    return {
+        ...state,
+        create
+    };
+};
+
+const evaluateState = (step: Step): State => {
+    switch (step.status) {
+        case 'creating':
+        case 'requesting': {
+            return { status: 'working' };
+        }
+        case 'created': {
+            return { status: 'created', created: step.created };
+        }
+        default: {
+            return { status: step.status };
+        }
+    }
+};
+
+export { useAddExtendedPatient };
+export type { Settings, Transformer, Creator };

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -1,55 +1,55 @@
-import { EffectiveDated, HasComments, Maybe } from 'utils';
+import { EffectiveDated, HasComments } from 'utils';
 
 type HasLocation = {
-    city: Maybe<string>;
-    state: Maybe<string>;
-    county: Maybe<string>;
-    country: Maybe<string>;
+    city?: string;
+    state?: string;
+    county?: string;
+    country?: string;
 };
 
 type Administrative = EffectiveDated & HasComments;
 
 type Name = EffectiveDated & {
     type: string;
-    prefix: Maybe<string>;
-    first: Maybe<string>;
-    middle: Maybe<string>;
-    secondMiddle: Maybe<string>;
-    last: Maybe<string>;
-    secondLast: Maybe<string>;
-    suffix: Maybe<string>;
-    degree: Maybe<string>;
+    prefix?: string;
+    first?: string;
+    middle?: string;
+    secondMiddle?: string;
+    last?: string;
+    secondLast?: string;
+    suffix?: string;
+    degree?: string;
 };
 
 type Address = EffectiveDated &
     HasComments & {
         type: string;
         use: string;
-        address1: Maybe<string>;
-        address2: Maybe<string>;
-        city: Maybe<string>;
-        state: Maybe<string>;
-        zipcode: Maybe<string>;
-        county: Maybe<string>;
-        country: Maybe<string>;
-        censusTract: Maybe<string>;
+        address1?: string;
+        address2?: string;
+        city?: string;
+        state?: string;
+        zipcode?: string;
+        county?: string;
+        country?: string;
+        censusTract?: string;
     };
 
 type PhoneEmail = EffectiveDated &
     HasComments & {
         type: string;
         use: string;
-        countryCode: Maybe<string>;
-        phoneNumber: Maybe<string>;
-        extension: Maybe<string>;
-        email: Maybe<string>;
-        url: Maybe<string>;
+        countryCode?: string;
+        phoneNumber?: string;
+        extension?: string;
+        email?: string;
+        url?: string;
     };
 
 type Identification = EffectiveDated & {
     type: string;
     id: string;
-    issuer: Maybe<string>;
+    issuer?: string;
 };
 
 type Race = EffectiveDated & {
@@ -58,41 +58,41 @@ type Race = EffectiveDated & {
 };
 
 type Ethnicity = EffectiveDated & {
-    ethnicity: Maybe<string>;
+    ethnicity: string;
     detailed: string[];
 };
 
 type Sex = {
-    currentSex: Maybe<string>;
-    unknownReason: Maybe<string>;
-    transgenderInformation: Maybe<string>;
-    additionalGender: Maybe<string>;
+    currentSex?: string;
+    unknownReason?: string;
+    transgenderInformation?: string;
+    additionalGender?: string;
 };
 
 type Birth = EffectiveDated &
     HasLocation & {
-        dateOfBirth: Maybe<string>;
-        sex: Maybe<string>;
-        multiple: Maybe<string>;
-        order: Maybe<number>;
+        dateOfBirth?: string;
+        sex?: string;
+        multiple?: string;
+        order?: number;
     };
 
 type Mortality = EffectiveDated &
     HasLocation & {
-        deceased: Maybe<string>;
-        deceasedOn: Maybe<string>;
+        deceased?: string;
+        deceasedOn?: string;
     };
 
 type GeneralInformation = EffectiveDated &
     HasComments & {
-        maritalStatus: Maybe<string>;
-        maternalMaidenName: Maybe<string>;
-        adultsInResidence: Maybe<number>;
-        childrenInResidence: Maybe<number>;
-        primaryOccupation: Maybe<string>;
-        educationLevel: Maybe<string>;
-        speaksEnglish: Maybe<string>;
-        stateHIVCase: Maybe<string>;
+        maritalStatus?: string;
+        maternalMaidenName?: string;
+        adultsInResidence?: number;
+        childrenInResidence?: number;
+        primaryOccupation?: string;
+        educationLevel?: string;
+        speaksEnglish?: string;
+        stateHIVCase?: string;
     };
 
 export type {

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -28,9 +28,9 @@ type Address = EffectiveDated &
         address1?: string;
         address2?: string;
         city?: string;
+        county?: string;
         state?: string;
         zipcode?: string;
-        county?: string;
         country?: string;
         censusTract?: string;
     };

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -63,7 +63,7 @@ type Ethnicity = EffectiveDated & {
 };
 
 type Sex = {
-    currentSex?: string;
+    current?: string;
     unknownReason?: string;
     transgenderInformation?: string;
     additionalGender?: string;

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -1,0 +1,110 @@
+import { EffectiveDated, HasComments, Maybe } from 'utils';
+
+type HasLocation = {
+    city: Maybe<string>;
+    state: Maybe<string>;
+    county: Maybe<string>;
+    country: Maybe<string>;
+};
+
+type Administrative = EffectiveDated & HasComments;
+
+type Name = EffectiveDated & {
+    type: string;
+    prefix: Maybe<string>;
+    first: Maybe<string>;
+    middle: Maybe<string>;
+    secondMiddle: Maybe<string>;
+    last: Maybe<string>;
+    secondLast: Maybe<string>;
+    suffix: Maybe<string>;
+    degree: Maybe<string>;
+};
+
+type Address = EffectiveDated &
+    HasComments & {
+        type: string;
+        use: string;
+        address1: Maybe<string>;
+        address2: Maybe<string>;
+        city: Maybe<string>;
+        state: Maybe<string>;
+        zipcode: Maybe<string>;
+        county: Maybe<string>;
+        country: Maybe<string>;
+        censusTract: Maybe<string>;
+    };
+
+type PhoneEmail = EffectiveDated &
+    HasComments & {
+        type: string;
+        use: string;
+        countryCode: Maybe<string>;
+        phoneNumber: Maybe<string>;
+        extension: Maybe<string>;
+        email: Maybe<string>;
+        url: Maybe<string>;
+    };
+
+type Identification = EffectiveDated & {
+    type: string;
+    id: string;
+    issuer: Maybe<string>;
+};
+
+type Race = EffectiveDated & {
+    race: string;
+    detailed: string[];
+};
+
+type Ethnicity = EffectiveDated & {
+    ethnicity: Maybe<string>;
+    detailed: string[];
+};
+
+type Sex = {
+    currentSex: Maybe<string>;
+    unknownReason: Maybe<string>;
+    transgenderInformation: Maybe<string>;
+    additionalGender: Maybe<string>;
+};
+
+type Birth = EffectiveDated &
+    HasLocation & {
+        dateOfBirth: Maybe<string>;
+        sex: Maybe<string>;
+        multiple: Maybe<string>;
+        order: Maybe<number>;
+    };
+
+type Mortality = EffectiveDated &
+    HasLocation & {
+        deceased: Maybe<string>;
+        deceasedOn: Maybe<string>;
+    };
+
+type GeneralInformation = EffectiveDated &
+    HasComments & {
+        maritalStatus: Maybe<string>;
+        maternalMaidenName: Maybe<string>;
+        adultsInResidence: Maybe<number>;
+        childrenInResidence: Maybe<number>;
+        primaryOccupation: Maybe<string>;
+        educationLevel: Maybe<string>;
+        speaksEnglish: Maybe<string>;
+        stateHIVCase: Maybe<string>;
+    };
+
+export type {
+    Administrative,
+    Name,
+    Address,
+    PhoneEmail,
+    Identification,
+    Race,
+    Ethnicity,
+    Sex,
+    Birth,
+    Mortality,
+    GeneralInformation
+};

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -71,7 +71,7 @@ type Sex = {
 
 type Birth = EffectiveDated &
     HasLocation & {
-        dateOfBirth?: string;
+        bornOn?: string;
         sex?: string;
         multiple?: string;
         order?: number;

--- a/apps/modernization-ui/src/apps/patient/data/asAddress.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAddress.spec.ts
@@ -1,0 +1,143 @@
+import { asAddress } from './asAddress';
+
+describe('when mapping a address entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-address' },
+            use: { value: 'use-value', name: 'use-address' }
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the type', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-address' },
+            use: { value: 'use-value', name: 'use-address' }
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ type: 'type-value' }));
+    });
+
+    it('should include the use', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-address' },
+            use: { value: 'use-value', name: 'use-address' }
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ use: 'use-value' }));
+    });
+
+    it('should include the address1', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            address1: 'address-1-value'
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ address1: 'address-1-value' }));
+    });
+
+    it('should include the address2', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            address2: 'address-2-value'
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ address2: 'address-2-value' }));
+    });
+
+    it('should include the city', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            city: 'city-value'
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ city: 'city-value' }));
+    });
+
+    it('should include the county', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            county: { value: 'county-value', name: 'county-name' }
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ county: 'county-value' }));
+    });
+
+    it('should include the state', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            state: { value: 'state-value', name: 'state-name' }
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ state: 'state-value' }));
+    });
+
+    it('should include the zicode', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            zicode: 'zicode-value'
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ zicode: 'zicode-value' }));
+    });
+
+    it('should include the country', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            country: { value: 'country-value', name: 'country-name' }
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ country: 'country-value' }));
+    });
+
+    it('should include the census tract', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
+            censusTract: 'census-tract-value'
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ censusTract: 'census-tract-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asAddress.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAddress.spec.ts
@@ -140,4 +140,17 @@ describe('when mapping a address entry to a format accepted by the API', () => {
 
         expect(actual).toEqual(expect.objectContaining({ censusTract: 'census-tract-value' }));
     });
+
+    it('should include the comment', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            comment: 'comment-value'
+        };
+
+        const actual = asAddress(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ comment: 'comment-value' }));
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/asAddress.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAddress.ts
@@ -1,0 +1,18 @@
+import { asValue } from 'options';
+import { Address } from './api';
+import { AddressEntry } from './entry';
+
+const asAddress = (entry: AddressEntry): Address => {
+    const { use, type, state, county, country, ...remaining } = entry;
+
+    return {
+        type: asValue(type),
+        use: asValue(use),
+        county: asValue(county),
+        state: asValue(state),
+        country: asValue(country),
+        ...remaining
+    };
+};
+
+export { asAddress };

--- a/apps/modernization-ui/src/apps/patient/data/asAdministrative.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAdministrative.spec.ts
@@ -1,0 +1,19 @@
+import { asAdministrative } from './asAdministrative';
+
+describe('when mapping an AdministrativeEntry to an Administrative', () => {
+    it('should include the as of date', () => {
+        const entry = { asOf: '04/13/2017' };
+
+        const actual = asAdministrative(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the comment', () => {
+        const entry = { asOf: '04/13/2017', comment: 'entered-value' };
+
+        const actual = asAdministrative(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ comment: 'entered-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asAdministrative.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAdministrative.ts
@@ -1,0 +1,6 @@
+import { Administrative } from './api';
+import { AdministrativeEntry } from './entry';
+
+const asAdministrative = (entry: AdministrativeEntry): Administrative => entry;
+
+export { asAdministrative };

--- a/apps/modernization-ui/src/apps/patient/data/asAdministrative.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAdministrative.ts
@@ -1,10 +1,5 @@
-/* eslint-disable no-redeclare */
 import { Administrative } from './api';
 import { AdministrativeEntry } from './entry';
 
-function asAdministrative(entry: AdministrativeEntry): Administrative;
-function asAdministrative(entry: undefined): undefined;
-function asAdministrative(entry: AdministrativeEntry | undefined): Administrative | undefined {
-    return entry;
-}
+const asAdministrative = (entry: AdministrativeEntry): Administrative => entry;
 export { asAdministrative };

--- a/apps/modernization-ui/src/apps/patient/data/asAdministrative.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asAdministrative.ts
@@ -1,6 +1,10 @@
+/* eslint-disable no-redeclare */
 import { Administrative } from './api';
 import { AdministrativeEntry } from './entry';
 
-const asAdministrative = (entry: AdministrativeEntry): Administrative => entry;
-
+function asAdministrative(entry: AdministrativeEntry): Administrative;
+function asAdministrative(entry: undefined): undefined;
+function asAdministrative(entry: AdministrativeEntry | undefined): Administrative | undefined {
+    return entry;
+}
 export { asAdministrative };

--- a/apps/modernization-ui/src/apps/patient/data/asBirth.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asBirth.spec.ts
@@ -1,0 +1,90 @@
+import { asBirth } from './asBirth';
+
+describe('when mapping a birth entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017'
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the born on', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            bornOn: '11/05/2003'
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ bornOn: '11/05/2003' }));
+    });
+
+    it('should include the current sex', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            sex: { value: 'birth-sex-value', name: 'birth-sex-name' }
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ sex: 'birth-sex-value' }));
+    });
+
+    it('should include the multiple birth', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            multiple: { value: 'multiple-value', name: 'multiple-name' }
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ multiple: 'multiple-value' }));
+    });
+
+    it('should include the city', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            city: 'city-value'
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ city: 'city-value' }));
+    });
+
+    it('should include the county', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            county: { value: 'county-value', name: 'county-name' }
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ county: 'county-value' }));
+    });
+
+    it('should include the state', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            state: { value: 'state-value', name: 'state-name' }
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ state: 'state-value' }));
+    });
+
+    it('should include the country', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            country: { value: 'country-value', name: 'country-name' }
+        };
+
+        const actual = asBirth(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ country: 'country-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asBirth.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asBirth.ts
@@ -1,0 +1,18 @@
+import { asValue } from 'options';
+import { Birth } from './api';
+import { BirthEntry } from './entry';
+
+const asBirth = (entry: BirthEntry): Birth => {
+    const { sex, multiple, county, state, country, ...remaining } = entry;
+
+    return {
+        sex: asValue(sex),
+        multiple: asValue(multiple),
+        county: asValue(county),
+        state: asValue(state),
+        country: asValue(country),
+        ...remaining
+    };
+};
+
+export { asBirth };

--- a/apps/modernization-ui/src/apps/patient/data/asEthnicity.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asEthnicity.spec.ts
@@ -1,0 +1,44 @@
+import { asEthnicity } from './asEthnicity';
+
+describe('when mapping a ethnicity entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            ethnicity: { value: 'ethnicity-value', name: 'ethnicity-name' },
+            detailed: []
+        };
+
+        const actual = asEthnicity(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the ethnicity', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            ethnicity: { value: 'ethnicity-value', name: 'ethnicity-name' },
+            detailed: []
+        };
+
+        const actual = asEthnicity(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ ethnicity: 'ethnicity-value' }));
+    });
+
+    it('should include the ethnicity details', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            ethnicity: { value: 'ethnicity-value', name: 'ethnicity-name' },
+            detailed: [
+                { value: 'detail-one-value', name: 'detail-one-name' },
+                { value: 'detail-two-value', name: 'detail-two-name' }
+            ]
+        };
+
+        const actual = asEthnicity(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({ detailed: expect.arrayContaining(['detail-one-value', 'detail-two-value']) })
+        );
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asEthnicity.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asEthnicity.ts
@@ -1,0 +1,15 @@
+import { asValue, asValues } from 'options';
+import { EthnicityEntry } from './entry';
+import { Ethnicity } from './api';
+
+const asEthnicity = (entry: EthnicityEntry): Ethnicity => {
+    const { ethnicity, detailed, ...remaining } = entry;
+
+    return {
+        ethnicity: asValue(ethnicity),
+        detailed: asValues(detailed),
+        ...remaining
+    };
+};
+
+export { asEthnicity };

--- a/apps/modernization-ui/src/apps/patient/data/asGeneral.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asGeneral.spec.ts
@@ -1,0 +1,112 @@
+import { asGeneral } from './asGeneral';
+
+describe('when mapping a general information entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017'
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the marital status', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            maritalStatus: { value: 'marital-status-value', name: 'marital-status-name' }
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ maritalStatus: 'marital-status-value' }));
+    });
+
+    it('should include the maternal maiden name', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            maternalMaidenName: 'maternal-maiden-name-value'
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ maternalMaidenName: 'maternal-maiden-name-value' }));
+    });
+
+    it('should include the adults in residence', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            adultsInResidence: 17
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ adultsInResidence: 17 }));
+    });
+
+    it('should include the children in residence', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            childrenInResidence: 39
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ childrenInResidence: 39 }));
+    });
+
+    it('should include the primary occupation', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            primaryOccupation: { value: 'primary-occupation-value', name: 'primary-occupation-name' }
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ primaryOccupation: 'primary-occupation-value' }));
+    });
+
+    it('should include the education level', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            educationLevel: { value: 'education-level-value', name: 'education-level-name' }
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ educationLevel: 'education-level-value' }));
+    });
+
+    it('should include wether the patient speaks english', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            speaksEnglish: { value: 'speaks-english-value', name: 'speaks-english-name' }
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ speaksEnglish: 'speaks-english-value' }));
+    });
+
+    it('should include the state HIV case', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            stateHIVCase: 'state-hiv-case-value'
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ stateHIVCase: 'state-hiv-case-value' }));
+    });
+
+    it('should include the comment', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            comment: 'comment-value'
+        };
+
+        const actual = asGeneral(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ comment: 'comment-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asGeneral.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asGeneral.ts
@@ -1,0 +1,17 @@
+import { asValue } from 'options';
+import { GeneralInformation } from './api';
+import { GeneralInformationEntry } from './entry';
+
+const asGeneral = (entry: GeneralInformationEntry): GeneralInformation => {
+    const { maritalStatus, primaryOccupation, educationLevel, speaksEnglish, ...remaining } = entry;
+
+    return {
+        maritalStatus: asValue(maritalStatus),
+        primaryOccupation: asValue(primaryOccupation),
+        educationLevel: asValue(educationLevel),
+        speaksEnglish: asValue(speaksEnglish),
+        ...remaining
+    };
+};
+
+export { asGeneral };

--- a/apps/modernization-ui/src/apps/patient/data/asIdentification.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asIdentification.spec.ts
@@ -1,0 +1,52 @@
+import { asIdentification } from './asIdentification';
+
+describe('when mapping an identification entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            id: 'id-value'
+        };
+
+        const actual = asIdentification(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the type', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            id: 'id-value'
+        };
+
+        const actual = asIdentification(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ type: 'type-value' }));
+    });
+
+    it('should include the id', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            id: 'id-value'
+        };
+
+        const actual = asIdentification(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ id: 'id-value' }));
+    });
+
+    it('should include the issuer', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            id: 'id-value',
+            issuer: { value: 'issuer-value', name: 'issuer-type' }
+        };
+
+        const actual = asIdentification(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ id: 'id-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asIdentification.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asIdentification.ts
@@ -1,0 +1,15 @@
+import { asValue } from 'options';
+import { Identification } from './api';
+import { IdentificationEntry } from './entry';
+
+const asIdentification = (entry: IdentificationEntry): Identification => {
+    const { type, issuer, ...remaining } = entry;
+
+    return {
+        type: asValue(type),
+        issuer: asValue(issuer),
+        ...remaining
+    };
+};
+
+export { asIdentification };

--- a/apps/modernization-ui/src/apps/patient/data/asMortality.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asMortality.spec.ts
@@ -1,0 +1,68 @@
+import { asMortality } from './asMortality';
+
+describe('when mapping a mortality entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017'
+        };
+
+        const actual = asMortality(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the deceased on', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            deceasedOn: '10/08/1927'
+        };
+
+        const actual = asMortality(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ deceasedOn: '10/08/1927' }));
+    });
+
+    it('should include the city', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            city: 'city-value'
+        };
+
+        const actual = asMortality(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ city: 'city-value' }));
+    });
+
+    it('should include the county', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            county: { value: 'county-value', name: 'county-name' }
+        };
+
+        const actual = asMortality(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ county: 'county-value' }));
+    });
+
+    it('should include the state', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            state: { value: 'state-value', name: 'state-name' }
+        };
+
+        const actual = asMortality(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ state: 'state-value' }));
+    });
+
+    it('should include the country', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            country: { value: 'country-value', name: 'country-name' }
+        };
+
+        const actual = asMortality(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ country: 'country-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asMortality.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asMortality.ts
@@ -1,0 +1,17 @@
+import { asValue } from 'options';
+import { Mortality } from './api';
+import { MortalityEntry } from './entry';
+
+const asMortality = (entry: MortalityEntry): Mortality => {
+    const { deceased, county, state, country, ...remaining } = entry;
+
+    return {
+        deceased: asValue(deceased),
+        county: asValue(county),
+        state: asValue(state),
+        country: asValue(country),
+        ...remaining
+    };
+};
+
+export { asMortality };

--- a/apps/modernization-ui/src/apps/patient/data/asName.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asName.spec.ts
@@ -1,0 +1,115 @@
+import { asName } from './asName';
+
+describe('when mapping a name entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = { asOf: '04/13/2017', type: { value: 'type-value', name: 'type-name' } };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the type', () => {
+        const entry = { asOf: '04/13/2017', type: { value: 'type-value', name: 'type-name' } };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ type: 'type-value' }));
+    });
+
+    it('should include the prefix', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            prefix: { value: 'prefix-value', name: 'prefix-name' }
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ prefix: 'prefix-value' }));
+    });
+
+    it('should include the first name', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            first: 'first-value'
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ first: 'first-value' }));
+    });
+
+    it('should include the middle name', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            middle: 'middle-value'
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ middle: 'middle-value' }));
+    });
+
+    it('should include the second middle name', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            secondMiddle: 'second-middle-value'
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ secondMiddle: 'second-middle-value' }));
+    });
+
+    it('should include the last name', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            last: 'last-value'
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ last: 'last-value' }));
+    });
+
+    it('should include the second last name', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            secondLast: 'second-last-value'
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ secondLast: 'second-last-value' }));
+    });
+
+    it('should include the suffix', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            suffix: { value: 'suffix-value', name: 'suffix-name' }
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ suffix: 'suffix-value' }));
+    });
+
+    it('should include the degree', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-name' },
+            degree: { value: 'degree-value', name: 'degree-name' }
+        };
+
+        const actual = asName(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ degree: 'degree-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asName.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asName.ts
@@ -4,17 +4,12 @@ import { Name } from './api';
 import { NameEntry } from './entry';
 
 const asName = (entry: NameEntry): Name => {
-    const { asOf, type, prefix, first, middle, secondMiddle, last, secondLast, suffix, degree } = entry;
+    const { type, prefix, suffix, degree, ...remaining } = entry;
 
     return {
-        asOf,
+        ...remaining,
         type: asValue(type),
         prefix: asValue(prefix),
-        first,
-        middle,
-        secondMiddle,
-        last,
-        secondLast,
         suffix: asValue(suffix),
         degree: asValue(degree)
     };

--- a/apps/modernization-ui/src/apps/patient/data/asName.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asName.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-redeclare */
+import { asValue } from 'options';
+import { Name } from './api';
+import { NameEntry } from './entry';
+
+const asName = (entry: NameEntry): Name => {
+    const { asOf, type, prefix, first, middle, secondMiddle, last, secondLast, suffix, degree } = entry;
+
+    return {
+        asOf,
+        type: asValue(type),
+        prefix: asValue(prefix),
+        first,
+        middle,
+        secondMiddle,
+        last,
+        secondLast,
+        suffix: asValue(suffix),
+        degree: asValue(degree)
+    };
+};
+export { asName };

--- a/apps/modernization-ui/src/apps/patient/data/asPhoneEmail.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asPhoneEmail.spec.ts
@@ -1,0 +1,117 @@
+import { asPhoneEmail } from './asPhoneEmail';
+
+describe('when mapping a phone email entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' }
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the type', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' }
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ type: 'type-value' }));
+    });
+
+    it('should include the use', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' }
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ use: 'use-value' }));
+    });
+
+    it('should include the country code', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            countryCode: 'country-code-value'
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ countryCode: 'country-code-value' }));
+    });
+
+    it('should include the phone number', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            phoneNumber: 'phone-number-value'
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ phoneNumber: 'phone-number-value' }));
+    });
+
+    it('should include the extension', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            extension: 'extension-value'
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ extension: 'extension-value' }));
+    });
+
+    it('should include the email', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            email: 'email-value'
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ email: 'email-value' }));
+    });
+
+    it('should include the url', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            url: 'url-value'
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ url: 'url-value' }));
+    });
+
+    it('should include the comment', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            type: { value: 'type-value', name: 'type-phone-email' },
+            use: { value: 'use-value', name: 'use-phone-email' },
+            comment: 'comment-value'
+        };
+
+        const actual = asPhoneEmail(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ comment: 'comment-value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asPhoneEmail.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asPhoneEmail.spec.ts
@@ -28,8 +28,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the use', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' }
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' }
         };
 
         const actual = asPhoneEmail(entry);
@@ -40,8 +40,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the country code', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' },
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
             countryCode: 'country-code-value'
         };
 
@@ -53,8 +53,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the phone number', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' },
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
             phoneNumber: 'phone-number-value'
         };
 
@@ -66,8 +66,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the extension', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' },
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
             extension: 'extension-value'
         };
 
@@ -79,8 +79,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the email', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' },
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
             email: 'email-value'
         };
 
@@ -92,8 +92,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the url', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' },
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
             url: 'url-value'
         };
 
@@ -105,8 +105,8 @@ describe('when mapping a phone email entry to a format accepted by the API', () 
     it('should include the comment', () => {
         const entry = {
             asOf: '04/13/2017',
-            type: { value: 'type-value', name: 'type-phone-email' },
-            use: { value: 'use-value', name: 'use-phone-email' },
+            type: { value: 'type-value', name: 'type-name' },
+            use: { value: 'use-value', name: 'use-name' },
             comment: 'comment-value'
         };
 

--- a/apps/modernization-ui/src/apps/patient/data/asPhoneEmail.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asPhoneEmail.ts
@@ -1,0 +1,15 @@
+import { asValue } from 'options';
+import { PhoneEmail } from './api';
+import { PhoneEmailEntry } from './entry';
+
+const asPhoneEmail = (entry: PhoneEmailEntry): PhoneEmail => {
+    const { type, use, ...remaining } = entry;
+
+    return {
+        type: asValue(type),
+        use: asValue(use),
+        ...remaining
+    };
+};
+
+export { asPhoneEmail };

--- a/apps/modernization-ui/src/apps/patient/data/asRace.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asRace.spec.ts
@@ -1,0 +1,44 @@
+import { asRace } from './asRace';
+
+describe('when mapping a race entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            race: { value: 'race-value', name: 'race-name' },
+            detailed: []
+        };
+
+        const actual = asRace(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the race', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            race: { value: 'race-value', name: 'race-name' },
+            detailed: []
+        };
+
+        const actual = asRace(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ race: 'race-value' }));
+    });
+
+    it('should include the race details', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            race: { value: 'race-value', name: 'race-name' },
+            detailed: [
+                { value: 'detail-one-value', name: 'detail-one-name' },
+                { value: 'detail-two-value', name: 'detail-two-name' }
+            ]
+        };
+
+        const actual = asRace(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({ detailed: expect.arrayContaining(['detail-one-value', 'detail-two-value']) })
+        );
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asRace.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asRace.ts
@@ -1,0 +1,15 @@
+import { asValue, asValues } from 'options';
+import { RaceEntry } from './entry';
+import { Race } from './api';
+
+const asRace = (entry: RaceEntry): Race => {
+    const { race, detailed, ...remaining } = entry;
+
+    return {
+        race: asValue(race),
+        detailed: asValues(detailed),
+        ...remaining
+    };
+};
+
+export { asRace };

--- a/apps/modernization-ui/src/apps/patient/data/asSex.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asSex.spec.ts
@@ -1,0 +1,57 @@
+import { asSex } from './asSex';
+
+describe('when mapping a sex entry to a format accepted by the API', () => {
+    it('should include the as of date', () => {
+        const entry = {
+            asOf: '04/13/2017'
+        };
+
+        const actual = asSex(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: '04/13/2017' }));
+    });
+
+    it('should include the current sex', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            current: { value: 'current-sex-value', name: 'current-sex-name' }
+        };
+
+        const actual = asSex(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ current: 'current-sex-value' }));
+    });
+
+    it('should include the unknown reason', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            unknownReason: { value: 'unknown-reason-value', name: 'unknown-reason-name' }
+        };
+
+        const actual = asSex(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ unknownReason: 'unknown-reason-value' }));
+    });
+
+    it('should include the current sex', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            transgenderInformation: { value: 'transgender-information-value', name: 'transgender-information-name' }
+        };
+
+        const actual = asSex(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ transgenderInformation: 'transgender-information-value' }));
+    });
+
+    it('should include the additional gender', () => {
+        const entry = {
+            asOf: '04/13/2017',
+            additionalGender: 'additional-gender'
+        };
+
+        const actual = asSex(entry);
+
+        expect(actual).toEqual(expect.objectContaining({ additionalGender: 'additional-gender' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/data/asSex.ts
+++ b/apps/modernization-ui/src/apps/patient/data/asSex.ts
@@ -1,0 +1,16 @@
+import { asValue } from 'options';
+import { Sex } from './api';
+import { SexEntry } from './entry';
+
+const asSex = (entry: SexEntry): Sex => {
+    const { current, unknownReason, transgenderInformation, ...remaining } = entry;
+
+    return {
+        current: asValue(current),
+        unknownReason: asValue(unknownReason),
+        transgenderInformation: asValue(transgenderInformation),
+        ...remaining
+    };
+};
+
+export { asSex };

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -1,56 +1,56 @@
 import { Selectable } from 'options';
-import { EffectiveDated, HasComments, Maybe } from 'utils';
+import { EffectiveDated, HasComments } from 'utils';
 
 type LocationEntry = {
-    city: Maybe<string>;
-    state: Maybe<Selectable>;
-    county: Maybe<Selectable>;
-    country: Maybe<Selectable>;
+    city?: string;
+    state?: Selectable;
+    county?: Selectable;
+    country?: Selectable;
 };
 
 type AdministrativeEntry = EffectiveDated & HasComments;
 
 type NameEntry = EffectiveDated & {
     type: Selectable;
-    prefix?: Maybe<Selectable>;
-    first?: Maybe<string>;
-    middle?: Maybe<string>;
-    secondMiddle?: Maybe<string>;
-    last?: Maybe<string>;
-    secondLast?: Maybe<string>;
-    suffix?: Maybe<Selectable>;
-    degree?: Maybe<Selectable>;
+    prefix?: Selectable;
+    first?: string;
+    middle?: string;
+    secondMiddle?: string;
+    last?: string;
+    secondLast?: string;
+    suffix?: Selectable;
+    degree?: Selectable;
 };
 
 type AddressEntry = EffectiveDated &
     HasComments & {
         type: Selectable;
         use: Selectable;
-        address1: Maybe<string>;
-        address2: Maybe<string>;
-        city: Maybe<string>;
-        state: Maybe<Selectable>;
-        zipcode: Maybe<string>;
-        county: Maybe<Selectable>;
-        country: Maybe<Selectable>;
-        censusTract: Maybe<string>;
+        address1: string;
+        address2: string;
+        city: string;
+        state: Selectable;
+        zipcode: string;
+        county: Selectable;
+        country: Selectable;
+        censusTract: string;
     };
 
 type PhoneEmailEntry = EffectiveDated &
     HasComments & {
         type: Selectable;
         use: Selectable;
-        countryCode: Maybe<string>;
-        phoneNumber: Maybe<string>;
-        extension: Maybe<string>;
-        email: Maybe<string>;
-        url: Maybe<string>;
+        countryCode: string;
+        phoneNumber: string;
+        extension: string;
+        email: string;
+        url: string;
     };
 
 type IdentificationEntry = EffectiveDated & {
     type: Selectable;
     id: string;
-    issuer: Maybe<Selectable>;
+    issuer: Selectable;
 };
 
 type RaceEntry = EffectiveDated & {
@@ -59,41 +59,41 @@ type RaceEntry = EffectiveDated & {
 };
 
 type EthnicityEntry = EffectiveDated & {
-    ethnicity: Maybe<Selectable>;
+    ethnicity: Selectable;
     detailed: Selectable[];
 };
 
 type SexEntry = EffectiveDated & {
-    currentSex: Maybe<Selectable>;
-    unknownReason: Maybe<Selectable>;
-    transgenderInformation: Maybe<Selectable>;
-    additionalGender: Maybe<string>;
+    currentSex: Selectable;
+    unknownReason: Selectable;
+    transgenderInformation: Selectable;
+    additionalGender: string;
 };
 
 type BirthEntry = EffectiveDated &
     LocationEntry & {
-        dateOfBirth: Maybe<String>;
-        sex: Maybe<Selectable>;
-        multiple: Maybe<Selectable>;
-        order: Maybe<number>;
+        dateOfBirth: string;
+        sex: Selectable;
+        multiple: Selectable;
+        order: number;
     };
 
 type MortalityEntry = EffectiveDated &
     LocationEntry & {
-        deceased: Maybe<Selectable>;
-        deceasedOn: Maybe<string>;
+        deceased: Selectable;
+        deceasedOn: string;
     };
 
 type GeneralInformationEntry = EffectiveDated &
     HasComments & {
-        maritalStatus: Maybe<Selectable>;
-        maternalMaidenName: Maybe<string>;
-        adultsInResidence?: Maybe<number>;
-        childrenInResidence?: Maybe<number>;
-        primaryOccupation: Maybe<Selectable>;
-        educationLevel: Maybe<Selectable>;
-        speaksEnglish: Maybe<Selectable>;
-        stateHIVCase?: Maybe<string>;
+        maritalStatus: Selectable;
+        maternalMaidenName: string;
+        adultsInResidence?: number;
+        childrenInResidence?: number;
+        primaryOccupation: Selectable;
+        educationLevel: Selectable;
+        speaksEnglish: Selectable;
+        stateHIVCase?: string;
     };
 
 export type {

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -1,0 +1,111 @@
+import { Selectable } from 'options';
+import { EffectiveDated, HasComments, Maybe } from 'utils';
+
+type LocationEntry = {
+    city: Maybe<string>;
+    state: Maybe<Selectable>;
+    county: Maybe<Selectable>;
+    country: Maybe<Selectable>;
+};
+
+type AdministrativeEntry = EffectiveDated & HasComments;
+
+type NameEntry = EffectiveDated & {
+    type: Selectable;
+    prefix?: Maybe<Selectable>;
+    first?: Maybe<string>;
+    middle?: Maybe<string>;
+    secondMiddle?: Maybe<string>;
+    last?: Maybe<string>;
+    secondLast?: Maybe<string>;
+    suffix?: Maybe<Selectable>;
+    degree?: Maybe<Selectable>;
+};
+
+type AddressEntry = EffectiveDated &
+    HasComments & {
+        type: Selectable;
+        use: Selectable;
+        address1: Maybe<string>;
+        address2: Maybe<string>;
+        city: Maybe<string>;
+        state: Maybe<Selectable>;
+        zipcode: Maybe<string>;
+        county: Maybe<Selectable>;
+        country: Maybe<Selectable>;
+        censusTract: Maybe<string>;
+    };
+
+type PhoneEmailEntry = EffectiveDated &
+    HasComments & {
+        type: Selectable;
+        use: Selectable;
+        countryCode: Maybe<string>;
+        phoneNumber: Maybe<string>;
+        extension: Maybe<string>;
+        email: Maybe<string>;
+        url: Maybe<string>;
+    };
+
+type IdentificationEntry = EffectiveDated & {
+    type: Selectable;
+    id: string;
+    issuer: Maybe<Selectable>;
+};
+
+type RaceEntry = EffectiveDated & {
+    race: Selectable;
+    detailed: Selectable[];
+};
+
+type EthnicityEntry = EffectiveDated & {
+    ethnicity: Maybe<Selectable>;
+    detailed: Selectable[];
+};
+
+type SexEntry = EffectiveDated & {
+    currentSex: Maybe<Selectable>;
+    unknownReason: Maybe<Selectable>;
+    transgenderInformation: Maybe<Selectable>;
+    additionalGender: Maybe<string>;
+};
+
+type BirthEntry = EffectiveDated &
+    LocationEntry & {
+        dateOfBirth: Maybe<String>;
+        sex: Maybe<Selectable>;
+        multiple: Maybe<Selectable>;
+        order: Maybe<number>;
+    };
+
+type MortalityEntry = EffectiveDated &
+    LocationEntry & {
+        deceased: Maybe<Selectable>;
+        deceasedOn: Maybe<string>;
+    };
+
+type GeneralInformationEntry = EffectiveDated &
+    HasComments & {
+        maritalStatus: Maybe<Selectable>;
+        maternalMaidenName: Maybe<string>;
+        adultsInResidence?: Maybe<number>;
+        childrenInResidence?: Maybe<number>;
+        primaryOccupation: Maybe<Selectable>;
+        educationLevel: Maybe<Selectable>;
+        speaksEnglish: Maybe<Selectable>;
+        stateHIVCase?: Maybe<string>;
+    };
+
+export type {
+    AdministrativeEntry,
+    NameEntry,
+    AddressEntry,
+    PhoneEmailEntry,
+    IdentificationEntry,
+    RaceEntry,
+    EthnicityEntry,
+    SexEntry,
+    BirthEntry,
+    MortalityEntry,
+    GeneralInformationEntry
+};

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -26,31 +26,31 @@ type AddressEntry = EffectiveDated &
     HasComments & {
         type: Selectable;
         use: Selectable;
-        address1: string;
-        address2: string;
-        city: string;
-        state: Selectable;
-        zipcode: string;
-        county: Selectable;
-        country: Selectable;
-        censusTract: string;
+        address1?: string;
+        address2?: string;
+        city?: string;
+        county?: Selectable;
+        state?: Selectable;
+        zipcode?: string;
+        country?: Selectable;
+        censusTract?: string;
     };
 
 type PhoneEmailEntry = EffectiveDated &
     HasComments & {
         type: Selectable;
         use: Selectable;
-        countryCode: string;
-        phoneNumber: string;
-        extension: string;
-        email: string;
-        url: string;
+        countryCode?: string;
+        phoneNumber?: string;
+        extension?: string;
+        email?: string;
+        url?: string;
     };
 
 type IdentificationEntry = EffectiveDated & {
     type: Selectable;
     id: string;
-    issuer: Selectable;
+    issuer?: Selectable;
 };
 
 type RaceEntry = EffectiveDated & {
@@ -64,35 +64,35 @@ type EthnicityEntry = EffectiveDated & {
 };
 
 type SexEntry = EffectiveDated & {
-    currentSex: Selectable;
-    unknownReason: Selectable;
-    transgenderInformation: Selectable;
-    additionalGender: string;
+    currentSex?: Selectable;
+    unknownReason?: Selectable;
+    transgenderInformation?: Selectable;
+    additionalGender?: string;
 };
 
 type BirthEntry = EffectiveDated &
     LocationEntry & {
-        dateOfBirth: string;
-        sex: Selectable;
-        multiple: Selectable;
-        order: number;
+        dateOfBirth?: string;
+        sex?: Selectable;
+        multiple?: Selectable;
+        order?: number;
     };
 
 type MortalityEntry = EffectiveDated &
     LocationEntry & {
-        deceased: Selectable;
-        deceasedOn: string;
+        deceased?: Selectable;
+        deceasedOn?: string;
     };
 
 type GeneralInformationEntry = EffectiveDated &
     HasComments & {
-        maritalStatus: Selectable;
-        maternalMaidenName: string;
+        maritalStatus?: Selectable;
+        maternalMaidenName?: string;
         adultsInResidence?: number;
         childrenInResidence?: number;
-        primaryOccupation: Selectable;
-        educationLevel: Selectable;
-        speaksEnglish: Selectable;
+        primaryOccupation?: Selectable;
+        educationLevel?: Selectable;
+        speaksEnglish?: Selectable;
         stateHIVCase?: string;
     };
 

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -64,7 +64,7 @@ type EthnicityEntry = EffectiveDated & {
 };
 
 type SexEntry = EffectiveDated & {
-    currentSex?: Selectable;
+    current?: Selectable;
     unknownReason?: Selectable;
     transgenderInformation?: Selectable;
     additionalGender?: string;

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -72,7 +72,7 @@ type SexEntry = EffectiveDated & {
 
 type BirthEntry = EffectiveDated &
     LocationEntry & {
-        dateOfBirth?: string;
+        bornOn?: string;
         sex?: Selectable;
         multiple?: Selectable;
         order?: number;

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -7,3 +7,4 @@ export { asRace } from './asRace';
 export { asEthnicity } from './asEthnicity';
 export { asSex } from './asSex';
 export { asBirth } from './asBirth';
+export { asMortality } from './asMortality';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -1,3 +1,4 @@
 export { asAdministrative } from './asAdministrative';
 export { asName } from './asName';
 export { asAddress } from './asAddress';
+export { asPhoneEmail } from './asPhoneEmail';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -4,3 +4,4 @@ export { asAddress } from './asAddress';
 export { asPhoneEmail } from './asPhoneEmail';
 export { asIdentification } from './asIdentification';
 export { asRace } from './asRace';
+export { asEthnicity } from './asEthnicity';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -5,3 +5,4 @@ export { asPhoneEmail } from './asPhoneEmail';
 export { asIdentification } from './asIdentification';
 export { asRace } from './asRace';
 export { asEthnicity } from './asEthnicity';
+export { asSex } from './asSex';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -8,3 +8,4 @@ export { asEthnicity } from './asEthnicity';
 export { asSex } from './asSex';
 export { asBirth } from './asBirth';
 export { asMortality } from './asMortality';
+export { asGeneral } from './asGeneral';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -1,1 +1,2 @@
 export { asAdministrative } from './asAdministrative';
+export { asName } from './asName';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -3,3 +3,4 @@ export { asName } from './asName';
 export { asAddress } from './asAddress';
 export { asPhoneEmail } from './asPhoneEmail';
 export { asIdentification } from './asIdentification';
+export { asRace } from './asRace';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -1,0 +1,1 @@
+export { asAdministrative } from './asAdministrative';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -1,2 +1,3 @@
 export { asAdministrative } from './asAdministrative';
 export { asName } from './asName';
+export { asAddress } from './asAddress';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -6,3 +6,4 @@ export { asIdentification } from './asIdentification';
 export { asRace } from './asRace';
 export { asEthnicity } from './asEthnicity';
 export { asSex } from './asSex';
+export { asBirth } from './asBirth';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -2,3 +2,4 @@ export { asAdministrative } from './asAdministrative';
 export { asName } from './asName';
 export { asAddress } from './asAddress';
 export { asPhoneEmail } from './asPhoneEmail';
+export { asIdentification } from './asIdentification';

--- a/apps/modernization-ui/src/options/selectable.ts
+++ b/apps/modernization-ui/src/options/selectable.ts
@@ -1,14 +1,11 @@
 import { Mapping, Maybe } from 'utils';
 
-type WithName = { name: string };
-type WithLabel = { label: string };
-
-type WithDisplay = WithName & WithLabel;
-
 type Selectable = {
     value: string;
+    name: string;
+    label?: string;
     order?: number;
-} & WithDisplay;
+};
 
 export type { Selectable };
 

--- a/apps/modernization-ui/src/utils/index.ts
+++ b/apps/modernization-ui/src/utils/index.ts
@@ -10,5 +10,12 @@ export * from './mapIf';
 type Predicate<T> = (item: T) => boolean;
 type Mapping<I, O> = (input: I) => O;
 type Maybe<V> = V | null | undefined;
+type EffectiveDated = {
+    asOf: string;
+};
 
-export type { Predicate, Mapping, Maybe };
+type HasComments = {
+    comment?: Maybe<string>;
+};
+
+export type { Predicate, Mapping, Maybe, EffectiveDated, HasComments };


### PR DESCRIPTION
## Description 

Creates the form and api types for adding a patient with extended data.

- Defines the structure of the object representing the full form for the creation of a patient with extended data.
- Defines the structure of the object representing the API request for the creation of a patient with extended data.
- Adds `transformer` function to transform from `form` to `api` type

## Tickets

* [CNFT1-2995](https://cdc-nbs.atlassian.net/browse/CNFT1-2995)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2995]: https://cdc-nbs.atlassian.net/browse/CNFT1-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ