### PR TITLE
CNFT2-2776 Pass config drag drop reorder

### DIFF
--- a/apps/modernization-ui/src/apps/dedup-config/PatientMatchConfiguration/PassConfiguration/PassConfigurationListItem.module.scss
+++ b/apps/modernization-ui/src/apps/dedup-config/PatientMatchConfiguration/PassConfiguration/PassConfigurationListItem.module.scss
@@ -3,10 +3,18 @@
 li {
     list-style-type: none;
     display: flex;
-    cursor: pointer;
-
+    justify-content: space-between;
+    gap: 1.5rem;
+    background-color: colors.$base-white;
     .leftBar {
         min-width: 0.25rem;
+    }
+
+    .rightBar {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-width: 3rem;
     }
 
     &.selected {
@@ -16,12 +24,15 @@ li {
             border-radius: 1.875rem;
             background-color: colors.$primary;
         }
+        .cardContent {
+            border-left: 0.25rem solid colors.$primary;
+        }
     }
 
     .cardContent {
-        margin-left: 0.75rem;
-        padding-top: 0.62rem;
-        padding-bottom: 0.62rem;
+        border-left: 0.25rem solid colors.$base-white;
+        padding: 0.62rem 0 0.62rem 0.75rem;
+        cursor: pointer;
 
         label {
             font-size: 1rem;
@@ -29,6 +40,7 @@ li {
             font-weight: 700;
             line-height: normal;
             color: colors.$primary;
+            padding: 0.25rem 0.5rem;
         }
 
         .description {

--- a/apps/modernization-ui/src/apps/dedup-config/PatientMatchConfiguration/PassConfiguration/PassConfigurationListItem.tsx
+++ b/apps/modernization-ui/src/apps/dedup-config/PatientMatchConfiguration/PassConfiguration/PassConfigurationListItem.tsx
@@ -1,4 +1,6 @@
+import { Draggable } from 'react-beautiful-dnd';
 import styles from './PassConfigurationListItem.module.scss';
+import { Icon } from 'components/Icon/Icon';
 
 type Props = {
     name?: string;
@@ -14,25 +16,23 @@ const defaultValues = {
     description: 'a description goes here'
 };
 
-const PassConfigurationListItem = ({
-    name = defaultValues.name,
-    description = defaultValues.description,
-    selected,
-    active = false,
-    onClick,
-    index
-}: Props) => {
+const PassConfigurationListItem = ({ name = defaultValues.name, selected, active = false, onClick, index }: Props) => {
     const activeStatus = active ? 'Active' : 'Inactive';
 
     return (
-        <li className={selected ? styles.selected : ''} onClick={() => onClick(index)}>
-            <div className={styles.leftBar}></div>
-            <div className={styles.cardContent}>
-                <label>{name}</label>
-                <div className={styles.description}>{description}</div>
-                <div className={active ? styles.active : styles.inactive}>{activeStatus}</div>
-            </div>
-        </li>
+        <Draggable draggableId={index.toString()} index={index} key={index}>
+            {(provided) => (
+                <li ref={provided.innerRef} {...provided.draggableProps} className={selected ? styles.selected : ''}>
+                    <div className={styles.cardContent} onClick={() => onClick(index)}>
+                        <label>{name}</label>
+                        <div className={active ? styles.active : styles.inactive}>{activeStatus}</div>
+                    </div>
+                    <div className={styles.rightBar} {...provided.dragHandleProps}>
+                        <Icon name="drag" size="m" />
+                    </div>
+                </li>
+            )}
+        </Draggable>
     );
 };
 


### PR DESCRIPTION
## Description

Drag drop reorder of Pass config.
Removed descriptions as per Henry Tavarez.

## Tickets

* [CNFT2-2776](https://cdc-nbs.atlassian.net/browse/CNFT2-2776)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT2-2776]: https://cdc-nbs.atlassian.net/browse/CNFT2-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ