### PR TITLE
[CNFT1-2756] API changes for extended add patient (part 2)

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/AddressDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/address/AddressDemographic.java
@@ -1,9 +1,13 @@
 package gov.cdc.nbs.patient.profile.address;
 
-import java.time.Instant;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
+import java.time.LocalDate;
 
 public record AddressDemographic(
-    Instant asOf,
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
+    LocalDate asOf,
     String type,
     String use,
     String address1,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/administrative/Administrative.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/administrative/Administrative.java
@@ -1,17 +1,25 @@
 package gov.cdc.nbs.patient.profile.administrative;
 
-import java.time.Instant;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
+import java.time.LocalDate;
 
 public record Administrative(
-    Instant asOf,
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
+    LocalDate asOf,
     String comment
 ) {
 
-  public Administrative(final Instant asOf) {
+  public Administrative(final LocalDate asOf) {
     this(asOf, null);
   }
 
-  public Administrative withComment(final String comment) {
-    return new Administrative(asOf(), comment);
+  public Administrative withAsOf(final LocalDate value) {
+    return new Administrative(value, comment());
+  }
+
+  public Administrative withComment(final String value) {
+    return new Administrative(asOf(), value);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/administrative/AdministrativePatientCommandMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/administrative/AdministrativePatientCommandMapper.java
@@ -2,6 +2,9 @@ package gov.cdc.nbs.patient.profile.administrative;
 
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.RequestContext;
+import gov.cdc.nbs.time.LocalDateInstantMapper;
+
+import java.time.Instant;
 
 public class AdministrativePatientCommandMapper {
 
@@ -10,9 +13,12 @@ public class AdministrativePatientCommandMapper {
       final RequestContext context,
       final Administrative administrative
   ) {
+
+    Instant asOf = LocalDateInstantMapper.from(administrative.asOf());
+
     return new PatientCommand.UpdateAdministrativeInfo(
         patient,
-        administrative.asOf(),
+        asOf,
         administrative.comment(),
         context.requestedBy(),
         context.requestedAt()

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/administrative/NewPatientAdministrative.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/administrative/NewPatientAdministrative.java
@@ -1,6 +1,0 @@
-package gov.cdc.nbs.patient.profile.administrative;
-
-import java.time.Instant;
-
-public record NewPatientAdministrative(Instant asOf, String comment) {
-}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/BirthDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/birth/BirthDemographic.java
@@ -1,9 +1,14 @@
 package gov.cdc.nbs.patient.profile.birth;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
 import java.time.LocalDate;
 
 public record BirthDemographic(
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
     LocalDate asOf,
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
     LocalDate bornOn,
     String sex,
     String multiple,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/CreatedPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/CreatedPatient.java
@@ -1,0 +1,13 @@
+package gov.cdc.nbs.patient.profile.create;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreatedPatient(
+    @JsonProperty(required = true)
+    long id,
+    @JsonProperty(required = true)
+    long shortId,
+    @JsonProperty(required = true)
+    String local
+) {
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.patient.profile.create;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.cdc.nbs.accumulation.Including;
 import gov.cdc.nbs.patient.profile.address.AddressDemographic;
 import gov.cdc.nbs.patient.profile.administrative.Administrative;
@@ -7,8 +8,9 @@ import gov.cdc.nbs.patient.profile.birth.BirthDemographic;
 import gov.cdc.nbs.patient.profile.ethnicity.EthnicityDemographic;
 import gov.cdc.nbs.patient.profile.gender.GenderDemographic;
 import gov.cdc.nbs.patient.profile.names.NameDemographic;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
 
-import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +27,7 @@ public record NewPatient(
     EthnicityDemographic ethnicity) {
 
   public record Phone(
-      Instant asOf,
+      @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
       String type,
       String use,
       String countryCode,
@@ -36,22 +38,24 @@ public record NewPatient(
       String comment) {
   }
 
+
   public record Race(
-      Instant asOf,
+      @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
       String race,
       List<String> detailed) {
   }
 
+
   public record Identification(
-      Instant asOf,
+      @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
       String type,
       String issuer,
       String id) {
   }
 
-  public NewPatient(Instant asOf) {
+  public NewPatient() {
     this(
-        new Administrative(asOf),
+        null,
         null,
         null,
         Collections.emptyList(),
@@ -153,8 +157,17 @@ public record NewPatient(
         ethnicity());
   }
 
-  public Optional<BirthDemographic> maybeBirth() {
-    return Optional.ofNullable(birth());
+  public NewPatient withEthnicity(final EthnicityDemographic ethnicity) {
+    return new NewPatient(
+        administrative(),
+        birth(),
+        gender(),
+        names(),
+        addresses(),
+        phoneEmails(),
+        races(),
+        identifications(),
+        ethnicity);
   }
 
   public NewPatient withGender(final GenderDemographic value) {
@@ -170,20 +183,21 @@ public record NewPatient(
         ethnicity());
   }
 
+  public Optional<Administrative> maybeAdministrative() {
+    return Optional.ofNullable(administrative());
+  }
+
+  public Optional<BirthDemographic> maybeBirth() {
+    return Optional.ofNullable(birth());
+  }
+
+  public Optional<EthnicityDemographic> maybeEthnicity() {
+    return Optional.ofNullable(ethnicity());
+  }
+
   public Optional<GenderDemographic> maybeGender() {
     return Optional.ofNullable(gender());
   }
 
-  public NewPatient withEthnicity(final EthnicityDemographic ethnicity) {
-    return new NewPatient(
-        administrative(),
-        birth(),
-        gender(),
-        names(),
-        addresses(),
-        phoneEmails(),
-        races(),
-        identifications(),
-        ethnicity);
-  }
+
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityDemographic.java
@@ -1,18 +1,20 @@
 package gov.cdc.nbs.patient.profile.ethnicity;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
+import gov.cdc.nbs.accumulation.Including;
+
+import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 
 public record EthnicityDemographic(
-    Instant asOf,
+    LocalDate asOf,
     String ethnicGroup,
     String unknownReason,
-    List<String> detailed) {
+    List<String> detailed
+) {
 
-  public EthnicityDemographic(final Instant asOf) {
-    this(asOf, null, null, new ArrayList<>());
+  public EthnicityDemographic(final LocalDate asOf) {
+    this(asOf, null, null, Collections.emptyList());
   }
 
   public EthnicityDemographic withEthnicGroup(final String ethnicGroup) {
@@ -23,12 +25,7 @@ public record EthnicityDemographic(
     return new EthnicityDemographic(asOf(), ethnicGroup(), unknownReason, detailed());
   }
 
-  public EthnicityDemographic withDetailed(final String detailed) {
-    return new EthnicityDemographic(asOf(), ethnicGroup(), unknownReason(), Arrays.asList(detailed));
-  }
-
   public EthnicityDemographic withDetail(final String detail) {
-    this.detailed.add(detail);
-    return this;
+    return new EthnicityDemographic(asOf(), ethnicGroup(), unknownReason(), Including.include(detailed(), detail));
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityPatientCommandMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityPatientCommandMapper.java
@@ -2,20 +2,35 @@ package gov.cdc.nbs.patient.profile.ethnicity;
 
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.RequestContext;
+import gov.cdc.nbs.time.LocalDateInstantMapper;
 
 public class EthnicityPatientCommandMapper {
 
   public static PatientCommand.UpdateEthnicityInfo asUpdateEthnicityInfo(
       final long patient,
       final RequestContext context,
-      final EthnicityDemographic ethnicity) {
+      final EthnicityDemographic ethnicity
+  ) {
     return new PatientCommand.UpdateEthnicityInfo(
         patient,
-        ethnicity.asOf(),
+        LocalDateInstantMapper.from(ethnicity.asOf()),
         ethnicity.ethnicGroup(),
         ethnicity.unknownReason(),
         context.requestedBy(),
         context.requestedAt());
+  }
+
+  public static PatientCommand.AddDetailedEthnicity asAddDetailedEthnicity(
+      final long patient,
+      final RequestContext context,
+      final String detail
+  ) {
+    return new PatientCommand.AddDetailedEthnicity(
+        patient,
+        detail,
+        context.requestedBy(),
+        context.requestedAt()
+    );
   }
 
   private EthnicityPatientCommandMapper() {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/gender/GenderDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/gender/GenderDemographic.java
@@ -1,8 +1,12 @@
 package gov.cdc.nbs.patient.profile.gender;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
 import java.time.LocalDate;
 
 public record GenderDemographic(
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
     LocalDate asOf,
     String current,
     String unknownReason,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/NameDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/NameDemographic.java
@@ -1,9 +1,13 @@
 package gov.cdc.nbs.patient.profile.names;
 
-import java.time.Instant;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
+import java.time.LocalDate;
 
 public record NameDemographic(
-    Instant asOf,
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
+    LocalDate asOf,
     String type,
     String prefix,
     String first,
@@ -16,8 +20,9 @@ public record NameDemographic(
 ) {
 
   public NameDemographic(
-      Instant asOf,
-      String type) {
+      LocalDate asOf,
+      String type
+  ) {
     this(asOf, type, null, null, null, null, null, null, null, null);
   }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/NameDemographicPatientCommandMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/NameDemographicPatientCommandMapper.java
@@ -3,6 +3,9 @@ package gov.cdc.nbs.patient.profile.names;
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.RequestContext;
 
+import java.time.Instant;
+import java.time.ZoneId;
+
 public class NameDemographicPatientCommandMapper {
 
   public static PatientCommand.AddName asAddName(
@@ -10,9 +13,12 @@ public class NameDemographicPatientCommandMapper {
       final RequestContext context,
       final NameDemographic demographic
   ) {
+
+    Instant asOf = demographic.asOf().atStartOfDay(ZoneId.systemDefault()).toInstant();
+
     return new PatientCommand.AddName(
         patient,
-        demographic.asOf(),
+        asOf,
         demographic.prefix(),
         demographic.first(),
         demographic.middle(),

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/time/LocalDateInstantMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/time/LocalDateInstantMapper.java
@@ -1,0 +1,16 @@
+package gov.cdc.nbs.time;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+public class LocalDateInstantMapper {
+
+  public static Instant from(final LocalDate localDate) {
+    return localDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
+  }
+
+  private LocalDateInstantMapper() {
+    // static
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/time/json/FormattedLocalDateJsonDeserializer.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/time/json/FormattedLocalDateJsonDeserializer.java
@@ -1,0 +1,32 @@
+package gov.cdc.nbs.time.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+public class FormattedLocalDateJsonDeserializer extends JsonDeserializer<LocalDate> {
+
+  private static final DateTimeFormatter READER = new DateTimeFormatterBuilder()
+      .appendOptional(DateTimeFormatter.ofPattern("MM/dd/uuuu"))
+      .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE)
+      .toFormatter();
+
+  @Override
+  public LocalDate deserialize(
+      final JsonParser jsonParser,
+      final DeserializationContext deserializationContext
+  )
+      throws IOException {
+
+    String value = jsonParser.getValueAsString();
+
+    return (value == null)
+        ? null
+        : LocalDate.parse(value, READER);
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/administrative/AdministrativeEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/administrative/AdministrativeEntrySteps.java
@@ -3,7 +3,7 @@ package gov.cdc.nbs.patient.profile.administrative;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
 
-import java.time.Instant;
+import java.time.LocalDate;
 
 public class AdministrativeEntrySteps {
 
@@ -13,9 +13,9 @@ public class AdministrativeEntrySteps {
     this.input = input;
   }
 
-  @Given("I am entering the administrative as of date {date}")
-  public void i_am_entering_patient_administrative_as_of(final Instant asOf) {
-    this.input.active(new Administrative(asOf));
+  @Given("I enter the patient administrative as of date {localDate}")
+  public void i_enter_the_patient_administrative_as_of(final LocalDate asOf) {
+    this.input.active(current -> current.withAsOf(asOf));
   }
 
   @Given("I enter the administrative comment {string}")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/administrative/AdministrativeSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/administrative/AdministrativeSupportConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
-import java.time.Instant;
+import java.time.LocalDate;
 
 @Configuration
 class AdministrativeSupportConfiguration {
@@ -14,6 +14,6 @@ class AdministrativeSupportConfiguration {
   @Bean
   @ScenarioScope
   Active<Administrative> activeAdministrative(final Clock clock) {
-    return new Active<>(() -> new Administrative(Instant.now(clock)));
+    return new Active<>(() -> new Administrative(LocalDate.now(clock)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateSteps.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.testing.support.Active;
 import gov.cdc.nbs.testing.support.Available;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -37,11 +36,6 @@ public class PatientCreateSteps {
     this.mapper = mapper;
   }
 
-  @Given("I add the comment {string} to the extended patient data")
-  public void i_add_the_comment(final String value) {
-    this.input.active(current -> current.withAdministrative(current.administrative().withComment(value)));
-  }
-
   @When("I create a patient with extended data")
   public void i_create_a_patient_with_extended_data() {
     this.input.maybeActive()
@@ -60,12 +54,12 @@ public class PatientCreateSteps {
     try {
 
 
-      PatientIdentifier created = mapper.readValue(
+      CreatedPatient created = mapper.readValue(
           result.andReturn().getResponse().getContentAsByteArray(),
-          PatientIdentifier.class
+          CreatedPatient.class
       );
 
-      return Optional.of(created);
+      return Optional.of(new PatientIdentifier(created.id(), created.shortId(), created.local()));
     } catch (IOException exception) {
       //  The response did not contain a created patient
       return Optional.empty();

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateSupportConfiguration.java
@@ -5,15 +5,12 @@ import io.cucumber.spring.ScenarioScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.Clock;
-import java.time.Instant;
-
 @Configuration
 class PatientCreateSupportConfiguration {
 
   @Bean
   @ScenarioScope
-  Active<NewPatient> activeNewPatient(final Clock clock) {
-    return new Active<>(() -> new NewPatient(Instant.now(clock)));
+  Active<NewPatient> activeNewPatient() {
+    return new Active<>(NewPatient::new);
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityDemographicSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityDemographicSupportConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
-import java.time.Instant;
+import java.time.LocalDate;
 
 @Configuration
 class EthnicityDemographicSupportConfiguration {
@@ -14,6 +14,6 @@ class EthnicityDemographicSupportConfiguration {
   @Bean
   @ScenarioScope
   Active<EthnicityDemographic> activeEthnicityDemographic(final Clock clock) {
-    return new Active<>(() -> new EthnicityDemographic(Instant.now(clock)));
+    return new Active<>(() -> new EthnicityDemographic(LocalDate.now(clock)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/ethnicity/EthnicityEntrySteps.java
@@ -2,7 +2,8 @@ package gov.cdc.nbs.patient.profile.ethnicity;
 
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
-import java.time.Instant;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 
 public class EthnicityEntrySteps {
@@ -13,8 +14,8 @@ public class EthnicityEntrySteps {
     this.input = input;
   }
 
-  @Given("I am entering the ethnicity as of date {date}")
-  public void i_am_entering_patient_ethnicity_as_of(final Instant asOf) {
+  @Given("I am entering the ethnicity as of date {localDate}")
+  public void i_am_entering_patient_ethnicity_as_of(final LocalDate asOf) {
     this.input.active(new EthnicityDemographic(asOf, null, null, new ArrayList<>()));
   }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/ethnicity/PatientProfileCreateEthnicitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/ethnicity/PatientProfileCreateEthnicitySteps.java
@@ -3,11 +3,13 @@ package gov.cdc.nbs.patient.profile.ethnicity;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Then;
-import java.time.Instant;
 import org.springframework.test.web.servlet.ResultActions;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.time.Instant;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 public class PatientProfileCreateEthnicitySteps {
 
@@ -19,7 +21,8 @@ public class PatientProfileCreateEthnicitySteps {
   PatientProfileCreateEthnicitySteps(
       final Active<PatientIdentifier> activePatient,
       final PatientProfileEthnicityRequester requester,
-      final Active<ResultActions> response) {
+      final Active<ResultActions> response
+  ) {
     this.activePatient = activePatient;
     this.requester = requester;
     this.response = response;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/gender/GenderDemographicSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/gender/GenderDemographicSupportConfiguration.java
@@ -13,7 +13,7 @@ class GenderDemographicSupportConfiguration {
 
   @Bean
   @ScenarioScope
-  Active<GenderDemographic> activeAdministrative(final Clock clock) {
+  Active<GenderDemographic> activeGenderDemographic(final Clock clock) {
     return new Active<>(() -> new GenderDemographic(LocalDate.now(clock)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/NameDemographicEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/NameDemographicEntrySteps.java
@@ -3,7 +3,7 @@ package gov.cdc.nbs.patient.profile.names;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
 
-import java.time.Instant;
+import java.time.LocalDate;
 
 public class NameDemographicEntrySteps {
 
@@ -15,8 +15,8 @@ public class NameDemographicEntrySteps {
     this.activeName = activeName;
   }
 
-  @Given("I am entering a {nameUse} name as of {date}")
-  public void i_am_entering_a_name_as_of(final String use, final Instant asOf) {
+  @Given("I am entering a {nameUse} name as of {localDate}")
+  public void i_am_entering_a_name_as_of(final String use, final LocalDate asOf) {
     this.activeName.active(new NameDemographic(asOf, use));
   }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/time/json/FormattedLocalDateJsonDeserializerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/time/json/FormattedLocalDateJsonDeserializerTest.java
@@ -1,0 +1,71 @@
+package gov.cdc.nbs.time.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FormattedLocalDateJsonDeserializerTest {
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setup() {
+    mapper = new ObjectMapper();
+  }
+
+  @ParameterizedTest
+  @MethodSource("dates")
+  void should_deserialize_from_various_date_formats(final String in, final String expected) throws IOException {
+
+    String json = "\"%s\"".formatted(in);
+    JsonParser parser = new JsonFactory().createParser(json);
+    DeserializationContext context = mapper.getDeserializationContext();
+
+    FormattedLocalDateJsonDeserializer deserializer = new FormattedLocalDateJsonDeserializer();
+
+    //  increment the parser to the first token
+    parser.nextToken();
+
+    LocalDate actual = deserializer.deserialize(parser, context);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> dates() {
+    return Stream.of(
+        Arguments.arguments(
+            "2023-11-14", "2023-11-14",
+            "11/14/2023", "2023-11-14"
+        )
+    );
+  }
+
+  @Test
+  void should_deserialize_null_to_null() throws IOException {
+
+    String json = "";
+    JsonParser parser = new JsonFactory().createParser(json);
+    DeserializationContext context = mapper.getDeserializationContext();
+
+    FormattedLocalDateJsonDeserializer deserializer = new FormattedLocalDateJsonDeserializer();
+
+    //  increment the parser to the first token
+    parser.nextToken();
+
+    LocalDate actual = deserializer.deserialize(parser, context);
+
+    assertThat(actual).isNull();
+
+  }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.administrative.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.administrative.feature
@@ -7,7 +7,7 @@
       And I can "find" any "patient"
 
     Scenario: I can create a patient with administrative demographics information
-      Given I am entering the administrative as of date 05/29/2023
+      Given I enter the patient administrative as of date 05/29/2023
       And I enter the administrative comment "testing extended patient data"
       And the administrative is included in the extended patient data
       When I create a patient with extended data

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.ethnicity.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.ethnicity.feature
@@ -10,14 +10,22 @@
       Given I am entering the ethnicity as of date 05/29/2023
       And I enter the ethnicity ethnic group Unknown
       And I enter the ethnicity unknown reason Refused to answer
-      And I enter the ethnicity detailed Spaniard
-      And I enter the ethnicity detailed Cuban
       And the ethnicity is included in the extended patient data
       When I create a patient with extended data
       Then I view the Patient Profile Ethnicity
       And the patient profile ethnicity has the as of date 05/29/2023
       And the patient profile ethnicity has the ethnic group Unknown
       And the patient profile ethnicity has the unknown reason Refused to answer
+
+    Scenario: I can create a patient with detailed ethnicity information
+      Given I am entering the ethnicity as of date 05/11/2023
+      And I enter the ethnicity ethnic group Hispanic or Latino
+      And I enter the ethnicity detailed Spaniard
+      And I enter the ethnicity detailed Cuban
+      And the ethnicity is included in the extended patient data
+      When I create a patient with extended data
+      Then I view the Patient Profile Ethnicity
+      And the patient profile ethnicity has the as of date 05/11/2023
+      And the patient profile ethnicity has the ethnic group Hispanic or Latino
       And the patient profile ethnicity has the ethnicity detail Spaniard
       And the patient profile ethnicity has the ethnicity detail Cuban
-

--- a/apps/modernization-ui/src/generated/models/CreatedPatient.ts
+++ b/apps/modernization-ui/src/generated/models/CreatedPatient.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CreatedPatient = {
+    id: number;
+    shortId: number;
+    local: string;
+};
+

--- a/apps/modernization-ui/src/generated/services/PatientProfileService.ts
+++ b/apps/modernization-ui/src/generated/services/PatientProfileService.ts
@@ -2,8 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { CreatedPatient } from '../models/CreatedPatient';
 import type { NewPatient } from '../models/NewPatient';
-import type { PatientIdentifier } from '../models/PatientIdentifier';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -11,14 +11,14 @@ export class PatientProfileService {
     /**
      * PatientProfile
      * Allows creation of a patient
-     * @returns PatientIdentifier Created
+     * @returns CreatedPatient Created
      * @throws ApiError
      */
     public static create({
         requestBody,
     }: {
         requestBody: NewPatient,
-    }): CancelablePromise<PatientIdentifier> {
+    }): CancelablePromise<CreatedPatient> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/nbs/api/profile',


### PR DESCRIPTION
## Description

Another piece of the integration of the patient add api that 

- Changes the request objects to receive `LocalDate` objects over `Instant` objects 
  - The API will accept dates in the `YYYY-MM-DD` and `MM/DD/YYYY` formats
  - There will be less overall changes when `Instant` is removed from the `Person` object.
- Creates a dedicated return object `CreatedPatient`

## Tickets

* [CNFT1-2756](https://cdc-nbs.atlassian.net/browse/CNFT1-2756)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2756]: https://cdc-nbs.atlassian.net/browse/CNFT1-2756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ