### PR TITLE
Cnft1 3181 repeating block error banner

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
@@ -244,7 +244,7 @@ describe('AddPatientExtendedForm', () => {
         );
         let link = within(errors[0]).getByRole('link');
         expect(link).toHaveTextContent('Name');
-        expect(link).toHaveAttribute('href', '#name');
+        expect(link).toHaveAttribute('href', '#names');
 
         // Address
         expect(errors[1]).toHaveTextContent(
@@ -252,7 +252,7 @@ describe('AddPatientExtendedForm', () => {
         );
         link = within(errors[1]).getByRole('link');
         expect(link).toHaveTextContent('Address');
-        expect(link).toHaveAttribute('href', '#address');
+        expect(link).toHaveAttribute('href', '#addresses');
 
         // Phone & Email
         expect(errors[2]).toHaveTextContent(
@@ -260,7 +260,7 @@ describe('AddPatientExtendedForm', () => {
         );
         link = within(errors[2]).getByRole('link');
         expect(link).toHaveTextContent('Phone & Email');
-        expect(link).toHaveAttribute('href', '#phoneAndEmail');
+        expect(link).toHaveAttribute('href', '#phoneEmails');
 
         // Identification
         expect(errors[3]).toHaveTextContent(
@@ -268,7 +268,7 @@ describe('AddPatientExtendedForm', () => {
         );
         link = within(errors[3]).getByRole('link');
         expect(link).toHaveTextContent('Identification');
-        expect(link).toHaveAttribute('href', '#identification');
+        expect(link).toHaveAttribute('href', '#identifications');
 
         // Race
         expect(errors[4]).toHaveTextContent(

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
@@ -226,7 +226,7 @@ describe('AddPatientExtendedForm', () => {
     });
 
     it('should display validation errors', () => {
-        const { getByText, getAllByRole } = render(
+        const { getAllByText, getAllByRole } = render(
             <Fixture
                 validationErrors={{
                     dirtySections: { name: true, phone: true, address: true, identification: true, race: true }
@@ -234,9 +234,9 @@ describe('AddPatientExtendedForm', () => {
             />
         );
 
-        expect(getByText('Please fix the following errors:')).toBeInTheDocument();
+        expect(getAllByText('Please fix the following errors:')).toHaveLength(6);
 
-        const errors = getAllByRole('listitem', getAllByRole('list')[0]);
+        const errors = within(getAllByRole('list')[0]).getAllByRole('listitem');
         expect(errors).toHaveLength(5);
         // Name error
         expect(errors[0]).toHaveTextContent(

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -43,7 +43,6 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
     const renderErrorMessages = () => {
         return (
             <ul className={styles.errorList}>
-                Is name dirty: {validationErrors?.dirtySections.name ? 'true' : 'false'}
                 {validationErrors?.dirtySections.name && <li>{generateErrorMessage('Name', 'names')}</li>}
                 {validationErrors?.dirtySections.address && <li>{generateErrorMessage('Address', 'addresses')}</li>}
                 {validationErrors?.dirtySections.phone && (

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -43,13 +43,14 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
     const renderErrorMessages = () => {
         return (
             <ul className={styles.errorList}>
-                {validationErrors?.dirtySections.name && <li>{generateErrorMessage('Name', 'name')}</li>}
-                {validationErrors?.dirtySections.address && <li>{generateErrorMessage('Address', 'address')}</li>}
+                Is name dirty: {validationErrors?.dirtySections.name ? 'true' : 'false'}
+                {validationErrors?.dirtySections.name && <li>{generateErrorMessage('Name', 'names')}</li>}
+                {validationErrors?.dirtySections.address && <li>{generateErrorMessage('Address', 'addresses')}</li>}
                 {validationErrors?.dirtySections.phone && (
-                    <li>{generateErrorMessage('Phone & Email', 'phoneAndEmail')}</li>
+                    <li>{generateErrorMessage('Phone & Email', 'phoneEmails')}</li>
                 )}
                 {validationErrors?.dirtySections.identification && (
-                    <li>{generateErrorMessage('Identification', 'identification')}</li>
+                    <li>{generateErrorMessage('Identification', 'identifications')}</li>
                 )}
                 {validationErrors?.dirtySections.race && <li>{generateErrorMessage('Race', 'races')}</li>}
             </ul>
@@ -77,7 +78,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                         <NameRepeatingBlock
                             id={name}
                             values={value}
-                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            isDirty={(isDirty) => setSubFormState({ name: isDirty })}
                             onChange={onChange}
                             errors={
                                 validationErrors?.dirtySections.identification
@@ -94,7 +95,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                         <AddressRepeatingBlock
                             id={name}
                             values={value}
-                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            isDirty={(isDirty) => setSubFormState({ address: isDirty })}
                             onChange={onChange}
                             errors={
                                 validationErrors?.dirtySections.identification
@@ -111,7 +112,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                         <PhoneAndEmailRepeatingBlock
                             id={name}
                             values={value}
-                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            isDirty={(isDirty) => setSubFormState({ phone: isDirty })}
                             onChange={onChange}
                             errors={
                                 validationErrors?.dirtySections.identification

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -103,11 +103,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                             values={value}
                             isDirty={(isDirty) => setSubFormState({ race: isDirty })}
                             onChange={onChange}
-                            errors={
-                                validationErrors?.dirtySections.identification
-                                    ? [generateErrorMessage('Race')]
-                                    : undefined
-                            }
+                            errors={validationErrors?.dirtySections.race ? [generateErrorMessage('Race')] : undefined}
                         />
                     )}
                 />

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -26,10 +26,16 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
 
     // Generates an error message that will contain a link to the section if an id is provided
     const generateErrorMessage = (section: string, id?: string) => {
+        const linkOrText = id ? (
+            <a id={`link-to-${id}`} href={`#${id}`}>
+                {section}
+            </a>
+        ) : (
+            section
+        );
         return (
             <React.Fragment key={section}>
-                Data has been entered in the {id ? <a href={`#${id}`}>{section}</a> : `${section}`} section. Please
-                press Add or clear the data and submit again.
+                Data has been entered in the {linkOrText} section. Please press Add or clear the data and submit again.
             </React.Fragment>
         );
     };
@@ -77,21 +83,21 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                 <PhoneAndEmailRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ phone: isDirty })}
                     onChange={(phoneEmailData) => setValue('phoneEmails', phoneEmailData)}
-                    errors={
-                        validationErrors?.dirtySections.address ? [generateErrorMessage('Phone & Email')] : undefined
-                    }
+                    errors={validationErrors?.dirtySections.phone ? [generateErrorMessage('Phone & Email')] : undefined}
                 />
                 <IdentificationRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
                     onChange={(identificationData) => setValue('identifications', identificationData)}
                     errors={
-                        validationErrors?.dirtySections.address ? [generateErrorMessage('Identification')] : undefined
+                        validationErrors?.dirtySections.identification
+                            ? [generateErrorMessage('Identification')]
+                            : undefined
                     }
                 />
                 <RaceRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ race: isDirty })}
                     onChange={(raceData) => setValue('races', raceData)}
-                    errors={validationErrors?.dirtySections.address ? [generateErrorMessage('Race')] : undefined}
+                    errors={validationErrors?.dirtySections.race ? [generateErrorMessage('Race')] : undefined}
                 />
                 <Card
                     id="ethnicity"

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -103,6 +103,11 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                             values={value}
                             isDirty={(isDirty) => setSubFormState({ race: isDirty })}
                             onChange={onChange}
+                            errors={
+                                validationErrors?.dirtySections.identification
+                                    ? [generateErrorMessage('Race')]
+                                    : undefined
+                            }
                         />
                     )}
                 />

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -15,6 +15,7 @@ import { RaceRepeatingBlock } from './inputs/race/RaceRepeatingBlock';
 import { AlertMessage } from 'design-system/message';
 import styles from './add-patient-extended-form.module.scss';
 import { SubFormDirtyState, ValidationErrors } from './useAddExtendedPatientInteraction';
+import React from 'react';
 
 type Props = {
     validationErrors?: ValidationErrors;
@@ -23,24 +24,28 @@ type Props = {
 export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Props) => {
     const { setValue } = useFormContext<ExtendedNewPatientEntry>();
 
+    // Generates an error message that will contain a link to the section if an id is provided
+    const generateErrorMessage = (section: string, id?: string) => {
+        return (
+            <React.Fragment key={section}>
+                Data has been entered in the {id ? <a href={`#${id}`}>{section}</a> : `${section}`} section. Please
+                press Add or clear the data and submit again.
+            </React.Fragment>
+        );
+    };
+
     const renderErrorMessages = () => {
-        const generateError = (section: string, id: string) => {
-            return (
-                <>
-                    Data has been entered in the <a href={`#${id}`}>{section}</a> section. Please press Add or clear the
-                    data and submit again.
-                </>
-            );
-        };
         return (
             <ul className={styles.errorList}>
-                {validationErrors?.dirtySections.name && <li>{generateError('Name', 'name')}</li>}
-                {validationErrors?.dirtySections.address && <li>{generateError('Address', 'address')}</li>}
-                {validationErrors?.dirtySections.phone && <li>{generateError('Phone & Email', 'phoneAndEmail')}</li>}
-                {validationErrors?.dirtySections.identification && (
-                    <li>{generateError('Identification', 'identification')}</li>
+                {validationErrors?.dirtySections.name && <li>{generateErrorMessage('Name', 'name')}</li>}
+                {validationErrors?.dirtySections.address && <li>{generateErrorMessage('Address', 'address')}</li>}
+                {validationErrors?.dirtySections.phone && (
+                    <li>{generateErrorMessage('Phone & Email', 'phoneAndEmail')}</li>
                 )}
-                {validationErrors?.dirtySections.race && <li>{generateError('Race', 'races')}</li>}
+                {validationErrors?.dirtySections.identification && (
+                    <li>{generateErrorMessage('Identification', 'identification')}</li>
+                )}
+                {validationErrors?.dirtySections.race && <li>{generateErrorMessage('Race', 'races')}</li>}
             </ul>
         );
     };
@@ -62,22 +67,31 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                 <NameRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ name: isDirty })}
                     onChange={(nameData) => setValue('names', nameData)}
+                    errors={validationErrors?.dirtySections.name ? [generateErrorMessage('Name')] : undefined}
                 />
                 <AddressRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ address: isDirty })}
                     onChange={(addressData) => setValue('addresses', addressData)}
+                    errors={validationErrors?.dirtySections.address ? [generateErrorMessage('Address')] : undefined}
                 />
                 <PhoneAndEmailRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ phone: isDirty })}
                     onChange={(phoneEmailData) => setValue('phoneEmails', phoneEmailData)}
+                    errors={
+                        validationErrors?.dirtySections.address ? [generateErrorMessage('Phone & Email')] : undefined
+                    }
                 />
                 <IdentificationRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
                     onChange={(identificationData) => setValue('identifications', identificationData)}
+                    errors={
+                        validationErrors?.dirtySections.address ? [generateErrorMessage('Identification')] : undefined
+                    }
                 />
                 <RaceRepeatingBlock
                     isDirty={(isDirty) => setSubFormState({ race: isDirty })}
                     onChange={(raceData) => setValue('races', raceData)}
+                    errors={validationErrors?.dirtySections.address ? [generateErrorMessage('Race')] : undefined}
                 />
                 <Card
                     id="ethnicity"

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -22,7 +22,7 @@ type Props = {
     setSubFormState: (state: Partial<SubFormDirtyState>) => void;
 };
 export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Props) => {
-    const { setValue, control } = useFormContext<ExtendedNewPatientEntry>();
+    const { control } = useFormContext<ExtendedNewPatientEntry>();
 
     // Generates an error message that will contain a link to the section if an id is provided
     const generateErrorMessage = (section: string, id?: string) => {
@@ -70,29 +70,73 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                     info={<span className="required-before">All required fields for adding comments</span>}>
                     <AdministrativeEntryFields />
                 </Card>
-                <NameRepeatingBlock
-                    isDirty={(isDirty) => setSubFormState({ name: isDirty })}
-                    onChange={(nameData) => setValue('names', nameData)}
-                    errors={validationErrors?.dirtySections.name ? [generateErrorMessage('Name')] : undefined}
+                <Controller
+                    control={control}
+                    name="names"
+                    render={({ field: { onChange, value, name } }) => (
+                        <NameRepeatingBlock
+                            id={name}
+                            values={value}
+                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            onChange={onChange}
+                            errors={
+                                validationErrors?.dirtySections.identification
+                                    ? [generateErrorMessage('Name')]
+                                    : undefined
+                            }
+                        />
+                    )}
                 />
-                <AddressRepeatingBlock
-                    isDirty={(isDirty) => setSubFormState({ address: isDirty })}
-                    onChange={(addressData) => setValue('addresses', addressData)}
-                    errors={validationErrors?.dirtySections.address ? [generateErrorMessage('Address')] : undefined}
+                <Controller
+                    control={control}
+                    name="addresses"
+                    render={({ field: { onChange, value, name } }) => (
+                        <AddressRepeatingBlock
+                            id={name}
+                            values={value}
+                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            onChange={onChange}
+                            errors={
+                                validationErrors?.dirtySections.identification
+                                    ? [generateErrorMessage('Address')]
+                                    : undefined
+                            }
+                        />
+                    )}
                 />
-                <PhoneAndEmailRepeatingBlock
-                    isDirty={(isDirty) => setSubFormState({ phone: isDirty })}
-                    onChange={(phoneEmailData) => setValue('phoneEmails', phoneEmailData)}
-                    errors={validationErrors?.dirtySections.phone ? [generateErrorMessage('Phone & Email')] : undefined}
+                <Controller
+                    control={control}
+                    name="phoneEmails"
+                    render={({ field: { onChange, value, name } }) => (
+                        <PhoneAndEmailRepeatingBlock
+                            id={name}
+                            values={value}
+                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            onChange={onChange}
+                            errors={
+                                validationErrors?.dirtySections.identification
+                                    ? [generateErrorMessage('Phone & Email')]
+                                    : undefined
+                            }
+                        />
+                    )}
                 />
-                <IdentificationRepeatingBlock
-                    isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
-                    onChange={(identificationData) => setValue('identifications', identificationData)}
-                    errors={
-                        validationErrors?.dirtySections.identification
-                            ? [generateErrorMessage('Identification')]
-                            : undefined
-                    }
+                <Controller
+                    control={control}
+                    name="identifications"
+                    render={({ field: { onChange, value, name } }) => (
+                        <IdentificationRepeatingBlock
+                            id={name}
+                            values={value}
+                            isDirty={(isDirty) => setSubFormState({ identification: isDirty })}
+                            onChange={onChange}
+                            errors={
+                                validationErrors?.dirtySections.identification
+                                    ? [generateErrorMessage('Identification')]
+                                    : undefined
+                            }
+                        />
+                    )}
                 />
                 <Controller
                     control={control}

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -79,11 +79,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                             values={value}
                             isDirty={(isDirty) => setSubFormState({ name: isDirty })}
                             onChange={onChange}
-                            errors={
-                                validationErrors?.dirtySections.identification
-                                    ? [generateErrorMessage('Name')]
-                                    : undefined
-                            }
+                            errors={validationErrors?.dirtySections.name ? [generateErrorMessage('Name')] : undefined}
                         />
                     )}
                 />
@@ -97,9 +93,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                             isDirty={(isDirty) => setSubFormState({ address: isDirty })}
                             onChange={onChange}
                             errors={
-                                validationErrors?.dirtySections.identification
-                                    ? [generateErrorMessage('Address')]
-                                    : undefined
+                                validationErrors?.dirtySections.address ? [generateErrorMessage('Address')] : undefined
                             }
                         />
                     )}
@@ -114,7 +108,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
                             isDirty={(isDirty) => setSubFormState({ phone: isDirty })}
                             onChange={onChange}
                             errors={
-                                validationErrors?.dirtySections.identification
+                                validationErrors?.dirtySections.phone
                                     ? [generateErrorMessage('Phone & Email')]
                                     : undefined
                             }

--- a/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended-form.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended-form.module.scss
@@ -22,7 +22,7 @@
         display: flex;
         flex-direction: column;
         gap: 1rem;
-        padding-bottom: 1rem;
+        padding-bottom: 12rem;
     }
 
     .errorList {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
@@ -44,9 +44,11 @@ jest.mock('location/useLocationCodedValues', () => ({
 const onChange = jest.fn();
 const isDirty = jest.fn();
 
+const Fixture = () => <AddressRepeatingBlock id="races" onChange={onChange} isDirty={isDirty} />;
+
 describe('RaceMultiEntry', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<AddressRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getAllByRole } = render(<Fixture />);
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');
@@ -58,7 +60,7 @@ describe('RaceMultiEntry', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText } = render(<AddressRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getByLabelText } = render(<Fixture />);
 
         const dateInput = getByLabelText('Address as of');
         expect(dateInput).toHaveValue(internalizeDate(new Date()));

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
@@ -22,11 +22,13 @@ const defaultValue: Partial<AddressEntry> = {
 };
 
 type Props = {
+    id: string;
+    values?: AddressEntry[];
     onChange: (data: AddressEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
     errors?: ReactNode[];
 };
-export const AddressRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
+export const AddressRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Props) => {
     const renderForm = () => <AddressEntryFields />;
     const renderView = (entry: AddressEntry) => <AddressView entry={entry} />;
 
@@ -41,9 +43,10 @@ export const AddressRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
 
     return (
         <RepeatingBlock<AddressEntry>
-            id="address"
+            id={id}
             title="Address"
             defaultValues={defaultValue}
+            values={values}
             columns={columns}
             onChange={onChange}
             isDirty={isDirty}

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
@@ -4,6 +4,7 @@ import { Column } from 'design-system/table';
 import { AddressView } from './AddressView';
 import { AddressEntryFields } from 'apps/patient/data/address/AddressEntryFields';
 import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
+import { ReactNode } from 'react';
 
 const defaultValue: Partial<AddressEntry> = {
     asOf: today(),
@@ -23,8 +24,9 @@ const defaultValue: Partial<AddressEntry> = {
 type Props = {
     onChange: (data: AddressEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
+    errors?: ReactNode[];
 };
-export const AddressRepeatingBlock = ({ onChange, isDirty }: Props) => {
+export const AddressRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
     const renderForm = () => <AddressEntryFields />;
     const renderView = (entry: AddressEntry) => <AddressView entry={entry} />;
 
@@ -47,6 +49,7 @@ export const AddressRepeatingBlock = ({ onChange, isDirty }: Props) => {
             isDirty={isDirty}
             formRenderer={renderForm}
             viewRenderer={renderView}
+            errors={errors}
         />
     );
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.spec.tsx
@@ -31,9 +31,11 @@ jest.mock('design-system/entry/multi-value/useMultiValueEntryState', () => ({
 const onChange = jest.fn();
 const isDirty = jest.fn();
 
+const Fixture = () => <IdentificationRepeatingBlock id="identifications" onChange={onChange} isDirty={isDirty} />;
+
 describe('IdentificationMultiEntry', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<IdentificationRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getAllByRole } = render(<Fixture />);
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');
@@ -43,7 +45,7 @@ describe('IdentificationMultiEntry', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText } = render(<IdentificationRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getByLabelText } = render(<Fixture />);
 
         const dateInput = getByLabelText('Identification as of');
         expect(dateInput).toHaveValue(internalizeDate(new Date()));

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
@@ -4,6 +4,7 @@ import { today } from 'date';
 import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { IdentificationView } from './IdentificationView';
+import { ReactNode } from 'react';
 
 const defaultValue: Partial<IdentificationEntry> = {
     asOf: today(),
@@ -14,8 +15,9 @@ const defaultValue: Partial<IdentificationEntry> = {
 type Props = {
     onChange: (data: IdentificationEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
+    errors?: ReactNode[];
 };
-export const IdentificationRepeatingBlock = ({ onChange, isDirty }: Props) => {
+export const IdentificationRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
     const renderForm = () => <IdentificationEntryFields />;
     const renderView = (entry: IdentificationEntry) => <IdentificationView entry={entry} />;
 
@@ -35,6 +37,7 @@ export const IdentificationRepeatingBlock = ({ onChange, isDirty }: Props) => {
             isDirty={isDirty}
             formRenderer={renderForm}
             viewRenderer={renderView}
+            errors={errors}
         />
     );
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
@@ -13,11 +13,13 @@ const defaultValue: Partial<IdentificationEntry> = {
     id: ''
 };
 type Props = {
+    id: string;
+    values?: IdentificationEntry[];
     onChange: (data: IdentificationEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
     errors?: ReactNode[];
 };
-export const IdentificationRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
+export const IdentificationRepeatingBlock = ({ id, errors, values, onChange, isDirty }: Props) => {
     const renderForm = () => <IdentificationEntryFields />;
     const renderView = (entry: IdentificationEntry) => <IdentificationView entry={entry} />;
 
@@ -29,9 +31,10 @@ export const IdentificationRepeatingBlock = ({ onChange, isDirty, errors }: Prop
     ];
     return (
         <RepeatingBlock<IdentificationEntry>
-            id="identification"
+            id={id}
             title="Identification"
             defaultValues={defaultValue}
+            values={values}
             columns={columns}
             onChange={onChange}
             isDirty={isDirty}

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.spec.tsx
@@ -32,9 +32,11 @@ jest.mock('apps/patient/profile/names/usePatientNameCodedValues', () => ({
     usePatientNameCodedValues: () => mockPatientNameCodedValues
 }));
 
+const Fixture = () => <NameRepeatingBlock id="names" onChange={onChange} isDirty={isDirty} />;
+
 describe('NameRepeatingBlock', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<NameRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getAllByRole } = render(<Fixture />);
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');
@@ -46,7 +48,7 @@ describe('NameRepeatingBlock', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText } = render(<NameRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getByLabelText } = render(<Fixture />);
 
         const dateInput = getByLabelText('Name as of');
         expect(dateInput).toHaveValue(internalizeDate(new Date()));

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
@@ -4,6 +4,7 @@ import { today } from 'date';
 import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { NameEntryView } from './NameEntryView';
+import { ReactNode } from 'react';
 
 const defaultValue: Partial<NameEntry> = {
     asOf: today(),
@@ -30,9 +31,10 @@ const columns: Column<NameEntry>[] = [
 type Props = {
     onChange: (data: NameEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
+    errors?: ReactNode[];
 };
 
-export const NameRepeatingBlock = ({ onChange, isDirty }: Props) => {
+export const NameRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
     const renderForm = () => <NameEntryFields />;
     const renderView = (entry: NameEntry) => <NameEntryView entry={entry} />;
 
@@ -46,6 +48,7 @@ export const NameRepeatingBlock = ({ onChange, isDirty }: Props) => {
             isDirty={isDirty}
             formRenderer={renderForm}
             viewRenderer={renderView}
+            errors={errors}
         />
     );
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
@@ -29,20 +29,23 @@ const columns: Column<NameEntry>[] = [
 ];
 
 type Props = {
+    id: string;
+    values?: NameEntry[];
     onChange: (data: NameEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
     errors?: ReactNode[];
 };
 
-export const NameRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
+export const NameRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Props) => {
     const renderForm = () => <NameEntryFields />;
     const renderView = (entry: NameEntry) => <NameEntryView entry={entry} />;
 
     return (
         <RepeatingBlock<NameEntry>
-            id="name"
+            id={id}
             title="Name"
             defaultValues={defaultValue}
+            values={values}
             columns={columns}
             onChange={onChange}
             isDirty={isDirty}

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.spec.tsx
@@ -36,9 +36,11 @@ const awaitRender = async () => {
     expect(await screen.findByText('URL')).toBeInTheDocument();
 };
 
+const Fixture = () => <PhoneAndEmailRepeatingBlock id="phoneAndEmail" onChange={onChange} isDirty={isDirty} />;
+
 describe('PhoneAndEmailMultiEntry', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<PhoneAndEmailRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getAllByRole } = render(<Fixture />);
         // wait on render to prevent act warning
         await awaitRender();
 
@@ -51,7 +53,7 @@ describe('PhoneAndEmailMultiEntry', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText } = render(<PhoneAndEmailRepeatingBlock onChange={onChange} isDirty={isDirty} />);
+        const { getByLabelText } = render(<Fixture />);
         // wait on render to prevent act warning
         await awaitRender();
 
@@ -84,9 +86,7 @@ describe('PhoneAndEmailMultiEntry', () => {
     });
 
     it('should trigger on change when value added', async () => {
-        const { getByLabelText, getAllByRole } = render(
-            <PhoneAndEmailRepeatingBlock onChange={onChange} isDirty={isDirty} />
-        );
+        const { getByLabelText, getAllByRole } = render(<Fixture />);
         // wait on render to prevent act warning
         await awaitRender();
         const type = getByLabelText('Type');

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
@@ -18,11 +18,13 @@ const defaultValue: Partial<PhoneEmailEntry> = {
     comment: ''
 };
 type Props = {
+    id: string;
+    values?: PhoneEmailEntry[];
     onChange: (data: PhoneEmailEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
     errors?: ReactNode[];
 };
-export const PhoneAndEmailRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
+export const PhoneAndEmailRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Props) => {
     const renderForm = () => <PhoneEmailEntryFields />;
     const renderView = (entry: PhoneEmailEntry) => <PhoneEntryView entry={entry} />;
 
@@ -36,9 +38,10 @@ export const PhoneAndEmailRepeatingBlock = ({ onChange, isDirty, errors }: Props
 
     return (
         <RepeatingBlock<PhoneEmailEntry>
-            id="phoneAndEmail"
+            id={id}
             title="Phone & email"
             defaultValues={defaultValue}
+            values={values}
             columns={columns}
             onChange={onChange}
             isDirty={isDirty}

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
@@ -4,6 +4,7 @@ import { today } from 'date';
 import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { PhoneEntryView } from './PhoneEntryView';
+import { ReactNode } from 'react';
 
 const defaultValue: Partial<PhoneEmailEntry> = {
     asOf: today(),
@@ -19,8 +20,9 @@ const defaultValue: Partial<PhoneEmailEntry> = {
 type Props = {
     onChange: (data: PhoneEmailEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
+    errors?: ReactNode[];
 };
-export const PhoneAndEmailRepeatingBlock = ({ onChange, isDirty }: Props) => {
+export const PhoneAndEmailRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
     const renderForm = () => <PhoneEmailEntryFields />;
     const renderView = (entry: PhoneEmailEntry) => <PhoneEntryView entry={entry} />;
 
@@ -42,6 +44,7 @@ export const PhoneAndEmailRepeatingBlock = ({ onChange, isDirty }: Props) => {
             isDirty={isDirty}
             formRenderer={renderForm}
             viewRenderer={renderView}
+            errors={errors}
         />
     );
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
@@ -5,6 +5,7 @@ import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { DetailedRaceDisplay } from './DetailedRaceDisplay';
 import { RaceEntryView } from './RaceEntryView';
+import { ReactNode } from 'react';
 
 const defaultValue: Partial<RaceEntry> = {
     asOf: today(),
@@ -15,8 +16,9 @@ const defaultValue: Partial<RaceEntry> = {
 type Props = {
     onChange: (data: RaceEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
+    errors?: ReactNode[];
 };
-export const RaceRepeatingBlock = ({ onChange, isDirty }: Props) => {
+export const RaceRepeatingBlock = ({ onChange, isDirty, errors }: Props) => {
     const renderForm = () => <RaceEntryFields />;
     const renderView = (entry: RaceEntry) => <RaceEntryView entry={entry} />;
 
@@ -39,6 +41,7 @@ export const RaceRepeatingBlock = ({ onChange, isDirty }: Props) => {
             isDirty={isDirty}
             formRenderer={renderForm}
             viewRenderer={renderView}
+            errors={errors}
         />
     );
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/nav/AddPatientExtendedNav.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/nav/AddPatientExtendedNav.tsx
@@ -4,10 +4,10 @@ import styles from './in-page-nav.module.scss';
 export const AddPatientExtendedInPageNav = () => {
     const sections: NavSection[] = [
         { id: 'administrative', label: 'Administrative' },
-        { id: 'name', label: 'Name' },
-        { id: 'address', label: 'Address' },
-        { id: 'phoneAndEmail', label: 'Phone & email' },
-        { id: 'identification', label: 'Identification' },
+        { id: 'names', label: 'Name' },
+        { id: 'addresses', label: 'Address' },
+        { id: 'phoneEmails', label: 'Phone & email' },
+        { id: 'identifications', label: 'Identification' },
         { id: 'races', label: 'Race' },
         { id: 'ethnicity', label: 'Ethnicity' },
         { id: 'sexAndBirth', label: 'Sex & birth' },

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
@@ -67,6 +67,7 @@ const useAddExtendedPatient = ({ transformer, creator }: Settings): AddExtendedP
     });
 
     const setSubFormState = (subFormState: Partial<SubFormDirtyState>) => {
+        console.log('setting to dirty', subFormState);
         setSubFormDirtyState((current) => {
             return { ...current, ...subFormState };
         });

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
@@ -67,7 +67,6 @@ const useAddExtendedPatient = ({ transformer, creator }: Settings): AddExtendedP
     });
 
     const setSubFormState = (subFormState: Partial<SubFormDirtyState>) => {
-        console.log('setting to dirty', subFormState);
         setSubFormDirtyState((current) => {
             return { ...current, ...subFormState };
         });

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -16,20 +16,13 @@
         @extend %thin-bottom;
     }
 
-    .errors {
-        display: flex;
-        flex-direction: column;
+    .errorList {
+        list-style: inside;
+        padding: 0;
+        margin: 0;
 
-        .errorHeading {
-            color: colors.$base-darkest;
-            font-size: 1.375rem;
-            font-weight: 700;
-        }
-
-        ul {
-            padding: 0;
-            margin: 0;
-            list-style-position: inside;
+        & > li {
+            line-height: 1.62rem;
         }
     }
 

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -90,7 +90,7 @@ type Props = {
 const Fixture = ({ values = [], errors }: Props) => (
     <RepeatingBlock<TestType>
         id="testing"
-        title={'Test'}
+        title={'Test title'}
         defaultValues={defaultValues}
         columns={columns}
         values={values}

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -66,10 +66,13 @@ const renderView = (entry: TestType) => {
         </section>
     );
 };
-const UnderTest = () => {
+type Props = {
+    errors?: string[];
+};
+const UnderTest = ({ errors }: Props) => {
     return (
         <RepeatingBlock<TestType>
-            title={'Test'}
+            title={'Test title'}
             defaultValues={defaultValues}
             columns={[
                 {
@@ -87,15 +90,20 @@ const UnderTest = () => {
             isDirty={isDirty}
             formRenderer={renderForm}
             viewRenderer={renderView}
+            errors={errors}
         />
     );
+};
+
+const awaitRender = async () => {
+    expect(await screen.findByText('Test title')).toBeInTheDocument();
 };
 
 describe('MultiValueEntry', () => {
     it('should display provided title', async () => {
         const { getByRole } = render(<UnderTest />);
         // wait on render to prevent act warning
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const heading = getByRole('heading');
         expect(heading).toHaveTextContent('Test');
@@ -103,7 +111,7 @@ describe('MultiValueEntry', () => {
 
     it('should display provided form', async () => {
         const { getByLabelText } = render(<UnderTest />);
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         expect(getByLabelText('First Input')).toBeInTheDocument();
         expect(getByLabelText('Second Input')).toBeInTheDocument();
@@ -111,7 +119,7 @@ describe('MultiValueEntry', () => {
 
     it('should display default values', async () => {
         const { getByLabelText } = render(<UnderTest />);
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const firstInput = getByLabelText('First Input');
         expect(firstInput).toBeInTheDocument();
@@ -124,7 +132,7 @@ describe('MultiValueEntry', () => {
 
     it('should display add button', async () => {
         const { getByRole } = render(<UnderTest />);
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         expect(button).toBeInTheDocument();
@@ -154,7 +162,7 @@ describe('MultiValueEntry', () => {
     it('should trigger on change when data is submitted', async () => {
         const { getByRole, getByLabelText } = render(<UnderTest />);
 
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         expect(button).toBeInTheDocument();
@@ -183,7 +191,7 @@ describe('MultiValueEntry', () => {
     it('should display submitted data in table', async () => {
         const { getByRole, getAllByRole } = render(<UnderTest />);
 
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         userEvent.click(button);
@@ -204,7 +212,7 @@ describe('MultiValueEntry', () => {
     it('should display icons in last column of table', async () => {
         const { getByRole, getAllByRole } = render(<UnderTest />);
 
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         userEvent.click(button);
@@ -234,7 +242,7 @@ describe('MultiValueEntry', () => {
     it('should render view when view icon clicked', async () => {
         const { getByRole, getAllByRole, getByText } = render(<UnderTest />);
 
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         userEvent.click(button);
@@ -258,7 +266,7 @@ describe('MultiValueEntry', () => {
     it('should delete row when delete icon clicked', async () => {
         const { getByRole, getAllByRole } = render(<UnderTest />);
 
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         userEvent.click(button);
@@ -281,7 +289,7 @@ describe('MultiValueEntry', () => {
     it('should allow edit of row', async () => {
         const { getByRole, getAllByRole, getByLabelText } = render(<UnderTest />);
 
-        expect(await screen.findByText('Test')).toBeInTheDocument();
+        await awaitRender();
 
         const button = getByRole('button');
         const input1 = getByLabelText('First Input');
@@ -339,5 +347,13 @@ describe('MultiValueEntry', () => {
         expect(columns[0]).toHaveTextContent('first changed again');
         expect(columns[1]).toHaveTextContent('second changed again');
         expect(columns[2]).toHaveTextContent('');
+    });
+
+    it('should display errors passed to component', async () => {
+        const { getByText } = render(<UnderTest errors={['First error', 'Second error']} />);
+        await awaitRender();
+
+        expect(getByText('First error')).toBeInTheDocument();
+        expect(getByText('Second error')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -1,14 +1,14 @@
-import { ReactNode, useEffect, useMemo } from 'react';
-import { DefaultValues, FieldValues, FormProvider, useForm, useFormState } from 'react-hook-form';
 import classNames from 'classnames';
 import { Button } from 'components/button';
 import { Heading } from 'components/heading';
-import { AlertMessage } from 'design-system/message';
 import { Shown } from 'conditional-render';
-import { Column, DataTable } from 'design-system/table';
-import { useMultiValueEntryState } from './useMultiValueEntryState';
-import styles from './RepeatingBlock.module.scss';
 import { Icon } from 'design-system/icon';
+import { AlertMessage } from 'design-system/message';
+import { Column, DataTable } from 'design-system/table';
+import { ReactNode, useEffect, useMemo } from 'react';
+import { DefaultValues, FieldValues, FormProvider, useForm } from 'react-hook-form';
+import styles from './RepeatingBlock.module.scss';
+import { useMultiValueEntryState } from './useMultiValueEntryState';
 
 type Props<V extends FieldValues> = {
     id: string;
@@ -36,7 +36,6 @@ const RepeatingBlock = <V extends FieldValues>({
     viewRenderer
 }: Props<V>) => {
     const form = useForm<V>({ mode: 'onSubmit', reValidateMode: 'onSubmit', defaultValues });
-    const { errors: formErrors } = useFormState({ control: form.control });
     const { status, selected, add, edit, update, remove, view, reset, state } = useMultiValueEntryState<V>({ values });
 
     useEffect(() => {
@@ -102,11 +101,11 @@ const RepeatingBlock = <V extends FieldValues>({
 
     // Combine error message prop and internal form error messages into an array for display in the banner
     const errorMessages = useMemo<ReactNode[]>(() => {
-        const formErrorMessages = Object.values(formErrors).map((error) => error?.message?.toString());
+        const formErrorMessages = Object.values(form.formState.errors).map((error) => error?.message?.toString());
         const messages: ReactNode[] = [...(errors ?? []), ...formErrorMessages];
 
         return messages.filter((a) => a != undefined);
-    }, [JSON.stringify(formErrors), errors]);
+    }, [JSON.stringify(form.formState.errors), errors]);
 
     // If a user clears the form, remove internal form validation errors
     useEffect(() => {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -98,13 +98,10 @@ export const RepeatingBlock = <V extends FieldValues>({
 
     // Combine error message prop and internal form error messages into an array for display in the banner
     const errorMessages = useMemo<ReactNode[]>(() => {
-        const messages: ReactNode[] = [];
         const formErrorMessages = Object.values(formErrors).map((error) => error?.message?.toString());
+        const messages: ReactNode[] = [...(errors ?? []), ...formErrorMessages];
 
-        return messages
-            .concat(errors)
-            .concat(formErrorMessages)
-            .filter((a) => a != undefined);
+        return messages.filter((a) => a != undefined);
     }, [JSON.stringify(formErrors), errors]);
 
     // If a user clears the form, remove internal form validation errors

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -14,7 +14,7 @@ type Props<V extends FieldValues> = {
     title: string;
     columns: Column<V>[];
     defaultValues?: DefaultValues<V>; // Provide all default values to allow `isDirty` to function
-    errors?: string[];
+    errors?: ReactNode[];
     onChange: (data: V[]) => void;
     isDirty: (isDirty: boolean) => void;
     formRenderer: (control: Control<V>) => ReactNode;

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -98,14 +98,13 @@ export const RepeatingBlock = <V extends FieldValues>({
 
     // Combine error message prop and internal form error messages into an array for display in the banner
     const errorMessages = useMemo<ReactNode[]>(() => {
+        const messages: ReactNode[] = [];
         const formErrorMessages = Object.values(formErrors).map((error) => error?.message?.toString());
 
-        // const messages: ReactNode[] = [];
-        return errors ? errors.concat(formErrorMessages) : formErrorMessages;
-        // return messages
-        //     .concat(errors)
-        //     .concat(formErrorMessages)
-        //     .filter((a) => a !== undefined);
+        return messages
+            .concat(errors)
+            .concat(formErrorMessages)
+            .filter((a) => a != undefined);
     }, [JSON.stringify(formErrors), errors]);
 
     // If a user clears the form, remove internal form validation errors

--- a/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
@@ -21,7 +21,11 @@ export const InPageNavigation: React.FC<InPageNavigationProps> = ({ sections, ti
             <div className={styles.navTitle}>{title}</div>
             <div className={styles.navOptions}>
                 {sections.map((section) => (
-                    <a key={section.id} href={`#${section.id}`} className={classNames(styles.navOption)}>
+                    <a
+                        key={section.id}
+                        id={`inPageNav-${section.id}`}
+                        href={`#${section.id}`}
+                        className={classNames(styles.navOption)}>
                         {section.label}
                     </a>
                 ))}

--- a/apps/modernization-ui/src/design-system/inPageNavigation/useInPageNavigation.ts
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/useInPageNavigation.ts
@@ -9,7 +9,7 @@ const useInPageNavigation = (threshold: number = 0) => {
             entries.forEach((entry) => {
                 const section = entry.target as HTMLElement;
                 const sectionId = section.id;
-                const sectionLink = document.querySelector(`a[href="#${sectionId}"]`);
+                const sectionLink = document.querySelector(`a[id="inPageNav-${sectionId}"]`);
                 if (entry.intersectionRatio > threshold) {
                     section?.classList.add(styles.active);
                     sectionLink?.classList.add(styles.active);
@@ -33,7 +33,7 @@ const useInPageNavigation = (threshold: number = 0) => {
 
         sections.forEach((section) => {
             const sectionId = section.id;
-            const sectionLink = document.querySelector(`a[href="#${sectionId}"]`);
+            const sectionLink = document.querySelector(`a[id="inPageNav-${sectionId}"]`);
             if (sectionLink) {
                 sectionLink.addEventListener('click', (event) => {
                     event.preventDefault();


### PR DESCRIPTION
## Description

Displays repeating block validation errors within banner at the top of the repeating block. Validations are triggered onSubmit.

## Tickets

* [CNFT1-3181](https://cdc-nbs.atlassian.net/browse/CNFT1-3181)

## Demo
![validationInRepeatingBLock](https://github.com/user-attachments/assets/70970a99-e478-4ff4-8cfe-a40cf74a8ad1)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3181]: https://cdc-nbs.atlassian.net/browse/CNFT1-3181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ