### PR TITLE
Fix form retaining value

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -54,11 +54,13 @@ const RepeatingBlock = <V extends FieldValues>({
     const handleSubmit = (value: V) => {
         // Submit button performs various actions based on the current state
         if (state.status === 'adding') {
+            // form reset must be triggered prior to `add` call,
+            // otherwise internal form state retains some values and fails to properly reset
+            form.reset(defaultValues);
             add(value);
-            form.reset(defaultValues);
         } else if (status === 'editing') {
-            update(state.index, value);
             form.reset(defaultValues);
+            update(state.index, value);
         }
     };
 


### PR DESCRIPTION
## Description

Internal form state is retaining some values when `reset` is called. Calling `form.reset` first and then performing a table update seems to resolve the issue.

## Tickets

* [CNFT1-3365](https://cdc-nbs.atlassian.net/browse/CNFT1-3365)

## Demo
![formStateFix](https://github.com/user-attachments/assets/907ec1f3-7aba-4229-a360-c4db2ced88ed)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3365]: https://cdc-nbs.atlassian.net/browse/CNFT1-3365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ