### PR TITLE
Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -111,7 +111,7 @@ jobs:
         run: zip -r test-report.zip ./build/reports/*
 
       - name: Publish Testing Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: testing
           path: ./test-report.zip


### PR DESCRIPTION
## Description

Resolves deprecation by bumping the version of `upload-artifact` to `v4`

![image](https://github.com/user-attachments/assets/b8c7c14a-9f38-4d9c-8821-6158e5432bf0)
