### PR TITLE
[FIX] Making the add patient api request a little more flexible

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
@@ -58,6 +58,32 @@ public record NewPatient(
       String id) {
   }
 
+  public NewPatient(
+      Administrative administrative,
+      BirthDemographic birth,
+      GenderDemographic gender,
+      EthnicityDemographic ethnicity,
+      MortalityDemographic mortality,
+      GeneralInformationDemographic general,
+      List<NameDemographic> names,
+      List<AddressDemographic> addresses,
+      List<Phone> phoneEmails,
+      List<Race> races,
+      List<Identification> identifications
+  ) {
+    this.administrative = administrative;
+    this.birth = birth;
+    this.gender = gender;
+    this.ethnicity = ethnicity;
+    this.mortality = mortality;
+    this.general = general;
+    this.names = names == null ? List.of() : List.copyOf(names);
+    this.addresses = addresses == null ? List.of() : List.copyOf(addresses);
+    this.phoneEmails = phoneEmails == null ? List.of() : List.copyOf(phoneEmails);
+    this.races = races == null ? List.of() : List.copyOf(races);
+    this.identifications = identifications == null ? List.of() : List.copyOf(identifications);
+  }
+
   public NewPatient() {
     this(
         null,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/NewPatient.java
@@ -13,7 +13,6 @@ import gov.cdc.nbs.patient.profile.names.NameDemographic;
 import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -92,11 +91,11 @@ public record NewPatient(
         null,
         null,
         null,
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList()
+        null,
+        null,
+        null,
+        null,
+        null
     );
   }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/general/GeneralInformationDemographic.java
@@ -1,8 +1,12 @@
 package gov.cdc.nbs.patient.profile.general;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
 import java.time.LocalDate;
 
 public record GeneralInformationDemographic(
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class)
     LocalDate asOf,
     String maritalStatus,
     String maternalMaidenName,


### PR DESCRIPTION
## Description

Updates the request for the `/nbs/api/profile` API to allow dates in the `MM/DD/YYYY` format to match the rest of the dates in the request.  Also, removes the need to specify empty arrays for the multi valued fields.
