### PR TITLE
[CNFT1-3278] name type in search results

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/name/PatientSearchResultLegalNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/name/PatientSearchResultLegalNameFinder.java
@@ -12,38 +12,44 @@ import java.util.Optional;
 class PatientSearchResultLegalNameFinder {
 
   private static final String QUERY = """
-      select
-          [name].first_nm,
-          [name].middle_nm,
-          [name].last_nm,
-          [suffix].code_desc_txt
-      from Person_name [name]
-          left join NBS_SRTE..Code_value_general [suffix] on
-                  [suffix].[code_set_nm] = 'P_NM_SFX'
-              and [suffix].[code] = [name].nm_suffix
-
-      where   [name].person_uid = ?
-          and [name].nm_use_cd = 'L'
-          and [name].record_status_cd = 'ACTIVE'
-          and [name].as_of_date = (
-              select
-                  max(eff_name.as_of_date)
-              from person_name [eff_name]\s
-              where   [eff_name].person_uid       = [name].[person_uid]
-                  and [eff_name].nm_use_cd        = [name].nm_use_cd
-                  and [eff_name].record_status_cd = [name].record_status_cd
-                  and [eff_name].as_of_date       <= ?
-          )
-          and [name].person_name_seq = (
-              select
-                  max(seq_name.person_name_seq)
-              from person_name [seq_name]
-              where   [seq_name].[person_uid] = [name].person_uid
-                  and [seq_name].nm_use_cd = [name].nm_use_cd
-                  and [seq_name].record_status_cd = [name].record_status_cd
-                  and [seq_name].[as_of_date] = [name].as_of_date
-          )
-            """;
+    select
+        [use].[code_short_desc_txt] as [type],
+        [name].first_nm,
+        [name].middle_nm,
+        [name].last_nm,
+        [suffix].code_short_desc_txt
+    from Person_name [name]
+    
+    join NBS_SRTE..Code_value_general [use] on
+               [use].[code_set_nm] = 'P_NM_USE'
+           and [use].[code] = [name].nm_use_cd
+    
+        left join NBS_SRTE..Code_value_general [suffix] on
+                [suffix].[code_set_nm] = 'P_NM_SFX'
+            and [suffix].[code] = [name].nm_suffix
+    
+    where   [name].person_uid = ?
+        and [name].nm_use_cd = 'L'
+        and [name].record_status_cd = 'ACTIVE'
+        and [name].as_of_date = (
+            select
+                max(eff_name.as_of_date)
+            from person_name [eff_name]
+            where   [eff_name].person_uid       = [name].[person_uid]
+                and [eff_name].nm_use_cd        = [name].nm_use_cd
+                and [eff_name].record_status_cd = [name].record_status_cd
+                and [eff_name].as_of_date       <= ?
+        )
+        and [name].person_name_seq = (
+            select
+                max(seq_name.person_name_seq)
+            from person_name [seq_name]
+            where   [seq_name].[person_uid] = [name].person_uid
+                and [seq_name].nm_use_cd = [name].nm_use_cd
+                and [seq_name].record_status_cd = [name].record_status_cd
+                and [seq_name].[as_of_date] = [name].as_of_date
+        )
+    """;
 
   private static final int PATIENT_PARAMETER = 1;
   private static final int AS_OF_PARAMETER = 2;
@@ -53,11 +59,7 @@ class PatientSearchResultLegalNameFinder {
 
   PatientSearchResultLegalNameFinder(final JdbcTemplate template) {
     this.template = template;
-    this.mapper = new PatientSearchResultNameMapper(
-        new PatientSearchResultNameMapper.Columns(
-            1, 2, 3, 4
-        )
-    );
+    this.mapper = new PatientSearchResultNameMapper();
   }
 
   Optional<PatientSearchResultName> find(final long patient, final Instant asOf) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/name/PatientSearchResultName.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/name/PatientSearchResultName.java
@@ -1,4 +1,4 @@
 package gov.cdc.nbs.patient.search.name;
 
-record PatientSearchResultName(String first, String middle, String last, String suffix) {
+record PatientSearchResultName(String type, String first, String middle, String last, String suffix) {
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/name/PatientSearchResultNameMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/name/PatientSearchResultNameMapper.java
@@ -7,11 +7,14 @@ import java.sql.SQLException;
 
 class PatientSearchResultNameMapper implements RowMapper<PatientSearchResultName> {
 
-  record Columns(int first, int middle, int last, int suffix) {
+  record Columns(int type, int first, int middle, int last, int suffix) {
   }
 
   private final Columns columns;
 
+  PatientSearchResultNameMapper() {
+    this(new Columns(1, 2, 3, 4, 5));
+  }
 
   PatientSearchResultNameMapper(final Columns columns) {
     this.columns = columns;
@@ -19,12 +22,14 @@ class PatientSearchResultNameMapper implements RowMapper<PatientSearchResultName
 
   @Override
   public PatientSearchResultName mapRow(final ResultSet resultSet, final int row) throws SQLException {
+    String type = resultSet.getString(columns.type());
     String first = resultSet.getString(columns.first());
     String middle = resultSet.getString(columns.middle());
     String last = resultSet.getString(columns.last());
     String suffix = resultSet.getString(columns.suffix());
 
     return new PatientSearchResultName(
+        type,
         first,
         middle,
         last,

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -53,6 +53,7 @@ type PatientSearchResultIdentification {
 }
 
 type PatientSearchResultName {
+  type: String
   first: String
   middle: String
   last: String

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/PatientNameDemographicSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/PatientNameDemographicSteps.java
@@ -5,8 +5,7 @@ import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.Instant;
 
 public class PatientNameDemographicSteps {
 
@@ -26,75 +25,58 @@ public class PatientNameDemographicSteps {
     mother.withName(patient.active());
   }
 
-  @Given("the patient has the {string} name {string} {string}")
+  @Given("the patient has the {nameUse} name {string} {string}")
   public void the_patient_has_the_name(
       final String type,
       final String first,
-      final String last) {
-
-    String resolvedType = resolveType(type);
+      final String last
+  ) {
 
     mother.withName(
         patient.active(),
-        resolvedType,
+        type,
         first,
-        last);
+        last
+    );
   }
 
-  @Given("the patient has the {string} name {string} {string} as of {string}")
+  @Given("the patient has the {nameUse} name {string} {string} as of {date}")
   public void the_patient_has_the_name_as_of(
       final String type,
       final String first,
       final String last,
-      final String asOf) {
-
-    String resolvedType = resolveType(type);
+      final Instant asOf
+  ) {
 
     mother.withName(
         patient.active(),
-        LocalDate.parse(asOf).atStartOfDay(ZoneId.systemDefault()).toInstant(),
-        resolvedType,
+        asOf,
+        type,
         first,
-        last);
+        last
+    );
   }
 
-  @Given("the patient has the {string} name {string} {string} {string}, {string} as of {string}")
+  @Given("the patient has the {nameUse} name {string} {string} {string}, {nameSuffix} as of {date}")
   public void the_patient_has_the_name_use_first_middle_last_suffix_as_of(
       final String type,
       final String first,
       final String middle,
       final String last,
       final String suffix,
-      final String asOf) {
-
-    String resolvedType = resolveType(type);
-    String resolvedSuffix = resolveSuffix(suffix);
+      final Instant asOf
+  ) {
 
     mother.withName(
         patient.active(),
-        LocalDate.parse(asOf).atStartOfDay(ZoneId.systemDefault()).toInstant(),
-        resolvedType,
+        asOf,
+        type,
         first,
         middle,
         last,
-        resolvedSuffix);
+        suffix
+    );
 
-  }
-
-  private String resolveType(final String use) {
-    return switch (use.toLowerCase()) {
-      case "legal" -> "L";
-      case "alias" -> "AL";
-      default -> throw new IllegalStateException("Unexpected name type: " + use);
-    };
-  }
-
-  private String resolveSuffix(final String suffix) {
-    return switch (suffix.toLowerCase()) {
-      case "junior", "jr" -> "JR";
-      case "esquire" -> "ESQ";
-      default -> throw new IllegalStateException("Unexpected name suffix: " + suffix);
-    };
   }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchRequester.java
@@ -31,6 +31,7 @@ class PatientSearchRequester {
               suffix
             }
             names {
+              type
               first
               middle
               last

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchVerificationSteps.java
@@ -121,7 +121,8 @@ public class PatientSearchVerificationSteps {
           "$.data.findPatientsByFilter.content[%s].identification[*].value",
           position
       );
-      case "patientid", "patient id", "short id" -> jsonPath("$.data.findPatientsByFilter.content[%s].shortId", position);
+      case "patientid", "patient id", "short id" ->
+          jsonPath("$.data.findPatientsByFilter.content[%s].shortId", position);
       default -> throw new AssertionError("Unexpected property check %s".formatted(field));
     };
   }
@@ -129,10 +130,27 @@ public class PatientSearchVerificationSteps {
   private Matcher<?> matchingValue(final String field, final String value) {
     return switch (field.toLowerCase()) {
       case "birthday", "sex" -> equalTo(value);
-      case "patientid","patient id", "short id" -> equalTo(Integer.parseInt(value));
+      case "patientid", "patient id", "short id" -> equalTo(Integer.parseInt(value));
       case "status" -> hasItem(PatientStatusCriteriaResolver.resolve(value).name());
       default -> hasItem(value);
     };
+  }
+
+  @Then("the search results have a patient with a(n) {string} {} name of {string}")
+  public void search_result_n_has_a_x_of_y(
+      final String type,
+      final String field,
+      final String value
+  ) throws Exception {
+
+    JsonPathResultMatchers pathMatcher = switch (field.toLowerCase()) {
+      case "first" -> jsonPath("$.data.findPatientsByFilter.content[*].names[?(@.type=='%s')].first", type);
+      case "last" -> jsonPath("$.data.findPatientsByFilter.content[*].names[?(@.type=='%s')].last", type);
+      default -> throw new IllegalStateException("Unexpected value: " + field);
+    };
+
+    this.results.active()
+        .andExpect(pathMatcher.value(matchingValue(field, value)));
   }
 
   @Then("the patient is in the search result(s)")

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -78,11 +78,11 @@ Feature: Patient Search
       | address    | 1234 Address |
 
   Scenario: I can find the most relevant patient when searching by first name
-    Given the patient has the "legal" name "Something" "Other"
+    Given the patient has the legal name "Something" "Other"
     And I have another patient
-    And the patient has the "legal" name "Jon" "Snow"
+    And the patient has the legal name "Jon" "Snow"
     And I have another patient
-    And the patient has the "legal" name "John" "Little"
+    And the patient has the legal name "John" "Little"
     And patients are available for search
     And I add the patient criteria for a "first name" equal to "John"
     When I search for patients
@@ -92,11 +92,11 @@ Feature: Patient Search
     And search result 2 has a "last name" of "Snow"
 
   Scenario: I can find the most relevant patient when searching by first name with soundex disabled
-    Given the patient has the "legal" name "Something" "Other"
+    Given the patient has the legal name "Something" "Other"
     And I have another patient
-    And the patient has the "legal" name "Jon" "Snow"
+    And the patient has the legal name "Jon" "Snow"
     And I have another patient
-    And the patient has the "legal" name "John" "Little"
+    And the patient has the legal name "John" "Little"
     And patients are available for search
     And I add the patient criteria for a "first name" equal to "John"
     And I add the patient criteria for a "disable soundex" equal to "true"
@@ -106,11 +106,11 @@ Feature: Patient Search
     And there are 1 patient search results
 
   Scenario: I can find the most relevant patient when searching by last name
-    Given the patient has the "legal" name "Something" "Other"
+    Given the patient has the legal name "Something" "Other"
     And I have another patient
-    And the patient has the "legal" name "Albert" "Smyth"
+    And the patient has the legal name "Albert" "Smyth"
     And I have another patient
-    And the patient has the "legal" name "Fatima" "Smith"
+    And the patient has the legal name "Fatima" "Smith"
     And patients are available for search
     And I add the patient criteria for a "last name" equal to "Smith"
     When I search for patients
@@ -120,11 +120,11 @@ Feature: Patient Search
     And search result 2 has a "last name" of "Smyth"
 
   Scenario: I can find the most relevant patient when searching by last name with soundex disabled
-    Given the patient has the "legal" name "Something" "Other"
+    Given the patient has the legal name "Something" "Other"
     And I have another patient
-    And the patient has the "legal" name "Albert" "Smyth"
+    And the patient has the legal name "Albert" "Smyth"
     And I have another patient
-    And the patient has the "legal" name "Fatima" "Smith"
+    And the patient has the legal name "Fatima" "Smith"
     And patients are available for search
     And I add the patient criteria for a "last name" equal to "Smith"
     And I add the patient criteria for a "disable soundex" equal to "true"
@@ -134,31 +134,33 @@ Feature: Patient Search
     And there are 1 patient search results
 
   Scenario: I can find the patient when searching for a hyphenated last name using a hyphen
-    Given the patient has the "legal" name "Something" "Other-than"
+    Given the patient has the legal name "Something" "Other-than"
     And patients are available for search
     And I add the patient criteria for a "last name" equal to "Other-than"
     When I search for patients
     Then search result 1 has a "last name" of "Other-than"
 
   Scenario: I can find the patient when searching for a hyphenated last name without using a hyphen
-    Given the patient has the "legal" name "Something" "Other-than"
+    Given the patient has the legal name "Something" "Other-than"
     And patients are available for search
     And I add the patient criteria for a "last name" equal to "Other than"
     When I search for patients
     Then search result 1 has a "last name" of "Other-than"
 
   Scenario: I can search for a Patient and find them by their legal name
-    Given the patient has the "legal" name "Something" "Other" as of "2022-01-01"
-    And the patient has the "legal" name "This" "One" "Here", "Junior" as of "2022-11-13"
-    And the patient has the "alias" name "Al" "Lias"
+    Given the patient has the legal name "Something" "Other" as of 01/01/2022
+    And the patient has the legal name "This" "One" "Here", Jr. as of 11/13/2022
+    And the patient has the Alias Name name "Al" "Lias"
     And patients are available for search
     When I search for patients
     Then the search results have a patient with a "legal first name" equal to "This"
     And the search results have a patient with a "legal middle name" equal to "One"
     And the search results have a patient with a "legal last name" equal to "Here"
-    And the search results have a patient with a "legal name suffix" equal to "Junior"
-    And the search results have a patient with a "first name" equal to "Something"
-    And the search results have a patient with a "last name" equal to "Other"
+    And the search results have a patient with a "legal name suffix" equal to "Jr."
+    And the search results have a patient with an "Legal" first name of "Something"
+    And the search results have a patient with an "Legal" last name of "Other"
+    And the search results have a patient with an "Alias Name" first name of "Al"
+    And the search results have a patient with an "Alias Name" last name of "Lias"
 
   Scenario: I can search for a Patient and find them by their legal name
     Given the patient has the "alias" name "Al" "Lias"
@@ -234,10 +236,10 @@ Feature: Patient Search
     Then the patient is not in the search results
 
   Scenario: BUG: CNFT1-2008 I can search for a Patient with invalid identification
-    Given the patient has the "legal" name "Max" "Headroom"
+    Given the patient has the legal name "Max" "Headroom"
     And the patient can be identified with a Medicare Number of "1009"
     And I have another patient
-    And the patient has the "legal" name "Max" "Smart"
+    And the patient has the legal name "Max" "Smart"
     And the patient has the gender Male
     And the patient can be identified with an Account Number without a value
     And patients are available for search
@@ -312,14 +314,14 @@ Feature: Patient Search
     Then the search results have a patient with a "first name" equal to "Liam"
 
   Scenario: I can find a patient by last name using special characters without an error 
-    Given the patient has the "legal" name "Sam" "Smith"
+    Given the patient has the legal name "Sam" "Smith"
     And patients are available for search
     And I add the patient criteria for a "last name" equal to "Sm~th"
     When I search for patients
     Then there are 1 patient search results
 
   Scenario: I can find a patient by first name using special characters without an error 
-    Given the patient has the "legal" name "Sam" "Smith"
+    Given the patient has the legal name "Sam" "Smith"
     And patients are available for search
     And I add the patient criteria for a "first name" equal to "S~m"
     When I search for patients

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.sorting.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.sorting.feature
@@ -33,11 +33,11 @@ Feature: Patient Search Sorting
     And search result 3 has a "birthday" of "1974-05-29"
 
   Scenario: I can find the most relevant patient when sorting by legal name  ascending
-    Given the patient has the "legal" name "Wanda" "Maximoff"
+    Given the patient has the legal name "Wanda" "Maximoff"
     And I have another patient
-    And the patient has the "legal" name "Helen" "Cho"
+    And the patient has the legal name "Helen" "Cho"
     And I have another patient
-    And the patient has the "legal" name "Pietro" "Maximoff"
+    And the patient has the legal name "Pietro" "Maximoff"
     And patients are available for search
     And I want patients sorted by "legal name" "asc"
     When I search for patients
@@ -49,11 +49,11 @@ Feature: Patient Search Sorting
     And search result 3 has a "last name" of "Maximoff"
 
   Scenario: I can find the most relevant patient when sorting by legal name descending
-    Given the patient has the "legal" name "Wanda" "Maximoff"
+    Given the patient has the legal name "Wanda" "Maximoff"
     And I have another patient
-    And the patient has the "legal" name "Helen" "Cho"
+    And the patient has the legal name "Helen" "Cho"
     And I have another patient
-    And the patient has the "legal" name "Pietro" "Maximoff"
+    And the patient has the legal name "Pietro" "Maximoff"
     And patients are available for search
     And I want patients sorted by "last name" "desc"
     When I search for patients
@@ -65,11 +65,11 @@ Feature: Patient Search Sorting
     And search result 3 has a "last name" of "Cho"
 
   Scenario: I can find the most relevant patient when sorting by last name  ascending
-    Given the patient has the "legal" name "Timothy" "Jackson"
+    Given the patient has the legal name "Timothy" "Jackson"
     And I have another patient
-    And the patient has the "legal" name "Jason" "Todd"
+    And the patient has the legal name "Jason" "Todd"
     And I have another patient
-    And the patient has the "legal" name "Stephanie" "Brown"
+    And the patient has the legal name "Stephanie" "Brown"
     And patients are available for search
     And I want patients sorted by "last name" "asc"
     When I search for patients
@@ -81,11 +81,11 @@ Feature: Patient Search Sorting
     And search result 3 has a "last name" of "Todd"
 
   Scenario: I can find the most relevant patient when sorting by last name descending
-    Given the patient has the "legal" name "Timothy" "Jackson"
+    Given the patient has the legal name "Timothy" "Jackson"
     And I have another patient
-    And the patient has the "legal" name "Jason" "Todd"
+    And the patient has the legal name "Jason" "Todd"
     And I have another patient
-    And the patient has the "legal" name "Stephanie" "Brown"
+    And the patient has the legal name "Stephanie" "Brown"
     And patients are available for search
     And I want patients sorted by "last name" "desc"
     When I search for patients
@@ -97,11 +97,11 @@ Feature: Patient Search Sorting
     And search result 3 has a "last name" of "Brown"
 
   Scenario: I can find the most relevant patient when sorting by first name  ascending
-    Given the patient has the "legal" name "Timothy" "Jackson"
+    Given the patient has the legal name "Timothy" "Jackson"
     And I have another patient
-    And the patient has the "legal" name "Jason" "Todd"
+    And the patient has the legal name "Jason" "Todd"
     And I have another patient
-    And the patient has the "legal" name "Stephanie" "Brown"
+    And the patient has the legal name "Stephanie" "Brown"
     And patients are available for search
     And I want patients sorted by "first name" "asc"
     When I search for patients
@@ -110,11 +110,11 @@ Feature: Patient Search Sorting
     And search result 3 has a "first name" of "Timothy"
 
   Scenario: I can find the most relevant patient when sorting by first name descending
-    Given the patient has the "legal" name "Timothy" "Jackson"
+    Given the patient has the legal name "Timothy" "Jackson"
     And I have another patient
-    And the patient has the "legal" name "Jason" "Todd"
+    And the patient has the legal name "Jason" "Todd"
     And I have another patient
-    And the patient has the "legal" name "Stephanie" "Brown"
+    And the patient has the legal name "Stephanie" "Brown"
     And patients are available for search
     And I want patients sorted by "first name" "desc"
     When I search for patients

--- a/apps/modernization-api/src/test/resources/features/search/investigation/InvestigationSearch.sorting.feature
+++ b/apps/modernization-api/src/test/resources/features/search/investigation/InvestigationSearch.sorting.feature
@@ -9,13 +9,13 @@ Feature: Investigation Search Sorting
 
   Scenario: I can find Investigations ordered by the patient's last name ascending
     Given I have a patient
-    And the patient has the "legal" name "Ben" "Hanscom"
+    And the patient has the legal name "Ben" "Hanscom"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Beverly" "Marsh"
+    And the patient has the legal name "Beverly" "Marsh"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Bill" "Denbrough"
+    And the patient has the legal name "Bill" "Denbrough"
     And the patient is a subject of an investigation
     And investigations are available for search
     And I want search results sorted by "last name" "asc"
@@ -26,13 +26,13 @@ Feature: Investigation Search Sorting
 
   Scenario: I can find Investigations ordered by the patient's last name Descending
     Given I have a patient
-    And the patient has the "legal" name "Ben" "Hanscom"
+    And the patient has the legal name "Ben" "Hanscom"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Beverly" "Marsh"
+    And the patient has the legal name "Beverly" "Marsh"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Bill" "Denbrough"
+    And the patient has the legal name "Bill" "Denbrough"
     And the patient is a subject of an investigation
     And investigations are available for search
     And I want search results sorted by "last name" "desc"
@@ -43,13 +43,13 @@ Feature: Investigation Search Sorting
 
   Scenario: I can find Investigations ordered by the patient's first name ascending
     Given I have a patient
-    And the patient has the "legal" name "Beverly" "Hanscom"
+    And the patient has the legal name "Beverly" "Hanscom"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Ben" "Marsh"
+    And the patient has the legal name "Ben" "Marsh"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Bill" "Denbrough"
+    And the patient has the legal name "Bill" "Denbrough"
     And the patient is a subject of an investigation
     And investigations are available for search
     And I want search results sorted by "first name" "asc"
@@ -60,13 +60,13 @@ Feature: Investigation Search Sorting
 
   Scenario: I can find Investigations ordered by the patient's first name Descending
     Given I have a patient
-    And the patient has the "legal" name "Beverly" "Hanscom"
+    And the patient has the legal name "Beverly" "Hanscom"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Ben" "Marsh"
+    And the patient has the legal name "Ben" "Marsh"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Bill" "Denbrough"
+    And the patient has the legal name "Bill" "Denbrough"
     And the patient is a subject of an investigation
     And investigations are available for search
     And I want search results sorted by "first name" "desc"
@@ -77,13 +77,13 @@ Feature: Investigation Search Sorting
 
   Scenario: I can find Investigations ordered by the patient's legal name ascending
     Given I have a patient
-    And the patient has the "legal" name "Torrhen" "Stark"
+    And the patient has the legal name "Torrhen" "Stark"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Lyanna" "Stark"
+    And the patient has the legal name "Lyanna" "Stark"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Talisa" "Maegyr"
+    And the patient has the legal name "Talisa" "Maegyr"
     And the patient is a subject of an investigation
     And investigations are available for search
     And I want search results sorted by "legal name" "asc"
@@ -94,13 +94,13 @@ Feature: Investigation Search Sorting
 
   Scenario: I can find Investigations ordered by the patient's legal name Descending
     Given I have a patient
-    And the patient has the "legal" name "Torrhen" "Stark"
+    And the patient has the legal name "Torrhen" "Stark"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Lyanna" "Stark"
+    And the patient has the legal name "Lyanna" "Stark"
     And the patient is a subject of an investigation
     And I have another patient
-    And the patient has the "legal" name "Talisa" "Maegyr"
+    And the patient has the legal name "Talisa" "Maegyr"
     And the patient is a subject of an investigation
     And investigations are available for search
     And I want search results sorted by "legal name" "desc"

--- a/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.sorting.feature
+++ b/apps/modernization-api/src/test/resources/features/search/lab-report/LabReportSearch.sorting.feature
@@ -9,13 +9,13 @@ Feature: Lab Report Search Sorting
 
   Scenario: I can find Lab Reports ordered by the patient's last name ascending
     Given I have a patient
-    And the patient has the "legal" name "Ryu" "Jose"
+    And the patient has the legal name "Ryu" "Jose"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Tem" "Ray"
+    And the patient has the legal name "Tem" "Ray"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Fraw" "Bow"
+    And the patient has the legal name "Fraw" "Bow"
     And the patient has a lab report
     And lab reports are available for search
     And I want search results sorted by "last name" "asc"
@@ -26,13 +26,13 @@ Feature: Lab Report Search Sorting
 
   Scenario: I can find Lab Reports ordered by the patient's last name descending
     Given I have a patient
-    And the patient has the "legal" name "Ryu" "Jose"
+    And the patient has the legal name "Ryu" "Jose"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Tem" "Ray"
+    And the patient has the legal name "Tem" "Ray"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Fraw" "Bow"
+    And the patient has the legal name "Fraw" "Bow"
     And the patient has a lab report
     And lab reports are available for search
     And I want search results sorted by "last name" "desc"
@@ -77,13 +77,13 @@ Feature: Lab Report Search Sorting
 
   Scenario: I can find Lab Reports ordered by the patient's first name ascending
     Given I have a patient
-    And the patient has the "legal" name "Ryu" "Jose"
+    And the patient has the legal name "Ryu" "Jose"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Tem" "Ray"
+    And the patient has the legal name "Tem" "Ray"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Fraw" "Bow"
+    And the patient has the legal name "Fraw" "Bow"
     And the patient has a lab report
     And lab reports are available for search
     And I want search results sorted by "first name" "asc"
@@ -94,13 +94,13 @@ Feature: Lab Report Search Sorting
 
   Scenario: I can find Lab Reports ordered by the patient's first name descending
     Given I have a patient
-    And the patient has the "legal" name "Ryu" "Jose"
+    And the patient has the legal name "Ryu" "Jose"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Tem" "Ray"
+    And the patient has the legal name "Tem" "Ray"
     And the patient has a lab report
     And I have another patient
-    And the patient has the "legal" name "Fraw" "Bow"
+    And the patient has the legal name "Fraw" "Bow"
     And the patient has a lab report
     And lab reports are available for search
     And I want search results sorted by "first name" "desc"

--- a/apps/modernization-ui/src/generated/gql/queries/findPatientsByFilter.gql
+++ b/apps/modernization-ui/src/generated/gql/queries/findPatientsByFilter.gql
@@ -8,12 +8,14 @@ query findPatientsByFilter($filter: PersonFilter!, $page: SortablePage, $share: 
             status
             shortId
             legalName{
+                type
                 first
                 middle
                 last
                 suffix
             }
             names{
+                type
                 first
                 middle
                 last

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -1511,6 +1511,7 @@ export type PatientSearchResultName = {
   last?: Maybe<Scalars['String']['output']>;
   middle?: Maybe<Scalars['String']['output']>;
   suffix?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type PatientSearchResults = {
@@ -2519,7 +2520,7 @@ export type FindPatientsByFilterQueryVariables = Exact<{
 }>;
 
 
-export type FindPatientsByFilterQuery = { __typename?: 'Query', findPatientsByFilter: { __typename?: 'PatientSearchResults', total: number, page: number, size: number, content: Array<{ __typename?: 'PatientSearchResult', patient: number, birthday?: any | null, age?: number | null, gender?: string | null, status: string, shortId: number, phones: Array<string>, emails: Array<string>, legalName?: { __typename?: 'PatientSearchResultName', first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null } | null, names: Array<{ __typename?: 'PatientSearchResultName', first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null }>, identification: Array<{ __typename?: 'PatientSearchResultIdentification', type: string, value: string }>, addresses: Array<{ __typename?: 'PatientSearchResultAddress', type?: string | null, use?: string | null, address?: string | null, address2?: string | null, city?: string | null, county?: string | null, state?: string | null, zipcode?: string | null }> }> } };
+export type FindPatientsByFilterQuery = { __typename?: 'Query', findPatientsByFilter: { __typename?: 'PatientSearchResults', total: number, page: number, size: number, content: Array<{ __typename?: 'PatientSearchResult', patient: number, birthday?: any | null, age?: number | null, gender?: string | null, status: string, shortId: number, phones: Array<string>, emails: Array<string>, legalName?: { __typename?: 'PatientSearchResultName', type?: string | null, first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null } | null, names: Array<{ __typename?: 'PatientSearchResultName', type?: string | null, first?: string | null, middle?: string | null, last?: string | null, suffix?: string | null }>, identification: Array<{ __typename?: 'PatientSearchResultIdentification', type: string, value: string }>, addresses: Array<{ __typename?: 'PatientSearchResultAddress', type?: string | null, use?: string | null, address?: string | null, address2?: string | null, city?: string | null, county?: string | null, state?: string | null, zipcode?: string | null }> }> } };
 
 export type FindTreatmentsForPatientQueryVariables = Exact<{
   patient: Scalars['ID']['input'];
@@ -5254,12 +5255,14 @@ export const FindPatientsByFilterDocument = gql`
       status
       shortId
       legalName {
+        type
         first
         middle
         last
         suffix
       }
       names {
+        type
         first
         middle
         last

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1147,6 +1147,7 @@ type PatientSearchResultIdentification {
 }
 
 type PatientSearchResultName {
+  type: String
   first: String
   middle: String
   last: String


### PR DESCRIPTION
## Description

Updates the finder that resolves patient names in search results to include the name type.  

- The client graphql schema was regenerated to reflect the changes 

Issuing the request 

```graphql
query search($filter: PersonFilter!, $page: SortablePage, $share: String) {
  findPatientsByFilter(filter: $filter, page: $page, share: $share) {
    content {
      patient
      shortId
      names {
        type
        first
        last
      }
    }
    total
    page
    size
  }
}

```

Will return the name type and use when the patient has a names.

```json
{
    "data": {
        "findPatientsByFilter": {
            "content": [
                {
                    "patient": 10055284,
                    "shortId": 91001,
                    "names": [
                        {
                            "type": "Alias Name",
                            "first": "Kitty",
                            "last": null
                        },
                        {
                            "type": "Legal",
                            "first": "Katherine",
                            "last": "Pryde"
                        }
                    ]
                }
            ],
            "total": 1,
            "page": 0,
            "size": 5
        }
    }
}
```

## Tickets

* [CNFT1-3278](https://cdc-nbs.atlassian.net/browse/CNFT1-3278)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3278]: https://cdc-nbs.atlassian.net/browse/CNFT1-3278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ