### PR TITLE
Cnft1 3183 inline validation removal extended form

### DIFF
--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -1,9 +1,7 @@
-import { render, waitFor, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { AddressEntry } from '../entry';
 import { AddressEntryFields } from './AddressEntryFields';
-import userEvent from '@testing-library/user-event';
 
 const mockPatientAddressCodedValues = {
     types: [{ name: 'House', value: 'H' }],
@@ -69,68 +67,5 @@ describe('AddressEntryFields', () => {
         expect(getByLabelText('Census tract')).toBeInTheDocument();
         expect(getByLabelText('Country')).toBeInTheDocument();
         expect(getByLabelText('Address comments')).toBeInTheDocument();
-    });
-
-    it('should require type', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const typeInput = getByLabelText('Type');
-        act(() => {
-            userEvent.click(typeInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require use', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const useInput = getByLabelText('Use');
-        act(() => {
-            userEvent.click(useInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Use is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require as of', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Address as of');
-        act(() => {
-            userEvent.click(asOf);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should be valid with as of, type, and use', async () => {
-        const { getByLabelText, queryByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Address as of');
-        const type = getByLabelText('Type');
-        const use = getByLabelText('Use');
-        await screen.findByText('Use');
-
-        act(() => {
-            userEvent.paste(asOf, '01/20/2020');
-            userEvent.tab();
-            userEvent.selectOptions(use, 'HM');
-            userEvent.tab();
-            userEvent.selectOptions(type, 'H');
-            userEvent.tab();
-        });
-
-        await waitFor(() => {
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('Use is required.')).not.toBeInTheDocument();
-        });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -35,12 +35,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="asOf"
                 rules={{ required: { value: true, message: 'As of date is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Address as of"
                         orientation="horizontal"
                         defaultValue={value}
-                        onBlur={onBlur}
                         onChange={onChange}
                         name={`address-${name}`}
                         disableFutureDates
@@ -53,12 +52,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="type"
                 rules={{ required: { value: true, message: 'Type is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
                         orientation="horizontal"
                         value={value}
-                        onBlur={onBlur}
                         onChange={onChange}
                         id={`address-${name}`}
                         name={`address-${name}`}
@@ -72,12 +70,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="use"
                 rules={{ required: { value: true, message: 'Use is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
                         orientation="horizontal"
                         value={value}
-                        onBlur={onBlur}
                         onChange={onChange}
                         id={`address-${name}`}
                         name={`address-${name}`}
@@ -91,7 +88,7 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="address1"
                 rules={maxLengthRule(100)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <AddressSuggestionInput
                         label="Street address 1"
                         orientation="horizontal"
@@ -104,7 +101,6 @@ export const AddressEntryFields = () => {
                         }}
                         defaultValue={value ?? ''}
                         onChange={onChange}
-                        onBlur={onBlur}
                         onSelection={handleSuggestionSelection}
                         error={error?.message}
                     />
@@ -114,12 +110,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="address2"
                 rules={maxLengthRule(100)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Street address 2"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         defaultValue={value}
                         type="text"
                         name={name}
@@ -133,12 +128,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="city"
                 rules={maxLengthRule(100)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="City"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         defaultValue={value}
                         type="text"
                         name={name}
@@ -173,12 +167,11 @@ export const AddressEntryFields = () => {
                     },
                     ...maxLengthRule(20)
                 }}
-                render={({ field: { onChange, value, name, onBlur }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Zip"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         defaultValue={value}
                         type="text"
                         name="zipcode"
@@ -207,12 +200,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="censusTract"
                 rules={maxLengthRule(10)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Census tract"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         defaultValue={value}
                         type="text"
                         name={name}
@@ -243,12 +235,11 @@ export const AddressEntryFields = () => {
                 control={control}
                 name="comment"
                 rules={maxLengthRule(2000)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Address comments"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         defaultValue={value}
                         type="text"
                         name={name}

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
@@ -1,10 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { PatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
-import { act } from 'react-dom/test-utils';
 import { FormProvider, useForm } from 'react-hook-form';
 import { IdentificationEntry } from '../entry';
 import { IdentificationEntryFields } from './IdentificationEntryFields';
-import userEvent from '@testing-library/user-event';
 
 const mockPatientIdentificationCodedValues: PatientIdentificationCodedValues = {
     types: [{ name: 'Account number', value: 'AN' }],
@@ -34,78 +32,12 @@ const Fixture = () => {
 
 describe('IdentificationEntryFields', () => {
     it('should render the proper labels', async () => {
-        const { getByLabelText } = render(<Fixture />);
-        await screen.findByText('ID value');
+        const { getByLabelText, findByText } = render(<Fixture />);
+        await findByText('ID value');
 
         expect(getByLabelText('Identification as of')).toBeInTheDocument();
         expect(getByLabelText('Type')).toBeInTheDocument();
         expect(getByLabelText('Assigning authority')).toBeInTheDocument();
         expect(getByLabelText('ID value')).toBeInTheDocument();
-    });
-
-    it('should require as of', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-        await screen.findByText('ID value');
-
-        const asOf = getByLabelText('Identification as of');
-        act(() => {
-            userEvent.click(asOf);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require type', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-        await screen.findByText('ID value');
-
-        const typeInput = getByLabelText('Type');
-        act(() => {
-            userEvent.click(typeInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require id value', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-        await screen.findByText('ID value');
-
-        const valueInput = getByLabelText('ID value');
-        act(() => {
-            userEvent.click(valueInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('ID value is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should be valid with as of, type, and id value', async () => {
-        const { getByLabelText, queryByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Identification as of');
-        const type = getByLabelText('Type');
-        const idValue = getByLabelText('ID value');
-        await screen.findByText('ID value');
-
-        act(() => {
-            userEvent.paste(asOf, '01/20/2020');
-            userEvent.tab();
-            userEvent.selectOptions(type, 'AN');
-            userEvent.tab();
-            userEvent.type(idValue, '1234');
-            userEvent.tab();
-        });
-
-        await waitFor(() => {
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('ID value is required.')).not.toBeInTheDocument();
-        });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
@@ -17,11 +17,10 @@ export const IdentificationEntryFields = () => {
                 control={control}
                 name="asOf"
                 rules={{ required: { value: true, message: 'As of date is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Identification as of"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         defaultValue={value}
                         onChange={onChange}
                         name={`identification-${name}`}
@@ -35,12 +34,11 @@ export const IdentificationEntryFields = () => {
                 control={control}
                 name="type"
                 rules={{ required: { value: true, message: 'Type is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
                         orientation="horizontal"
                         value={value}
-                        onBlur={onBlur}
                         onChange={onChange}
                         id={`identification-${name}`}
                         name={`identification-${name}`}
@@ -53,13 +51,12 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="issuer"
-                render={({ field: { onChange, onBlur, value, name } }) => (
+                render={({ field: { onChange, value, name } }) => (
                     <SingleSelect
                         label="Assigning authority"
                         orientation="horizontal"
                         value={value}
                         onChange={onChange}
-                        onBlur={onBlur}
                         name={name}
                         id={name}
                         options={coded.authorities}
@@ -70,11 +67,10 @@ export const IdentificationEntryFields = () => {
                 control={control}
                 name="id"
                 rules={{ required: { value: true, message: 'ID value is required.' }, ...maxLengthRule(100) }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="ID value"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
@@ -1,8 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
 import { NameEntry } from '../entry';
 import { FormProvider, useForm } from 'react-hook-form';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+
 import { NameEntryFields } from './NameEntryFields';
 
 const mockPatientNameCodedValues = {
@@ -54,49 +53,5 @@ describe('Name entry fields', () => {
         expect(getByLabelText('Second last')).toBeInTheDocument();
         expect(getByLabelText('Suffix')).toBeInTheDocument();
         expect(getByLabelText('Degree')).toBeInTheDocument();
-    });
-
-    it('should require as of', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Name as of');
-        act(() => {
-            userEvent.click(asOf);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require type', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const type = getByLabelText('Type');
-        act(() => {
-            userEvent.click(type);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should be valid with as of, race', async () => {
-        const { getByLabelText, queryByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Name as of');
-        const type = getByLabelText('Type');
-        act(() => {
-            userEvent.paste(asOf, '01/20/2020');
-            userEvent.tab();
-            userEvent.selectOptions(type, 'AN');
-            userEvent.tab();
-        });
-
-        await waitFor(() => {
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
-        });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -16,11 +16,10 @@ export const NameEntryFields = () => {
                 control={control}
                 name="asOf"
                 rules={{ required: { value: true, message: 'As of date is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Name as of"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         defaultValue={value}
                         onChange={onChange}
                         name={`name-${name}`}
@@ -34,12 +33,11 @@ export const NameEntryFields = () => {
                 control={control}
                 name="type"
                 rules={{ required: { value: true, message: 'Type is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
                         orientation="horizontal"
                         value={value}
-                        onBlur={onBlur}
                         onChange={onChange}
                         id={`name-${name}`}
                         name={`name-${name}`}
@@ -52,14 +50,13 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="prefix"
-                render={({ field: { onChange, onBlur, value, name } }) => (
+                render={({ field: { onChange, value, name } }) => (
                     <SingleSelect
                         label="Prefix"
                         orientation="horizontal"
                         value={value}
                         id={name}
                         onChange={onChange}
-                        onBlur={onBlur}
                         name={name}
                         options={coded.prefixes}
                     />
@@ -70,11 +67,10 @@ export const NameEntryFields = () => {
                 control={control}
                 name="last"
                 rules={validNameRule}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Last"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -89,11 +85,10 @@ export const NameEntryFields = () => {
                 control={control}
                 name="secondLast"
                 rules={validNameRule}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second last"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -108,11 +103,10 @@ export const NameEntryFields = () => {
                 control={control}
                 name="first"
                 rules={validNameRule}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="First"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -127,11 +121,10 @@ export const NameEntryFields = () => {
                 control={control}
                 name="middle"
                 rules={validNameRule}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Middle"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -146,11 +139,10 @@ export const NameEntryFields = () => {
                 control={control}
                 name="secondMiddle"
                 rules={validNameRule}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second middle"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
@@ -1,9 +1,7 @@
-import { render, waitFor, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { PhoneEmailEntry } from '../entry';
 import { PhoneEmailEntryFields } from './PhoneEmailEntryFields';
-import userEvent from '@testing-library/user-event';
 
 const mockPatientPhoneCodedValues = {
     types: [{ name: 'Phone', value: 'PH' }],
@@ -48,67 +46,5 @@ describe('PhoneEmailEntryFields', () => {
         expect(getByLabelText('Extension')).toBeInTheDocument();
         expect(getByLabelText('Email')).toBeInTheDocument();
         expect(getByLabelText('Phone & email comments')).toBeInTheDocument();
-    });
-
-    it('should require type', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const typeInput = getByLabelText('Type');
-        act(() => {
-            userEvent.click(typeInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require use', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const useInput = getByLabelText('Use');
-        act(() => {
-            userEvent.click(useInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Use is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require as of', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Phone & email as of');
-        act(() => {
-            userEvent.click(asOf);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should be valid with as of, type, and use', async () => {
-        const { getByLabelText, queryByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Phone & email as of');
-        const type = getByLabelText('Type');
-        const use = getByLabelText('Use');
-        await screen.findByText('Use');
-        act(() => {
-            userEvent.paste(asOf, '01/20/2020');
-            userEvent.tab();
-            userEvent.selectOptions(use, 'H');
-            userEvent.tab();
-            userEvent.selectOptions(type, 'PH');
-            userEvent.tab();
-        });
-
-        await waitFor(() => {
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('Use is required.')).not.toBeInTheDocument();
-        });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -17,12 +17,11 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="asOf"
                 rules={{ required: { value: true, message: 'As of date is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Phone & email as of"
                         orientation="horizontal"
                         defaultValue={value}
-                        onBlur={onBlur}
                         onChange={onChange}
                         name={`phone-${name}`}
                         disableFutureDates
@@ -35,12 +34,11 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="type"
                 rules={{ required: { value: true, message: 'Type is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         value={value}
                         id={`phone-${name}`}
                         name={`phone-${name}`}
@@ -54,12 +52,11 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="use"
                 rules={{ required: { value: true, message: 'Use is required.' } }}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         value={value}
                         id={`phone-${name}`}
                         name={`phone-${name}`}
@@ -78,13 +75,12 @@ export const PhoneEmailEntryFields = () => {
                         message: 'A country code should be 1 to 3 digits'
                     }
                 }}
-                render={({ field: { onChange, value, onBlur, name }, fieldState: { error } }) => {
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => {
                     return (
                         <Input
                             label="Country code"
                             orientation="horizontal"
                             onChange={onChange}
-                            onBlur={onBlur}
                             defaultValue={value}
                             type="tel"
                             htmlFor={name}
@@ -103,11 +99,10 @@ export const PhoneEmailEntryFields = () => {
                         properNumber: (value) => validatePhoneNumber(value ?? '')
                     }
                 }}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Phone number"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -132,11 +127,10 @@ export const PhoneEmailEntryFields = () => {
                         message: 'A Extension should be 1 to 4 digits'
                     }
                 }}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Extension"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -158,11 +152,10 @@ export const PhoneEmailEntryFields = () => {
                     },
                     ...maxLengthRule(100)
                 }}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Email"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -177,11 +170,10 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="url"
                 rules={maxLengthRule(100)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="URL"
                         orientation="horizontal"
-                        onBlur={onBlur}
                         onChange={onChange}
                         defaultValue={value}
                         type="text"
@@ -196,12 +188,11 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="comment"
                 rules={maxLengthRule(2000)}
-                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Phone & email comments"
                         orientation="horizontal"
                         onChange={onChange}
-                        onBlur={onBlur}
                         defaultValue={value}
                         type="text"
                         name={`phone-${name}`}

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
@@ -1,8 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
 import { CodedValue } from 'coded/CodedValue';
 import { RaceEntry } from '../entry';
 import { FormProvider, useForm } from 'react-hook-form';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { RaceEntryFields } from './RaceEntryFields';
 import userEvent from '@testing-library/user-event';
 
@@ -56,50 +55,6 @@ describe('Race entry fields', () => {
 
         await waitFor(() => {
             expect(getByText('Detailed race')).toBeInTheDocument();
-        });
-    });
-
-    it('should require as of', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Race as of');
-        act(() => {
-            userEvent.click(asOf);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should require race', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-
-        const raceInput = getByLabelText('Race');
-        act(() => {
-            userEvent.click(raceInput);
-            userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(getByText('Race is required.')).toBeInTheDocument();
-        });
-    });
-
-    it('should be valid with as of, race', async () => {
-        const { getByLabelText, queryByText } = render(<Fixture />);
-
-        const asOf = getByLabelText('Race as of');
-        const race = getByLabelText('Race');
-        act(() => {
-            userEvent.paste(asOf, '01/20/2020');
-            userEvent.tab();
-            userEvent.selectOptions(race, '1');
-            userEvent.tab();
-        });
-
-        await waitFor(() => {
-            expect(queryByText('As of date is required')).not.toBeInTheDocument();
-            expect(queryByText('Race is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -16,10 +16,9 @@ export const RaceEntryFields = () => {
                 control={control}
                 name="asOf"
                 rules={{ required: { value: true, message: 'As of date is required.' } }}
-                render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
+                render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Race as of"
-                        onBlur={onBlur}
                         orientation="horizontal"
                         defaultValue={value}
                         onChange={onChange}
@@ -36,12 +35,11 @@ export const RaceEntryFields = () => {
                 rules={{
                     required: { value: true, message: 'Race is required.' }
                 }}
-                render={({ field: { onBlur, onChange, name, value }, fieldState: { error } }) => (
+                render={({ field: { onChange, name, value }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Race"
                         orientation="horizontal"
                         required
-                        onBlur={onBlur}
                         onChange={onChange}
                         value={value}
                         id={name}


### PR DESCRIPTION
## Description
Removing inline validation for the repeated blocks 
Test Coverage is reporting no impact after changes were made 
<img width="818" alt="Screenshot 2024-09-27 at 1 02 25 PM" src="https://github.com/user-attachments/assets/3a571ba0-dffb-4656-bcff-f7eef6e8f665">


## Tickets

* [CNFT1-3206](https://cdc-nbs.atlassian.net/browse/CNFT1-3206)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3206]: https://cdc-nbs.atlassian.net/browse/CNFT1-3206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ