### PR TITLE
reference from bug

### DIFF
--- a/apps/modernization-ui/src/apps/search/laboratory-report/result/ResultedTestDisplay.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/result/ResultedTestDisplay.tsx
@@ -27,7 +27,7 @@ export const ResultedTestDisplay = ({ test }: Props) => {
 
         return (
             <div className={styles.testResult}>
-                Reference range: <span>{display}</span>
+                <b>Reference range:</b> <span>{display}</span>
             </div>
         );
     };


### PR DESCRIPTION
## Description

"Reference from" phrase is now displaying in bold

![Screenshot 2024-09-13 at 10 55 01 AM](https://github.com/user-attachments/assets/12c92921-d127-468d-888f-4697e24bf6b1)


## Tickets

* [CNFT1-3073](https://cdc-nbs.atlassian.net/browse/CNFT1-3073)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3073]: https://cdc-nbs.atlassian.net/browse/CNFT1-3073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ