### PR TITLE
[CNFT1-3230] Patient Extended Add race demographics validation

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/api.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/api.ts
@@ -4,13 +4,13 @@ import {
     Address,
     PhoneEmail,
     Identification,
-    Race,
     Ethnicity,
     Sex,
     Birth,
     Mortality,
     GeneralInformation
 } from 'apps/patient/data/api';
+import { Race } from 'apps/patient/data/race/api';
 
 type NewPatient = {
     administrative?: Administrative;

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -5,13 +5,13 @@ import {
     AddressEntry,
     PhoneEmailEntry,
     IdentificationEntry,
-    RaceEntry,
     EthnicityEntry,
     SexEntry,
     BirthEntry,
     MortalityEntry,
     GeneralInformationEntry
 } from 'apps/patient/data/entry';
+import { RaceEntry } from 'apps/patient/data/race';
 
 type ExtendedNewPatientEntry = {
     administrative?: AdministrativeEntry;

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/DetailedRaceDisplay.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/DetailedRaceDisplay.tsx
@@ -1,8 +1,6 @@
-import { RaceEntry } from 'apps/patient/data/entry';
+import { RaceEntry } from 'apps/patient/data/race';
 
 type Props = {
     entry: RaceEntry;
 };
-export const DetailedRaceDisplay = ({ entry }: Props) => {
-    return <div>{entry.detailed?.map((v) => v.name).join(', ')}</div>;
-};
+export const DetailedRaceDisplay = ({ entry }: Props) => entry.detailed?.map((v) => v.name).join(', ');

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceEntryView.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceEntryView.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { CodedValue } from 'coded';
 import { RaceEntryView } from './RaceEntryView';
-import { RaceEntry } from 'apps/patient/data/entry';
+import { RaceEntry } from 'apps/patient/data/race';
 import { asSelectable } from 'options';
 
 const mockRaceCodedValues: CodedValue[] = [{ value: '1', name: 'race name' }];
@@ -19,6 +19,7 @@ jest.mock('coded/race/useDetailedRaceCodedValues', () => ({
 }));
 
 const entry: RaceEntry = {
+    id: 331,
     asOf: '12/25/2020',
     race: asSelectable('1', 'test'),
     detailed: [asSelectable('2', 'test 2'), asSelectable('3', 'test 3')]

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceEntryView.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceEntryView.tsx
@@ -1,4 +1,4 @@
-import { RaceEntry } from 'apps/patient/data/entry';
+import { RaceEntry } from 'apps/patient/data/race';
 import { ValueView } from 'design-system/data-display/ValueView';
 
 type Props = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { CodedValue } from 'coded';
 import { internalizeDate } from 'date';
 import { RaceRepeatingBlock } from './RaceRepeatingBlock';
@@ -79,7 +79,7 @@ describe('RaceRepeatingBlock', () => {
     });
 
     it('should not allow adding the same race more than once', async () => {
-        const { getByLabelText, getByRole } = render(
+        const { getByLabelText, getByRole, getByText } = render(
             <RaceRepeatingBlock
                 id="testing"
                 values={[
@@ -102,10 +102,14 @@ describe('RaceRepeatingBlock', () => {
         act(() => {
             userEvent.selectOptions(category, '1');
             userEvent.tab();
+
+            userEvent.click(add);
         });
 
-        expect(isDirty).toHaveBeenCalledWith(true);
-
-        expect(add).toBeDisabled();
+        await waitFor(() => {
+            expect(getByRole('listitem')).toHaveTextContent(
+                /Race race one name has already been added to the repeating block/
+            );
+        });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
@@ -1,10 +1,11 @@
 import { Column } from 'design-system/table';
 import { RepeatingBlock } from 'design-system/entry/multi-value';
-import { useConceptOptions } from 'options/concepts';
+import { useRaceCategoryOptions } from 'options/race/useRaceCategoryOptions';
 import { RaceEntryFields, RaceEntry, initial } from 'apps/patient/data/race';
 import { DetailedRaceDisplay } from './DetailedRaceDisplay';
 import { RaceEntryView } from './RaceEntryView';
 import { ReactNode } from 'react';
+import { categoryValidator } from './categoryValidator';
 
 const columns: Column<RaceEntry>[] = [
     { id: 'race-as-of', name: 'As of', render: (v) => v.asOf },
@@ -24,10 +25,10 @@ type Props = {
     errors?: ReactNode[];
 };
 
-const RaceRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Props) => {
-    const categories = useConceptOptions('P_RACE_CAT', { lazy: false }).options;
+const RaceRepeatingBlock = ({ id, values = [], errors, onChange, isDirty }: Props) => {
+    const { categories } = useRaceCategoryOptions();
 
-    const renderForm = () => <RaceEntryFields categories={categories} />;
+    const renderForm = () => <RaceEntryFields categories={categories} categoryValidator={categoryValidator(values)} />;
     const renderView = (entry: RaceEntry) => <RaceEntryView entry={entry} />;
 
     return (

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.spec.ts
@@ -1,0 +1,50 @@
+import { categoryValidator } from './categoryValidator';
+
+describe('categoryValidator', () => {
+    it('should allow the same race category when validating the entry that contains the race category', async () => {
+        const entries = [
+            {
+                id: 3,
+                asOf: '06/05/2024',
+                race: { value: 'race-one-value', name: 'race one name' },
+                detailed: []
+            }
+        ];
+
+        const actual = categoryValidator(entries)(3, { value: 'race-one-value', name: 'race one name' });
+
+        await expect(actual).resolves.toBe(true);
+    });
+
+    it('should allow differing race categories across entries', async () => {
+        const entries = [
+            {
+                id: 3,
+                asOf: '06/05/2024',
+                race: { value: 'race-one-value', name: 'race one name' },
+                detailed: []
+            }
+        ];
+
+        const actual = categoryValidator(entries)(5, { value: 'race-two-value', name: 'race two name' });
+
+        await expect(actual).resolves.toBe(true);
+    });
+
+    it('should not allow the same race category more than once across multiple entries', async () => {
+        const entries = [
+            {
+                id: 3,
+                asOf: '06/05/2024',
+                race: { value: 'race-one-value', name: 'race one name' },
+                detailed: []
+            }
+        ];
+
+        const actual = categoryValidator(entries)(5, { value: 'race-one-value', name: 'race one name' });
+
+        await expect(actual).resolves.toBe(
+            'Race race one name has already been added to the repeating block.Please select another race to add .'
+        );
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.ts
@@ -1,0 +1,28 @@
+import { Selectable } from 'options';
+import { RaceEntry } from 'apps/patient/data/race';
+import { Predicate } from 'utils';
+import { allOf } from 'utils/predicate';
+
+const withCategory =
+    (category: Selectable): Predicate<RaceEntry> =>
+    (entry) =>
+        entry.race.value === category.value;
+
+const withId = (id: number) => (entry: RaceEntry) => entry.id !== id;
+
+const categoryValidator = (entries: RaceEntry[]) => (id: number, category: Selectable) =>
+    new Promise<string | boolean>((resolve) => {
+        //  find any existing entries that have the same category but not the same if
+        const resolved = entries.find(allOf(withCategory(category), withId(id)));
+
+        if (resolved) {
+            //  validation fails
+            resolve(
+                `Race ${category.name} has already been added to the repeating block.Please select another race to add .`
+            );
+        } else {
+            resolve(true);
+        }
+    });
+
+export { categoryValidator };

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.spec.ts
@@ -108,6 +108,7 @@ describe('when transforming entered extended patient data', () => {
             administrative: { asOf: '04/13/2017' },
             races: [
                 {
+                    id: 331,
                     asOf: '04/13/2017',
                     race: { value: 'race-value', name: 'race-name' },
                     detailed: []

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -52,11 +52,6 @@ type Identification = EffectiveDated & {
     issuer?: string;
 };
 
-type Race = EffectiveDated & {
-    race: string;
-    detailed: string[];
-};
-
 type Ethnicity = EffectiveDated & {
     ethnicity: string;
     detailed: string[];
@@ -103,7 +98,6 @@ export type {
     Address,
     PhoneEmail,
     Identification,
-    Race,
     Ethnicity,
     Sex,
     Birth,

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -53,11 +53,6 @@ type IdentificationEntry = EffectiveDated & {
     issuer?: Selectable;
 };
 
-type RaceEntry = EffectiveDated & {
-    race: Selectable;
-    detailed: Selectable[];
-};
-
 type EthnicityEntry = EffectiveDated & {
     ethnicity: Selectable;
     detailed: Selectable[];
@@ -103,7 +98,6 @@ export type {
     AddressEntry,
     PhoneEmailEntry,
     IdentificationEntry,
-    RaceEntry,
     EthnicityEntry,
     SexEntry,
     BirthEntry,

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -1,16 +1,19 @@
 import { useDetailedRaceCodedValues } from 'coded/race';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
-import { RaceEntry } from './entry';
+import { RaceCategoryValidator, RaceEntry } from './entry';
 import { MultiSelect, SingleSelect } from 'design-system/select';
 import { Selectable } from 'options';
 
 type RaceEntryFieldsProps = {
     categories: Selectable[];
+    categoryValidator: RaceCategoryValidator;
 };
 
-const RaceEntryFields = ({ categories }: RaceEntryFieldsProps) => {
+const RaceEntryFields = ({ categories, categoryValidator }: RaceEntryFieldsProps) => {
     const { control } = useFormContext<RaceEntry>();
+
+    const id = useWatch({ control, name: 'id' });
 
     const selectedCategory = useWatch({ control, name: 'race' });
     const detailedRaces = useDetailedRaceCodedValues(selectedCategory?.value);
@@ -39,7 +42,8 @@ const RaceEntryFields = ({ categories }: RaceEntryFieldsProps) => {
                 control={control}
                 name="race"
                 rules={{
-                    required: { value: true, message: 'Race is required.' }
+                    required: { value: true, message: 'Race is required.' },
+                    validate: (category) => categoryValidator(id, category)
                 }}
                 render={({ field: { onBlur, onChange, name, value }, fieldState: { error } }) => (
                     <SingleSelect
@@ -60,7 +64,6 @@ const RaceEntryFields = ({ categories }: RaceEntryFieldsProps) => {
             <Controller
                 control={control}
                 name="detailed"
-                shouldUnregister
                 render={({ field: { onChange, value, name } }) => (
                     <MultiSelect
                         label="Detailed race"

--- a/apps/modernization-ui/src/apps/patient/data/race/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/api.ts
@@ -1,0 +1,8 @@
+import { EffectiveDated } from 'utils';
+
+type Race = EffectiveDated & {
+    race: string;
+    detailed: string[];
+};
+
+export type { Race };

--- a/apps/modernization-ui/src/apps/patient/data/race/asRace.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/asRace.spec.ts
@@ -3,6 +3,7 @@ import { asRace } from './asRace';
 describe('when mapping a race entry to a format accepted by the API', () => {
     it('should include the as of date', () => {
         const entry = {
+            id: 331,
             asOf: '04/13/2017',
             race: { value: 'race-value', name: 'race-name' },
             detailed: []
@@ -15,6 +16,7 @@ describe('when mapping a race entry to a format accepted by the API', () => {
 
     it('should include the race', () => {
         const entry = {
+            id: 331,
             asOf: '04/13/2017',
             race: { value: 'race-value', name: 'race-name' },
             detailed: []
@@ -27,6 +29,7 @@ describe('when mapping a race entry to a format accepted by the API', () => {
 
     it('should include the race details', () => {
         const entry = {
+            id: 331,
             asOf: '04/13/2017',
             race: { value: 'race-value', name: 'race-name' },
             detailed: [

--- a/apps/modernization-ui/src/apps/patient/data/race/asRace.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/asRace.ts
@@ -1,14 +1,14 @@
 import { asValue, asValues } from 'options';
-import { RaceEntry } from '../entry';
-import { Race } from '../api';
+import { RaceEntry } from './entry';
+import { Race } from './api';
 
 const asRace = (entry: RaceEntry): Race => {
-    const { race, detailed, ...remaining } = entry;
+    const { race, detailed, asOf } = entry;
 
     return {
+        asOf,
         race: asValue(race),
-        detailed: asValues(detailed),
-        ...remaining
+        detailed: asValues(detailed)
     };
 };
 

--- a/apps/modernization-ui/src/apps/patient/data/race/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/entry.ts
@@ -3,13 +3,17 @@ import { Selectable } from 'options';
 import { EffectiveDated } from 'utils';
 
 type RaceEntry = EffectiveDated & {
+    id: number;
     race: Selectable;
     detailed: Selectable[];
 };
 
-export type { RaceEntry };
+type RaceCategoryValidator = (id: number, category: Selectable) => Promise<string | boolean>;
+
+export type { RaceEntry, RaceCategoryValidator };
 
 const initial = (asOf: string = today()): Partial<RaceEntry> => ({
+    id: new Date().getTime(),
     asOf,
     race: undefined,
     detailed: []

--- a/apps/modernization-ui/src/options/race/useRaceCategoryOptions.ts
+++ b/apps/modernization-ui/src/options/race/useRaceCategoryOptions.ts
@@ -1,0 +1,14 @@
+import { useConceptOptions } from 'options/concepts';
+import { Selectable } from 'options/selectable';
+
+type Interaction = {
+    categories: Selectable[];
+};
+
+const useRaceCategoryOptions = (): Interaction => {
+    const { options: categories } = useConceptOptions('P_RACE_CAT', { lazy: false });
+
+    return { categories };
+};
+
+export { useRaceCategoryOptions };

--- a/apps/modernization-ui/src/utils/index.ts
+++ b/apps/modernization-ui/src/utils/index.ts
@@ -7,7 +7,8 @@ export * from './exists';
 export * from './focusedTarget';
 export * from './mapIf';
 
-type Predicate<T> = (item: T) => boolean;
+export type { Predicate } from './predicate';
+
 type Mapping<I, O> = (input: I) => O;
 type Maybe<V> = V | null | undefined;
 type EffectiveDated = {
@@ -18,4 +19,4 @@ type HasComments = {
     comment?: string;
 };
 
-export type { Predicate, Mapping, Maybe, EffectiveDated, HasComments };
+export type { Mapping, Maybe, EffectiveDated, HasComments };

--- a/apps/modernization-ui/src/utils/predicate/allOf.spec.ts
+++ b/apps/modernization-ui/src/utils/predicate/allOf.spec.ts
@@ -1,0 +1,41 @@
+import { allOf } from './allOf';
+
+describe('allOf', () => {
+    it('should return true no predicates are given', () => {
+        const actual = allOf()(3);
+
+        expect(actual).toBe(true);
+    });
+
+    it('should return true if all predicates pass', () => {
+        const first = jest.fn().mockReturnValue(true);
+        const second = jest.fn().mockReturnValue(true);
+        const third = jest.fn().mockReturnValue(true);
+        const fourth = jest.fn().mockReturnValue(true);
+
+        const actual = allOf<number>(first, second, third, fourth, () => true)(6);
+
+        expect(actual).toBe(true);
+
+        expect(first).toBeCalledWith(6);
+        expect(second).toBeCalledWith(6);
+        expect(third).toBeCalledWith(6);
+        expect(fourth).toBeCalledWith(6);
+    });
+
+    it('should return false, failing fast,  if any predicates fails', () => {
+        const first = jest.fn().mockReturnValue(true);
+        const second = jest.fn().mockReturnValue(false);
+        const third = jest.fn().mockReturnValue(true);
+        const fourth = jest.fn().mockReturnValue(true);
+
+        const actual = allOf<number>(first, second, third, fourth, () => true)(6);
+
+        expect(actual).toBe(false);
+
+        expect(first).toBeCalledWith(6);
+        expect(second).toBeCalledWith(6);
+        expect(third).not.toBeCalled();
+        expect(fourth).not.toBeCalled();
+    });
+});

--- a/apps/modernization-ui/src/utils/predicate/allOf.ts
+++ b/apps/modernization-ui/src/utils/predicate/allOf.ts
@@ -1,0 +1,17 @@
+import { Predicate } from './predicate';
+
+const allOf =
+    <R>(...predicates: Predicate<R>[]) =>
+    (item: R) => {
+        for (const predicate of predicates) {
+            const result = predicate(item);
+
+            if (!result) {
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+export { allOf };

--- a/apps/modernization-ui/src/utils/predicate/index.ts
+++ b/apps/modernization-ui/src/utils/predicate/index.ts
@@ -1,0 +1,3 @@
+export type { Predicate } from './predicate';
+
+export { allOf } from './allOf';

--- a/apps/modernization-ui/src/utils/predicate/predicate.ts
+++ b/apps/modernization-ui/src/utils/predicate/predicate.ts
@@ -1,0 +1,3 @@
+type Predicate<T> = (item: T) => boolean;
+
+export type { Predicate };


### PR DESCRIPTION
## Description

Adds validation to the Patient add extended that prevents a user from adding a Patient with duplicate race categories.  

- Adds `useRaceCategoryOptions` hook to encapsulate the look-up of race categories
- Adds `RaceCategoryValidator` type to unable defining how the category's are validated
- Adds an implementation of the `RaceCategoryValidator` to validate races within a repeating block

![CNFT1-3230](https://github.com/user-attachments/assets/47306509-faf5-41a7-ba39-479df94dd165)


## Tickets

* [CNFT1-3230](https://cdc-nbs.atlassian.net/browse/CNFT1-3230)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3230]: https://cdc-nbs.atlassian.net/browse/CNFT1-3230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ