### PR TITLE
CNFT1-3287: Other names header for search

### DIFF
--- a/apps/modernization-ui/src/address/display/displayAddress.spec.tsx
+++ b/apps/modernization-ui/src/address/display/displayAddress.spec.tsx
@@ -23,9 +23,6 @@ describe('when given an address', () => {
             state: 'NY',
             zipcode: '10013'
         };
-
-        // expect(addressElement.props.children).toBe('14 North Moore St, Suite A\nNew York, NY 10013');
-
         const addressElement = displayAddress(address);
         expect(addressElement.type).toBe(ItemGroup);
         expect(addressElement.props.children).toBe('14 North Moore St, Suite A\nNew York, NY 10013');

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
@@ -4,7 +4,7 @@ import { internalizeDate } from 'date';
 import { Result, ResultItem, ResultItemGroup } from 'apps/search/layout/result/list';
 import {
     displayPhones,
-    displayNames,
+    displayOtherNames,
     displayEmails,
     displayAddresses,
     displayProfileLegalName
@@ -29,7 +29,7 @@ const PatientSearchResultListItem = ({ result }: Props) => (
                 {displayPhones(result)}
             </ResultItem>
             <ResultItem label="Other names" orientation="vertical">
-                {displayNames(result)}
+                {displayOtherNames(result)}
             </ResultItem>
         </ResultItemGroup>
         <ResultItemGroup>

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { PatientSearchResult } from 'generated/graphql/schema';
-import { displayProfileLink, displayPhones, displayEmails } from './patientSearchResult';
+import { displayProfileLink, displayPhones, displayEmails, displayAddresses } from './patientSearchResult';
 
 describe('patientSearchResult functions', () => {
     const mockPatient: PatientSearchResult = {
@@ -31,7 +31,7 @@ describe('patientSearchResult functions', () => {
                 zipcode: '42303'
             },
             {
-                use: 'Home',
+                use: 'Business',
                 address: '2222 Test Valley Rd',
                 city: 'OWENSBORO',
                 county: 'Appling County',
@@ -39,7 +39,7 @@ describe('patientSearchResult functions', () => {
                 zipcode: '30309'
             },
             {
-                use: 'Home',
+                use: 'Alternate',
                 address: '3333 Test Valley Rd',
                 city: 'OWENSBORO',
                 state: 'KY',
@@ -66,5 +66,14 @@ describe('patientSearchResult functions', () => {
         );
         const link = getByText('John Doe');
         expect(link).toHaveAttribute('href', '/patient-profile/84001/summary');
+    });
+
+    it('should render addresses correctly', () => {
+        const { getByText, queryAllByText } = render(displayAddresses(mockPatient));
+        expect(getByText('Home')).toBeInTheDocument();
+        expect(queryAllByText('2222 Test Valley Rd', { exact: false })).toHaveLength(2);
+        expect(queryAllByText('3333 Test Valley Rd', { exact: false })).toHaveLength(1);
+        expect(getByText('Business')).toBeInTheDocument();
+        expect(getByText('Alternate')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -1,7 +1,13 @@
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { PatientSearchResult } from 'generated/graphql/schema';
-import { displayProfileLink, displayPhones, displayEmails, displayAddresses } from './patientSearchResult';
+import {
+    displayProfileLink,
+    displayPhones,
+    displayEmails,
+    displayAddresses,
+    displayOtherNames
+} from './patientSearchResult';
 
 describe('patientSearchResult functions', () => {
     const mockPatient: PatientSearchResult = {
@@ -17,8 +23,9 @@ describe('patientSearchResult functions', () => {
         },
         names: [
             {
-                first: 'jonny',
-                last: 'TestnullTest'
+                first: 'Johnny',
+                last: 'TestnullTest',
+                type: 'Alias'
             }
         ],
         identification: [],
@@ -75,5 +82,11 @@ describe('patientSearchResult functions', () => {
         expect(queryAllByText('3333 Test Valley Rd', { exact: false })).toHaveLength(1);
         expect(getByText('Business')).toBeInTheDocument();
         expect(getByText('Alternate')).toBeInTheDocument();
+    });
+
+    it('should render other names correctly', () => {
+        const { getByText } = render(displayOtherNames(mockPatient));
+        expect(getByText('Alias')).toBeInTheDocument();
+        expect(getByText('Johnny TestnullTest')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -1,5 +1,5 @@
 import { PatientSearchResult } from 'generated/graphql/schema';
-import { displayName } from 'name';
+import { displayName, displayNameElement, matchesLegalName } from 'name';
 import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
 
@@ -12,12 +12,18 @@ const displayProfileLegalName = (result: PatientSearchResult) => {
     return displayProfileLink(result.shortId, legalNameDisplay);
 };
 
-const displayNames = (result: PatientSearchResult): string => {
+// Displays Other names, that are not the legal name
+const displayOtherNames = (result: PatientSearchResult): JSX.Element => {
     const legalName = result.legalName;
-    return result.names
-        .filter((name) => name?.first != legalName?.first || name?.last != legalName?.last)
-        .map(displayName())
-        .join('\n');
+    return (
+        <div>
+            {result.names
+                .filter((name) => !matchesLegalName(name, legalName))
+                .map((name, index) => (
+                    <div key={index}>{displayNameElement(name)}</div>
+                ))}
+        </div>
+    );
 };
 
 // Returns JSX that represents a list of addresses to display
@@ -32,4 +38,11 @@ const displayAddresses = (result: PatientSearchResult): JSX.Element => (
 const displayPhones = (result: PatientSearchResult): string => result.phones.join('\n');
 const displayEmails = (result: PatientSearchResult): string => result.emails.join('\n');
 
-export { displayNames, displayProfileLink, displayProfileLegalName, displayPhones, displayAddresses, displayEmails };
+export {
+    displayOtherNames,
+    displayProfileLink,
+    displayProfileLegalName,
+    displayPhones,
+    displayAddresses,
+    displayEmails
+};

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -5,7 +5,7 @@ import { internalizeDate } from 'date';
 import {
     displayPhones,
     displayProfileLink,
-    displayNames,
+    displayOtherNames,
     displayEmails,
     displayAddresses
 } from 'apps/search/patient/result';
@@ -46,7 +46,7 @@ const columns: Column<PatientSearchResult>[] = [
     },
     { ...ADDRESS, render: displayAddresses },
     { ...PHONE, render: displayPhones },
-    { ...NAMES, render: displayNames },
+    { ...NAMES, render: displayOtherNames },
     { ...IDENTIFICATIONS, render: displayIdentifications },
     { ...EMAIL, render: displayEmails }
 ];

--- a/apps/modernization-ui/src/name/displayName.ts
+++ b/apps/modernization-ui/src/name/displayName.ts
@@ -1,13 +1,5 @@
 import { exists } from 'utils';
-
-type DisplayableName = {
-    first?: string | null;
-    middle?: string | null;
-    last?: string | null;
-    suffix?: string | null;
-};
-
-type Format = 'full' | 'short' | 'fullLastFirst';
+import { DisplayableName, NameFormat } from './types';
 
 /**
  * Displays a name in a 'full' or 'short' format.  Where the 'short' format will
@@ -28,7 +20,7 @@ type Format = 'full' | 'short' | 'fullLastFirst';
  * @param {string} format The format to display names in, either 'full', 'short' or 'fullLastFirst'
  * @return {string}
  */
-const displayName = (format: Format = 'full') => {
+const displayName = (format: NameFormat = 'full') => {
     switch (format) {
         case 'full':
             return displayFullName;

--- a/apps/modernization-ui/src/name/displayNameElement.spec.tsx
+++ b/apps/modernization-ui/src/name/displayNameElement.spec.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import { displayNameElement } from './displayNameElement';
+import { DisplayableName } from './types';
+
+describe('displayNameElement', () => {
+    it('should render short name format by default with label', () => {
+        const name: DisplayableName = { first: 'John', last: 'Doe', type: 'Home' };
+        const { getByText } = render(displayNameElement(name));
+        expect(getByText('Home')).toBeInTheDocument();
+        expect(getByText('John Doe')).toBeInTheDocument();
+    });
+
+    it('should render full name format by default with label', () => {
+        const name: DisplayableName = { first: 'John', last: 'Doe', middle: 'Sawyer', type: 'Home' };
+        const { getByText } = render(displayNameElement(name, 'full'));
+        expect(getByText('Home')).toBeInTheDocument();
+        expect(getByText('John Sawyer Doe')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/name/displayNameElement.tsx
+++ b/apps/modernization-ui/src/name/displayNameElement.tsx
@@ -1,0 +1,18 @@
+import { ItemGroup } from 'design-system/item';
+import { displayName } from './displayName';
+import { DisplayableName, NameFormat } from './types';
+
+/** Returns the full text + label address element. Example: "Home 123 Main St Springfield, IL 62701"
+ * @param {DisplayableName} name - The address object to display.
+ * @param {NameFormat} format - The format to display names in, either 'full', 'short' or 'fullLastFirst'. Default = 'full'.
+ * @return {JSX.Element} The address block as JSX.
+ */
+export const displayNameElement = (name: DisplayableName, format?: NameFormat): JSX.Element => {
+    const nameText = displayName(format)(name);
+    const nameHeader = name.type ?? undefined;
+    return (
+        <ItemGroup type="name" label={nameHeader}>
+            {nameText}
+        </ItemGroup>
+    );
+};

--- a/apps/modernization-ui/src/name/displayNameElement.tsx
+++ b/apps/modernization-ui/src/name/displayNameElement.tsx
@@ -2,8 +2,8 @@ import { ItemGroup } from 'design-system/item';
 import { displayName } from './displayName';
 import { DisplayableName, NameFormat } from './types';
 
-/** Returns the full text + label address element. Example: "Home 123 Main St Springfield, IL 62701"
- * @param {DisplayableName} name - The address object to display.
+/** Returns the full text + label name element. Example: "Alias Name\nMarty McFly"
+ * @param {DisplayableName} name - The name object to display.
  * @param {NameFormat} format - The format to display names in, either 'full', 'short' or 'fullLastFirst'. Default = 'full'.
  * @return {JSX.Element} The address block as JSX.
  */

--- a/apps/modernization-ui/src/name/index.ts
+++ b/apps/modernization-ui/src/name/index.ts
@@ -1,1 +1,3 @@
 export * from './displayName';
+export * from './displayNameElement';
+export * from './nameUtils';

--- a/apps/modernization-ui/src/name/nameUtils.spec.ts
+++ b/apps/modernization-ui/src/name/nameUtils.spec.ts
@@ -1,0 +1,52 @@
+import { matchesLegalName } from './nameUtils';
+import { DisplayableName } from './types';
+
+describe('matchesLegalName', () => {
+    const legalName: DisplayableName = {
+        first: 'John',
+        middle: 'W',
+        last: 'Wick',
+        suffix: 'III'
+    };
+
+    it('should return false if legalName is null or undefined', () => {
+        const name: DisplayableName = { first: 'John', last: 'Wick' };
+        expect(matchesLegalName(name, null)).toBe(false);
+        expect(matchesLegalName(name, undefined)).toBe(false);
+    });
+
+    it('should return true for matching first and last names in short format', () => {
+        const name: DisplayableName = { first: 'John', last: 'Wick' };
+        expect(matchesLegalName(name, legalName, 'short')).toBe(true);
+    });
+
+    it('should return false for non-matching first and last names in short format', () => {
+        const name: DisplayableName = { first: 'Jane', last: 'Wick' };
+        expect(matchesLegalName(name, legalName, 'short')).toBe(false);
+    });
+
+    it('should return true for matching full names in full format', () => {
+        const name: DisplayableName = { first: 'John', middle: 'W', last: 'Wick', suffix: 'III' };
+        expect(matchesLegalName(name, legalName, 'full')).toBe(true);
+    });
+
+    it('should return false for non-matching full names in full format', () => {
+        const name: DisplayableName = { first: 'John', middle: 'A', last: 'Wick', suffix: 'III' };
+        expect(matchesLegalName(name, legalName, 'full')).toBe(false);
+    });
+
+    it('should return true for matching full names in fullLastFirst format', () => {
+        const name: DisplayableName = { first: 'John', middle: 'W', last: 'Wick', suffix: 'III' };
+        expect(matchesLegalName(name, legalName, 'fullLastFirst')).toBe(true);
+    });
+
+    it('should return false for non-matching full names in fullLastFirst format', () => {
+        const name: DisplayableName = { first: 'John', middle: 'A', last: 'Wick', suffix: 'III' };
+        expect(matchesLegalName(name, legalName, 'fullLastFirst')).toBe(false);
+    });
+
+    it('should default to short format if no format is provided', () => {
+        const name: DisplayableName = { first: 'John', last: 'Wick' };
+        expect(matchesLegalName(name, legalName)).toBe(true);
+    });
+});

--- a/apps/modernization-ui/src/name/nameUtils.ts
+++ b/apps/modernization-ui/src/name/nameUtils.ts
@@ -1,0 +1,28 @@
+import { DisplayableName, NameFormat } from './types';
+
+/**
+ * Matches a name to the specified legal name. Default format is 'short' (first and last name only).
+ * @param {string} name The name to check
+ * @param {string} legalName The legal name checked against
+ * @param {NameFormat} format The format to display names in, either 'full', 'short' or 'fullLastFirst'. Default = 'short'.
+ * @return {boolean} True if matches.
+ */
+export const matchesLegalName = (
+    name: DisplayableName,
+    legalName?: DisplayableName | null | undefined,
+    format?: NameFormat
+): boolean => {
+    if (!name || !legalName) {
+        return false;
+    }
+    if (format === 'fullLastFirst' || format === 'full') {
+        return (
+            name?.first === legalName?.first &&
+            name?.middle === legalName?.middle &&
+            name?.last === legalName?.last &&
+            name?.suffix === legalName?.suffix
+        );
+    } else {
+        return name?.first === legalName?.first && name?.last === legalName?.last;
+    }
+};

--- a/apps/modernization-ui/src/name/types.ts
+++ b/apps/modernization-ui/src/name/types.ts
@@ -1,0 +1,9 @@
+export type NameFormat = 'full' | 'short' | 'fullLastFirst';
+
+export type DisplayableName = {
+    type?: string | null;
+    first?: string | null;
+    middle?: string | null;
+    last?: string | null;
+    suffix?: string | null;
+};


### PR DESCRIPTION
## Description

Implement the header for other names in search for list and table.

![image](https://github.com/user-attachments/assets/4240a0b5-5e2b-428a-bc67-65fa70cafebb)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3287)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
