### PR TITLE
[CNFT1-3243] Reset paginiation on new search

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
@@ -1,22 +1,47 @@
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SearchLayout } from './SearchLayout';
 import { SkipLinkProvider } from 'SkipLink/SkipLinkContext';
-import { SearchPageProvider } from '../SearchPage';
+import { SearchResultDisplayProvider } from '../useSearchResultDisplay';
+
+jest.mock('page', () => ({
+    usePage: () => ({
+        page: {
+            status: 0,
+            pageSize: 1,
+            total: 1,
+            current: 1
+        },
+        firstPage: jest.fn(),
+        reload: jest.fn(),
+        request: jest.fn(),
+        ready: jest.fn(),
+        resize: jest.fn(),
+        reset: jest.fn()
+    })
+}));
+
+jest.mock('sorting', () => ({
+    useSorting: () => ({
+        reset: jest.fn(),
+        sortBy: jest.fn(),
+        toggle: jest.fn()
+    })
+}));
 
 jest.mock('apps/search', () => ({
     useSearchResultDisplay: () => ({
         view: 'list'
     }),
-    useSearchInteraction: () => ({ status: 'no-input', results: { total: 199, terms: [] } })
+    useSearchInteraction: () => ({ status: 'no-input', results: { total: 1, terms: [] } })
 }));
 
-describe('no input', () => {
-    it('should render no input', async () => {
-        const { container } = render(
+describe('when a search is performed without ', () => {
+    it('should render no input', () => {
+        const { getByText } = render(
             <MemoryRouter>
                 <SkipLinkProvider>
-                    <SearchPageProvider>
+                    <SearchResultDisplayProvider>
                         <SearchLayout
                             criteria={jest.fn()}
                             resultsAsList={jest.fn()}
@@ -24,13 +49,11 @@ describe('no input', () => {
                             onSearch={jest.fn()}
                             onClear={jest.fn()}
                         />
-                    </SearchPageProvider>
+                    </SearchResultDisplayProvider>
                 </SkipLinkProvider>
             </MemoryRouter>
         );
 
-        await waitFor(() => {
-            expect(container).toHaveTextContent('You must enter at least one item to search');
-        });
+        expect(getByText(/You must enter at least one item to search/)).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/search/useSearchInteraction.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchInteraction.tsx
@@ -13,7 +13,7 @@ type SearchInteractionStatus =
 type SearchResults<R> = {
     total: number;
     page: number;
-    size?: number;
+    size: number;
     content: R[];
     terms: Term[];
 };

--- a/apps/modernization-ui/src/apps/search/useSearchResults.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResults.spec.tsx
@@ -1,16 +1,56 @@
 import { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { SearchResultSettings, useSearchResults } from './useSearchResults';
-import { SearchPageProvider } from './SearchPage';
+import { Page } from 'page';
+import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 
+let mockCriteria: Criteria | undefined = undefined;
 const mockClear = jest.fn();
 const mockChange = jest.fn();
 
 jest.mock('./useSearchCriteria', () => ({
     useSearchCriteria: () => ({
+        criteria: mockCriteria,
         clear: mockClear,
         change: mockChange
+    })
+}));
+
+const mockPage: Page = {
+    status: 0,
+    pageSize: 5,
+    total: 7,
+    current: 11
+};
+
+const mockFirstPage = jest.fn();
+const mockReload = jest.fn();
+const mockRequest = jest.fn();
+const mockReady = jest.fn();
+const mockResize = jest.fn();
+const mockPageReset = jest.fn();
+
+jest.mock('page', () => ({
+    usePage: () => ({
+        page: mockPage,
+        firstPage: mockFirstPage,
+        reload: mockReload,
+        request: mockRequest,
+        ready: mockReady,
+        resize: mockResize,
+        reset: mockPageReset
+    })
+}));
+
+const mockSortReset = jest.fn();
+const mockSortBy = jest.fn();
+const mockToggle = jest.fn();
+
+jest.mock('sorting', () => ({
+    useSorting: () => ({
+        reset: mockSortReset,
+        sortBy: mockSortBy,
+        toggle: mockToggle
     })
 }));
 
@@ -19,15 +59,15 @@ type APIParameters = { search: string };
 type Result = { label: string; value: string };
 
 const wrapper = ({ children }: { children: ReactNode }) => (
-    <MemoryRouter>
-        <SearchPageProvider>{children}</SearchPageProvider>
-    </MemoryRouter>
+    <SearchResultDisplayProvider>{children}</SearchResultDisplayProvider>
 );
 
 const setup = (props?: Partial<SearchResultSettings<Criteria, APIParameters, Result>>) => {
     const defaultTransformer = (criteria: Criteria) => ({ search: criteria.name });
-    const defaultResultResolver = () => Promise.resolve({ total: 0, content: [], page: 0 });
-    const defaultTermResolver = () => [];
+    const defaultResultResolver = () => Promise.resolve({ total: 0, content: [], page: 0, size: 7 });
+    const defaultTermResolver = () => [
+        { source: 'default-source', title: 'title-value', name: 'name-value', value: 'value-vlaue' }
+    ];
     //
     const transformer = props?.transformer ?? defaultTransformer;
     const resultResolver = props?.resultResolver ?? defaultResultResolver;
@@ -49,8 +89,18 @@ describe('when searching using useSearchResults', () => {
         expect(result.current.status).toEqual('waiting');
     });
 
-    it('should change to status to completed when search results have been resolved', async () => {
+    it('should change to status to loading after invoking a search', async () => {
         const { result } = setup();
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        expect(result.current.status).toEqual('loading');
+    });
+
+    it('should change to status to no-input when terms cannot be resolved', async () => {
+        const { result } = setup({ termResolver: () => [] });
 
         await act(async () => {
             result.current.search({ name: 'name-value' });
@@ -84,13 +134,17 @@ describe('when searching using useSearchResults', () => {
     });
 
     it('should change to status to error when search produces an error', async () => {
-        const { result } = setup({ resultResolver: () => Promise.reject(new Error('there has been an error')) });
+        const { result } = setup({
+            resultResolver: () => Promise.reject(new Error('there has been an error'))
+        });
+
+        mockCriteria = { name: 'name-value' };
 
         await act(async () => {
             result.current.search({ name: 'name-value' });
         });
 
-        expect(result.current.status).toEqual('no-input');
+        expect(result.current.status).toEqual('error');
     });
 
     it('should change to status to waiting when reset after error', async () => {
@@ -107,7 +161,7 @@ describe('when searching using useSearchResults', () => {
         expect(result.current.status).toEqual('waiting');
     });
 
-    it('should use change the criteria when searching', async () => {
+    it('should change the criteria when searching', async () => {
         const transformer = jest.fn(() => ({ search: 'name-value' }));
 
         const terms = [{ source: 'mock-source', title: 'Mocked Title', name: 'Mocked Name', value: 'mock' }];
@@ -125,5 +179,27 @@ describe('when searching using useSearchResults', () => {
         expect(termResolver).toHaveBeenCalledWith({ name: 'name-value' });
 
         expect(mockChange).toHaveBeenCalledWith(expect.objectContaining({ name: 'name-value' }));
+    });
+
+    it('should use the request first page when criteria changes', async () => {
+        mockCriteria = { name: 'mocked' };
+
+        const resultResolver = jest.fn();
+        resultResolver.mockResolvedValue({ total: 2, content: [], page: 3, size: 5 });
+
+        mockPage.current = 227;
+        mockPage.pageSize = 307;
+
+        const { result, rerender } = setup({ resultResolver });
+
+        await act(async () => {
+            result.current.search({ name: 'name-value' });
+        });
+
+        rerender();
+
+        expect(resultResolver).toBeCalledWith(
+            expect.objectContaining({ page: expect.objectContaining({ number: 1, size: 307 }) })
+        );
     });
 });

--- a/apps/modernization-ui/src/apps/search/useSearchResults.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchResults.ts
@@ -6,17 +6,19 @@ import { useSearchCriteria } from './useSearchCriteria';
 import { SearchResults } from './useSearchInteraction';
 import { Term } from './terms';
 
+type Page = { number: number; size: number };
+
 type Resolved<R> = Omit<SearchResults<R>, 'terms'>;
 
 type Waiting = { status: 'waiting' };
 
 type Resetting = { status: 'resetting' };
 
-type Initializing<C> = { status: 'initializing'; criteria: C };
+type Initializing<C> = { status: 'initializing'; criteria: C; page: Page };
 
-type Requesting<C> = { status: 'requesting'; criteria: C };
+type Requesting<C> = { status: 'requesting'; criteria: C; page: Page };
 
-type Fetching<A> = { status: 'fetching'; parameters: A; terms: Term[] };
+type Fetching<A> = { status: 'fetching'; parameters: A; terms: Term[]; page: Page };
 
 type Completed<A, R> = { status: 'completed'; parameters: A; results: SearchResults<R> };
 
@@ -37,23 +39,40 @@ type State<C, A, R> =
 type Action<C, A, R> =
     | { type: 'wait' }
     | { type: 'reset' }
-    | { type: 'refresh' }
-    | { type: 'initialize'; criteria: C }
-    | { type: 'request'; criteria: C }
-    | { type: 'fetch'; parameters: A; terms: Term[] }
+    | { type: 'change-sort' }
+    | ({ type: 'change-page' } & Page)
+    | { type: 'initialize'; criteria: C; page: Page }
+    | { type: 'request'; criteria: C; page: Page }
+    | { type: 'fetch'; parameters: A; terms: Term[]; page: Page }
     | { type: 'complete'; found: Resolved<R> }
-    | { type: 'no-input'; parameters: A; page: number; size: number }
+    | { type: 'no-input'; parameters: A; page: Page }
     | { type: 'error'; reason: string };
 
 const reducer = <C, A, R>(current: State<C, A, R>, action: Action<C, A, R>): State<C, A, R> => {
     if (action.type === 'request') {
-        return { status: 'requesting', criteria: action.criteria };
+        const { criteria, page } = action;
+        return { status: 'requesting', criteria, page };
     } else if (action.type === 'fetch') {
-        return { status: 'fetching', parameters: action.parameters, terms: action.terms };
+        const { parameters, terms, page } = action;
+        return { status: 'fetching', parameters, terms, page };
     } else if (action.type === 'complete' && current.status === 'fetching') {
         return { ...current, status: 'completed', results: { ...action.found, terms: current.terms } };
-    } else if (action.type === 'refresh' && current.status === 'completed') {
-        return { status: 'fetching', parameters: current.parameters, terms: current.results.terms };
+    } else if (action.type === 'change-sort' && current.status === 'completed') {
+        const page = { number: current.results.page, size: current.results.size };
+
+        return {
+            status: 'fetching',
+            parameters: current.parameters,
+            terms: current.results.terms,
+            page
+        };
+    } else if (action.type === 'change-page' && current.status === 'completed') {
+        return {
+            status: 'fetching',
+            parameters: current.parameters,
+            terms: current.results.terms,
+            page: { number: action.number, size: action.size }
+        };
     } else if (action.type === 'error') {
         return { status: 'error', reason: action.reason };
     } else if (action.type === 'reset') {
@@ -61,12 +80,15 @@ const reducer = <C, A, R>(current: State<C, A, R>, action: Action<C, A, R>): Sta
     } else if (action.type === 'wait') {
         return { status: 'waiting' };
     } else if (action.type === 'no-input') {
+        const { page } = action;
+
         return {
             status: 'no-input',
-            results: { total: 0, content: [], terms: [], page: action.page, size: action.size }
+            results: { total: 0, content: [], terms: [], page: page.number, size: page.size }
         };
     } else if (action.type === 'initialize') {
-        return { status: 'initializing', criteria: action.criteria };
+        const { page } = action;
+        return { status: 'initializing', criteria: action.criteria, page };
     }
     return current;
 };
@@ -173,7 +195,7 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
     useEffect(() => {
         if (searchCriteria) {
             //  the search criteria has changed initialize a search
-            dispatch({ type: 'initialize', criteria: searchCriteria });
+            dispatch({ type: 'initialize', criteria: searchCriteria, page: { number: 1, size: page.pageSize } });
         }
     }, [searchCriteria, dispatch]);
 
@@ -192,11 +214,13 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
 
     useEffect(() => {
         if (state.status === 'requesting') {
-            const parameters = transformer(state.criteria);
-            const terms = termResolver(state.criteria);
+            const { criteria, page } = state;
+
+            const parameters = transformer(criteria);
+            const terms = termResolver(criteria);
 
             if (noInputCheck(terms)) {
-                dispatch({ type: 'no-input', parameters, page: page.current, size: page.pageSize });
+                dispatch({ type: 'no-input', parameters, page });
             } else {
                 changeCriteria(state.criteria);
             }
@@ -209,9 +233,9 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
             const terms = termResolver(state.criteria);
 
             if (noInputCheck(terms)) {
-                dispatch({ type: 'no-input', parameters, page: page.current, size: page.pageSize });
+                dispatch({ type: 'no-input', parameters, page: state.page });
             } else {
-                dispatch({ type: 'fetch', parameters, terms });
+                dispatch({ type: 'fetch', parameters, terms, page: state.page });
             }
         }
     }, [state.status, noInputCheck]);
@@ -221,22 +245,23 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
             // the criteria has changed invoke search
             resultResolver({
                 parameters: state.parameters,
-                page: {
-                    number: page.current,
-                    size: page.pageSize
-                },
+                page: state.page,
                 sort
-            }).then(orElseEmptyResult(page.pageSize, handleComplete), handleError);
-        } else if (state.status === 'completed' && page.status === PageStatus.Requested) {
+            }).then(orElseEmptyResult(state.page.size, handleComplete), handleError);
+        }
+    }, [state.status]);
+
+    useEffect(() => {
+        if (state.status === 'completed' && page.status === PageStatus.Requested) {
             //  the page changing without the criteria changing
-            dispatch({ type: 'refresh' });
+            dispatch({ type: 'change-page', number: page.current, size: page.pageSize });
         }
     }, [state.status, page.status, page.pageSize, page.current]);
 
     useEffect(() => {
         if (sort?.direction) {
             //  the sorting changing without the criteria changing
-            dispatch({ type: 'refresh' });
+            dispatch({ type: 'change-sort' });
         }
     }, [sort?.direction, sort?.property]);
 
@@ -254,7 +279,10 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
     );
     const error = useMemo(() => (state.status === 'error' ? state.reason : undefined), [state.status]);
     const reset = useCallback(() => dispatch({ type: 'reset' }), [dispatch]);
-    const search = useCallback((criteria: C) => dispatch({ type: 'request', criteria }), [dispatch]);
+    const search = useCallback(
+        (criteria: C) => dispatch({ type: 'request', criteria, page: { number: 1, size: page.pageSize } }),
+        [dispatch, page.pageSize]
+    );
 
     return {
         status,


### PR DESCRIPTION
## Description

When a new search is performed or the sorting is change, the pagination is now reset to the first page.

![CNFT1-3243](https://github.com/user-attachments/assets/6864b6e9-64e2-46ef-b5c1-14bafc9fa34e)


## Tickets

* [CNFT1-3243](https://cdc-nbs.atlassian.net/browse/CNFT1-3243)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3243]: https://cdc-nbs.atlassian.net/browse/CNFT1-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ