### PR TITLE
[CNFT1-3282] Include address type in patient search results

### DIFF
--- a/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
+++ b/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
@@ -311,8 +311,8 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query search($filter: PersonFilter!, $page: SortablePage, $share: String) {\n  findPatientsByFilter(filter: $filter, page: $page, share: $share) {\n    content {\n      patient\n      shortId\n      legalName {\n        first\n        middle\n        last\n        suffix\n      }\n    }\n    total\n    page\n    size\n  }\n}\n",
-								"variables": "{\n    \"filter\" :{\n        \"recordStatus\": [\"ACTIVE\"]\n    },\n    \"page\": {\n        \"pageNumber\": 0,\n        \"pageSize\": 5,\n        \"sort\" : {\n            \"property\": \"lastNm\",\n            \"direction\": \"DESC\"\n        }\n\t}\n}"
+								"query": "query search($filter: PersonFilter!, $page: SortablePage, $share: String) {\n  findPatientsByFilter(filter: $filter, page: $page, share: $share) {\n    content {\n      patient\n      shortId\n      legalName {\n        first\n        middle\n        last\n        suffix\n      }\n      addresses {\n        type\n        use\n        address\n        city\n        county\n        zipcode\n        state\n      }\n    }\n    total\n    page\n    size\n  }\n}\n",
+								"variables": "{\n    \"filter\" :{\n        \"recordStatus\": [\"ACTIVE\"]\n    },\n    \"page\": {\n        \"pageNumber\": 0,\n        \"pageSize\": 5\n\t}\n}"
 							}
 						},
 						"url": {
@@ -328,50 +328,6 @@
 									"key": "",
 									"value": null
 								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Patient Search (7.0.0)",
-					"protocolProfileBehavior": {
-						"followRedirects": false,
-						"followOriginalHttpMethod": false,
-						"followAuthorizationHeader": false
-					},
-					"request": {
-						"auth": {
-							"type": "oauth2",
-							"oauth2": [
-								{
-									"key": "accessToken",
-									"value": "{{token}}",
-									"type": "string"
-								},
-								{
-									"key": "addTokenTo",
-									"value": "header",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "graphql",
-							"graphql": {
-								"query": "query search($filter:PersonFilter!,$page:SortablePage){\n    findPatientsByFilter(filter:$filter,page:$page){\n        content{\n            id\n            shortId\n            names {\n                firstNm\n                middleNm\n                lastNm\n            } \n        }\n        total\n    }\n}",
-								"variables": "{\n\t\t\"filter\": {\n\t\t\t\"recordStatus\": [\n\t\t\t\t\"ACTIVE\"\n\t\t\t]\n\t\t},\n\t\t\"page\": {\n\t\t\t\"pageNumber\": 0,\n\t\t\t\"pageSize\": 25,\n\t\t\t\"sortDirection\": \"ASC\",\n\t\t\t\"sortField\": \"lastNm\"\n\t\t}\n\t}"
-							}
-						},
-						"url": {
-							"raw": "{{base}}/graphql",
-							"host": [
-								"{{base}}"
-							],
-							"path": [
-								"graphql"
 							]
 						}
 					},
@@ -569,7 +525,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"administrative\": {\n        \"asOf\": \"{{localDate}}\",\n        \"comment\": \"testing extended patient data\"\n    },\n    \"names\": [],\n    \"addresses\": [],\n    \"phoneEmails\": [],\n    \"races\": [],\n    \"identifications\": []\n}",
+									"raw": "{\n    \"administrative\": {\n        \"asOf\": \"{{localDate}}\",\n        \"comment\": \"testing extended patient data\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/address/Address.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/address/Address.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.address;
 
 public record Address(
+    String type,
     String use,
     String address,
     String address2,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/address/AddressRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/address/AddressRowMapper.java
@@ -7,15 +7,19 @@ import java.sql.SQLException;
 
 public class AddressRowMapper implements RowMapper<Address> {
 
-  public record Columns(int use, int address, int address2, int city, int state, int zipcode, int country, int county) {
+  public record Columns(int type, int use, int address, int address2, int city, int state, int zipcode, int country,
+                        int county) {
     public Columns() {
-      this(1, 2, 3, 4, 5, 6, 7, 8);
+      this(1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
   }
 
 
   private final Columns columns;
 
+  public AddressRowMapper() {
+    this(new Columns());
+  }
 
   public AddressRowMapper(final Columns columns) {
     this.columns = columns;
@@ -23,6 +27,7 @@ public class AddressRowMapper implements RowMapper<Address> {
 
   @Override
   public Address mapRow(final ResultSet resultSet, final int row) throws SQLException {
+    String type = resultSet.getString(columns.type());
     String use = resultSet.getString(columns.use());
     String address = resultSet.getString(columns.address());
     String address2 = resultSet.getString(columns.address2());
@@ -33,6 +38,7 @@ public class AddressRowMapper implements RowMapper<Address> {
     String county = resultSet.getString(columns.county());
 
     return new Address(
+        type,
         use,
         address,
         address2,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/address/PatientSummaryAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/address/PatientSummaryAddressFinder.java
@@ -12,7 +12,14 @@ import java.util.Collection;
 class PatientSummaryAddressFinder {
   private static final String QUERY = """
       select
-          [use].[code_short_desc_txt]     as [use],
+          coalesce(
+                [type].code_short_desc_txt,
+                [locators].cd
+          )                               as [type],
+          coalesce(
+                [use].code_short_desc_txt,
+                [locators].[use_cd]
+          )                               as [use],
           [address].street_addr1          as [address_1],
           [address].street_addr2          as [address_2],
           [address].city_desc_txt         as [city],
@@ -26,7 +33,11 @@ class PatientSummaryAddressFinder {
                   [address].[postal_locator_uid] = [locators].[locator_uid]
               and [address].record_status_cd = [locators].record_status_cd
 
-          join NBS_SRTE..Code_value_general [use] on
+          left join  NBS_SRTE..Code_value_general [type] on
+                  [type].code_set_nm = 'EL_TYPE_PST_PAT'
+              and [type].code = [locators].cd
+    
+          left join NBS_SRTE..Code_value_general [use] on
                   [use].code_set_nm = 'EL_USE_PST_PAT'
               and [use].code = [locators].[use_cd]
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/address/PatientSummaryHomeAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/address/PatientSummaryHomeAddressFinder.java
@@ -13,8 +13,15 @@ import java.util.Optional;
 @Component
 class PatientSummaryHomeAddressFinder {
   private static final String QUERY = """
-            select
-          [use].[code_short_desc_txt]     as [use],
+    select
+          coalesce(
+                [type].code_short_desc_txt,
+                [locators].cd
+          )                               as [type],
+          coalesce(
+                [use].code_short_desc_txt,
+                [locators].[use_cd]
+          )                               as [use],
           [address].street_addr1          as [address_1],
           [address].street_addr2          as [address_2],
           [address].city_desc_txt         as [city],
@@ -22,41 +29,45 @@ class PatientSummaryHomeAddressFinder {
           [address].zip_cd                as [zip],
           [country].code_short_desc_txt   as [country],
           [county].code_desc_txt          as [county]
-      from Entity_locator_participation [locators]
-
+    from Entity_locator_participation [locators]
+    
           join Postal_locator [address] on
                   [address].[postal_locator_uid] = [locators].[locator_uid]
               and [address].record_status_cd = [locators].record_status_cd
-
-          join NBS_SRTE..Code_value_general [use] on
+    
+      left join  NBS_SRTE..Code_value_general [type] on
+                  [type].code_set_nm = 'EL_TYPE_PST_PAT'
+              and [type].code = [locators].cd
+    
+          left join NBS_SRTE..Code_value_general [use] on
                   [use].code_set_nm = 'EL_USE_PST_PAT'
               and [use].code = [locators].[use_cd]
-
+    
           left join NBS_SRTE..State_code [state] on
                   [state].state_cd = [address].state_cd
-
+    
           left join NBS_SRTE..Country_code [country] on
                   [country].code = [address].cntry_cd
-
+    
           left join NBS_SRTE..State_county_code_value [county] on [county].code = [address].cnty_cd
-
-
-      where   [locators].entity_uid = ?
-          and [locators].[class_cd] = 'PST'
-          and [locators].use_cd = 'H'
-          and [locators].record_status_cd = 'ACTIVE'
-          and [locators].as_of_date = (
+    
+    
+    where   [locators].entity_uid = ?
+        and [locators].[class_cd] = 'PST'
+        and [locators].use_cd = 'H'
+        and [locators].record_status_cd = 'ACTIVE'
+        and [locators].as_of_date = (
                   select
                       max(eff_home.as_of_date)
                   from Entity_locator_participation [eff_home]
-
+    
                   where   [eff_home].[entity_uid]         = [locators].entity_uid
                       and [eff_home].[class_cd]           = [locators].[class_cd]
                       and [eff_home].[use_cd]             = [locators].[use_cd]
                       and [eff_home].[record_status_cd]   = [locators].[record_status_cd]
                       and [eff_home].[as_of_date]         <= ?
               )
-            """;
+    """;
   private static final int PATIENT_PARAMETER = 1;
   private static final int AS_OF_PARAMETER = 2;
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/address/PatientSearchResultAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/address/PatientSearchResultAddressFinder.java
@@ -12,38 +12,49 @@ import java.util.Collection;
 class PatientSearchResultAddressFinder {
 
   private static final String QUERY = """
-      select
-          [use].[code_short_desc_txt]     as [use],
-          [address].street_addr1          as [address_1],
-          [address].street_addr2          as [address_2],
-          [address].city_desc_txt         as [city],
-          [state].[state_nm]              as [state],
-          [address].zip_cd                as [zipcode],
-          [country].code_short_desc_txt   as [country],
-          [county].code_desc_txt          as [county]
-      from Entity_locator_participation [locators]
+        select
+            coalesce(
+                [type].code_short_desc_txt,
+                [locators].cd
+            )                               as [type],
+            coalesce(
+                [use].code_short_desc_txt,
+                [locators].[use_cd]
+            )                               as [use],
+            [address].street_addr1          as [address_1],
+            [address].street_addr2          as [address_2],
+            [address].city_desc_txt         as [city],
+            [state].state_nm                as [state],
+            [address].zip_cd                as [zipcode],
+            [country].code_short_desc_txt   as [country],
+            [county].code_desc_txt          as [county]
+        from Entity_locator_participation [locators]
 
-          join Postal_locator [address] on
-                  [address].[postal_locator_uid] = [locators].[locator_uid]
-              and [address].record_status_cd = [locators].record_status_cd
+            join Postal_locator [address] on
+                    [address].[postal_locator_uid] = [locators].[locator_uid]
+                and [address].record_status_cd = [locators].record_status_cd
 
-          join NBS_SRTE..Code_value_general [use] on
-                  [use].code_set_nm = 'EL_USE_PST_PAT'
-              and [use].code = [locators].[use_cd]
+            left join  NBS_SRTE..Code_value_general [type] on
+                    [type].code_set_nm = 'EL_TYPE_PST_PAT'
+                and [type].code = [locators].cd
+        
+            left join NBS_SRTE..Code_value_general [use] on
+                    [use].code_set_nm = 'EL_USE_PST_PAT'
+                and [use].code = [locators].[use_cd]
 
-          left join NBS_SRTE..State_county_code_value [county] on [county].code = [address].cnty_cd
+            left join NBS_SRTE..State_county_code_value [county] on [county].code = [address].cnty_cd
 
-          left join NBS_SRTE..State_code [state] on
-                  [state].state_cd = [address].state_cd
+            left join NBS_SRTE..State_code [state] on
+                    [state].state_cd = [address].state_cd
 
-          left join NBS_SRTE..Country_code [country] on
-                  [country].code = [address].cntry_cd
+            left join NBS_SRTE..Country_code [country] on
+                    [country].code = [address].cntry_cd
 
-      where   [locators].entity_uid = ?
-          and [locators].[class_cd] = 'PST'
-          and [locators].[use_cd] not in ('BIR', 'DTH')
-          and [locators].[record_status_cd] = 'ACTIVE'
-                   """;
+        where   [locators].entity_uid = ?
+            and [locators].[class_cd] = 'PST'
+            and [locators].[use_cd] not in ('BIR', 'DTH')
+            and [locators].[record_status_cd] = 'ACTIVE'
+        """;
   private static final int PATIENT_PARAMETER = 1;
 
   private final JdbcTemplate template;
@@ -51,7 +62,7 @@ class PatientSearchResultAddressFinder {
 
   PatientSearchResultAddressFinder(final JdbcTemplate template) {
     this.template = template;
-    this.mapper = new AddressRowMapper(new AddressRowMapper.Columns());
+    this.mapper = new AddressRowMapper();
   }
 
   Collection<Address> find(final long patient) {

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -60,7 +60,8 @@ type PatientSearchResultName {
 }
 
 type PatientSearchResultAddress {
-  use: String!
+  type: String
+  use: String
   address: String
   address2: String
   city: String

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
@@ -14,12 +14,11 @@ import gov.cdc.nbs.support.util.RandomUtil;
 import gov.cdc.nbs.testing.identity.SequentialIdentityGenerator;
 import gov.cdc.nbs.testing.support.Active;
 import gov.cdc.nbs.testing.support.Available;
+import jakarta.persistence.EntityManager;
 import net.datafaker.Faker;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import jakarta.persistence.EntityManager;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -54,7 +53,8 @@ public class PatientMother {
       final Active<PatientIdentifier> active,
       final PatientCleaner cleaner,
       final RevisionPatientCreator revisionCreator,
-      final JdbcClient jdbcClient) {
+      final JdbcClient jdbcClient
+  ) {
     this.settings = settings;
     this.idGenerator = idGenerator;
     this.localIdentifierGenerator = localIdentifierGenerator;
@@ -117,8 +117,10 @@ public class PatientMother {
         new PatientCommand.Delete(
             identifier.id(),
             this.settings.createdBy(),
-            this.settings.createdOn()),
-        id -> 0);
+            this.settings.createdOn()
+        ),
+        id -> 0
+    );
   }
 
   public void superseded(final PatientIdentifier identifier) {
@@ -133,15 +135,9 @@ public class PatientMother {
       final String city,
       final String county,
       final String state,
-      final String zip) {
-    withAddress(
-        identifier,
-        "H",
-        address,
-        city,
-        county,
-        state,
-        zip);
+      final String zip
+  ) {
+    withAddress(identifier, "H", address, city, county, state, zip);
   }
 
   public void withAddress(
@@ -151,7 +147,21 @@ public class PatientMother {
       final String city,
       final String county,
       final String state,
-      final String zip) {
+      final String zip
+  ) {
+    withAddress(identifier, "H", use, address, city, county, state, zip);
+  }
+
+  public void withAddress(
+      final PatientIdentifier identifier,
+      final String type,
+      final String use,
+      final String address,
+      final String city,
+      final String county,
+      final String state,
+      final String zip
+  ) {
     Person patient = managed(identifier);
 
     patient.add(
@@ -159,7 +169,7 @@ public class PatientMother {
             patient.getId(),
             idGenerator.next(),
             RandomUtil.getRandomDateInPast(),
-            "H",
+            type,
             use,
             address,
             null,
@@ -171,7 +181,9 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withAddress(final PatientIdentifier identifier) {
@@ -191,14 +203,17 @@ public class PatientMother {
             RandomUtil.country(),
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withIdentification(final PatientIdentifier identifier) {
     withIdentification(
         identifier,
         RandomUtil.getRandomFromArray(IdentificationMother.IDENTIFICATION_CODE_LIST),
-        RandomUtil.getRandomNumericString(8));
+        RandomUtil.getRandomNumericString(8)
+    );
   }
 
   public void withIdentification(
@@ -215,7 +230,9 @@ public class PatientMother {
             RandomUtil.maybeOneFrom("GA"),
             type,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withRace(final PatientIdentifier identifier) {
@@ -224,7 +241,8 @@ public class PatientMother {
 
   public void withRace(
       final PatientIdentifier identifier,
-      final String race) {
+      final String race
+  ) {
     Person patient = managed(identifier);
 
     patient.add(
@@ -239,7 +257,8 @@ public class PatientMother {
   public void withRaceIncluding(
       final PatientIdentifier identifier,
       final String race,
-      final String detail) {
+      final String detail
+  ) {
     Person patient = managed(identifier);
 
     patient.update(
@@ -249,7 +268,9 @@ public class PatientMother {
             race,
             List.of(detail),
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withName(final PatientIdentifier identifier) {
@@ -260,20 +281,23 @@ public class PatientMother {
         faker.name().firstName(),
         faker.name().firstName(),
         faker.name().lastName(),
-        null);
+        null
+    );
   }
 
   public void withName(
       final PatientIdentifier identifier,
       final String type,
       final String first,
-      final String last) {
+      final String last
+  ) {
     withName(
         identifier,
         RandomUtil.getRandomDateInPast(),
         type,
         first,
-        last);
+        last
+    );
   }
 
   public void withName(
@@ -281,7 +305,8 @@ public class PatientMother {
       final Instant asOf,
       final String type,
       final String first,
-      final String last) {
+      final String last
+  ) {
     withName(
         identifier,
         asOf,
@@ -289,7 +314,8 @@ public class PatientMother {
         first,
         null,
         last,
-        null);
+        null
+    );
   }
 
   public void withName(
@@ -299,7 +325,8 @@ public class PatientMother {
       final String first,
       final String middle,
       final String last,
-      final String suffix) {
+      final String suffix
+  ) {
     Person patient = managed(identifier);
 
     patient.add(
@@ -316,7 +343,9 @@ public class PatientMother {
             null,
             type,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withPhone(final PatientIdentifier identifier) {
@@ -336,12 +365,15 @@ public class PatientMother {
             null,
             RandomUtil.getRandomString(),
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withPhone(
       final PatientIdentifier identifier,
-      final String number) {
+      final String number
+  ) {
     withPhone(identifier, null, number, null);
   }
 
@@ -349,7 +381,8 @@ public class PatientMother {
       final PatientIdentifier identifier,
       final String countryCode,
       final String number,
-      final String extension) {
+      final String extension
+  ) {
     Person patient = managed(identifier);
 
     patient.add(
@@ -366,13 +399,13 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withEmail(final PatientIdentifier identifier) {
-    withEmail(
-        identifier,
-        faker.internet().emailAddress());
+    withEmail(identifier, faker.internet().emailAddress());
   }
 
   public void withEmail(final PatientIdentifier identifier, final String email) {
@@ -392,12 +425,15 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withBirthday(
       final PatientIdentifier identifier,
-      final LocalDate birthday) {
+      final LocalDate birthday
+  ) {
     Person patient = managed(identifier);
 
     patient.update(
@@ -413,8 +449,10 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()),
-        this.addressIdentifierGenerator);
+            this.settings.createdOn()
+        ),
+        this.addressIdentifierGenerator
+    );
   }
 
   public void withBirthInformation(final PatientIdentifier identifier) {
@@ -433,8 +471,10 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()),
-        this.addressIdentifierGenerator);
+            this.settings.createdOn()
+        ),
+        this.addressIdentifierGenerator
+    );
   }
 
   public void withGender(final PatientIdentifier identifier) {
@@ -454,7 +494,9 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withLocalId(final PatientIdentifier identifier, final String localId) {
@@ -487,14 +529,16 @@ public class PatientMother {
             null,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()),
-        this.addressIdentifierGenerator);
-
+            this.settings.createdOn()
+        ),
+        this.addressIdentifierGenerator
+    );
   }
 
   public void withEthnicity(
       final PatientIdentifier identifier,
-      final String ethnicity) {
+      final String ethnicity
+  ) {
     Person patient = managed(identifier);
 
     patient.update(
@@ -504,13 +548,16 @@ public class PatientMother {
             ethnicity,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withSpecificEthnicity(
       final PatientIdentifier identifier,
       final String ethnicity,
-      final String detail) {
+      final String detail
+  ) {
     Person patient = managed(identifier);
 
     patient.update(
@@ -520,16 +567,18 @@ public class PatientMother {
             ethnicity,
             null,
             this.settings.createdBy(),
-            this.settings.createdOn()));
+            this.settings.createdOn()
+        )
+    );
 
     patient.add(
         new PatientCommand.AddDetailedEthnicity(
             identifier.id(),
             detail,
             this.settings.createdBy(),
-            this.settings.createdOn()));
-
-
+            this.settings.createdOn()
+        )
+    );
   }
 
   public void withEthnicity(final PatientIdentifier identifier) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/address/PatientProfileAddressSteps.java
@@ -72,7 +72,8 @@ public class PatientProfileAddressSteps {
       final String use,
       final String address,
       final String city,
-      final String zip) {
+      final String zip
+  ) {
 
     PatientIdentifier identifier = activePatient.active();
 
@@ -85,7 +86,8 @@ public class PatientProfileAddressSteps {
         city,
         null,
         null,
-        zip);
+        zip
+    );
 
   }
 
@@ -100,6 +102,30 @@ public class PatientProfileAddressSteps {
       case "temporary" -> "TMP";
       default -> throw new IllegalStateException("Unexpected address use: " + use.toLowerCase());
     };
+  }
+
+  @Given("the patient has a {addressType} - {addressUse} address at {string} {string} {string}")
+  public void the_patient_has_an_address_at(
+      final String type,
+      final String use,
+      final String address,
+      final String city,
+      final String zip
+  ) {
+
+    PatientIdentifier identifier = activePatient.active();
+
+    mother.withAddress(
+        identifier,
+        type,
+        use,
+        address,
+        city,
+        null,
+        null,
+        zip
+    );
+
   }
 
   @Given("the new patient's address is entered")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchRequester.java
@@ -43,6 +43,7 @@ class PatientSearchRequester {
             emails
             phones
             addresses {
+                type
                 use
                 address
                 address2

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
@@ -91,6 +91,8 @@ public class PatientSearchVerificationSteps {
       case "status" -> jsonPath("$.data.findPatientsByFilter.content[%s].status", position);
       case "birthday" -> jsonPath("$.data.findPatientsByFilter.content[%s].birthday", position);
       case "address" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].address", position);
+      case "address type" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].type", position);
+      case "address use" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].use", position);
       case "city" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].city", position);
       case "state" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].state", position);
       case "county" -> jsonPath("$.data.findPatientsByFilter.content[%s].addresses[*].county", position);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/concept/address/AddressTypeSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/concept/address/AddressTypeSteps.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.support.concept.address;
+
+import gov.cdc.nbs.testing.support.concept.ConceptParameterResolver;
+import io.cucumber.java.ParameterType;
+
+public class AddressTypeSteps {
+
+  private final ConceptParameterResolver resolver;
+
+  AddressTypeSteps(final ConceptParameterResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @ParameterType(name = "addressType", value = "\".*\"|.*")
+  public String addressType(final String type) {
+    String adjusted = type.replaceAll("\"", "");
+    return this.resolver.resolve(
+        "EL_TYPE_PST_PAT",
+        adjusted
+    ).orElse(adjusted);
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/concept/address/AddressUseSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/concept/address/AddressUseSteps.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.support.concept.address;
+
+import gov.cdc.nbs.testing.support.concept.ConceptParameterResolver;
+import io.cucumber.java.ParameterType;
+
+public class AddressUseSteps {
+
+  private final ConceptParameterResolver resolver;
+
+  AddressUseSteps(final ConceptParameterResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @ParameterType(name = "addressUse", value = "\".*\"|.*")
+  public String addressUse(final String type) {
+    String adjusted = type.replaceAll("\"", "");
+    return this.resolver.resolve(
+        "EL_USE_PST_PAT",
+        adjusted
+    ).orElse(adjusted);
+  }
+
+}

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.address.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.address.feature
@@ -1,0 +1,16 @@
+@patient-search @patient-search-results
+Feature: Patient Search Result Addresses
+
+  Background:
+    Given I am logged into NBS
+    And I can "find" any "patient"
+    And I want patients sorted by "relevance" "desc"
+    And I have a patient
+
+  Scenario: I can view address type and use from patient search results
+    Given the patient has a House - Home address at "6151 Richmond Street" "Miami" "33266"
+    And patients are available for search
+    And I would like to search for a patient using a short ID
+    When I search for patients
+    Then the search results have a patient with an "address type" equal to "House"
+    And the search results have a patient with an "address use" equal to "Home"

--- a/apps/modernization-ui/src/generated/gql/queries/findPatientsByFilter.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findPatientsByFilter.gql
@@ -24,6 +24,7 @@ query findPatientsByFilter($filter: PersonFilter!, $page: SortablePage, $share: 
                 value
             }
             addresses{
+                type
                 use
                 address
                 address2

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -1494,7 +1494,8 @@ export type PatientSearchResultAddress = {
   city?: Maybe<Scalars['String']['output']>;
   county?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Scalars['String']['output']>;
-  use: Scalars['String']['output'];
+  type?: Maybe<Scalars['String']['output']>;
+  use?: Maybe<Scalars['String']['output']>;
   zipcode?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2518,7 +2519,7 @@ export type FindPatientsByFilterQueryVariables = Exact<{
 }>;
 
 
-export type FindPatientsByFilterQuery = { __typename?: 'Query', findPatientsByFilter: { __typename?: 'PatientSearchResults', total: number, page: number, size: number, content: Array<{ __typename?: 'PatientSearchResult', patient: number, birthday?: any | null, age?: number | null, gender?: string | null, status: string, shortId: number, phones: Array<string>, emails: Array<string>, legalName?: { __typename?: 'PatientSearchResultName', first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null } | null, names: Array<{ __typename?: 'PatientSearchResultName', first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null }>, identification: Array<{ __typename?: 'PatientSearchResultIdentification', type: string, value: string }>, addresses: Array<{ __typename?: 'PatientSearchResultAddress', use: string, address?: string | null, address2?: string | null, city?: string | null, county?: string | null, state?: string | null, zipcode?: string | null }> }> } };
+export type FindPatientsByFilterQuery = { __typename?: 'Query', findPatientsByFilter: { __typename?: 'PatientSearchResults', total: number, page: number, size: number, content: Array<{ __typename?: 'PatientSearchResult', patient: number, birthday?: any | null, age?: number | null, gender?: string | null, status: string, shortId: number, phones: Array<string>, emails: Array<string>, legalName?: { __typename?: 'PatientSearchResultName', first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null } | null, names: Array<{ __typename?: 'PatientSearchResultName', first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null }>, identification: Array<{ __typename?: 'PatientSearchResultIdentification', type: string, value: string }>, addresses: Array<{ __typename?: 'PatientSearchResultAddress', type?: string | null, use?: string | null, address?: string | null, address2?: string | null, city?: string | null, county?: string | null, state?: string | null, zipcode?: string | null }> }> } };
 
 export type FindTreatmentsForPatientQueryVariables = Exact<{
   patient: Scalars['ID']['input'];
@@ -3426,8 +3427,8 @@ export function useAddressTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AddressTypesQuery, AddressTypesQueryVariables>(AddressTypesDocument, options);
         }
-export function useAddressTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AddressTypesQuery, AddressTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAddressTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AddressTypesQuery, AddressTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AddressTypesQuery, AddressTypesQueryVariables>(AddressTypesDocument, options);
         }
 export type AddressTypesQueryHookResult = ReturnType<typeof useAddressTypesQuery>;
@@ -3466,8 +3467,8 @@ export function useAddressUsesLazyQuery(baseOptions?: Apollo.LazyQueryHookOption
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AddressUsesQuery, AddressUsesQueryVariables>(AddressUsesDocument, options);
         }
-export function useAddressUsesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AddressUsesQuery, AddressUsesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAddressUsesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AddressUsesQuery, AddressUsesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AddressUsesQuery, AddressUsesQueryVariables>(AddressUsesDocument, options);
         }
 export type AddressUsesQueryHookResult = ReturnType<typeof useAddressUsesQuery>;
@@ -3506,8 +3507,8 @@ export function useAssigningAuthoritiesLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>(AssigningAuthoritiesDocument, options);
         }
-export function useAssigningAuthoritiesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAssigningAuthoritiesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>(AssigningAuthoritiesDocument, options);
         }
 export type AssigningAuthoritiesQueryHookResult = ReturnType<typeof useAssigningAuthoritiesQuery>;
@@ -3548,8 +3549,8 @@ export function useCountiesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<C
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<CountiesQuery, CountiesQueryVariables>(CountiesDocument, options);
         }
-export function useCountiesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CountiesQuery, CountiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useCountiesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CountiesQuery, CountiesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<CountiesQuery, CountiesQueryVariables>(CountiesDocument, options);
         }
 export type CountiesQueryHookResult = ReturnType<typeof useCountiesQuery>;
@@ -3588,8 +3589,8 @@ export function useCountriesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<CountriesQuery, CountriesQueryVariables>(CountriesDocument, options);
         }
-export function useCountriesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CountriesQuery, CountriesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useCountriesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CountriesQuery, CountriesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<CountriesQuery, CountriesQueryVariables>(CountriesDocument, options);
         }
 export type CountriesQueryHookResult = ReturnType<typeof useCountriesQuery>;
@@ -3628,8 +3629,8 @@ export function useDegreesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<De
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<DegreesQuery, DegreesQueryVariables>(DegreesDocument, options);
         }
-export function useDegreesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<DegreesQuery, DegreesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useDegreesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<DegreesQuery, DegreesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<DegreesQuery, DegreesQueryVariables>(DegreesDocument, options);
         }
 export type DegreesQueryHookResult = ReturnType<typeof useDegreesQuery>;
@@ -3668,8 +3669,8 @@ export function useDetailedEthnicitiesLazyQuery(baseOptions?: Apollo.LazyQueryHo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>(DetailedEthnicitiesDocument, options);
         }
-export function useDetailedEthnicitiesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useDetailedEthnicitiesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>(DetailedEthnicitiesDocument, options);
         }
 export type DetailedEthnicitiesQueryHookResult = ReturnType<typeof useDetailedEthnicitiesQuery>;
@@ -3710,8 +3711,8 @@ export function useDetailedRacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<DetailedRacesQuery, DetailedRacesQueryVariables>(DetailedRacesDocument, options);
         }
-export function useDetailedRacesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<DetailedRacesQuery, DetailedRacesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useDetailedRacesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<DetailedRacesQuery, DetailedRacesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<DetailedRacesQuery, DetailedRacesQueryVariables>(DetailedRacesDocument, options);
         }
 export type DetailedRacesQueryHookResult = ReturnType<typeof useDetailedRacesQuery>;
@@ -3750,8 +3751,8 @@ export function useEducationLevelsLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<EducationLevelsQuery, EducationLevelsQueryVariables>(EducationLevelsDocument, options);
         }
-export function useEducationLevelsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<EducationLevelsQuery, EducationLevelsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useEducationLevelsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<EducationLevelsQuery, EducationLevelsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<EducationLevelsQuery, EducationLevelsQueryVariables>(EducationLevelsDocument, options);
         }
 export type EducationLevelsQueryHookResult = ReturnType<typeof useEducationLevelsQuery>;
@@ -3790,8 +3791,8 @@ export function useEthnicGroupsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<EthnicGroupsQuery, EthnicGroupsQueryVariables>(EthnicGroupsDocument, options);
         }
-export function useEthnicGroupsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<EthnicGroupsQuery, EthnicGroupsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useEthnicGroupsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<EthnicGroupsQuery, EthnicGroupsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<EthnicGroupsQuery, EthnicGroupsQueryVariables>(EthnicGroupsDocument, options);
         }
 export type EthnicGroupsQueryHookResult = ReturnType<typeof useEthnicGroupsQuery>;
@@ -3830,8 +3831,8 @@ export function useEthnicityUnknownReasonsLazyQuery(baseOptions?: Apollo.LazyQue
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>(EthnicityUnknownReasonsDocument, options);
         }
-export function useEthnicityUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useEthnicityUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>(EthnicityUnknownReasonsDocument, options);
         }
 export type EthnicityUnknownReasonsQueryHookResult = ReturnType<typeof useEthnicityUnknownReasonsQuery>;
@@ -3871,8 +3872,8 @@ export function useFindAllConditionCodesLazyQuery(baseOptions?: Apollo.LazyQuery
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>(FindAllConditionCodesDocument, options);
         }
-export function useFindAllConditionCodesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllConditionCodesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>(FindAllConditionCodesDocument, options);
         }
 export type FindAllConditionCodesQueryHookResult = ReturnType<typeof useFindAllConditionCodesQuery>;
@@ -3917,8 +3918,8 @@ export function useFindAllEthnicityValuesLazyQuery(baseOptions?: Apollo.LazyQuer
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>(FindAllEthnicityValuesDocument, options);
         }
-export function useFindAllEthnicityValuesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllEthnicityValuesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>(FindAllEthnicityValuesDocument, options);
         }
 export type FindAllEthnicityValuesQueryHookResult = ReturnType<typeof useFindAllEthnicityValuesQuery>;
@@ -3977,8 +3978,8 @@ export function useFindAllJurisdictionsLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>(FindAllJurisdictionsDocument, options);
         }
-export function useFindAllJurisdictionsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllJurisdictionsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>(FindAllJurisdictionsDocument, options);
         }
 export type FindAllJurisdictionsQueryHookResult = ReturnType<typeof useFindAllJurisdictionsQuery>;
@@ -4024,8 +4025,8 @@ export function useFindAllOutbreaksLazyQuery(baseOptions?: Apollo.LazyQueryHookO
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>(FindAllOutbreaksDocument, options);
         }
-export function useFindAllOutbreaksSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllOutbreaksSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>(FindAllOutbreaksDocument, options);
         }
 export type FindAllOutbreaksQueryHookResult = ReturnType<typeof useFindAllOutbreaksQuery>;
@@ -4070,8 +4071,8 @@ export function useFindAllPatientIdentificationTypesLazyQuery(baseOptions?: Apol
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>(FindAllPatientIdentificationTypesDocument, options);
         }
-export function useFindAllPatientIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllPatientIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>(FindAllPatientIdentificationTypesDocument, options);
         }
 export type FindAllPatientIdentificationTypesQueryHookResult = ReturnType<typeof useFindAllPatientIdentificationTypesQuery>;
@@ -4116,8 +4117,8 @@ export function useFindAllProgramAreasLazyQuery(baseOptions?: Apollo.LazyQueryHo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>(FindAllProgramAreasDocument, options);
         }
-export function useFindAllProgramAreasSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllProgramAreasSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>(FindAllProgramAreasDocument, options);
         }
 export type FindAllProgramAreasQueryHookResult = ReturnType<typeof useFindAllProgramAreasQuery>;
@@ -4162,8 +4163,8 @@ export function useFindAllRaceValuesLazyQuery(baseOptions?: Apollo.LazyQueryHook
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>(FindAllRaceValuesDocument, options);
         }
-export function useFindAllRaceValuesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllRaceValuesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>(FindAllRaceValuesDocument, options);
         }
 export type FindAllRaceValuesQueryHookResult = ReturnType<typeof useFindAllRaceValuesQuery>;
@@ -4209,8 +4210,8 @@ export function useFindAllUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllUsersQuery, FindAllUsersQueryVariables>(FindAllUsersDocument, options);
         }
-export function useFindAllUsersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllUsersQuery, FindAllUsersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllUsersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllUsersQuery, FindAllUsersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllUsersQuery, FindAllUsersQueryVariables>(FindAllUsersDocument, options);
         }
 export type FindAllUsersQueryHookResult = ReturnType<typeof useFindAllUsersQuery>;
@@ -4272,8 +4273,8 @@ export function useFindContactsNamedByPatientLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>(FindContactsNamedByPatientDocument, options);
         }
-export function useFindContactsNamedByPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindContactsNamedByPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>(FindContactsNamedByPatientDocument, options);
         }
 export type FindContactsNamedByPatientQueryHookResult = ReturnType<typeof useFindContactsNamedByPatientQuery>;
@@ -4312,8 +4313,8 @@ export function useFindDistinctCodedResultsLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>(FindDistinctCodedResultsDocument, options);
         }
-export function useFindDistinctCodedResultsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDistinctCodedResultsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>(FindDistinctCodedResultsDocument, options);
         }
 export type FindDistinctCodedResultsQueryHookResult = ReturnType<typeof useFindDistinctCodedResultsQuery>;
@@ -4352,8 +4353,8 @@ export function useFindDistinctResultedTestLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>(FindDistinctResultedTestDocument, options);
         }
-export function useFindDistinctResultedTestSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDistinctResultedTestSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>(FindDistinctResultedTestDocument, options);
         }
 export type FindDistinctResultedTestQueryHookResult = ReturnType<typeof useFindDistinctResultedTestQuery>;
@@ -4407,8 +4408,8 @@ export function useFindDocumentsForPatientLazyQuery(baseOptions?: Apollo.LazyQue
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>(FindDocumentsForPatientDocument, options);
         }
-export function useFindDocumentsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDocumentsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>(FindDocumentsForPatientDocument, options);
         }
 export type FindDocumentsForPatientQueryHookResult = ReturnType<typeof useFindDocumentsForPatientQuery>;
@@ -4472,8 +4473,8 @@ export function useFindDocumentsRequiringReviewForPatientLazyQuery(baseOptions?:
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>(FindDocumentsRequiringReviewForPatientDocument, options);
         }
-export function useFindDocumentsRequiringReviewForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDocumentsRequiringReviewForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>(FindDocumentsRequiringReviewForPatientDocument, options);
         }
 export type FindDocumentsRequiringReviewForPatientQueryHookResult = ReturnType<typeof useFindDocumentsRequiringReviewForPatientQuery>;
@@ -4537,8 +4538,8 @@ export function useFindInvestigationsByFilterLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>(FindInvestigationsByFilterDocument, options);
         }
-export function useFindInvestigationsByFilterSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindInvestigationsByFilterSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>(FindInvestigationsByFilterDocument, options);
         }
 export type FindInvestigationsByFilterQueryHookResult = ReturnType<typeof useFindInvestigationsByFilterQuery>;
@@ -4597,8 +4598,8 @@ export function useFindInvestigationsForPatientLazyQuery(baseOptions?: Apollo.La
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>(FindInvestigationsForPatientDocument, options);
         }
-export function useFindInvestigationsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindInvestigationsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>(FindInvestigationsForPatientDocument, options);
         }
 export type FindInvestigationsForPatientQueryHookResult = ReturnType<typeof useFindInvestigationsForPatientQuery>;
@@ -4680,8 +4681,8 @@ export function useFindLabReportsByFilterLazyQuery(baseOptions?: Apollo.LazyQuer
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>(FindLabReportsByFilterDocument, options);
         }
-export function useFindLabReportsByFilterSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindLabReportsByFilterSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>(FindLabReportsByFilterDocument, options);
         }
 export type FindLabReportsByFilterQueryHookResult = ReturnType<typeof useFindLabReportsByFilterQuery>;
@@ -4752,8 +4753,8 @@ export function useFindLabReportsForPatientLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>(FindLabReportsForPatientDocument, options);
         }
-export function useFindLabReportsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindLabReportsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>(FindLabReportsForPatientDocument, options);
         }
 export type FindLabReportsForPatientQueryHookResult = ReturnType<typeof useFindLabReportsForPatientQuery>;
@@ -4816,8 +4817,8 @@ export function useFindMorbidityReportsForPatientLazyQuery(baseOptions?: Apollo.
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>(FindMorbidityReportsForPatientDocument, options);
         }
-export function useFindMorbidityReportsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindMorbidityReportsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>(FindMorbidityReportsForPatientDocument, options);
         }
 export type FindMorbidityReportsForPatientQueryHookResult = ReturnType<typeof useFindMorbidityReportsForPatientQuery>;
@@ -4879,8 +4880,8 @@ export function useFindPatientNamedByContactLazyQuery(baseOptions?: Apollo.LazyQ
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>(FindPatientNamedByContactDocument, options);
         }
-export function useFindPatientNamedByContactSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindPatientNamedByContactSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>(FindPatientNamedByContactDocument, options);
         }
 export type FindPatientNamedByContactQueryHookResult = ReturnType<typeof useFindPatientNamedByContactQuery>;
@@ -5234,8 +5235,8 @@ export function useFindPatientProfileLazyQuery(baseOptions?: Apollo.LazyQueryHoo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindPatientProfileQuery, FindPatientProfileQueryVariables>(FindPatientProfileDocument, options);
         }
-export function useFindPatientProfileSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindPatientProfileQuery, FindPatientProfileQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindPatientProfileSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindPatientProfileQuery, FindPatientProfileQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindPatientProfileQuery, FindPatientProfileQueryVariables>(FindPatientProfileDocument, options);
         }
 export type FindPatientProfileQueryHookResult = ReturnType<typeof useFindPatientProfileQuery>;
@@ -5269,6 +5270,7 @@ export const FindPatientsByFilterDocument = gql`
         value
       }
       addresses {
+        type
         use
         address
         address2
@@ -5313,8 +5315,8 @@ export function useFindPatientsByFilterLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>(FindPatientsByFilterDocument, options);
         }
-export function useFindPatientsByFilterSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindPatientsByFilterSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>(FindPatientsByFilterDocument, options);
         }
 export type FindPatientsByFilterQueryHookResult = ReturnType<typeof useFindPatientsByFilterQuery>;
@@ -5368,8 +5370,8 @@ export function useFindTreatmentsForPatientLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>(FindTreatmentsForPatientDocument, options);
         }
-export function useFindTreatmentsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindTreatmentsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>(FindTreatmentsForPatientDocument, options);
         }
 export type FindTreatmentsForPatientQueryHookResult = ReturnType<typeof useFindTreatmentsForPatientQuery>;
@@ -5423,8 +5425,8 @@ export function useFindVaccinationsForPatientLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>(FindVaccinationsForPatientDocument, options);
         }
-export function useFindVaccinationsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindVaccinationsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>(FindVaccinationsForPatientDocument, options);
         }
 export type FindVaccinationsForPatientQueryHookResult = ReturnType<typeof useFindVaccinationsForPatientQuery>;
@@ -5463,8 +5465,8 @@ export function useGenderUnknownReasonsLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>(GenderUnknownReasonsDocument, options);
         }
-export function useGenderUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGenderUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>(GenderUnknownReasonsDocument, options);
         }
 export type GenderUnknownReasonsQueryHookResult = ReturnType<typeof useGenderUnknownReasonsQuery>;
@@ -5503,8 +5505,8 @@ export function useGendersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Ge
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GendersQuery, GendersQueryVariables>(GendersDocument, options);
         }
-export function useGendersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GendersQuery, GendersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGendersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GendersQuery, GendersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GendersQuery, GendersQueryVariables>(GendersDocument, options);
         }
 export type GendersQueryHookResult = ReturnType<typeof useGendersQuery>;
@@ -5543,8 +5545,8 @@ export function useIdentificationTypesLazyQuery(baseOptions?: Apollo.LazyQueryHo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<IdentificationTypesQuery, IdentificationTypesQueryVariables>(IdentificationTypesDocument, options);
         }
-export function useIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<IdentificationTypesQuery, IdentificationTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<IdentificationTypesQuery, IdentificationTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<IdentificationTypesQuery, IdentificationTypesQueryVariables>(IdentificationTypesDocument, options);
         }
 export type IdentificationTypesQueryHookResult = ReturnType<typeof useIdentificationTypesQuery>;
@@ -5583,8 +5585,8 @@ export function useMaritalStatusesLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<MaritalStatusesQuery, MaritalStatusesQueryVariables>(MaritalStatusesDocument, options);
         }
-export function useMaritalStatusesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<MaritalStatusesQuery, MaritalStatusesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useMaritalStatusesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<MaritalStatusesQuery, MaritalStatusesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<MaritalStatusesQuery, MaritalStatusesQueryVariables>(MaritalStatusesDocument, options);
         }
 export type MaritalStatusesQueryHookResult = ReturnType<typeof useMaritalStatusesQuery>;
@@ -5623,8 +5625,8 @@ export function useNameTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<NameTypesQuery, NameTypesQueryVariables>(NameTypesDocument, options);
         }
-export function useNameTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NameTypesQuery, NameTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useNameTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NameTypesQuery, NameTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<NameTypesQuery, NameTypesQueryVariables>(NameTypesDocument, options);
         }
 export type NameTypesQueryHookResult = ReturnType<typeof useNameTypesQuery>;
@@ -5663,8 +5665,8 @@ export function usePhoneTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PhoneTypesQuery, PhoneTypesQueryVariables>(PhoneTypesDocument, options);
         }
-export function usePhoneTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PhoneTypesQuery, PhoneTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePhoneTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PhoneTypesQuery, PhoneTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PhoneTypesQuery, PhoneTypesQueryVariables>(PhoneTypesDocument, options);
         }
 export type PhoneTypesQueryHookResult = ReturnType<typeof usePhoneTypesQuery>;
@@ -5703,8 +5705,8 @@ export function usePhoneUsesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PhoneUsesQuery, PhoneUsesQueryVariables>(PhoneUsesDocument, options);
         }
-export function usePhoneUsesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PhoneUsesQuery, PhoneUsesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePhoneUsesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PhoneUsesQuery, PhoneUsesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PhoneUsesQuery, PhoneUsesQueryVariables>(PhoneUsesDocument, options);
         }
 export type PhoneUsesQueryHookResult = ReturnType<typeof usePhoneUsesQuery>;
@@ -5743,8 +5745,8 @@ export function usePreferredGendersLazyQuery(baseOptions?: Apollo.LazyQueryHookO
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PreferredGendersQuery, PreferredGendersQueryVariables>(PreferredGendersDocument, options);
         }
-export function usePreferredGendersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PreferredGendersQuery, PreferredGendersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePreferredGendersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PreferredGendersQuery, PreferredGendersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PreferredGendersQuery, PreferredGendersQueryVariables>(PreferredGendersDocument, options);
         }
 export type PreferredGendersQueryHookResult = ReturnType<typeof usePreferredGendersQuery>;
@@ -5783,8 +5785,8 @@ export function usePrefixesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<P
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PrefixesQuery, PrefixesQueryVariables>(PrefixesDocument, options);
         }
-export function usePrefixesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PrefixesQuery, PrefixesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePrefixesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PrefixesQuery, PrefixesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PrefixesQuery, PrefixesQueryVariables>(PrefixesDocument, options);
         }
 export type PrefixesQueryHookResult = ReturnType<typeof usePrefixesQuery>;
@@ -5823,8 +5825,8 @@ export function usePrimaryLanguagesLazyQuery(baseOptions?: Apollo.LazyQueryHookO
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>(PrimaryLanguagesDocument, options);
         }
-export function usePrimaryLanguagesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePrimaryLanguagesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>(PrimaryLanguagesDocument, options);
         }
 export type PrimaryLanguagesQueryHookResult = ReturnType<typeof usePrimaryLanguagesQuery>;
@@ -5863,8 +5865,8 @@ export function usePrimaryOccupationsLazyQuery(baseOptions?: Apollo.LazyQueryHoo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>(PrimaryOccupationsDocument, options);
         }
-export function usePrimaryOccupationsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePrimaryOccupationsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>(PrimaryOccupationsDocument, options);
         }
 export type PrimaryOccupationsQueryHookResult = ReturnType<typeof usePrimaryOccupationsQuery>;
@@ -5903,8 +5905,8 @@ export function useRaceCategoriesLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<RaceCategoriesQuery, RaceCategoriesQueryVariables>(RaceCategoriesDocument, options);
         }
-export function useRaceCategoriesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<RaceCategoriesQuery, RaceCategoriesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useRaceCategoriesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<RaceCategoriesQuery, RaceCategoriesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<RaceCategoriesQuery, RaceCategoriesQueryVariables>(RaceCategoriesDocument, options);
         }
 export type RaceCategoriesQueryHookResult = ReturnType<typeof useRaceCategoriesQuery>;
@@ -5944,8 +5946,8 @@ export function useStatesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Sta
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<StatesQuery, StatesQueryVariables>(StatesDocument, options);
         }
-export function useStatesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<StatesQuery, StatesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useStatesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<StatesQuery, StatesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<StatesQuery, StatesQueryVariables>(StatesDocument, options);
         }
 export type StatesQueryHookResult = ReturnType<typeof useStatesQuery>;
@@ -5984,8 +5986,8 @@ export function useSuffixesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<S
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<SuffixesQuery, SuffixesQueryVariables>(SuffixesDocument, options);
         }
-export function useSuffixesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SuffixesQuery, SuffixesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useSuffixesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SuffixesQuery, SuffixesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<SuffixesQuery, SuffixesQueryVariables>(SuffixesDocument, options);
         }
 export type SuffixesQueryHookResult = ReturnType<typeof useSuffixesQuery>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1154,7 +1154,8 @@ type PatientSearchResultName {
 }
 
 type PatientSearchResultAddress {
-  use: String!
+  type: String
+  use: String
   address: String
   address2: String
   city: String


### PR DESCRIPTION
## Description

Updates the finder that resolves patient addresses in search results to include the address type.  

- The client graphql schema was regenerated to reflect the changes 
- The Postman collection was updated to include address type and use in the Patient Search request.

Issuing the request 

```graphql
query search($filter: PersonFilter!, $page: SortablePage, $share: String) {
  findPatientsByFilter(filter: $filter, page: $page, share: $share) {
    content {
      patient
      shortId
      legalName {
        first
        middle
        last
        suffix
      }
      addresses {
        type
        use
        address
        city
        county
        zipcode
        state
      }
    }
    total
    page
    size
  }
}
```

Will return the address type and use when the patient has an address.

```json
{
    "data": {
        "findPatientsByFilter": {
            "content": [
                {
                    "patient": 10055284,
                    "shortId": 91001,
                    "legalName": {
                        "first": "Katherine",
                        "middle": null,
                        "last": "Pryde",
                        "suffix": null
                    },
                    "addresses": [
                        {
                            "type": "Group Home - other",
                            "use": "Home",
                            "address": "1407 Graymalkin Lane",
                            "city": "Salem Center",
                            "county": "Westchester County",
                            "zipcode": "10565",
                            "state": "NY"
                        }
                    ]
                }
            ],
            "total": 1,
            "page": 0,
            "size": 5
        }
    }
}
```

## Tickets

* [CNFT1-3282](https://cdc-nbs.atlassian.net/browse/CNFT1-3282)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3282]: https://cdc-nbs.atlassian.net/browse/CNFT1-3282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ