### PR TITLE
CNT-61 Add lab report same as reporting facility

### DIFF
--- a/testing/regression/cypress/e2e/features/nbs-classic/data-entry.feature
+++ b/testing/regression/cypress/e2e/features/nbs-classic/data-entry.feature
@@ -1,0 +1,21 @@
+Feature: Classic Data Entry
+
+  Background: 
+    Given I am logged in as secure user
+
+  Scenario: Adding a Lab Report with detailed fields
+    When I click on Data Entry in the menu bar
+    And I click on Lab Report
+    And I click on the Lab Report tab
+    And I enter "2" in the Reporting Facility field
+    And I click the Quick Code Lookup button
+    And I check the "Same as Reporting Facility" checkbox
+    And I select the third element in the Jurisdiction dropdown
+    And I select the sixth element in the Resulted Test dropdown
+    And I select the second element in the Coded Result dropdown
+    And I enter "1" in the Numeric Result field
+    And I select % for the Units field
+    And I enter "automated test results" in the Text Result field
+    And I click the add button to add the lab report
+    And I click the submit button
+

--- a/testing/regression/cypress/e2e/pages/nbs-classic/dataEntry.page.js
+++ b/testing/regression/cypress/e2e/pages/nbs-classic/dataEntry.page.js
@@ -1,0 +1,74 @@
+class LabReportPage {
+    dataEntryMenu = 'a[href="/nbs/LoadNavbar.do?ContextAction=DataEntry"]';
+    labReportLink = 'font.boldEightBlack';
+    labReportTab = 'td#tabs0head1';
+    reportingFacilityField = '#NBS_LAB365Text';
+    quickCodeLookupButton = '#NBS_LAB365CodeLookupButton';
+    sameAsReportingFacilityCheckbox = 'input[name="pageClientVO.answer(NBS_LAB267)"]';
+    jurisdictionField = 'input[name="INV107_textbox"]';
+    resultedTestField = 'input[name="NBS_LAB220_textbox"]';
+    codedResultField = 'input[name="NBS_LAB280_textbox"]';
+    numericResultField = '#NBS_LAB364';
+    unitsField = 'input[name="LAB115_textbox"]';
+    textResultField = '#NBS_LAB208';
+    addButton = '#AddButtonToggleRESULTED_TEST_CONTAINER > td > input';
+    submitButton = 'input#SubmitTop';
+    
+    clickDataEntry() {
+      cy.get(this.dataEntryMenu).click();
+    }
+  
+    clickLabReport() {
+      cy.get(this.labReportLink).contains('Lab Report').click();
+    }
+  
+    clickLabReportTab() {
+      cy.get(this.labReportTab).first().click();
+    }
+  
+    enterReportingFacility(value) {
+      cy.get(this.reportingFacilityField).type(value);
+    }
+  
+    clickQuickCodeLookup() {
+      cy.get(this.quickCodeLookupButton).click();
+    }
+  
+    checkSameAsReportingFacility() {
+      cy.get(this.sameAsReportingFacilityCheckbox).check();
+    }
+  
+    selectJurisdiction() {
+      cy.get(this.jurisdictionField).type('{downarrow}{downarrow}{enter}');
+    }
+
+    selectResultedTest() {
+      cy.get(this.resultedTestField).type('{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{enter}');
+    }
+
+    selectCodedResult() {
+      cy.get(this.codedResultField).type('{downarrow}{enter}');
+    }
+
+    enterNumericResult(value) {
+      cy.get(this.numericResultField).type(value);
+    }
+
+    selectUnits() {
+      cy.get(this.unitsField).type('%{enter}');
+   }
+
+    enterTextResult(text) {
+      cy.get(this.textResultField).type(text);
+   }
+
+    clickAddButton() {
+      cy.get(this.addButton).click();
+  }
+
+    clickSubmitButton() {
+      cy.get(this.submitButton).first().click(); // Clicking the first submit button
+  }
+}
+  export const labReportPage = new LabReportPage();
+  

--- a/testing/regression/cypress/step_definitions/nbs-classic/dataEntry.steps.js
+++ b/testing/regression/cypress/step_definitions/nbs-classic/dataEntry.steps.js
@@ -1,0 +1,58 @@
+import { labReportPage } from 'cypress/e2e/pages/nbs-classic/dataEntry.page';
+import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+When('I click on Data Entry in the menu bar', () => {
+  labReportPage.clickDataEntry();
+});
+
+When('I click on Lab Report', () => {
+  labReportPage.clickLabReport();
+});
+
+When('I click on the Lab Report tab', () => {
+  labReportPage.clickLabReportTab();
+});
+
+When('I enter {string} in the Reporting Facility field', (value) => {
+  labReportPage.enterReportingFacility(value);
+});
+
+When('I click the Quick Code Lookup button', () => {
+  labReportPage.clickQuickCodeLookup();
+});
+
+When('I check the "Same as Reporting Facility" checkbox', () => {
+  labReportPage.checkSameAsReportingFacility();
+});
+
+When('I select the third element in the Jurisdiction dropdown', () => {
+  labReportPage.selectJurisdiction();
+});
+
+When('I select the sixth element in the Resulted Test dropdown', () => {
+  labReportPage.selectResultedTest();
+});
+
+When('I select the second element in the Coded Result dropdown', () => {
+  labReportPage.selectCodedResult();
+});
+
+When('I enter {string} in the Numeric Result field', (value) => {
+  labReportPage.enterNumericResult(value);
+});
+
+When('I select % for the Units field', () => {
+  labReportPage.selectUnits();
+});
+
+When('I enter {string} in the Text Result field', (text) => {
+  labReportPage.enterTextResult(text);
+});
+
+When('I click the add button to add the lab report', () => {
+  labReportPage.clickAddButton();
+});
+
+When('I click the submit button', () => {
+  labReportPage.clickSubmitButton();
+});


### PR DESCRIPTION
Classic test scenario - adding lab report from the data entry module.

## Description

Classic test scenario - adding lab report from the data entry module.
<img width="1505" alt="classic_add_lab_report" src="https://github.com/user-attachments/assets/c40b9538-f9e8-46fe-9e3e-8ccc5d805ed1">


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-61)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
