### PR TITLE
[CNFT1-3230] extended add race validation (part 1)

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -1,11 +1,11 @@
+import { Controller, useFormContext } from 'react-hook-form';
+import { Card } from './card/Card';
+import { ExtendedNewPatientEntry } from './entry';
 import { AdministrativeEntryFields } from 'apps/patient/data/administrative/AdministrativeEntryFields';
 import { EthnicityEntryFields } from 'apps/patient/data/ethnicity/EthnicityEntryFields';
 import { GeneralInformationEntryFields } from 'apps/patient/data/general/GeneralInformationEntryFields';
 import { MortalityEntryFields } from 'apps/patient/data/mortality/MortalityEntryFields';
 import { SexAndBirthEntryFields } from 'apps/patient/data/sexAndBirth/SexAndBirthEntryFields';
-import { useFormContext } from 'react-hook-form';
-import { Card } from './card/Card';
-import { ExtendedNewPatientEntry } from './entry';
 import { AddressRepeatingBlock } from './inputs/address/AddressRepeatingBlock';
 import { IdentificationRepeatingBlock } from './inputs/identification/IdentificationRepeatingBlock';
 import { NameRepeatingBlock } from './inputs/name/NameRepeatingBlock';
@@ -21,7 +21,7 @@ type Props = {
     setSubFormState: (state: Partial<SubFormDirtyState>) => void;
 };
 export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Props) => {
-    const { setValue } = useFormContext<ExtendedNewPatientEntry>();
+    const { setValue, control } = useFormContext<ExtendedNewPatientEntry>();
 
     const renderErrorMessages = () => {
         const generateError = (section: string, id: string) => {
@@ -75,9 +75,17 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                     isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
                     onChange={(identificationData) => setValue('identifications', identificationData)}
                 />
-                <RaceRepeatingBlock
-                    isDirty={(isDirty) => setSubFormState({ race: isDirty })}
-                    onChange={(raceData) => setValue('races', raceData)}
+                <Controller
+                    control={control}
+                    name="races"
+                    render={({ field: { onChange, value, name } }) => (
+                        <RaceRepeatingBlock
+                            id={name}
+                            values={value}
+                            isDirty={(isDirty) => setSubFormState({ race: isDirty })}
+                            onChange={onChange}
+                        />
+                    )}
                 />
                 <Card
                     id="ethnicity"

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.spec.tsx
@@ -18,7 +18,7 @@ const mockEntry = {
             {
                 asOf: internalizeDate(new Date()),
                 type: 'AN',
-                first: test
+                first: 'test'
             }
         ]
     }
@@ -32,7 +32,7 @@ jest.mock('apps/patient/profile/names/usePatientNameCodedValues', () => ({
     usePatientNameCodedValues: () => mockPatientNameCodedValues
 }));
 
-describe('NameMultiEntry', () => {
+describe('NameRepeatingBlock', () => {
     it('should display correct table headers', async () => {
         const { getAllByRole } = render(<NameRepeatingBlock onChange={onChange} isDirty={isDirty} />);
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.spec.tsx
@@ -2,12 +2,14 @@ import { render } from '@testing-library/react';
 import { CodedValue } from 'coded';
 import { internalizeDate } from 'date';
 import { RaceRepeatingBlock } from './RaceRepeatingBlock';
+import { Selectable } from 'options';
 
-const mockRaceCodedValues: CodedValue[] = [{ value: '1', name: 'race name' }];
+const mockRaceCodedValues: Selectable[] = [{ value: '1', name: 'race name' }];
 
-jest.mock('coded/race/useRaceCodedValues', () => ({
-    useRaceCodedValues: () => mockRaceCodedValues
+jest.mock('options/concepts', () => ({
+    useConceptOptions: () => ({ options: mockRaceCodedValues })
 }));
+
 const mockDetailedOptions: CodedValue[] = [
     { value: '2', name: 'detailed race1' },
     { value: '3', name: 'detailed race2' }
@@ -35,9 +37,9 @@ jest.mock('design-system/entry/multi-value/useMultiValueEntryState', () => ({
 const onChange = jest.fn();
 const isDirty = jest.fn();
 
-describe('RaceMultiEntry', () => {
+describe('RaceRepeatingBlock', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<RaceRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getAllByRole } = render(<RaceRepeatingBlock id="testing" onChange={onChange} isDirty={isDirty} />);
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');
@@ -46,7 +48,9 @@ describe('RaceMultiEntry', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText, getAllByRole } = render(<RaceRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getByLabelText, getAllByRole } = render(
+            <RaceRepeatingBlock id="testing" onChange={onChange} isDirty={isDirty} />
+        );
 
         const dateInput = getByLabelText('Race as of');
         expect(dateInput).toHaveValue(internalizeDate(new Date()));

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
@@ -1,40 +1,40 @@
-import { RaceEntry } from 'apps/patient/data/entry';
-import { RaceEntryFields } from 'apps/patient/data/race/RaceEntryFields';
-import { today } from 'date';
-import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
+import { RepeatingBlock } from 'design-system/entry/multi-value';
+import { useConceptOptions } from 'options/concepts';
+import { RaceEntryFields, RaceEntry, initial } from 'apps/patient/data/race';
 import { DetailedRaceDisplay } from './DetailedRaceDisplay';
 import { RaceEntryView } from './RaceEntryView';
 
-const defaultValue: Partial<RaceEntry> = {
-    asOf: today(),
-    race: undefined,
-    detailed: undefined
-};
+const columns: Column<RaceEntry>[] = [
+    { id: 'race-as-of', name: 'As of', render: (v) => v.asOf },
+    { id: 'race-name', name: 'Race', render: (v) => v.race.name },
+    {
+        id: 'race-detailed',
+        name: 'Detailed race',
+        render: (v) => <DetailedRaceDisplay entry={v} />
+    }
+];
 
 type Props = {
+    id: string;
+    values?: RaceEntry[];
     onChange: (data: RaceEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
 };
-export const RaceRepeatingBlock = ({ onChange, isDirty }: Props) => {
-    const renderForm = () => <RaceEntryFields />;
+
+const RaceRepeatingBlock = ({ id, values, onChange, isDirty }: Props) => {
+    const categories = useConceptOptions('P_RACE_CAT', { lazy: false }).options;
+
+    const renderForm = () => <RaceEntryFields categories={categories} />;
     const renderView = (entry: RaceEntry) => <RaceEntryView entry={entry} />;
 
-    const columns: Column<RaceEntry>[] = [
-        { id: 'raceAsOf', name: 'As of', render: (v) => v.asOf },
-        { id: 'raceName', name: 'Race', render: (v) => v.race.name },
-        {
-            id: 'detailedRace',
-            name: 'Detailed race',
-            render: (v) => <DetailedRaceDisplay entry={v} />
-        }
-    ];
     return (
         <RepeatingBlock<RaceEntry>
-            id="races"
+            id={id}
             title="Race"
-            defaultValues={defaultValue}
             columns={columns}
+            defaultValues={initial()}
+            values={values}
             onChange={onChange}
             isDirty={isDirty}
             formRenderer={renderForm}
@@ -42,3 +42,5 @@ export const RaceRepeatingBlock = ({ onChange, isDirty }: Props) => {
         />
     );
 };
+
+export { RaceRepeatingBlock };

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
@@ -1,16 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { CodedValue } from 'coded/CodedValue';
-import { RaceEntry } from '../entry';
 import { FormProvider, useForm } from 'react-hook-form';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { RaceEntryFields } from './RaceEntryFields';
+import { act, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { CodedValue } from 'coded/CodedValue';
+import { RaceEntry } from './entry';
+import { RaceEntryFields, RaceEntryFieldsProps } from './RaceEntryFields';
 
-const mockRaceCodedValues: CodedValue[] = [{ value: '1', name: 'race name' }];
-
-jest.mock('coded/race/useRaceCodedValues', () => ({
-    useRaceCodedValues: () => mockRaceCodedValues
-}));
 const mockDetailedOptions: CodedValue[] = [
     { value: '2', name: 'detailed race1' },
     { value: '3', name: 'detailed race2' }
@@ -20,7 +14,9 @@ jest.mock('coded/race/useDetailedRaceCodedValues', () => ({
     useDetailedRaceCodedValues: () => mockDetailedOptions
 }));
 
-const Fixture = () => {
+type Props = Partial<RaceEntryFieldsProps>;
+
+const Fixture = ({ categories = [{ value: '1', name: 'race name' }] }: Props) => {
     const form = useForm<RaceEntry>({
         mode: 'onBlur',
         defaultValues: {
@@ -32,7 +28,7 @@ const Fixture = () => {
 
     return (
         <FormProvider {...form}>
-            <RaceEntryFields />
+            <RaceEntryFields categories={categories} />
         </FormProvider>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -1,12 +1,17 @@
-import { useDetailedRaceCodedValues, useRaceCodedValues } from 'coded/race';
+import { useDetailedRaceCodedValues } from 'coded/race';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
-import { RaceEntry } from '../entry';
+import { RaceEntry } from './entry';
 import { MultiSelect, SingleSelect } from 'design-system/select';
+import { Selectable } from 'options';
 
-export const RaceEntryFields = () => {
+type RaceEntryFieldsProps = {
+    categories: Selectable[];
+};
+
+const RaceEntryFields = ({ categories }: RaceEntryFieldsProps) => {
     const { control } = useFormContext<RaceEntry>();
-    const categories = useRaceCodedValues();
+
     const selectedCategory = useWatch({ control, name: 'race' });
     const detailedRaces = useDetailedRaceCodedValues(selectedCategory?.value);
 
@@ -44,31 +49,35 @@ export const RaceEntryFields = () => {
                         onBlur={onBlur}
                         onChange={onChange}
                         value={value}
-                        id={name}
+                        id={`race-${name}`}
                         name={name}
                         options={categories}
                         error={error?.message}
                     />
                 )}
             />
-            {detailedRaces.length > 0 && (
-                <Controller
-                    control={control}
-                    name="detailed"
-                    shouldUnregister
-                    render={({ field: { onChange, value, name } }) => (
-                        <MultiSelect
-                            label="Detailed race"
-                            orientation="horizontal"
-                            id={name}
-                            name={name}
-                            value={value}
-                            onChange={onChange}
-                            options={detailedRaces}
-                        />
-                    )}
-                />
-            )}
+
+            <Controller
+                control={control}
+                name="detailed"
+                shouldUnregister
+                render={({ field: { onChange, value, name } }) => (
+                    <MultiSelect
+                        label="Detailed race"
+                        orientation="horizontal"
+                        id={`race-${name}`}
+                        name={name}
+                        disabled={selectedCategory === undefined}
+                        value={value}
+                        onChange={onChange}
+                        options={detailedRaces}
+                    />
+                )}
+            />
         </section>
     );
 };
+
+export { RaceEntryFields };
+
+export type { RaceEntryFieldsProps };

--- a/apps/modernization-ui/src/apps/patient/data/race/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/entry.ts
@@ -1,0 +1,18 @@
+import { today } from 'date';
+import { Selectable } from 'options';
+import { EffectiveDated } from 'utils';
+
+type RaceEntry = EffectiveDated & {
+    race: Selectable;
+    detailed: Selectable[];
+};
+
+export type { RaceEntry };
+
+const initial = (asOf: string = today()): Partial<RaceEntry> => ({
+    asOf,
+    race: undefined,
+    detailed: []
+});
+
+export { initial };

--- a/apps/modernization-ui/src/apps/patient/data/race/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/index.ts
@@ -1,0 +1,5 @@
+export { initial } from './entry';
+export type { RaceEntry } from './entry';
+
+export { RaceEntryFields } from './RaceEntryFields';
+export { asRace } from './asRace';

--- a/apps/modernization-ui/src/design-system/entry/multi-value/index.ts
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/index.ts
@@ -1,0 +1,1 @@
+export { RepeatingBlock } from './RepeatingBlock';

--- a/apps/modernization-ui/src/design-system/entry/multi-value/useMultiValueEntryState.ts
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/useMultiValueEntryState.ts
@@ -1,10 +1,9 @@
 import { useReducer } from 'react';
-import { FieldValues } from 'react-hook-form';
 
 type State<V> =
     | { status: 'adding'; data: V[] }
-    | { status: 'viewing'; data: V[]; index: number }
-    | { status: 'editing'; data: V[]; index: number };
+    | { status: 'viewing'; data: V[]; index: number; selected: V }
+    | { status: 'editing'; data: V[]; index: number; selected: V };
 
 type Action<V> =
     | { type: 'add'; item: V }
@@ -14,43 +13,74 @@ type Action<V> =
     | { type: 'view'; index: number }
     | { type: 'reset' };
 
-const useMultiValueEntryState = <V extends FieldValues>() => {
-    const reducer = (_state: State<V>, action: Action<V>): State<V> => {
-        const data = [..._state.data];
-        switch (action.type) {
-            case 'add':
-                return { status: 'adding', data: [...data, action.item] };
-            case 'view':
-                return { status: 'viewing', data, index: action.index };
-            case 'edit':
-                return { status: 'editing', data, index: action.index };
-            case 'update':
-                data[action.index] = action.item;
-                return { status: 'adding', data };
-            case 'delete':
-                data.splice(action.index, 1);
-                if (_state.status === 'adding') {
-                    return { ..._state, data };
-                } else {
-                    if (_state.index === action.index) {
-                        // currently editing or viewing the deleted entry
-                        return { status: 'adding', data };
-                    } else if (_state.index > action.index) {
-                        // editing or viewing an entry with index > than deleted index. updated index - 1
-                        return { status: _state.status, data, index: _state.index - 1 };
-                    } else {
-                        // editing or viewing an entry with index < than deleted index. keep current index
-                        return { ..._state, data };
-                    }
-                }
-            case 'reset':
-                return { status: 'adding', data: _state.data };
+const reducer = <V>(current: State<V>, action: Action<V>): State<V> => {
+    // const data = [...current.data];
+    switch (action.type) {
+        case 'add':
+            return { status: 'adding', data: [...current.data, action.item] };
+        case 'view':
+            return { ...current, status: 'viewing', index: action.index, selected: current.data[action.index] };
+        case 'edit':
+            return { ...current, status: 'editing', index: action.index, selected: current.data[action.index] };
+        case 'update': {
+            const data = [...current.data];
+
+            data[action.index] = action.item;
+            return { status: 'adding', data };
         }
-    };
-    const [state, dispatch] = useReducer(reducer, { status: 'adding', data: [] });
+        case 'delete': {
+            const data = [...current.data];
+            data.splice(action.index, 1);
+            if (current.status === 'adding') {
+                return { ...current, data };
+            } else {
+                if (current.index === action.index) {
+                    // currently editing or viewing the deleted entry
+                    return { status: 'adding', data };
+                } else if (current.index > action.index) {
+                    // editing or viewing an entry with index > than deleted index. updated index - 1
+                    return {
+                        status: current.status,
+                        data,
+                        index: current.index - 1,
+                        selected: data[current.index - 1]
+                    };
+                } else {
+                    // editing or viewing an entry with index < than deleted index. keep current index
+                    return { ...current, data };
+                }
+            }
+        }
+        case 'reset':
+            return { status: 'adding', data: current.data };
+    }
+};
+
+type Interaction<V> = {
+    state: State<V>;
+    status: 'adding' | 'viewing' | 'editing';
+    selected?: V;
+    add: (item: V) => void;
+    edit: (index: number) => void;
+    update: (index: number, item: V) => void;
+    remove: (index: number) => void;
+    view: (index: number) => void;
+    reset: () => void;
+};
+
+type Settings<V> = {
+    values?: V[];
+};
+
+const useMultiValueEntryState = <V>({ values = [] }: Settings<V>): Interaction<V> => {
+    const [state, dispatch] = useReducer(reducer<V>, { status: 'adding', data: values });
+
+    const selected = state.status === 'editing' || state.status === 'viewing' ? state.selected : undefined;
 
     return {
         state,
+        status: state.status,
+        selected,
         add: (item: V) => dispatch({ type: 'add', item }),
         edit: (index: number) => dispatch({ type: 'edit', index }),
         update: (index: number, item: V) => dispatch({ type: 'update', index, item }),


### PR DESCRIPTION
## Description

In preparation for Race validations, changes were made to `RepeatingBlock` that allow values to be passed in.  This allows the `RepeatingBlock` component values to be initialized from the form using the `Controller`.

```typescript
                <Controller
                    control={control}
                    name="races"
                    render={({ field: { onChange, value, name } }) => (
                        <RaceRepeatingBlock
                            id={name}
                            values={value}
                            isDirty={(isDirty) => setSubFormState({ race: isDirty })}
                            onChange={onChange}
                        />
                    )}
                />
```

## Tickets

* [CNFT1-3230](https://cdc-nbs.atlassian.net/browse/CNFT1-3230)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3230]: https://cdc-nbs.atlassian.net/browse/CNFT1-3230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ