### PR TITLE
CNFT1-2780 API: Create Extended patient data entry form for Mortality

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.patient.profile.administrative.Administrative;
 import gov.cdc.nbs.patient.profile.birth.BirthDemographic;
 import gov.cdc.nbs.patient.profile.ethnicity.EthnicityDemographic;
 import gov.cdc.nbs.patient.profile.gender.GenderDemographic;
+import gov.cdc.nbs.patient.profile.mortality.MortalityDemographic;
 import gov.cdc.nbs.patient.profile.names.NameDemographic;
 import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
 
@@ -24,7 +25,8 @@ public record NewPatient(
     List<Phone> phoneEmails,
     List<Race> races,
     List<Identification> identifications,
-    EthnicityDemographic ethnicity) {
+    EthnicityDemographic ethnicity,
+    MortalityDemographic mortality) {
 
   public record Phone(
       @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
@@ -63,6 +65,7 @@ public record NewPatient(
         Collections.emptyList(),
         Collections.emptyList(),
         Collections.emptyList(),
+        null,
         null);
   }
 
@@ -76,7 +79,8 @@ public record NewPatient(
         phoneEmails(),
         races(),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withName(final NameDemographic name) {
@@ -89,7 +93,8 @@ public record NewPatient(
         phoneEmails(),
         races(),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withAddress(final AddressDemographic value) {
@@ -102,7 +107,8 @@ public record NewPatient(
         phoneEmails(),
         races(),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withPhoneEmail(final Phone value) {
@@ -115,7 +121,8 @@ public record NewPatient(
         Including.include(phoneEmails(), value),
         races(),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withRace(final Race value) {
@@ -128,7 +135,8 @@ public record NewPatient(
         phoneEmails(),
         Including.include(races(), value),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withIdentification(final Identification value) {
@@ -141,7 +149,8 @@ public record NewPatient(
         phoneEmails(),
         races(),
         Including.include(identifications(), value),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withBirth(final BirthDemographic value) {
@@ -154,7 +163,8 @@ public record NewPatient(
         phoneEmails(),
         races(),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public NewPatient withEthnicity(final EthnicityDemographic ethnicity) {
@@ -167,7 +177,22 @@ public record NewPatient(
         phoneEmails(),
         races(),
         identifications(),
-        ethnicity);
+        ethnicity,
+        mortality());
+  }
+
+  public NewPatient withMortality(final MortalityDemographic mortality) {
+    return new NewPatient(
+        administrative(),
+        birth(),
+        gender(),
+        names(),
+        addresses(),
+        phoneEmails(),
+        races(),
+        identifications(),
+        ethnicity(),
+        mortality);
   }
 
   public NewPatient withGender(final GenderDemographic value) {
@@ -180,7 +205,8 @@ public record NewPatient(
         phoneEmails(),
         races(),
         identifications(),
-        ethnicity());
+        ethnicity(),
+        mortality());
   }
 
   public Optional<Administrative> maybeAdministrative() {
@@ -197,6 +223,10 @@ public record NewPatient(
 
   public Optional<GenderDemographic> maybeGender() {
     return Optional.ofNullable(gender());
+  }
+
+  public Optional<MortalityDemographic> maybeMortality() {
+    return Optional.ofNullable(mortality());
   }
 
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographic.java
@@ -1,0 +1,46 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
+import java.time.LocalDate;
+
+
+
+public record MortalityDemographic(
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
+    String deceased,
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate deceasedOn,
+    String city,
+    String state,
+    String county,
+    String country) {
+
+  public MortalityDemographic(final LocalDate asOf) {
+    this(asOf, null, null, null, null, null, null);
+  }
+
+  public MortalityDemographic withDeceased(final String deceased) {
+    return new MortalityDemographic(asOf(), deceased, deceasedOn(), city(), state(), county(), country());
+  }
+
+  public MortalityDemographic withDeceasedOn(final LocalDate deceasedOn) {
+    return new MortalityDemographic(asOf(), deceased(), deceasedOn, city(), state(), county(), country());
+  }
+
+  public MortalityDemographic withCity(final String city) {
+    return new MortalityDemographic(asOf(), deceased(), deceasedOn(), city, state(), county(), country());
+  }
+
+  public MortalityDemographic withState(final String state) {
+    return new MortalityDemographic(asOf(), deceased(), deceasedOn(), city(), state, county(), country());
+  }
+
+  public MortalityDemographic withCounty(final String county) {
+    return new MortalityDemographic(asOf(), deceased(), deceasedOn(), city(), state(), county, country());
+  }
+
+  public MortalityDemographic withCountry(final String country) {
+    return new MortalityDemographic(asOf(), deceased(), deceasedOn(), city(), state(), county(), country);
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicPatientCommandMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicPatientCommandMapper.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import gov.cdc.nbs.patient.PatientCommand;
+import gov.cdc.nbs.patient.RequestContext;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class MortalityDemographicPatientCommandMapper {
+
+  public static PatientCommand.UpdateMortality asUpdateMortality(
+      final long patient,
+      final RequestContext context,
+      final MortalityDemographic demographic) {
+
+    Instant asOf = demographic.asOf().atStartOfDay(ZoneId.systemDefault()).toInstant();
+
+    return new PatientCommand.UpdateMortality(
+        patient,
+        asOf,
+        demographic.deceased(),
+        demographic.deceasedOn(),
+        demographic.city(),
+        demographic.state(),
+        demographic.county(),
+        demographic.country(),
+        context.requestedBy(),
+        context.requestedAt());
+  }
+
+  private MortalityDemographicPatientCommandMapper() {
+    // static
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateEntrySteps.java
@@ -4,6 +4,7 @@ import gov.cdc.nbs.patient.profile.administrative.Administrative;
 import gov.cdc.nbs.patient.profile.birth.BirthDemographic;
 import gov.cdc.nbs.patient.profile.ethnicity.EthnicityDemographic;
 import gov.cdc.nbs.patient.profile.gender.GenderDemographic;
+import gov.cdc.nbs.patient.profile.mortality.MortalityDemographic;
 import gov.cdc.nbs.patient.profile.names.NameDemographic;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
@@ -15,6 +16,7 @@ public class PatientCreateEntrySteps {
   private final Active<GenderDemographic> activeGenderDemographic;
   private final Active<NameDemographic> activeName;
   private final Active<EthnicityDemographic> activeEthnicity;
+  private final Active<MortalityDemographic> activeMortality;
   private final Active<NewPatient> input;
 
   public PatientCreateEntrySteps(
@@ -23,10 +25,12 @@ public class PatientCreateEntrySteps {
       final Active<GenderDemographic> activeGenderDemographic,
       final Active<NameDemographic> activeName,
       final Active<EthnicityDemographic> activeEthnicity,
+      final Active<MortalityDemographic> activeMortality,
       final Active<NewPatient> input) {
     this.activeAdministrative = activeAdministrative;
     this.activeBirthDemographic = activeBirthDemographic;
     this.activeGenderDemographic = activeGenderDemographic;
+    this.activeMortality = activeMortality;
     this.activeName = activeName;
     this.activeEthnicity = activeEthnicity;
     this.input = input;
@@ -60,5 +64,11 @@ public class PatientCreateEntrySteps {
   public void the_gender_demographics_are_included_in_the_extended_patient_data() {
     this.activeGenderDemographic.maybeActive()
         .ifPresent(demographic -> this.input.active(current -> current.withGender(demographic)));
+  }
+
+  @Given("the mortality demographics are included in the extended patient data")
+  public void the_mortality_demographics_are_included_in_the_extended_patient_data() {
+    this.activeMortality.maybeActive()
+        .ifPresent(demographic -> this.input.active(current -> current.withMortality(demographic)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateEntrySteps.java
@@ -16,7 +16,7 @@ public class PatientCreateEntrySteps {
   private final Active<GenderDemographic> activeGenderDemographic;
   private final Active<NameDemographic> activeName;
   private final Active<EthnicityDemographic> activeEthnicity;
-  private final Active<MortalityDemographic> activeMortality;
+  private final Active<MortalityDemographic> activeMortalityDemographic;
   private final Active<NewPatient> input;
 
   public PatientCreateEntrySteps(
@@ -25,12 +25,12 @@ public class PatientCreateEntrySteps {
       final Active<GenderDemographic> activeGenderDemographic,
       final Active<NameDemographic> activeName,
       final Active<EthnicityDemographic> activeEthnicity,
-      final Active<MortalityDemographic> activeMortality,
+      final Active<MortalityDemographic> activeMortalityDemographic,
       final Active<NewPatient> input) {
     this.activeAdministrative = activeAdministrative;
     this.activeBirthDemographic = activeBirthDemographic;
     this.activeGenderDemographic = activeGenderDemographic;
-    this.activeMortality = activeMortality;
+    this.activeMortalityDemographic = activeMortalityDemographic;
     this.activeName = activeName;
     this.activeEthnicity = activeEthnicity;
     this.input = input;
@@ -68,7 +68,7 @@ public class PatientCreateEntrySteps {
 
   @Given("the mortality demographics are included in the extended patient data")
   public void the_mortality_demographics_are_included_in_the_extended_patient_data() {
-    this.activeMortality.maybeActive()
+    this.activeMortalityDemographic.maybeActive()
         .ifPresent(demographic -> this.input.active(current -> current.withMortality(demographic)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicEntrySteps.java
@@ -42,4 +42,9 @@ public class MortalityDemographicEntrySteps {
   public void i_am_entering_patient_mortality_deceased_on_date_of(final LocalDate deceasedOn) {
     this.input.active(current -> current.withDeceasedOn(deceasedOn));
   }
+
+  @Given("I enter the mortality deceased option as {indicator}")
+  public void i_enter_the_patient_mortality_deceased_option_as(final String indicator) {
+    this.input.active(current -> current.withDeceased(indicator));
+  }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicEntrySteps.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Given;
+
+import java.time.LocalDate;
+
+public class MortalityDemographicEntrySteps {
+
+  private final Active<MortalityDemographic> input;
+
+  MortalityDemographicEntrySteps(final Active<MortalityDemographic> input) {
+    this.input = input;
+  }
+
+  @Given("I am entering the mortality as of date {localDate}")
+  public void i_am_entering_patient_mortality_as_of(final LocalDate asOf) {
+    this.input.active(new MortalityDemographic(asOf, null, null, null, null, null, null));
+  }
+
+  @Given("I enter the mortality city {string}")
+  public void i_enter_the_patient_mortality_city(final String city) {
+    this.input.active(current -> current.withCity(city));
+  }
+
+  @Given("I enter the mortality country {country}")
+  public void i_enter_the_patient_mortality_country(final String country) {
+    this.input.active(current -> current.withCountry(country));
+  }
+
+  @Given("I enter the mortality county {county}")
+  public void i_enter_the_patient_mortality_county(final String county) {
+    this.input.active(current -> current.withCounty(county));
+  }
+
+  @Given("I enter the mortality state {state}")
+  public void i_enter_the_patient_mortality_state(final String state) {
+    this.input.active(current -> current.withState(state));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicEntrySteps.java
@@ -37,4 +37,9 @@ public class MortalityDemographicEntrySteps {
   public void i_enter_the_patient_mortality_state(final String state) {
     this.input.active(current -> current.withState(state));
   }
+
+  @Given("I enter the mortality deceased on date of {localDate}")
+  public void i_am_entering_patient_mortality_deceased_on_date_of(final LocalDate deceasedOn) {
+    this.input.active(current -> current.withDeceasedOn(deceasedOn));
+  }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/MortalityDemographicSupportConfiguration.java
@@ -1,0 +1,19 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.spring.ScenarioScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+@Configuration
+class MortalityDemographicSupportConfiguration {
+
+  @Bean
+  @ScenarioScope
+  Active<MortalityDemographic> activeMortalityDemographic(final Clock clock) {
+    return new Active<>(() -> new MortalityDemographic(LocalDate.now(clock)));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
@@ -6,7 +6,7 @@ import io.cucumber.java.en.Then;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.Instant;
-
+import java.time.LocalDate;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 public class PatientProfileCreateMortalitySteps {
@@ -40,8 +40,8 @@ public class PatientProfileCreateMortalitySteps {
                 .value(value.toString()));
   }
 
-  @Then("the patient profile mortality has the deceased on date {date}")
-  public void the_patient_profile_mortality_has_the_deceased_on_date_of(final Instant value) throws Exception {
+  @Then("the patient profile mortality has the deceased on date {localDate}")
+  public void the_patient_profile_mortality_has_the_deceased_on_date_of(final LocalDate value) throws Exception {
     this.response.active()
         .andExpect(
             jsonPath("$.data.findPatientProfile.mortality.deceasedOn")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
@@ -81,4 +81,13 @@ public class PatientProfileCreateMortalitySteps {
             jsonPath("$.data.findPatientProfile.mortality.country.id")
                 .value(value));
   }
+
+  @Then("the patient profile mortality has the decease option as {indicator}")
+  public void the_patient_profile_mortality_has_the_decease_option_as(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.deceased.id")
+                .value(value));
+  }
+
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
@@ -1,0 +1,42 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Then;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+public class PatientProfileCreateMortalitySteps {
+
+  private final Active<PatientIdentifier> activePatient;
+  private final PatientProfileMortalityRequester requester;
+  private final Active<ResultActions> response;
+
+
+  PatientProfileCreateMortalitySteps(
+      final Active<PatientIdentifier> activePatient,
+      final PatientProfileMortalityRequester requester,
+      final Active<ResultActions> response) {
+    this.activePatient = activePatient;
+    this.requester = requester;
+    this.response = response;
+  }
+
+  @Then("I view the Patient Profile Mortality demographics")
+  public void i_view_the_patient_profile_mortality_demographics() {
+    this.activePatient.maybeActive()
+        .map(requester::mortality)
+        .ifPresent(this.response::active);
+  }
+
+  @Then("the patient profile mortality has the as of date {date}")
+  public void the_patient_profile_mortality_has_an_as_of_date_of(final Instant value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.asOf")
+                .value(value.toString()));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
@@ -39,4 +39,46 @@ public class PatientProfileCreateMortalitySteps {
             jsonPath("$.data.findPatientProfile.mortality.asOf")
                 .value(value.toString()));
   }
+
+  @Then("the patient profile mortality has the deceased on date {date}")
+  public void the_patient_profile_mortality_has_the_deceased_on_date_of(final Instant value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.deceasedOn")
+                .value(value.toString()));
+  }
+
+
+  @Then("the patient profile mortality has the city {string}")
+  public void the_patient_profile_mortality_has_the_city(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.city")
+                .value(value));
+  }
+
+  @Then("the patient profile mortality has the county {county}")
+  public void the_patient_profile_mortality_has_the_county(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.county.id")
+                .value(value));
+  }
+
+  @Then("the patient profile mortality has the state {state}")
+  public void the_patient_profile_mortality_has_the_state(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.state.id")
+                .value(value));
+  }
+
+
+  @Then("the patient profile mortality has the country {country}")
+  public void the_patient_profile_mortality_has_the_country(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.mortality.country.id")
+                .value(value));
+  }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileCreateMortalitySteps.java
@@ -82,8 +82,8 @@ public class PatientProfileCreateMortalitySteps {
                 .value(value));
   }
 
-  @Then("the patient profile mortality has the decease option as {indicator}")
-  public void the_patient_profile_mortality_has_the_decease_option_as(final String value) throws Exception {
+  @Then("the patient profile mortality has the deceased option as {indicator}")
+  public void the_patient_profile_mortality_has_the_deceased_option_as(final String value) throws Exception {
     this.response.active()
         .andExpect(
             jsonPath("$.data.findPatientProfile.mortality.deceased.id")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileMortalityRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/mortality/PatientProfileMortalityRequester.java
@@ -1,0 +1,62 @@
+package gov.cdc.nbs.patient.profile.mortality;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import gov.cdc.nbs.graphql.GraphQLRequest;
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+class PatientProfileMortalityRequester {
+
+  private static final String QUERY = """
+      query profileMortalityInformation($patient: ID!) {
+              findPatientProfile(patient: $patient) {
+                id
+                local
+                version
+                mortality {
+                    asOf
+                    deceasedOn
+                    city
+                    county {
+                      id
+                      description
+                    }
+                    deceased {
+                      id
+                      description
+                    }
+                    state {
+                      id
+                      description
+                    }
+                    country {
+                      id
+                      description
+                    }
+                }
+              }
+            }
+      """;
+
+  private final GraphQLRequest graphql;
+
+  PatientProfileMortalityRequester(final GraphQLRequest graphql) {
+    this.graphql = graphql;
+  }
+
+  ResultActions mortality(final PatientIdentifier patient) {
+    try {
+      return graphql.query(
+          QUERY,
+          JsonNodeFactory.instance.objectNode()
+              .put("patient", patient.id()))
+          .andDo(print());
+    } catch (Exception exception) {
+      throw new IllegalStateException("Unable to request patient mortality demographics");
+    }
+  }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
@@ -9,7 +9,7 @@
     Scenario: I can create a patient with mortality information
       Given I am entering the mortality as of date 06/29/2023
       And I enter the mortality deceased on date of 05/29/2023
-      And I enter the mortality deceased option as "Yes"
+      And I enter the mortality deceased option as Yes
       And I enter the mortality city "Salem Center"
       And I enter the mortality country United States
       And I enter the mortality county Westchester County
@@ -19,7 +19,7 @@
       Then I view the Patient Profile Mortality demographics
       And the patient profile mortality has the as of date 06/29/2023
       And the patient profile mortality has the deceased on date 05/29/2023
-      And the patient profile mortality has the deceased option as "Yes"
+      And the patient profile mortality has the deceased option as Yes
       And the patient profile mortality has the city "Salem Center"
       And the patient profile mortality has the country United States
       And the patient profile mortality has the county Westchester County

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
@@ -7,7 +7,8 @@
       And I can "find" any "patient"
 
     Scenario: I can create a patient with mortality information
-      Given I am entering the mortality as of date 05/29/2023
+      Given I am entering the mortality as of date 06/29/2023
+      And I enter the mortality deceased on date of 05/29/2023
       And I enter the mortality city "Salem Center"
       And I enter the mortality country United States
       And I enter the mortality county Westchester County
@@ -15,4 +16,9 @@
       And the mortality demographics are included in the extended patient data
       When I create a patient with extended data
       Then I view the Patient Profile Mortality demographics
-      And the patient profile mortality has the as of date 05/29/2023
+      And the patient profile mortality has the as of date 06/29/2023
+      And the patient profile mortality has the deceased on date 05/29/2023
+      And the patient profile mortality has the city "Salem Center"
+      And the patient profile mortality has the country United States
+      And the patient profile mortality has the county Westchester County
+      And the patient profile mortality has the state New York

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
@@ -9,6 +9,7 @@
     Scenario: I can create a patient with mortality information
       Given I am entering the mortality as of date 06/29/2023
       And I enter the mortality deceased on date of 05/29/2023
+      And I enter the mortality deceased option as "Yes"
       And I enter the mortality city "Salem Center"
       And I enter the mortality country United States
       And I enter the mortality county Westchester County
@@ -18,6 +19,7 @@
       Then I view the Patient Profile Mortality demographics
       And the patient profile mortality has the as of date 06/29/2023
       And the patient profile mortality has the deceased on date 05/29/2023
+      And the patient profile mortality has the deceased option as "Yes"
       And the patient profile mortality has the city "Salem Center"
       And the patient profile mortality has the country United States
       And the patient profile mortality has the county Westchester County

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.mortality.feature
@@ -1,0 +1,18 @@
+@patient_extended_create
+  Feature: Creation of Patients with mortality data
+
+    Background:
+      Given I am logged into NBS
+      And I can "add" any "patient"
+      And I can "find" any "patient"
+
+    Scenario: I can create a patient with mortality information
+      Given I am entering the mortality as of date 05/29/2023
+      And I enter the mortality city "Salem Center"
+      And I enter the mortality country United States
+      And I enter the mortality county Westchester County
+      And I enter the mortality state New York
+      And the mortality demographics are included in the extended patient data
+      When I create a patient with extended data
+      Then I view the Patient Profile Mortality demographics
+      And the patient profile mortality has the as of date 05/29/2023


### PR DESCRIPTION
## Description

Build on `PatientCreationService` update mortality demographics if present

## Tickets

* [CNFT1-2780](https://cdc-nbs.atlassian.net/browse/CNFT1-2780)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-2780]: https://cdc-nbs.atlassian.net/browse/CNFT1-2780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ