### PR TITLE
[CNFT1-3074] Fixes interaction between useSearchCriteria and useSearchResults to prevent double searches

### DIFF
--- a/apps/modernization-ui/src/apps/search/useSearchCriteria.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchCriteria.ts
@@ -99,7 +99,7 @@ const useSearchCritiera = <C extends object>({ defaultValues }: Options<C>): Int
         }
     }, [state.status, dispatch]);
 
-    const criteria = useMemo(() => (state.status === 'waiting' ? state.criteria : undefined), [state.status]);
+    const criteria = state.status === 'waiting' ? state.criteria : undefined;
     const clear = useCallback(() => dispatch({ type: 'clear' }), [dispatch]);
     const change = useCallback((criteria: C) => dispatch({ type: 'prepare', criteria }), [dispatch]);
 

--- a/apps/modernization-ui/src/apps/search/useSearchResults.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchResults.ts
@@ -172,9 +172,17 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
 
     useEffect(() => {
         if (searchCriteria) {
+            //  the search criteria has changed initialize a search
             dispatch({ type: 'initialize', criteria: searchCriteria });
         }
     }, [searchCriteria, dispatch]);
+
+    useEffect(() => {
+        if (state.status === 'completed' && !searchCriteria) {
+            //  the search criteria has removed, reset the search
+            dispatch({ type: 'reset' });
+        }
+    }, [state.status, searchCriteria, dispatch]);
 
     useEffect(() => {
         if (state.status === 'resetting') {

--- a/apps/modernization-ui/src/apps/search/useSearchResultsFormAdapter.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchResultsFormAdapter.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import { FieldValues, UseFormReturn } from 'react-hook-form';
 import { SearchInteraction, SearchResultSettings, useSearchResults } from 'apps/search';
 import { removeTerm, Term } from 'apps/search/terms';
@@ -16,12 +15,6 @@ const useSearchResultsFormAdapter = <C extends object, A extends object, R exten
         resultResolver: settings.resultResolver,
         termResolver: settings.termResolver
     });
-
-    const { pathname } = useLocation();
-
-    useEffect(() => {
-        interaction.reset();
-    }, [pathname]);
 
     useEffect(() => {
         if (interaction.status === 'resetting') {


### PR DESCRIPTION
## Description

This is an attempt to fix an issue encountered in the INT1 environment that I am unable to recreate locally.  When trying to recreate the issue I noticed that when searching from the home page the URL is reset after the search has completed.  This did not prevent the results from showing up locally. 

## Tickets

* [CNFT1-3074](https://cdc-nbs.atlassian.net/browse/CNFT1-3074)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3074]: https://cdc-nbs.atlassian.net/browse/CNFT1-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ