### PR TITLE
Fix panel appearing behind results

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/navigation/search-navigation.module.scss
@@ -2,6 +2,7 @@
     display: flex;
     gap: 1rem;
     flex-shrink: 0;
+    z-index: 100;
 
     h1 {
         margin: 0;

--- a/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
@@ -26,7 +26,7 @@
             font-weight: 400;
             font-size: 1rem;
             text-align: left;
-            width: 15.25rem;
+            width: 12.25rem;
             border-radius: 0;
             &:first-of-type {
                 border-top: none;
@@ -57,8 +57,8 @@
     }
     .menu {
         position: absolute;
-        top: 3rem;
-        right: 0;
+        top: 2.8rem;
+        right: 0.05rem;
         display: flex;
         display: flex;
         flex-direction: column;
@@ -67,5 +67,6 @@
         background-color: colors.$base-white;
         border-radius: 0.25rem;
         overflow: hidden;
+        padding: 0.5rem 1rem;
     }
 }

--- a/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
@@ -26,7 +26,7 @@
             font-weight: 400;
             font-size: 1rem;
             text-align: left;
-            width: 100%;
+            width: 15.25rem;
             border-radius: 0;
             &:first-of-type {
                 border-top: none;


### PR DESCRIPTION
## Description

The panel that appears when clicking `Add new` after performing a patient search was appearing behind the search results display. This was probably due to some global styles being removed.

The designs also were not easily inspected and no example exists within the design system. A best effort was made to match the image


## Demo

### Before
![image](https://github.com/user-attachments/assets/bb540b30-27dc-4ba4-967c-68aad59d1508)


### After
![image](https://github.com/user-attachments/assets/ab178ce9-9592-48a1-9c6d-252ea565b27d)


