### PR TITLE
[CNFT1-2783] Patient Add API: General Information

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.patient.profile.administrative.Administrative;
 import gov.cdc.nbs.patient.profile.birth.BirthDemographic;
 import gov.cdc.nbs.patient.profile.ethnicity.EthnicityDemographic;
 import gov.cdc.nbs.patient.profile.gender.GenderDemographic;
+import gov.cdc.nbs.patient.profile.general.GeneralInformationDemographic;
 import gov.cdc.nbs.patient.profile.mortality.MortalityDemographic;
 import gov.cdc.nbs.patient.profile.names.NameDemographic;
 import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
@@ -20,13 +21,15 @@ public record NewPatient(
     Administrative administrative,
     BirthDemographic birth,
     GenderDemographic gender,
+    EthnicityDemographic ethnicity,
+    MortalityDemographic mortality,
+    GeneralInformationDemographic general,
     List<NameDemographic> names,
     List<AddressDemographic> addresses,
     List<Phone> phoneEmails,
     List<Race> races,
-    List<Identification> identifications,
-    EthnicityDemographic ethnicity,
-    MortalityDemographic mortality) {
+    List<Identification> identifications
+) {
 
   public record Phone(
       @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
@@ -60,13 +63,15 @@ public record NewPatient(
         null,
         null,
         null,
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList(),
         null,
-        null);
+        null,
+        null,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList()
+    );
   }
 
   public NewPatient withAdministrative(final Administrative administrative) {
@@ -74,13 +79,15 @@ public record NewPatient(
         administrative,
         birth(),
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         addresses(),
         phoneEmails(),
         races(),
-        identifications(),
-        ethnicity(),
-        mortality());
+        identifications()
+    );
   }
 
   public NewPatient withName(final NameDemographic name) {
@@ -88,13 +95,15 @@ public record NewPatient(
         administrative(),
         birth(),
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         Including.include(names(), name),
         addresses(),
         phoneEmails(),
         races(),
-        identifications(),
-        ethnicity(),
-        mortality());
+        identifications()
+    );
   }
 
   public NewPatient withAddress(final AddressDemographic value) {
@@ -102,13 +111,15 @@ public record NewPatient(
         administrative(),
         birth(),
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         Including.include(addresses(), value),
         phoneEmails(),
         races(),
-        identifications(),
-        ethnicity(),
-        mortality());
+        identifications()
+    );
   }
 
   public NewPatient withPhoneEmail(final Phone value) {
@@ -116,13 +127,14 @@ public record NewPatient(
         administrative(),
         birth(),
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         addresses(),
         Including.include(phoneEmails(), value),
         races(),
-        identifications(),
-        ethnicity(),
-        mortality());
+        identifications());
   }
 
   public NewPatient withRace(final Race value) {
@@ -130,13 +142,15 @@ public record NewPatient(
         administrative(),
         birth(),
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         addresses(),
         phoneEmails(),
         Including.include(races(), value),
-        identifications(),
-        ethnicity(),
-        mortality());
+        identifications()
+    );
   }
 
   public NewPatient withIdentification(final Identification value) {
@@ -144,13 +158,15 @@ public record NewPatient(
         administrative(),
         birth(),
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         addresses(),
         phoneEmails(),
         races(),
-        Including.include(identifications(), value),
-        ethnicity(),
-        mortality());
+        Including.include(identifications(), value)
+    );
   }
 
   public NewPatient withBirth(final BirthDemographic value) {
@@ -158,41 +174,31 @@ public record NewPatient(
         administrative(),
         value,
         gender(),
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         addresses(),
         phoneEmails(),
         races(),
-        identifications(),
-        ethnicity(),
-        mortality());
+        identifications()
+    );
   }
 
-  public NewPatient withEthnicity(final EthnicityDemographic ethnicity) {
+  public NewPatient withEthnicity(final EthnicityDemographic value) {
     return new NewPatient(
         administrative(),
         birth(),
         gender(),
+        value,
+        mortality(),
+        general(),
         names(),
         addresses(),
         phoneEmails(),
         races(),
-        identifications(),
-        ethnicity,
-        mortality());
-  }
-
-  public NewPatient withMortality(final MortalityDemographic mortality) {
-    return new NewPatient(
-        administrative(),
-        birth(),
-        gender(),
-        names(),
-        addresses(),
-        phoneEmails(),
-        races(),
-        identifications(),
-        ethnicity(),
-        mortality);
+        identifications()
+    );
   }
 
   public NewPatient withGender(final GenderDemographic value) {
@@ -200,13 +206,47 @@ public record NewPatient(
         administrative(),
         birth(),
         value,
+        ethnicity(),
+        mortality(),
+        general(),
         names(),
         addresses(),
         phoneEmails(),
         races(),
-        identifications(),
+        identifications()
+    );
+  }
+
+  public NewPatient withMortality(final MortalityDemographic value) {
+    return new NewPatient(
+        administrative(),
+        birth(),
+        gender(),
         ethnicity(),
-        mortality());
+        value,
+        general(),
+        names(),
+        addresses(),
+        phoneEmails(),
+        races(),
+        identifications()
+    );
+  }
+
+  public NewPatient withGeneralInformation(final GeneralInformationDemographic value) {
+    return new NewPatient(
+        administrative(),
+        birth(),
+        gender(),
+        ethnicity(),
+        mortality(),
+        value,
+        names(),
+        addresses(),
+        phoneEmails(),
+        races(),
+        identifications()
+    );
   }
 
   public Optional<Administrative> maybeAdministrative() {
@@ -229,5 +269,8 @@ public record NewPatient(
     return Optional.ofNullable(mortality());
   }
 
+  public Optional<GeneralInformationDemographic> maybeGeneralInformation() {
+    return Optional.ofNullable(general());
+  }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.patient.profile.create;
 
+import gov.cdc.nbs.authorization.permission.scope.PermissionScopeResolver;
 import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.entity.odse.PersonName;
 import gov.cdc.nbs.patient.PatientCommand;
@@ -20,85 +21,98 @@ import static gov.cdc.nbs.patient.profile.birth.BirthDemographicPatientCommandMa
 import static gov.cdc.nbs.patient.profile.ethnicity.EthnicityPatientCommandMapper.asAddDetailedEthnicity;
 import static gov.cdc.nbs.patient.profile.ethnicity.EthnicityPatientCommandMapper.asUpdateEthnicityInfo;
 import static gov.cdc.nbs.patient.profile.gender.GenderDemographicPatientCommandMapper.asUpdateGender;
+import static gov.cdc.nbs.patient.profile.general.GeneralInformationDemographicPatientCommandMapper.asUpdateGeneralInfo;
+import static gov.cdc.nbs.patient.profile.general.GeneralInformationDemographicPatientCommandMapper.maybeAsAssociateStateHIVCase;
 import static gov.cdc.nbs.patient.profile.names.NameDemographicPatientCommandMapper.asAddName;
 import static gov.cdc.nbs.patient.profile.mortality.MortalityDemographicPatientCommandMapper.asUpdateMortality;
 
 @Component
 class PatientCreationService {
 
-  private final PatientIdentifierGenerator patientIdentifierGenerator;
-  private final AddressIdentifierGenerator addressIdentifierGenerator;
-  private final EntityManager entityManager;
+    private final PatientIdentifierGenerator patientIdentifierGenerator;
+    private final AddressIdentifierGenerator addressIdentifierGenerator;
+    private final PermissionScopeResolver resolver;
+    private final EntityManager entityManager;
 
-  PatientCreationService(
-      final PatientIdentifierGenerator patientIdentifierGenerator,
-      final AddressIdentifierGenerator addressIdentifierGenerator,
-      final EntityManager entityManager) {
-    this.patientIdentifierGenerator = patientIdentifierGenerator;
-    this.addressIdentifierGenerator = addressIdentifierGenerator;
-    this.entityManager = entityManager;
-  }
+    PatientCreationService(
+            final PatientIdentifierGenerator patientIdentifierGenerator,
+            final AddressIdentifierGenerator addressIdentifierGenerator,
+            final PermissionScopeResolver resolver,
+            final EntityManager entityManager) {
+        this.patientIdentifierGenerator = patientIdentifierGenerator;
+        this.addressIdentifierGenerator = addressIdentifierGenerator;
+        this.resolver = resolver;
+        this.entityManager = entityManager;
+    }
 
-  @Transactional
-  public CreatedPatient create(
-      final RequestContext context,
-      final NewPatient newPatient) {
-    PatientIdentifier identifier = patientIdentifierGenerator.generate();
+    @Transactional
+    public CreatedPatient create(
+            final RequestContext context,
+            final NewPatient newPatient) {
+        PatientIdentifier identifier = patientIdentifierGenerator.generate();
 
-    Person patient = new Person(
-        new PatientCommand.CreatePatient(
-            identifier.id(),
-            identifier.local(),
-            context.requestedBy(),
-            context.requestedAt()));
+        Person patient = new Person(
+                new PatientCommand.CreatePatient(
+                        identifier.id(),
+                        identifier.local(),
+                        context.requestedBy(),
+                        context.requestedAt()));
 
-    newPatient.maybeAdministrative()
-        .map(administrative -> asUpdateAdministrativeInfo(identifier.id(), context, administrative))
-        .ifPresent(patient::update);
+        newPatient.maybeAdministrative()
+                .map(administrative -> asUpdateAdministrativeInfo(identifier.id(), context, administrative))
+                .ifPresent(patient::update);
 
-    newPatient.maybeBirth()
-        .map(demographic -> asUpdateBirth(identifier.id(), context, demographic))
-        .ifPresent(command -> patient.update(command, addressIdentifierGenerator));
+        newPatient.maybeBirth()
+                .map(demographic -> asUpdateBirth(identifier.id(), context, demographic))
+                .ifPresent(command -> patient.update(command, addressIdentifierGenerator));
 
-    newPatient.maybeGender()
-        .map(demographic -> asUpdateGender(identifier.id(), context, demographic))
-        .ifPresent(patient::update);
+        newPatient.maybeGender()
+                .map(demographic -> asUpdateGender(identifier.id(), context, demographic))
+                .ifPresent(patient::update);
 
-    newPatient.maybeEthnicity()
-        .map(demographic -> asUpdateEthnicityInfo(identifier.id(), context, demographic))
-        .ifPresent(patient::update);
+        newPatient.maybeEthnicity()
+                .map(demographic -> asUpdateEthnicityInfo(identifier.id(), context, demographic))
+                .ifPresent(patient::update);
 
-    newPatient.maybeEthnicity()
-        .map(EthnicityDemographic::detailed)
-        .stream()
-        .flatMap(Collection::stream)
-        .map(demographic -> asAddDetailedEthnicity(identifier.id(), context, demographic))
-        .forEach(patient::add);
+        newPatient.maybeEthnicity()
+                .map(EthnicityDemographic::detailed)
+                .stream()
+                .flatMap(Collection::stream)
+                .map(demographic -> asAddDetailedEthnicity(identifier.id(), context, demographic))
+                .forEach(patient::add);
 
-    newPatient.names()
-        .stream()
-        .map(demographic -> asAddName(identifier.id(), context, demographic))
-        .forEach(patient::add);
+        newPatient.maybeGeneralInformation()
+                .map(demographic -> asUpdateGeneralInfo(identifier.id(), context, demographic))
+                .ifPresent(patient::update);
 
-    newPatient.maybeMortality()
-        .map(demographic -> asUpdateMortality(identifier.id(), context, demographic))
-        .ifPresent(command -> patient.update(command, addressIdentifierGenerator));
+        newPatient.maybeGeneralInformation()
+                .flatMap(demographic -> maybeAsAssociateStateHIVCase(identifier.id(), context, demographic))
+                .ifPresent(association -> patient.associate(resolver, association));
+        ;
 
-    this.entityManager.persist(patient);
+        newPatient.names()
+                .stream()
+                .map(demographic -> asAddName(identifier.id(), context, demographic))
+                .forEach(patient::add);
 
-    CreatedPatient.Name legalName = patient.legalName(LocalDate.now())
-        .map(this::asName)
-        .orElse(null);
+        newPatient.maybeMortality()
+                .map(demographic -> asUpdateMortality(identifier.id(), context, demographic))
+                .ifPresent(command -> patient.update(command, addressIdentifierGenerator));
 
-    return new CreatedPatient(
-        identifier.id(),
-        identifier.shortId(),
-        identifier.local(),
-        legalName
-    );
-  }
+        this.entityManager.persist(patient);
 
-  private CreatedPatient.Name asName(final PersonName name) {
-    return new CreatedPatient.Name(name.getFirstNm(), name.getLastNm());
-  }
+        CreatedPatient.Name legalName = patient.legalName(LocalDate.now())
+                .map(this::asName)
+                .orElse(null);
+
+        return new CreatedPatient(
+                identifier.id(),
+                identifier.shortId(),
+                identifier.local(),
+                legalName);
+    }
+
+    private CreatedPatient.Name asName(final PersonName name) {
+        return new CreatedPatient.Name(name.getFirstNm(), name.getLastNm());
+    }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographic.java
@@ -1,0 +1,183 @@
+package gov.cdc.nbs.patient.profile.general;
+
+import java.time.LocalDate;
+
+public record GeneralInformationDemographic(
+    LocalDate asOf,
+    String maritalStatus,
+    String maternalMaidenName,
+    Integer adultsInResidence,
+    Integer childrenInResidence,
+    String primaryOccupation,
+    String educationLevel,
+    String primaryLanguage,
+    String speaksEnglish,
+    String stateHIVCase
+) {
+
+  public GeneralInformationDemographic(final LocalDate asOf) {
+    this(
+        asOf,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    );
+  }
+
+  public GeneralInformationDemographic withAsOf(final LocalDate value) {
+    return new GeneralInformationDemographic(
+        value,
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+
+  public GeneralInformationDemographic withMaritalStatus(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        value,
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withMaternalMaidenName(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        value,
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withAdultsInResidence(final int value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        value,
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withChildrenInResidence(final int value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        value,
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withPrimaryOccupation(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        value,
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withEducationLevel(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        value,
+        primaryLanguage(),
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withPrimaryLanguage(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        value,
+        speaksEnglish(),
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withSpeaksEnglish(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        value,
+        stateHIVCase()
+    );
+  }
+
+  public GeneralInformationDemographic withStateHIVCase(final String value) {
+    return new GeneralInformationDemographic(
+        asOf(),
+        maritalStatus(),
+        maternalMaidenName(),
+        adultsInResidence(),
+        childrenInResidence(),
+        primaryOccupation(),
+        educationLevel(),
+        primaryLanguage(),
+        speaksEnglish(),
+        value
+    );
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographicPatientCommandMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographicPatientCommandMapper.java
@@ -1,0 +1,64 @@
+package gov.cdc.nbs.patient.profile.general;
+
+import gov.cdc.nbs.patient.PatientCommand;
+import gov.cdc.nbs.patient.RequestContext;
+import gov.cdc.nbs.time.LocalDateInstantMapper;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public class GeneralInformationDemographicPatientCommandMapper {
+
+  public static PatientCommand.UpdateGeneralInfo asUpdateGeneralInfo(
+      final long patient,
+      final RequestContext context,
+      final GeneralInformationDemographic demographic
+  ) {
+
+    Instant asOf = LocalDateInstantMapper.from(demographic.asOf());
+
+    return new PatientCommand.UpdateGeneralInfo(
+        patient,
+        asOf,
+        demographic.maritalStatus(),
+        demographic.maternalMaidenName(),
+        demographic.adultsInResidence(),
+        demographic.childrenInResidence(),
+        demographic.primaryOccupation(),
+        demographic.educationLevel(),
+        demographic.primaryLanguage(),
+        demographic.speaksEnglish(),
+        context.requestedBy(),
+        context.requestedAt()
+    );
+
+  }
+
+  public static PatientCommand.AssociateStateHIVCase asAssociateStateHIVCase(
+      final long patient,
+      final RequestContext context,
+      final GeneralInformationDemographic demographic
+  ) {
+    return new PatientCommand.AssociateStateHIVCase(
+        patient,
+        demographic.stateHIVCase(),
+        context.requestedBy(),
+        context.requestedAt()
+    );
+  }
+
+  public static Optional<PatientCommand.AssociateStateHIVCase> maybeAsAssociateStateHIVCase(
+      final long patient,
+      final RequestContext context,
+      final GeneralInformationDemographic demographic
+  ) {
+    return demographic.stateHIVCase() == null || demographic.stateHIVCase().isBlank()
+        ? Optional.empty()
+        : Optional.of(asAssociateStateHIVCase(patient, context, demographic));
+  }
+
+  private GeneralInformationDemographicPatientCommandMapper() {
+    //  static
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/create/PatientCreateEntrySteps.java
@@ -5,6 +5,7 @@ import gov.cdc.nbs.patient.profile.birth.BirthDemographic;
 import gov.cdc.nbs.patient.profile.ethnicity.EthnicityDemographic;
 import gov.cdc.nbs.patient.profile.gender.GenderDemographic;
 import gov.cdc.nbs.patient.profile.mortality.MortalityDemographic;
+import gov.cdc.nbs.patient.profile.general.GeneralInformationDemographic;
 import gov.cdc.nbs.patient.profile.names.NameDemographic;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
@@ -17,6 +18,7 @@ public class PatientCreateEntrySteps {
   private final Active<NameDemographic> activeName;
   private final Active<EthnicityDemographic> activeEthnicity;
   private final Active<MortalityDemographic> activeMortalityDemographic;
+  private final Active<GeneralInformationDemographic> activeGeneralInformation;
   private final Active<NewPatient> input;
 
   public PatientCreateEntrySteps(
@@ -26,13 +28,16 @@ public class PatientCreateEntrySteps {
       final Active<NameDemographic> activeName,
       final Active<EthnicityDemographic> activeEthnicity,
       final Active<MortalityDemographic> activeMortalityDemographic,
-      final Active<NewPatient> input) {
+      final Active<GeneralInformationDemographic> activeGeneralInformation,
+      final Active<NewPatient> input
+  ) {
     this.activeAdministrative = activeAdministrative;
     this.activeBirthDemographic = activeBirthDemographic;
     this.activeGenderDemographic = activeGenderDemographic;
     this.activeMortalityDemographic = activeMortalityDemographic;
     this.activeName = activeName;
     this.activeEthnicity = activeEthnicity;
+    this.activeGeneralInformation = activeGeneralInformation;
     this.input = input;
   }
 
@@ -70,5 +75,11 @@ public class PatientCreateEntrySteps {
   public void the_mortality_demographics_are_included_in_the_extended_patient_data() {
     this.activeMortalityDemographic.maybeActive()
         .ifPresent(demographic -> this.input.active(current -> current.withMortality(demographic)));
+  }
+
+  @Given("the general information demographics are included in the extended patient data")
+  public void the_general_information_is_included_in_the_extended_patient_data() {
+    this.activeGeneralInformation.maybeActive()
+        .ifPresent(demographic -> this.input.active(current -> current.withGeneralInformation(demographic)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographicEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographicEntrySteps.java
@@ -1,0 +1,66 @@
+package gov.cdc.nbs.patient.profile.general;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Given;
+
+import java.time.LocalDate;
+
+public class GeneralInformationDemographicEntrySteps {
+
+  private final Active<GeneralInformationDemographic> input;
+
+  GeneralInformationDemographicEntrySteps(final Active<GeneralInformationDemographic> input) {
+    this.input = input;
+  }
+
+  @Given("I enter the general information as of date {localDate}")
+  public void i_enter_the_general_as_of(final LocalDate asOf) {
+    this.input.active(current -> current.withAsOf(asOf));
+  }
+
+  @Given("I enter the general information marital status as {maritalStatus}")
+  public void i_enter_the_general_marital_status(final String value) {
+    this.input.active(current -> current.withMaritalStatus(value));
+  }
+
+  @Given("I enter the general information maternal maiden name as {string}")
+  public void i_enter_the_general_maternal_maiden_name(final String value) {
+    this.input.active(current -> current.withMaternalMaidenName(value));
+  }
+
+  @Given("I enter the general information adults in residence as {int}")
+  public void i_enter_the_general_adults_in_residence(final int value) {
+    this.input.active(current -> current.withAdultsInResidence(value));
+  }
+
+  @Given("I enter the general information children in residence as {int}")
+  public void i_enter_the_general_children_in_residence(final int value) {
+    this.input.active(current -> current.withChildrenInResidence(value));
+  }
+
+  @Given("I enter the general information primary occupation of {occupation}")
+  public void i_enter_the_general_primary_occupation(final String value) {
+    this.input.active(current -> current.withPrimaryOccupation(value));
+  }
+
+  @Given("I enter the general information education level of {educationLevel}")
+  public void i_enter_the_general_education_level(final String value) {
+    this.input.active(current -> current.withEducationLevel(value));
+  }
+
+  @Given("I enter the general information primary language of {language}")
+  public void i_enter_the_general_primary_language(final String value) {
+    this.input.active(current -> current.withPrimaryLanguage(value));
+  }
+
+  @Given("I enter the general information that the patient {indicator} speak english")
+  public void i_enter_the_general_speaks_english(final String value) {
+    this.input.active(current -> current.withSpeaksEnglish(value));
+  }
+
+  @Given("I enter the general information state HIV case of {string}")
+  public void i_enter_the_general_state_HIV_case(final String value) {
+    this.input.active(current -> current.withStateHIVCase(value));
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographicSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographicSupportConfiguration.java
@@ -1,0 +1,19 @@
+package gov.cdc.nbs.patient.profile.general;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.spring.ScenarioScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+@Configuration
+class GeneralInformationDemographicSupportConfiguration {
+
+  @Bean
+  @ScenarioScope
+  Active<GeneralInformationDemographic> activeGeneralInformationDemographic(final Clock clock) {
+    return new Active<>(() -> new GeneralInformationDemographic(LocalDate.now(clock)));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/PatientCreateMutationGeneralSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/PatientCreateMutationGeneralSteps.java
@@ -1,0 +1,46 @@
+package gov.cdc.nbs.patient.profile.general;
+
+import gov.cdc.nbs.entity.odse.Person;
+import gov.cdc.nbs.message.patient.input.PatientInput;
+import gov.cdc.nbs.patient.demographic.GeneralInformation;
+import gov.cdc.nbs.support.util.RandomUtil;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class PatientCreateMutationGeneralSteps {
+
+  private final Active<PatientInput> input;
+  private final Active<Person> patient;
+
+
+  PatientCreateMutationGeneralSteps(
+      final Active<PatientInput> input,
+      final Active<Person> patient
+  ) {
+    this.input = input;
+    this.patient = patient;
+  }
+
+  @Given("the new patient's marital status is entered")
+  public void the_new_patient_marital_status_is_entered() {
+    PatientInput active = this.input.active();
+
+    active.setAsOf(RandomUtil.getRandomDateInPast());
+    active.setMaritalStatus(RandomUtil.getRandomString());
+  }
+
+  @Then("the new patient has the entered marital status")
+  public void the_new_patient_has_the_entered_martial_status() {
+    Person actual = patient.active();
+    PatientInput expected = this.input.active();
+
+    assertThat(actual)
+        .extracting(Person::getGeneralInformation)
+        .returns(expected.getMaritalStatus(), GeneralInformation::maritalStatus);
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/PatientProfileGeneralSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/PatientProfileGeneralSteps.java
@@ -1,30 +1,12 @@
 package gov.cdc.nbs.patient.profile.general;
 
-import gov.cdc.nbs.entity.odse.Person;
-import gov.cdc.nbs.message.patient.input.PatientInput;
-import gov.cdc.nbs.patient.demographic.GeneralInformation;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
-import gov.cdc.nbs.support.util.RandomUtil;
 import gov.cdc.nbs.testing.support.Active;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.result.JsonPathResultMatchers;
-
-import java.time.Instant;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToIgnoringCase;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 
 public class PatientProfileGeneralSteps {
-
-  private final Active<PatientInput> input;
-  private final Active<Person> patient;
 
   private final Active<PatientIdentifier> activePatient;
   private final Active<ResultActions> response;
@@ -32,37 +14,16 @@ public class PatientProfileGeneralSteps {
 
 
   PatientProfileGeneralSteps(
-      final Active<PatientInput> input,
-      final Active<Person> patient,
       final Active<PatientIdentifier> activePatient,
       final Active<ResultActions> response,
       final PatientGeneralRequester requester
   ) {
-    this.input = input;
-    this.patient = patient;
     this.activePatient = activePatient;
     this.response = response;
     this.requester = requester;
   }
 
-  @Given("the new patient's marital status is entered")
-  public void the_new_patient_marital_status_is_entered() {
-    PatientInput active = this.input.active();
-
-    active.setAsOf(RandomUtil.getRandomDateInPast());
-    active.setMaritalStatus(RandomUtil.getRandomString());
-  }
-
-  @Then("the new patient has the entered marital status")
-  public void the_new_patient_has_the_entered_martial_status() {
-    Person actual = patient.active();
-    PatientInput expected = this.input.active();
-
-    assertThat(actual)
-        .extracting(Person::getGeneralInformation)
-        .returns(expected.getMaritalStatus(), GeneralInformation::maritalStatus);
-  }
-
+  @When("I view the Patient Profile General Information")
   @When("I view the patient's general information")
   public void i_view_the_patient_profile_general_information() {
     this.activePatient.maybeActive()
@@ -70,84 +31,4 @@ public class PatientProfileGeneralSteps {
         .ifPresent(this.response::active);
   }
 
-  @Then("the patient's general information is as of {date}")
-  public void the_patients_general_information_includes_the_as_of(final Instant value) throws Exception {
-    this.response.active()
-        .andExpect(
-            jsonPath("$.data.findPatientProfile.general.asOf", equalTo(value.toString()))
-        );
-  }
-
-  @Then("the patient's general information includes the marital status {maritalStatus}")
-  public void the_patients_general_information_includes_the_marital_status(final String value) throws Exception {
-    this.response.active()
-        .andExpect(
-            jsonPath("$.data.findPatientProfile.general.maritalStatus.id", equalTo(value))
-        );
-  }
-
-  @Then("the patient's general information includes the occupation {occupation}")
-  public void the_patients_general_information_includes_the_occupation(final String value) throws Exception {
-    this.response.active()
-        .andExpect(
-            jsonPath("$.data.findPatientProfile.general.occupation.id", equalTo(value))
-        );
-  }
-
-  @Then("the patient's general information includes an education level of {educationLevel}")
-  public void the_patients_general_information_includes_the_education_level(final String value) throws Exception {
-    this.response.active()
-        .andExpect(
-            jsonPath("$.data.findPatientProfile.general.educationLevel.id", equalTo(value))
-        );
-  }
-
-  @Then("the patient's general information includes a primary language of {language}")
-  public void the_patients_general_information_includes_the_primary_language(final String value) throws Exception {
-    this.response.active()
-        .andExpect(
-            jsonPath("$.data.findPatientProfile.general.primaryLanguage.id", equalTo(value))
-        );
-  }
-
-  @Then("the patient's general information includes that the patient {indicator} speak English")
-  public void the_patients_general_information_includes_speaks_english(final String value) throws Exception {
-    this.response.active()
-        .andExpect(
-            jsonPath("$.data.findPatientProfile.general.speaksEnglish.id", equalTo(value))
-        );
-  }
-
-  @Then("the patient's general information includes a(n) {string} of {string}")
-  public void the_patients_general_information_includes(final String field, final String value) throws Exception {
-    JsonPathResultMatchers pathMatcher = matchingPath(field);
-
-    this.response.active()
-        .andExpect(pathMatcher.value(equalTo(value)));
-  }
-
-  @Then("the patient's general information includes {int} {string}")
-  public void the_patients_general_information_includes(final int value, final String field) throws Exception {
-    JsonPathResultMatchers pathMatcher = matchingPath(field);
-
-    this.response.active()
-        .andDo(print())
-        .andExpect(pathMatcher.value(equalTo(value)));
-  }
-
-  @Then("the patient's general information does not include state HIV case due to {string}")
-  public void the_patients_general_information_does_not_include_state_HIV_case(final String reason) throws Exception {
-    this.response.active()
-        .andExpect(jsonPath("$.data.findPatientProfile.general.stateHIVCase.reason", equalToIgnoringCase(reason)));
-  }
-
-  private JsonPathResultMatchers matchingPath(final String field) {
-    return switch (field.toLowerCase()) {
-      case "mother's maiden name" -> jsonPath("$.data.findPatientProfile.general.maternalMaidenName");
-      case "adults in the house" -> jsonPath("$.data.findPatientProfile.general.adultsInHouse");
-      case "children in the house" -> jsonPath("$.data.findPatientProfile.general.childrenInHouse");
-      case "state hiv case" -> jsonPath("$.data.findPatientProfile.general.stateHIVCase.value");
-      default -> throw new AssertionError("Unexpected Patient General Information  property %s".formatted(field));
-    };
-  }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/PatientProfileGeneralVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/general/PatientProfileGeneralVerificationSteps.java
@@ -1,0 +1,129 @@
+package gov.cdc.nbs.patient.profile.general;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Then;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+
+public class PatientProfileGeneralVerificationSteps {
+
+  private final Active<ResultActions> response;
+
+  PatientProfileGeneralVerificationSteps(final Active<ResultActions> response) {
+    this.response = response;
+  }
+
+  @Then("the patient('s) general information is as of {date}")
+  public void the_patients_general_information_includes_the_as_of(final Instant value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.general.asOf", equalTo(value.toString()))
+        );
+  }
+
+  @Then("the patient('s) general information includes the marital status {maritalStatus}")
+  public void the_patients_general_information_includes_the_marital_status(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.general.maritalStatus.id", equalTo(value))
+        );
+  }
+
+  @Then("the patient('s) general information includes the occupation {occupation}")
+  public void the_patients_general_information_includes_the_occupation(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.general.occupation.id", equalTo(value))
+        );
+  }
+
+  @Then("the patient('s) general information includes an education level of {educationLevel}")
+  public void the_patients_general_information_includes_the_education_level(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.general.educationLevel.id", equalTo(value))
+        );
+  }
+
+  @Then("the patient('s) general information includes a primary language of {language}")
+  public void the_patients_general_information_includes_the_primary_language(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.general.primaryLanguage.id", equalTo(value))
+        );
+  }
+
+  @Then("the patient('s) general information includes that the patient {indicator} speak English")
+  public void the_patients_general_information_includes_speaks_english(final String value) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath("$.data.findPatientProfile.general.speaksEnglish.id", equalTo(value))
+        );
+  }
+
+  @Then("the patient('s) general information includes a mother's maiden name of {string}")
+  public void the_patients_general_information_includes_maternal_maiden_name(final String value)
+      throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.maternalMaidenName").value(equalTo(value)));
+  }
+
+  @Then("the patient('s) general information does not include a mother's maiden name of")
+  public void the_patients_general_information_does_not_include()
+      throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.maternalMaidenName").isEmpty());
+  }
+
+  @Then("the patient('s) general information includes {int} adults in the house")
+  public void the_patients_general_information_includes_adults_in_residence(final int value)
+      throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.adultsInHouse").value(equalTo(value)));
+  }
+
+  @Then("the patient('s) general information does not include adults in the house")
+  public void the_patients_general_information_does_not_include_adults_in_residence()
+      throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.adultsInHouse").isEmpty());
+  }
+
+  @Then("the patient('s) general information includes {int} children in the house")
+  public void the_patients_general_information_includes_children_in_residence(final int value)
+      throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.childrenInHouse").value(equalTo(value)));
+  }
+
+  @Then("the patient('s) general information does not include children in the house")
+  public void the_patients_general_information_does_not_include_children_in_residence()
+      throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.childrenInHouse").isEmpty());
+  }
+
+  @Then("the patient('s) general information includes a state HIV case of {string}")
+  public void the_patients_general_information_includes_a_state_HIV_case(final String value) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.stateHIVCase.value").value(equalTo(value)));
+  }
+
+  @Then("the patient('s) general information does not include a state HIV case")
+  public void the_patients_general_information_does_not_include_a_state_HIV_case() throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.stateHIVCase.value").isEmpty());
+  }
+
+  @Then("the patient's general information does not include state HIV case due to {string}")
+  public void the_patients_general_information_does_not_include_state_HIV_case(final String reason) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.data.findPatientProfile.general.stateHIVCase.reason", equalToIgnoringCase(reason)));
+  }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.general.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/ExtendedPatientCreation.general.feature
@@ -1,0 +1,54 @@
+@patient_extended_create
+Feature: Creation of Patients with extended General Information data
+
+  Background:
+    Given I am logged into NBS
+    And I can "add" any "patient"
+    And I can "find" any "patient"
+
+  Scenario: I can create a patient with general information demographics
+    Given I enter the general information as of date 05/29/2023
+    And I enter the general information marital status as Unmarried
+    And I enter the general information maternal maiden name as "Zawistowska"
+    And I enter the general information adults in residence as 7
+    And I enter the general information children in residence as 3
+    And I enter the general information primary occupation of Industrial Gas Manufacturing
+    And I enter the general information education level of Professional Degree
+    And I enter the general information primary language of Polish
+    And I enter the general information that the patient does not speak english
+    And the general information demographics are included in the extended patient data
+    When I create a patient with extended data
+    Then I view the Patient Profile General Information
+    And the patient's general information is as of 05/29/2023
+    And the patient's general information includes the marital status Unmarried
+    And the patient's general information includes a mother's maiden name of "Zawistowska"
+    And the patient's general information includes 7 adults in the house
+    And the patient's general information includes 3 children in the house
+    And the patient's general information includes the occupation Industrial Gas Manufacturing
+    And the patient's general information includes an education level of Professional Degree
+    And the patient's general information includes a primary language of Polish
+    And the patient's general information includes that the patient does not speak English
+
+  Scenario: I can add a patient with general information demographics that include a State HIV case when I have access to HIV fields
+    Given I can "HIVQuestions" any "Global"
+    And I enter the general information state HIV case of "case-number"
+    And the general information demographics are included in the extended patient data
+    When I create a patient with extended data
+    Then I view the Patient Profile General Information
+    Then the patient's general information includes a state HIV case of "case-number"
+
+  Scenario: I can add a patient with general information demographics that does not include a blank State HIV case
+    Given I can "HIVQuestions" any "Global"
+    And I enter the general information state HIV case of ""
+    And the general information demographics are included in the extended patient data
+    When I create a patient with extended data
+    Then I view the Patient Profile General Information
+    And the patient's general information does not include a state HIV case
+
+  Scenario: I can add a patient's general information but it will not include the state HIV case a patient may be associated with without having access to HIV Fields
+    Given I enter the general information state HIV case of "case-number"
+    And the general information demographics are included in the extended patient data
+    When I create a patient with extended data
+    And I can "HIVQuestions" any "Global"
+    Then I view the Patient Profile General Information
+    And the patient's general information does not include a state HIV case

--- a/apps/modernization-api/src/test/resources/features/patient/profile/demographics/general/PatientProfileGeneralInformationChange.HIV-fields.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/demographics/general/PatientProfileGeneralInformationChange.HIV-fields.feature
@@ -6,29 +6,31 @@ Feature: Patient Profile General Information Changes
     And I can "find" any "patient"
     And I can "edit" any "patient"
     And I have a patient
-    And the patient is associated with state HIV case "case-number"
 
   Scenario: I can view the state HIV case of a patient when I have access to HIV Fields
     Given I can "HIVQuestions" any "Global"
+    And the patient is associated with state HIV case "case-number"
     When I view the patient's general information
-    Then the patient's general information includes a "state HIV case" of "case-number"
+    Then the patient's general information includes a state HIV case of "case-number"
 
   Scenario: I can not view the state HIV case of a patient without access to HIV Fields
-    When I view the patient's general information
+    When the patient is associated with state HIV case "case-number"
+    And I view the patient's general information
     Then the patient's general information does not include state HIV case due to "insufficient permissions"
 
   Scenario: I can update a patient's general information to include the state HIV case a patient may be associated with when I have access to HIV Fields
     Given I can "HIVQuestions" any "Global"
+    And the patient is associated with state HIV case "initial-case-number"
     And I want to change the patient's general information to include that the patient is associated with state HIV case "changed case-number"
     When the patient profile general information changes are submitted as of 04/17/2013
     And I view the patient's general information
-    Then the patient's general information includes a "state HIV case" of "changed case-number"
+    Then the patient's general information includes a state HIV case of "changed case-number"
 
-  Scenario: I can not update a patient's general information to include the state HIV case a patient may be associated with without access to HIV Fields
+  Scenario: I can update a patient's general information but it will not include the state HIV case a patient may be associated with without having access to HIV Fields
     Given I want to change the patient's general information to include that the patient is associated with state HIV case "changed case-number"
     When the patient profile general information changes are submitted as of 04/17/2013
     And I can "HIVQuestions" any "Global"
     And I view the patient's general information
-    Then the patient's general information includes a "state HIV case" of "case-number"
+    Then the patient's general information does not include a state HIV case
 
 

--- a/apps/modernization-api/src/test/resources/features/patient/profile/demographics/general/PatientProfileGeneralInformationChange.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/demographics/general/PatientProfileGeneralInformationChange.feature
@@ -22,19 +22,19 @@ Feature: Patient Profile General Information Changes
     Given I want to change the patient's general information to include the mother's maiden name of "Maiden Name"
     When the patient profile general information changes are submitted as of 04/17/2013
     And I view the patient's general information
-    Then the patient's general information includes a "mother's maiden name" of "Maiden Name"
+    Then the patient's general information includes a mother's maiden name of "Maiden Name"
 
   Scenario: I can update a patient's general information to include adults in house
     Given I want to change the patient's general information to include 11 adults in the house
     When the patient profile general information changes are submitted as of 04/17/2013
     And I view the patient's general information
-    Then the patient's general information includes 11 "adults in the house"
+    Then the patient's general information includes 11 adults in the house
 
   Scenario: I can update a patient's general information to include children in house
     Given I want to change the patient's general information to include 67 children in the house
     When the patient profile general information changes are submitted as of 04/17/2013
     And I view the patient's general information
-    Then the patient's general information includes 67 "children in the house"
+    Then the patient's general information includes 67 children in the house
 
   Scenario: I can update a patient's general information to include occupation
     Given I want to change the patient's general information to include the occupation of Envelope Manufacturing

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -202,7 +202,7 @@ describe('when transforming entered extended patient data', () => {
             administrative: { asOf: '04/13/2017' },
             general: {
                 asOf: '04/13/2017',
-                comment: 'general-information'
+                maternalMaidenName: 'general-information'
             }
         };
 
@@ -210,7 +210,7 @@ describe('when transforming entered extended patient data', () => {
 
         expect(actual).toEqual(
             expect.objectContaining({
-                general: expect.objectContaining({ comment: 'general-information' })
+                general: expect.objectContaining({ maternalMaidenName: 'general-information' })
             })
         );
     });

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -85,18 +85,17 @@ type MortalityEntry = EffectiveDated &
         deceasedOn?: string;
     };
 
-type GeneralInformationEntry = EffectiveDated &
-    HasComments & {
-        maritalStatus?: Selectable;
-        maternalMaidenName?: string;
-        adultsInResidence?: number;
-        childrenInResidence?: number;
-        primaryOccupation?: Selectable;
-        educationLevel?: Selectable;
-        primaryLanguage?: Selectable;
-        speaksEnglish?: Selectable;
-        stateHIVCase?: string;
-    };
+type GeneralInformationEntry = EffectiveDated & {
+    maritalStatus?: Selectable;
+    maternalMaidenName?: string;
+    adultsInResidence?: number;
+    childrenInResidence?: number;
+    primaryOccupation?: Selectable;
+    educationLevel?: Selectable;
+    primaryLanguage?: Selectable;
+    speaksEnglish?: Selectable;
+    stateHIVCase?: string;
+};
 
 export type {
     AdministrativeEntry,

--- a/apps/modernization-ui/src/apps/patient/data/general/asGeneral.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/general/asGeneral.spec.ts
@@ -109,15 +109,4 @@ describe('when mapping a general information entry to a format accepted by the A
 
         expect(actual).toEqual(expect.objectContaining({ stateHIVCase: 'state-hiv-case-value' }));
     });
-
-    it('should include the comment', () => {
-        const entry = {
-            asOf: '04/13/2017',
-            comment: 'comment-value'
-        };
-
-        const actual = asGeneral(entry);
-
-        expect(actual).toEqual(expect.objectContaining({ comment: 'comment-value' }));
-    });
 });


### PR DESCRIPTION
## Description

Adds support for general information demographics in the Patient Add API

```cucumber
Feature: Creation of Patients with extended General Information data

  Background:
    Given I am logged into NBS
    And I can "add" any "patient"
    And I can "find" any "patient"

  Scenario: I can create a patient with general information demographics
    Given I enter the general information as of date 05/29/2023
    And I enter the general information marital status as Unmarried
    And I enter the general information maternal maiden name as "Zawistowska"
    And I enter the general information adults in residence as 7
    And I enter the general information children in residence as 3
    And I enter the general information primary occupation of Industrial Gas Manufacturing
    And I enter the general information education level of Professional Degree
    And I enter the general information primary language of Polish
    And I enter the general information that the patient does not speak english
    And the general information demographics are included in the extended patient data
    When I create a patient with extended data
    Then I view the Patient Profile General Information
    And the patient's general information is as of 05/29/2023
    And the patient's general information includes the marital status Unmarried
    And the patient's general information includes a mother's maiden name of "Zawistowska"
    And the patient's general information includes 7 adults in the house
    And the patient's general information includes 3 children in the house
    And the patient's general information includes the occupation Industrial Gas Manufacturing
    And the patient's general information includes an education level of Professional Degree
    And the patient's general information includes a primary language of Polish
    And the patient's general information includes that the patient does not speak English

  Scenario: I can add a patient with general information demographics that include a State HIV case when I have access to HIV fields
    Given I can "HIVQuestions" any "Global"
    And I enter the general information state HIV case of "case-number"
    And the general information demographics are included in the extended patient data
    When I create a patient with extended data
    Then I view the Patient Profile General Information
    Then the patient's general information includes a state HIV case of "case-number"

  Scenario: I can add a patient with general information demographics that does not include a blank State HIV case
    Given I can "HIVQuestions" any "Global"
    And I enter the general information state HIV case of ""
    And the general information demographics are included in the extended patient data
    When I create a patient with extended data
    Then I view the Patient Profile General Information
    And the patient's general information does not include a state HIV case

  Scenario: I can add a patient's general information but it will not include the state HIV case a patient may be associated with without having access to HIV Fields
    Given I enter the general information state HIV case of "case-number"
    And the general information demographics are included in the extended patient data
    When I create a patient with extended data
    And I can "HIVQuestions" any "Global"
    Then I view the Patient Profile General Information
    And the patient's general information does not include a state HIV case

```

## Tickets

* [CNFT1-2783](https://cdc-nbs.atlassian.net/browse/CNFT1-2783)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
