### PR TITLE
Cnft1 3196 census tract validation

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
@@ -58,9 +58,7 @@ describe('RaceMultiEntry', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText, getAllByRole, getAllByText } = render(
-            <AddressRepeatingBlock onChange={onChange} isDirty={isDirty} />
-        );
+        const { getByLabelText } = render(<AddressRepeatingBlock onChange={onChange} isDirty={isDirty} />);
 
         const dateInput = getByLabelText('Address as of');
         expect(dateInput).toHaveValue(internalizeDate(new Date()));
@@ -90,7 +88,7 @@ describe('RaceMultiEntry', () => {
         expect(county).toHaveValue('');
 
         const censusTract = getByLabelText('Census tract');
-        expect(censusTract).toHaveValue('');
+        expect(censusTract).toHaveValue(null);
 
         const country = getByLabelText('Country');
         expect(country).toHaveValue('');

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
@@ -88,7 +88,7 @@ describe('RaceMultiEntry', () => {
         expect(county).toHaveValue('');
 
         const censusTract = getByLabelText('Census tract');
-        expect(censusTract).toHaveValue(null);
+        expect(censusTract).toHaveValue('');
 
         const country = getByLabelText('Country');
         expect(country).toHaveValue('');

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -134,46 +134,41 @@ describe('AddressEntryFields', () => {
         });
     });
 
-    it('should invalidate Census Tract format', async () => {
+    test.each([
+        { value: '0000.00', valid: false },
+        { value: '0001.00', valid: false },
+        { value: '0001.01', valid: true },
+        { value: '1000.00', valid: false },
+        { value: '9999.99', valid: false },
+        { value: '9999.98', valid: true },
+        { value: '0001', valid: true },
+        { value: '9999', valid: true },
+        { value: '0000', valid: false },
+        { value: '9999.00', valid: false },
+        { value: '0001.99', valid: false },
+        { value: '1234.56', valid: true }
+    ])('should validate Census Tract format for value: $value', async ({ value, valid }) => {
         const { getByLabelText, getByText, queryByText } = render(<Fixture />);
-
         const censusTractInput = getByLabelText('Census tract');
 
-        const testCases = [
-            { value: '0000.00', valid: false },
-            { value: '0001.00', valid: false },
-            { value: '0001.01', valid: true },
-            { value: '1000.00', valid: false },
-            { value: '9999.99', valid: false },
-            { value: '9999.98', valid: true },
-            { value: '0001', valid: true },
-            { value: '9999', valid: true },
-            { value: '0000', valid: false },
-            { value: '9999.00', valid: false },
-            { value: '0001.99', valid: false },
-            { value: '1234.56', valid: true }
-        ];
+        userEvent.clear(censusTractInput);
+        userEvent.paste(censusTractInput, value);
+        userEvent.tab();
 
-        for (const { value, valid } of testCases) {
-            userEvent.clear(censusTractInput);
-            userEvent.paste(censusTractInput, value);
-            userEvent.tab();
-
-            await waitFor(() => {
-                if (valid) {
-                    expect(
-                        queryByText(
-                            'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
-                        )
-                    ).not.toBeInTheDocument();
-                } else {
-                    expect(
-                        getByText(
-                            'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
-                        )
-                    ).toBeInTheDocument();
-                }
-            });
-        }
+        await waitFor(() => {
+            if (valid) {
+                expect(
+                    queryByText(
+                        'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
+                    )
+                ).not.toBeInTheDocument();
+            } else {
+                expect(
+                    getByText(
+                        'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
+                    )
+                ).toBeInTheDocument();
+            }
+        });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -133,4 +133,23 @@ describe('AddressEntryFields', () => {
             expect(queryByText('Use is required.')).not.toBeInTheDocument();
         });
     });
+
+    it('should invalidate Census Tract format', async () => {
+        const { getByLabelText, getByText } = render(<Fixture />);
+
+        const censusTractInput = getByLabelText('Census tract');
+
+        act(() => {
+            userEvent.clear(censusTractInput);
+            userEvent.type(censusTractInput, '12345');
+            userEvent.tab();
+        });
+        await waitFor(() => {
+            expect(
+                getByText(
+                    'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
+                )
+            ).toBeInTheDocument();
+        });
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { FormProvider, useForm } from 'react-hook-form';
 import { AddressEntry } from '../entry';
@@ -116,7 +116,7 @@ describe('AddressEntryFields', () => {
         const asOf = getByLabelText('Address as of');
         const type = getByLabelText('Type');
         const use = getByLabelText('Use');
-        await screen.findByText('Use');
+        await waitFor(() => expect(use).toBeInTheDocument());
 
         act(() => {
             userEvent.paste(asOf, '01/20/2020');
@@ -148,26 +148,21 @@ describe('AddressEntryFields', () => {
         { value: '0001.99', valid: false },
         { value: '1234.56', valid: true }
     ])('should validate Census Tract format for value: $value', async ({ value, valid }) => {
-        const { getByLabelText, getByText, queryByText } = render(<Fixture />);
+        const { getByLabelText, queryByText } = render(<Fixture />);
         const censusTractInput = getByLabelText('Census tract');
 
         userEvent.clear(censusTractInput);
         userEvent.paste(censusTractInput, value);
         userEvent.tab();
 
+        const validationMessage =
+            'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.';
+
         await waitFor(() => {
             if (valid) {
-                expect(
-                    queryByText(
-                        'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
-                    )
-                ).not.toBeInTheDocument();
+                expect(queryByText(validationMessage)).not.toBeInTheDocument();
             } else {
-                expect(
-                    getByText(
-                        'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
-                    )
-                ).toBeInTheDocument();
+                expect(queryByText(validationMessage)).toBeInTheDocument();
             }
         });
     });

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -135,21 +135,45 @@ describe('AddressEntryFields', () => {
     });
 
     it('should invalidate Census Tract format', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
+        const { getByLabelText, getByText, queryByText } = render(<Fixture />);
 
         const censusTractInput = getByLabelText('Census tract');
 
-        act(() => {
+        const testCases = [
+            { value: '0000.00', valid: false },
+            { value: '0001.00', valid: false },
+            { value: '0001.01', valid: true },
+            { value: '1000.00', valid: false },
+            { value: '9999.99', valid: false },
+            { value: '9999.98', valid: true },
+            { value: '0001', valid: true },
+            { value: '9999', valid: true },
+            { value: '0000', valid: false },
+            { value: '9999.00', valid: false },
+            { value: '0001.99', valid: false },
+            { value: '1234.56', valid: true }
+        ];
+
+        for (const { value, valid } of testCases) {
             userEvent.clear(censusTractInput);
-            userEvent.type(censusTractInput, '12345');
+            userEvent.paste(censusTractInput, value);
             userEvent.tab();
-        });
-        await waitFor(() => {
-            expect(
-                getByText(
-                    'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
-                )
-            ).toBeInTheDocument();
-        });
+
+            await waitFor(() => {
+                if (valid) {
+                    expect(
+                        queryByText(
+                            'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
+                        )
+                    ).not.toBeInTheDocument();
+                } else {
+                    expect(
+                        getByText(
+                            'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
+                        )
+                    ).toBeInTheDocument();
+                }
+            });
+        }
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -159,10 +159,11 @@ describe('AddressEntryFields', () => {
             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.';
 
         await waitFor(() => {
+            const validationError = queryByText(validationMessage);
             if (valid) {
-                expect(queryByText(validationMessage)).not.toBeInTheDocument();
+                expect(validationError).not.toBeInTheDocument();
             } else {
-                expect(queryByText(validationMessage)).toBeInTheDocument();
+                expect(validationError).toBeInTheDocument();
             }
         });
     });

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -208,7 +208,7 @@ export const AddressEntryFields = () => {
                 name="censusTract"
                 rules={{
                     pattern: {
-                        value: /^\d{3}[1-9](\.\d[1-8])?$/,
+                        value: /^(0[0-9]{3}|[1-9][0-9]{3})(\.(0[1-9]|[1-8][0-9]|9[0-8]))?$/,
                         message:
                             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
                     }

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -208,7 +208,7 @@ export const AddressEntryFields = () => {
                 name="censusTract"
                 rules={{
                     pattern: {
-                        value: /^(0[0-9]{3}|[1-9][0-9]{3})(\.(0[1-9]|[1-9][0-9]?))?$/,
+                        value: /^\d{3}[1-9](\.\d[1-8])?$/,
                         message:
                             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
                     }

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -208,7 +208,7 @@ export const AddressEntryFields = () => {
                 name="censusTract"
                 rules={{
                     pattern: {
-                        value: /^\d{4}(\.\d{2})?$/,
+                        value: /^(0[0-9]{3}|[1-9][0-9]{3})(\.(0[1-9]|[1-9][0-9]?))?$/,
                         message:
                             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
                     }
@@ -225,7 +225,6 @@ export const AddressEntryFields = () => {
                         htmlFor={name}
                         id={name}
                         error={error?.message}
-                        pattern="^\d{4}(\.\d{2})?$"
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -208,7 +208,7 @@ export const AddressEntryFields = () => {
                 name="censusTract"
                 rules={{
                     pattern: {
-                        value: /^(\d{4}|\d{4}\.(0[1-9]|[1-9][0-8]))$/,
+                        value: /^\d{4}(\.\d{2})?$/,
                         message:
                             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
                     }
@@ -220,11 +220,12 @@ export const AddressEntryFields = () => {
                         onChange={onChange}
                         onBlur={onBlur}
                         defaultValue={value}
-                        type="text"
+                        type="number"
                         name={name}
                         htmlFor={name}
                         id={name}
                         error={error?.message}
+                        pattern="^\d{4}(\.\d{2})?$"
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -206,7 +206,14 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="censusTract"
-                rules={maxLengthRule(10)}
+                rules={{
+                    pattern: {
+                        value: /^(\d{4}|\d{4}\.(0[1-9]|[1-9][0-8]))$/,
+                        message:
+                            'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
+                    },
+                    ...maxLengthRule(7)
+                }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Census tract"

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -208,7 +208,7 @@ export const AddressEntryFields = () => {
                 name="censusTract"
                 rules={{
                     pattern: {
-                        value: /^(0[0-9]{3}|[1-9][0-9]{3})(\.(0[1-9]|[1-8][0-9]|9[0-8]))?$/,
+                        value: /^(?!0000)(\d{4})(?:\.(?!00|99)\d{2})?$/,
                         message:
                             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
                     }

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -220,7 +220,9 @@ export const AddressEntryFields = () => {
                         onChange={onChange}
                         onBlur={onBlur}
                         defaultValue={value}
-                        type="number"
+                        type="text"
+                        mask="____.__"
+                        pattern="^(?!0000)(\d{4})(?:\.(?!00|99)\d{2})?$"
                         name={name}
                         htmlFor={name}
                         id={name}

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -211,8 +211,7 @@ export const AddressEntryFields = () => {
                         value: /^(\d{4}|\d{4}\.(0[1-9]|[1-9][0-8]))$/,
                         message:
                             'Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.'
-                    },
-                    ...maxLengthRule(7)
+                    }
                 }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input


### PR DESCRIPTION
See attached images observing the button enabled after correct format added
<img width="549" alt="Screenshot 2024-10-02 at 7 57 40 AM" src="https://github.com/user-attachments/assets/16103300-7b39-4834-b27c-261f4a686a66">
<img width="612" alt="Screenshot 2024-10-02 at 7 57 54 AM" src="https://github.com/user-attachments/assets/b2ddd56a-b043-4369-920b-c627a200ce12">
## Description
Census Tract should be in numeric XXXX or XXXX.xx format where XXXX is the basic tract and xx is the suffix. XXXX ranges from 0001 to 9999. The suffix is limited to a range between .01 and .98.

Must not allow nonNumeric input

examples of button disabled for invalid format
<img width="500" alt="Screenshot 2024-10-02 at 8 00 43 AM" src="https://github.com/user-attachments/assets/8c1f2bf0-7c39-444e-bc07-cb829bebb6b7">


## Tickets

* [CNFT1-3196](https://cdc-nbs.atlassian.net/browse/CNFT1-3196)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3196]: https://cdc-nbs.atlassian.net/browse/CNFT1-3196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ