### PR TITLE
[CNFT1-3369] Prevents the cancel modal from appearing after a patient is created

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended.module.scss
@@ -6,7 +6,7 @@
     height: calc(100vh - 75px);
     background-color: colors.$base-white;
 
-    .contet {
+    .content {
         display: flex;
         width: 100%;
         flex-direction: column;

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -42,7 +42,11 @@ const initial = (asOf: string = today()) => ({
     general: {
         asOf: asOf
     },
-    phoneEmails: []
+    names: [],
+    addresses: [],
+    phoneEmails: [],
+    identifications: [],
+    races: []
 });
 
 export { initial };

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddPatientExtendedDefaults.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddPatientExtendedDefaults.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { ExtendedNewPatientEntry, initial as initialEntry } from './entry';
+
+type Interaction = {
+    /** provides the default values for Extended New Patient Entry  */
+    initialize: () => ExtendedNewPatientEntry;
+};
+
+/**
+ * Provides a function to initialize the default form values for New patient - extended.
+ *
+ * @return {Interaction} to initialize the default state of ExtendedNewPatientEntry
+ */
+const useAddPatientExtendedDefaults = (): Interaction => {
+    const location = useLocation();
+
+    const initialize = useCallback(() => {
+        if (location.state?.defaults) {
+            return location.state?.defaults;
+        } else {
+            return initialEntry();
+        }
+    }, [location.state?.defaults]);
+
+    return { initialize };
+};
+
+export { useAddPatientExtendedDefaults };

--- a/apps/modernization-ui/src/navigation/index.ts
+++ b/apps/modernization-ui/src/navigation/index.ts
@@ -1,0 +1,1 @@
+export { useNavigationBlock } from './useNavigationBlock';


### PR DESCRIPTION
## Description

Adds finer control over when navigation blocking is applied to ensure that the cancel modal does not appear after a patient has been created.

![CNFT1-3369](https://github.com/user-attachments/assets/626d30c3-d9d0-452b-a5ec-e381c0c282bf)


## Tickets

* [CNFT1-3369](https://cdc-nbs.atlassian.net/browse/CNFT1-3369)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3369]: https://cdc-nbs.atlassian.net/browse/CNFT1-3369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ