### PR TITLE
CNFT1-3280: Patient Search table reorder columns and lock only Patient ID column

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -13,22 +13,20 @@ import {
 const displayIdentifications = (result: PatientSearchResult): string =>
     result.identification.map((identification) => identification.type + '\n' + identification.value).join('\n');
 
+// column definitions
+const PATIENT_ID = { id: 'patientid', name: 'Patient ID' };
 const LEGAL_NAME = { id: 'legalName', name: 'Legal name' };
 const DATE_OF_BIRTH = { id: 'birthday', name: 'Date of birth' };
 const SEX = { id: 'sex', name: 'Current sex' };
-const PATIENT_ID = { id: 'patientid', name: 'Patient ID' };
-
 const ADDRESS = { id: 'address', name: 'Address' };
-
 const PHONE = { id: 'phoneNumber', name: 'Phone' };
-
 const NAMES = { id: 'names', name: 'Other names' };
-
 const IDENTIFICATIONS = { id: 'identification', name: 'ID' };
-
 const EMAIL = { id: 'email', name: 'Email' };
 
+// table columns
 const columns: Column<PatientSearchResult>[] = [
+    { ...PATIENT_ID, sortable: true, render: (row) => row.shortId },
     {
         ...LEGAL_NAME,
         fixed: true,
@@ -41,7 +39,6 @@ const columns: Column<PatientSearchResult>[] = [
         render: (result) => internalizeDate(result.birthday)
     },
     { ...SEX, sortable: true, render: (result) => result.gender },
-    { ...PATIENT_ID, sortable: true, render: (row) => row.shortId },
     { ...ADDRESS, render: displayAddresses },
     { ...PHONE, render: displayPhones },
     { ...NAMES, render: displayNames },
@@ -49,11 +46,12 @@ const columns: Column<PatientSearchResult>[] = [
     { ...EMAIL, render: displayEmails }
 ];
 
+// column preferences
 const preferences: ColumnPreference[] = [
-    { ...LEGAL_NAME },
-    { ...DATE_OF_BIRTH },
-    { ...SEX },
     { ...PATIENT_ID },
+    { ...LEGAL_NAME, moveable: true, toggleable: true },
+    { ...DATE_OF_BIRTH, moveable: true, toggleable: true },
+    { ...SEX, moveable: true, toggleable: true },
     { ...ADDRESS, moveable: true, toggleable: true },
     { ...PHONE, moveable: true, toggleable: true },
     { ...NAMES, moveable: true, toggleable: true },

--- a/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
+++ b/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
@@ -88,9 +88,11 @@ const ColumnPreferencesPanel = ({ close }: Props) => {
                                                 selected={!preference.hidden}
                                                 onChange={handleVisibilityChange(preference)}
                                             />
-                                            <span className={styles.handle} {...draggable.dragHandleProps}>
-                                                <Icon name="drag" />
-                                            </span>
+                                            {preference.moveable && (
+                                                <span className={styles.handle} {...draggable.dragHandleProps}>
+                                                    <Icon name="drag" />
+                                                </span>
+                                            )}
                                         </div>
                                     )}
                                 </Draggable>


### PR DESCRIPTION
## Description

On Patient Search, made these changes:
- moved Patient ID as first column
- make columns draggable: Legal name, Date of Birth, Current sex
- remove drag icon for locked columns (this is universal change for all column preferences)

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3280)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
