### PR TITLE
[CNFT1-3350] Searches for Unknown gender returns only patients with an unknown gender

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaFilterResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaFilterResolver.java
@@ -12,7 +12,6 @@ import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.message.enums.Gender;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -77,33 +76,11 @@ class PatientSearchCriteriaFilterResolver {
 
     Gender gender = Gender.resolve(criteria.getGender());
 
-    if (gender == null) {
-      return Optional.empty();
-    } else if (!Objects.equals(gender, Gender.U)) {
-      //  not unknown, search for the team exactly
-      return Optional.of(
-          TermQuery.of(
-              query -> query.field(CURRENT_GENDER).value(gender.value())
-          )
-      );
-    } else {
-      //  for unknown, search for values of U or NULL
-      return Optional.of(
-          BoolQuery.of(
-              query -> query.should(
-                  should -> should.term(term -> term.field(CURRENT_GENDER).value(gender.value()))
-              ).should(
-                  should -> should.bool(
-                      bool -> bool.mustNot(
-                          not -> not.exists(
-                              exists -> exists.field(CURRENT_GENDER)
-                          )
-                      )
-                  )
-              )
-          )
-      );
-    }
+    return (gender == null) ? Optional.empty() : Optional.of(
+        TermQuery.of(
+            query -> query.field(CURRENT_GENDER).value(gender.value())
+        )
+    );
   }
 
   private Optional<QueryVariant> applyDeceasedCriteria(final PatientFilter criteria) {

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -293,7 +293,7 @@ Feature: Patient Search
     Then the search results have a patient with a "gender" equal to "Unknown"
     And the search results have a patient without a "gender" equal to "Female"
     And the search results have a patient without a "gender" equal to "Male"
-    And there are 2 patient search results
+    And there is only one patient search result
 
   Scenario: BUG: CNFT1-1560 Patients with only a country code are searchable
     Given the patient has a "country code" of "+32"


### PR DESCRIPTION
## Description

Removes the functionality of an "Unknown" gender search returning both patients with "Unknown" genders as well as patients without a gender specified.  When a search is performed with criteria specifying a gender of "Unknown" only patients with a gender of "Unknown" will be returned.

## Tickets

* [CNFT1-3350](https://cdc-nbs.atlassian.net/browse/CNFT1-3350)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3350]: https://cdc-nbs.atlassian.net/browse/CNFT1-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ