### PR TITLE
Suppresses several instances of javaarchitecture:S7027

### DIFF
--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/Codeset.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/Codeset.java
@@ -60,6 +60,9 @@ public class Codeset {
   @Column(name = "status_to_time")
   private Instant statusToTime;
 
+  @SuppressWarnings(
+  //  Bidirectional mappings require knowledge of each other
+  "javaarchitecture:S7027")
   @ManyToOne(fetch = FetchType.LAZY, cascade = {
       CascadeType.MERGE,
       CascadeType.REMOVE,

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaNndMetadatum.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaNndMetadatum.java
@@ -98,6 +98,9 @@ public class WaNndMetadatum {
   @Column(name = "local_id", length = 50)
   private String localId;
 
+  @SuppressWarnings(
+  //  Bidirectional mappings require knowledge of each other
+  "javaarchitecture:S7027")
   @OneToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "wa_ui_metadata_uid", nullable = false)
   private WaUiMetadata waUiMetadataUid;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaTemplate.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/WaTemplate.java
@@ -42,6 +42,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "WA_template", catalog = "NBS_ODSE")
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class WaTemplate {
   private static final String DRAFT = "Draft";
   private static final long TAB = 1010L;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/condition/ConditionCode.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/condition/ConditionCode.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(catalog = "NBS_SRTE", name = "Condition_code")
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class ConditionCode implements Serializable {
     @Id
     @Column(name = "condition_cd", nullable = false, length = 20)

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/condition/LdfPageSet.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/condition/LdfPageSet.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 @Setter
 @Entity
 @Table(catalog = "NBS_SRTE", name = "LDF_page_set")
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class LdfPageSet implements Serializable {
 
     @Id

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/WaQuestion.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/WaQuestion.java
@@ -31,6 +31,7 @@ import static gov.cdc.nbs.questionbank.util.PageBuilderUtil.requireNonNull;
 @Table(name = "WA_question", catalog = "NBS_ODSE")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "data_type", discriminatorType = DiscriminatorType.STRING)
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public abstract class WaQuestion {
 
     public static final String ACTIVE = "Active";

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/WaQuestionHist.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/entity/question/WaQuestionHist.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 @Setter
 @Entity
 @Table(name = "WA_question_hist", catalog = "NBS_ODSE")
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class WaQuestionHist {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLFilterApplier.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/filter/querydsl/QueryDSLFilterApplier.java
@@ -19,6 +19,7 @@ public class QueryDSLFilterApplier {
     Stream<BooleanExpression> resolve(final Filter filter, final Expression<?> expression);
   }
 
+  @SuppressWarnings("javaarchitecture:S7027") // static method uses default implementation
   public static Stream<BooleanExpression> apply(
       final ExpressionResolver expressionResolver,
       final Collection<Filter> filters) {

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/request/UpdatePageQuestionRequest.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/question/request/UpdatePageQuestionRequest.java
@@ -3,6 +3,9 @@ package gov.cdc.nbs.questionbank.page.content.question.request;
 import gov.cdc.nbs.questionbank.question.model.Question.MessagingInfo;
 import gov.cdc.nbs.questionbank.question.request.QuestionRequest.ReportingInfo;
 
+@SuppressWarnings(
+//  Sealed classes require the implementing classes be listed if not in the same file
+"javaarchitecture:S7027")
 public sealed interface UpdatePageQuestionRequest permits UpdatePageTextQuestionRequest,
     UpdatePageNumericQuestionRequest, UpdatePageDateQuestionRequest, UpdatePageCodedQuestionRequest {
   // general

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/reorder/models/ReorderablePage.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/content/reorder/models/ReorderablePage.java
@@ -33,6 +33,7 @@ public class ReorderablePage {
     /**
      * Converts the ReorderablePage into a list of PageEntry's
      */
+    @SuppressWarnings("javaarchitecture:S7027") // References static fields
     public List<PageEntry> toPageEntries() {
         List<PageEntry> entries = new ArrayList<>();
         int orderNumber = 1;

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/entity/AuthPermSet.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/entity/AuthPermSet.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "Auth_perm_set", catalog = "NBS_ODSE")
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class AuthPermSet {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/NBSEntity.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/NBSEntity.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 @Entity
 @Table(name = "Entity")
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class NBSEntity {
     @Id
     @Column(name = "entity_uid", nullable = false)

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 @Getter
 @Setter
 @Entity
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class Person {
   @Id
   @Column(name = "person_uid", nullable = false)

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PersonEthnicGroup.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PersonEthnicGroup.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "Person_ethnic_group")
 @EntityListeners(PatientEthnicityHistoryListener.class)
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class PersonEthnicGroup {
     @EmbeddedId
     private PersonEthnicGroupId id;

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PostalEntityLocatorParticipation.java
@@ -15,6 +15,7 @@ import jakarta.persistence.OneToOne;
 @Entity
 @DiscriminatorValue(PostalEntityLocatorParticipation.POSTAL_CLASS_CODE)
 @EntityListeners(PatientPostalLocatorHistoryListener.class)
+@SuppressWarnings("javaarchitecture:S7027") //  Bidirectional mappings require knowledge of each other
 public class PostalEntityLocatorParticipation extends EntityLocatorParticipation {
 
     static final String POSTAL_CLASS_CODE = "PST";

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientEntityLocatorHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientEntityLocatorHistoryListener.java
@@ -14,6 +14,7 @@ public class PatientEntityLocatorHistoryListener {
     }
 
     @PreUpdate
+    @SuppressWarnings("javaarchitecture:S7027")
     void preUpdate(final EntityLocatorParticipation entityLocatorParticipation) {
         int version = entityLocatorParticipation.getVersionCtrlNbr() - 1;
         this.creator.createEntityLocatorHistory(entityLocatorParticipation.getId().getEntityUid(),

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientEthnicityHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientEthnicityHistoryListener.java
@@ -17,6 +17,7 @@ public class PatientEthnicityHistoryListener {
     }
 
     @PreRemove
+    @SuppressWarnings("javaarchitecture:S7027")
     void preRemove(final PersonEthnicGroup personEthnicGroup) {
         long personUid = personEthnicGroup.getPersonUid().getId();
         String personEthnicityGroupCd = personEthnicGroup.getId().getEthnicGroupCd();

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientIdentificationHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientIdentificationHistoryListener.java
@@ -18,6 +18,7 @@ public class PatientIdentificationHistoryListener {
     }
 
     @PreUpdate
+    @SuppressWarnings("javaarchitecture:S7027")
     void preUpdate(final EntityId entityId) {
         int entityIdSequence = entityId.getId().getEntityIdSeq();
         int currentVersion = getCurrentVersionNumber(entityId.getId(), entityIdSequence);

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientNameHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientNameHistoryListener.java
@@ -18,6 +18,7 @@ public class PatientNameHistoryListener {
     }
 
     @PreUpdate
+    @SuppressWarnings("javaarchitecture:S7027")
     void preUpdate(PersonName personName) {
         int personNameSequence = personName.getId().getPersonNameSeq();
         int currentVersion = getCurrentVersionNumber(personName.getPersonUid(), personNameSequence);

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientPhoneLocatorHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientPhoneLocatorHistoryListener.java
@@ -17,6 +17,7 @@ public class PatientPhoneLocatorHistoryListener {
     }
 
     @PreUpdate
+    @SuppressWarnings("javaarchitecture:S7027")
     void preUpdate(final TeleEntityLocatorParticipation teleEntityLocatorParticipation) {
         long locatorId = teleEntityLocatorParticipation.getId().getLocatorUid();
         int currentVersion = getCurrentVersionNumber(locatorId);

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientPostalLocatorHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientPostalLocatorHistoryListener.java
@@ -17,6 +17,7 @@ public class PatientPostalLocatorHistoryListener {
     }
 
     @PreUpdate
+    @SuppressWarnings("javaarchitecture:S7027")
     void preUpdate(final PostalEntityLocatorParticipation postalEntityLocatorParticipation) {
         long locatorId = postalEntityLocatorParticipation.getId().getLocatorUid();
         int currentVersion = getCurrentVersionNumber(locatorId);

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientRaceHistoryListener.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientRaceHistoryListener.java
@@ -17,6 +17,7 @@ public class PatientRaceHistoryListener {
     }
 
     @PreRemove
+    @SuppressWarnings("javaarchitecture:S7027")
     void preRemove(final PersonRace personRace) {
         long personUid = personRace.getPersonUid().getId();
         String raceCode = personRace.getRaceCd();


### PR DESCRIPTION
## Description

Sonar's new rule `javaarchitecture:S7027` is not great. It flags the following scenarios I consider false positives:
1. Bi-directional mappings in `@Entity`s
2. Static variable references
3. Sealed interfaces using `permits`
4. `@EntityListeners`

This PR suppresses several of these.
