### PR TITLE
[CNFT1]-passing display type with name and id for profileLink to change table view for firstColumn

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
@@ -18,7 +18,7 @@ const PatientSearchResultListItem = ({ result }: Props) => (
     <Result>
         <ResultItemGroup>
             <ResultItem label="Legal name" orientation="vertical">
-                {displayProfileLink(result)}
+                {displayProfileLink(result, 'name')}
             </ResultItem>
             <ResultItem label="Date of birth">{internalizeDate(result.birthday)}</ResultItem>
             <ResultItem label="Current sex">{result.gender}</ResultItem>

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
@@ -4,10 +4,10 @@ import { internalizeDate } from 'date';
 import { Result, ResultItem, ResultItemGroup } from 'apps/search/layout/result/list';
 import {
     displayPhones,
-    displayProfileLink,
     displayNames,
     displayEmails,
-    displayAddresses
+    displayAddresses,
+    displayProfileLegalName
 } from 'apps/search/patient/result';
 
 type Props = {
@@ -18,7 +18,7 @@ const PatientSearchResultListItem = ({ result }: Props) => (
     <Result>
         <ResultItemGroup>
             <ResultItem label="Legal name" orientation="vertical">
-                {displayProfileLink(result, 'name')}
+                {displayProfileLegalName(result)}
             </ResultItem>
             <ResultItem label="Date of birth">{internalizeDate(result.birthday)}</ResultItem>
             <ResultItem label="Current sex">{result.gender}</ResultItem>

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -3,13 +3,6 @@ import { BrowserRouter } from 'react-router-dom';
 import { PatientSearchResult } from 'generated/graphql/schema';
 import { displayProfileLink, displayPhones, displayEmails } from './patientSearchResult';
 
-jest.mock('name', () => ({
-    displayName: jest.fn(() => jest.fn((name) => `${name.last}, ${name.first}`))
-}));
-jest.mock('address/display', () => ({
-    displayAddress: jest.fn((address) => `${address.street}, ${address.city}`)
-}));
-
 describe('patientSearchResult functions', () => {
     const mockPatient: PatientSearchResult = {
         patient: 10043290,
@@ -57,17 +50,17 @@ describe('patientSearchResult functions', () => {
         emails: ['emily.reynolds@owensborohealth.org']
     };
 
-    test('displayPhones returns correct string', () => {
+    it('should displayPhones returns correct string', () => {
         const result = displayPhones(mockPatient);
         expect(result).toBe('270-685-4067');
     });
 
-    test('displayEmails returns correct string', () => {
+    it('should displayEmails returns correct string', () => {
         const result = displayEmails(mockPatient);
         expect(result).toBe('emily.reynolds@owensborohealth.org');
     });
 
-    test('displayProfileLink renders correctly with shortId', () => {
+    it('should displayProfileLink renders correctly with shortId', () => {
         const { getByText } = render(
             <BrowserRouter>{displayProfileLink(mockPatient.shortId, 'John Doe')}</BrowserRouter>
         );

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -1,0 +1,77 @@
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { PatientSearchResult } from 'generated/graphql/schema';
+import { displayProfileLink, displayPhones, displayEmails } from './patientSearchResult';
+
+jest.mock('name', () => ({
+    displayName: jest.fn(() => jest.fn((name) => `${name.last}, ${name.first}`))
+}));
+jest.mock('address/display', () => ({
+    displayAddress: jest.fn((address) => `${address.street}, ${address.city}`)
+}));
+
+describe('patientSearchResult functions', () => {
+    const mockPatient: PatientSearchResult = {
+        patient: 10043290,
+        birthday: '1974-04-04',
+        age: 50,
+        gender: 'Female',
+        status: 'ACTIVE',
+        shortId: 84001,
+        legalName: {
+            first: 'John',
+            last: 'Doe'
+        },
+        names: [
+            {
+                first: 'jonny',
+                last: 'TestnullTest'
+            }
+        ],
+        identification: [],
+        addresses: [
+            {
+                use: 'Home',
+                address: '2222 Test Valley Rd',
+                city: 'OWENSBORO',
+                state: 'KY',
+                zipcode: '42303'
+            },
+            {
+                use: 'Home',
+                address: '2222 Test Valley Rd',
+                city: 'OWENSBORO',
+                county: 'Appling County',
+                state: 'KY',
+                zipcode: '30309'
+            },
+            {
+                use: 'Home',
+                address: '3333 Test Valley Rd',
+                city: 'OWENSBORO',
+                state: 'KY',
+                zipcode: '30309'
+            }
+        ],
+        phones: ['270-685-4067'],
+        emails: ['emily.reynolds@owensborohealth.org']
+    };
+
+    test('displayPhones returns correct string', () => {
+        const result = displayPhones(mockPatient);
+        expect(result).toBe('270-685-4067');
+    });
+
+    test('displayEmails returns correct string', () => {
+        const result = displayEmails(mockPatient);
+        expect(result).toBe('emily.reynolds@owensborohealth.org');
+    });
+
+    test('displayProfileLink renders correctly with shortId', () => {
+        const { getByText } = render(
+            <BrowserRouter>{displayProfileLink(mockPatient.shortId, 'John Doe')}</BrowserRouter>
+        );
+        const link = getByText('John Doe');
+        expect(link).toHaveAttribute('href', '/patient-profile/84001/summary');
+    });
+});

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -3,16 +3,13 @@ import { displayName } from 'name';
 import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
 
-const displayProfileLink = (result: PatientSearchResult) => {
-    return <Link to={`/patient-profile/${result.shortId}/summary`}>{result.shortId || 'No Data'}</Link>;
+const displayProfileLink = (shortId: number, displayName?: string) => {
+    return <Link to={`/patient-profile/${shortId}/summary`}>{displayName || shortId}</Link>;
 };
 
 const displayProfileLegalName = (result: PatientSearchResult) => {
-    return (
-        <Link to={`/patient-profile/${result.shortId}/summary`}>
-            {(result.legalName && displayName('fullLastFirst')(result.legalName)) || 'No Data'}
-        </Link>
-    );
+    const legalNameDisplay = (result.legalName && displayName('fullLastFirst')(result.legalName)) || 'No Data';
+    return displayProfileLink(result.shortId, legalNameDisplay);
 };
 
 const displayNames = (result: PatientSearchResult): string => {

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -3,11 +3,11 @@ import { displayName } from 'name';
 import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
 
-const displayProfileLink = (result: PatientSearchResult) => (
-    <Link to={`/patient-profile/${result.shortId}/summary`}>
-        {(result.legalName && displayName('fullLastFirst')(result.legalName)) || 'No Data'}
-    </Link>
-);
+const displayProfileLink = (result: PatientSearchResult, displayType: 'name' | 'id') => {
+    const displayContent =
+        displayType === 'name' ? result.legalName && displayName('fullLastFirst')(result.legalName) : result.shortId;
+    return <Link to={`/patient-profile/${result.shortId}/summary`}>{displayContent || 'No Data'}</Link>;
+};
 
 const displayNames = (result: PatientSearchResult): string => {
     const legalName = result.legalName;

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -3,10 +3,16 @@ import { displayName } from 'name';
 import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
 
-const displayProfileLink = (result: PatientSearchResult, displayType: 'name' | 'id') => {
-    const displayContent =
-        displayType === 'name' ? result.legalName && displayName('fullLastFirst')(result.legalName) : result.shortId;
-    return <Link to={`/patient-profile/${result.shortId}/summary`}>{displayContent || 'No Data'}</Link>;
+const displayProfileLink = (result: PatientSearchResult) => {
+    return <Link to={`/patient-profile/${result.shortId}/summary`}>{result.shortId || 'No Data'}</Link>;
+};
+
+const displayProfileLegalName = (result: PatientSearchResult) => {
+    return (
+        <Link to={`/patient-profile/${result.shortId}/summary`}>
+            {(result.legalName && displayName('fullLastFirst')(result.legalName)) || 'No Data'}
+        </Link>
+    );
 };
 
 const displayNames = (result: PatientSearchResult): string => {
@@ -22,4 +28,4 @@ const displayAddresses = (result: PatientSearchResult): string => result.address
 const displayPhones = (result: PatientSearchResult): string => result.phones.join('\n');
 const displayEmails = (result: PatientSearchResult): string => result.emails.join('\n');
 
-export { displayNames, displayProfileLink, displayPhones, displayAddresses, displayEmails };
+export { displayNames, displayProfileLink, displayProfileLegalName, displayPhones, displayAddresses, displayEmails };

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -34,7 +34,7 @@ const columns: Column<PatientSearchResult>[] = [
         ...PATIENT_ID,
         fixed: true,
         sortable: true,
-        render: displayProfileLink
+        render: (result) => displayProfileLink(result.shortId)
     },
     {
         ...DATE_OF_BIRTH,

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -9,6 +9,7 @@ import {
     displayEmails,
     displayAddresses
 } from 'apps/search/patient/result';
+import { displayName } from 'name';
 
 const displayIdentifications = (result: PatientSearchResult): string =>
     result.identification.map((identification) => identification.type + '\n' + identification.value).join('\n');
@@ -30,10 +31,10 @@ const EMAIL = { id: 'email', name: 'Email' };
 
 const columns: Column<PatientSearchResult>[] = [
     {
-        ...LEGAL_NAME,
+        ...PATIENT_ID,
         fixed: true,
         sortable: true,
-        render: displayProfileLink
+        render: (result) => displayProfileLink(result, 'id')
     },
     {
         ...DATE_OF_BIRTH,
@@ -41,7 +42,11 @@ const columns: Column<PatientSearchResult>[] = [
         render: (result) => internalizeDate(result.birthday)
     },
     { ...SEX, sortable: true, render: (result) => result.gender },
-    { ...PATIENT_ID, sortable: true, render: (row) => row.shortId },
+    {
+        ...LEGAL_NAME,
+        sortable: true,
+        render: (result) => result.legalName && displayName('fullLastFirst')(result.legalName)
+    },
     { ...ADDRESS, render: displayAddresses },
     { ...PHONE, render: displayPhones },
     { ...NAMES, render: displayNames },
@@ -50,10 +55,10 @@ const columns: Column<PatientSearchResult>[] = [
 ];
 
 const preferences: ColumnPreference[] = [
+    { ...PATIENT_ID },
     { ...LEGAL_NAME },
     { ...DATE_OF_BIRTH },
     { ...SEX },
-    { ...PATIENT_ID },
     { ...ADDRESS, moveable: true, toggleable: true },
     { ...PHONE, moveable: true, toggleable: true },
     { ...NAMES, moveable: true, toggleable: true },

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -34,7 +34,7 @@ const columns: Column<PatientSearchResult>[] = [
         ...PATIENT_ID,
         fixed: true,
         sortable: true,
-        render: (result) => displayProfileLink(result, 'id')
+        render: displayProfileLink
     },
     {
         ...DATE_OF_BIRTH,


### PR DESCRIPTION
## Description

Adding Patient ID as the first column in the Patient search results - Table view.
Adds hyperlink to Patient ID which routes to patient profile 
<img width="797" alt="Screenshot 2024-10-09 at 8 14 59 AM" src="https://github.com/user-attachments/assets/f905c831-0355-45cb-95c0-36f1896abdfc">

## Tickets

* [CNFT1-3290](https://cdc-nbs.atlassian.net/browse/CNFT1-3290)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3290]: https://cdc-nbs.atlassian.net/browse/CNFT1-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ