### PR TITLE
Fixing dropdown input fields

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
@@ -130,7 +130,8 @@ const phoneEmailsExtended = (initial: NewPatientEntry): PhoneEmailEntry[] | unde
                 asOf: initial.asOf,
                 type: asSelectable('PH', 'Phone'),
                 use: asSelectable('WP', 'Primary work place'),
-                phoneNumber: initial.workPhone
+                phoneNumber: initial.workPhone,
+                extension: initial.extension ?? undefined
             });
         }
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
@@ -5,18 +5,19 @@ import { AddressView } from './AddressView';
 import { AddressEntryFields } from 'apps/patient/data/address/AddressEntryFields';
 import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { ReactNode } from 'react';
+import { asSelectable } from 'options';
 
 const defaultValue: Partial<AddressEntry> = {
     asOf: today(),
-    type: undefined,
-    use: undefined,
+    type: asSelectable(''),
+    use: asSelectable(''),
     address1: '',
     address2: '',
     city: '',
-    state: undefined,
+    state: null,
     zipcode: '',
-    county: undefined,
-    country: undefined,
+    county: null,
+    country: null,
     censusTract: '',
     comment: ''
 };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
@@ -5,11 +5,12 @@ import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { IdentificationView } from './IdentificationView';
 import { ReactNode } from 'react';
+import { asSelectable } from 'options';
 
 const defaultValue: Partial<IdentificationEntry> = {
     asOf: today(),
-    type: undefined,
-    issuer: undefined,
+    type: asSelectable(''),
+    issuer: asSelectable(''),
     id: ''
 };
 type Props = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
@@ -5,18 +5,19 @@ import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { NameEntryView } from './NameEntryView';
 import { ReactNode } from 'react';
+import { asSelectable } from 'options';
 
 const defaultValue: Partial<NameEntry> = {
     asOf: today(),
-    type: undefined,
-    prefix: undefined,
+    type: asSelectable(''),
+    prefix: null,
     first: '',
     middle: '',
     secondMiddle: '',
     last: '',
     secondLast: '',
-    suffix: undefined,
-    degree: undefined
+    suffix: null,
+    degree: null
 };
 
 const columns: Column<NameEntry>[] = [

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
@@ -5,11 +5,12 @@ import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { Column } from 'design-system/table';
 import { PhoneEntryView } from './PhoneEntryView';
 import { ReactNode } from 'react';
+import { asSelectable } from 'options';
 
 const defaultValue: Partial<PhoneEmailEntry> = {
     asOf: today(),
-    type: undefined,
-    use: undefined,
+    type: asSelectable(''),
+    use: asSelectable(''),
     countryCode: '',
     phoneNumber: '',
     extension: '',

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.spec.tsx
@@ -51,7 +51,7 @@ describe('RaceRepeatingBlock', () => {
     });
 
     it('should display proper defaults', async () => {
-        const { getByLabelText, getByRole } = render(
+        const { getByLabelText } = render(
             <RaceRepeatingBlock id="testing" onChange={onChange} isDirty={isDirty} />
         );
 
@@ -61,7 +61,7 @@ describe('RaceRepeatingBlock', () => {
         const race = getByLabelText('Race');
         expect(race).toHaveValue('');
 
-        const detailedRace = getByRole('combobox');
+        const detailedRace = getByLabelText('Detailed race');
         expect(detailedRace).toHaveValue('');
     });
 

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -12,14 +12,14 @@ type AdministrativeEntry = EffectiveDated & HasComments;
 
 type NameEntry = EffectiveDated & {
     type: Selectable;
-    prefix?: Selectable;
+    prefix?: Maybe<Selectable>;
     first?: string;
     middle?: string;
     secondMiddle?: string;
     last?: string;
     secondLast?: string;
-    suffix?: Selectable;
-    degree?: Selectable;
+    suffix?: Maybe<Selectable>;
+    degree?: Maybe<Selectable>;
 };
 
 type AddressEntry = EffectiveDated &
@@ -29,10 +29,10 @@ type AddressEntry = EffectiveDated &
         address1?: string;
         address2?: string;
         city?: string;
-        county?: Selectable;
-        state?: Selectable;
+        county?: Maybe<Selectable>;
+        state?: Maybe<Selectable>;
         zipcode?: string;
-        country?: Selectable;
+        country?: Maybe<Selectable>;
         censusTract?: string;
     };
 

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -12,14 +12,14 @@ type AdministrativeEntry = EffectiveDated & HasComments;
 
 type NameEntry = EffectiveDated & {
     type: Selectable;
-    prefix?: Maybe<Selectable>;
+    prefix: Maybe<Selectable>;
     first?: string;
     middle?: string;
     secondMiddle?: string;
     last?: string;
     secondLast?: string;
-    suffix?: Maybe<Selectable>;
-    degree?: Maybe<Selectable>;
+    suffix: Maybe<Selectable>;
+    degree: Maybe<Selectable>;
 };
 
 type AddressEntry = EffectiveDated &
@@ -29,10 +29,10 @@ type AddressEntry = EffectiveDated &
         address1?: string;
         address2?: string;
         city?: string;
-        county?: Maybe<Selectable>;
-        state?: Maybe<Selectable>;
+        county: Maybe<Selectable>;
+        state: Maybe<Selectable>;
         zipcode?: string;
-        country?: Maybe<Selectable>;
+        country: Maybe<Selectable>;
         censusTract?: string;
     };
 

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -164,12 +164,13 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="suffix"
-                render={({ field: { onChange, value, name } }) => (
+                render={({ field: { onBlur, onChange, value, name } }) => (
                     <SingleSelect
                         label="Suffix"
                         orientation="horizontal"
                         value={value}
                         onChange={onChange}
+                        onBlur={onBlur}
                         id={name}
                         name={name}
                         options={coded.suffixes}

--- a/apps/modernization-ui/src/apps/patient/data/race/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/entry.ts
@@ -1,5 +1,5 @@
 import { today } from 'date';
-import { Selectable } from 'options';
+import { asSelectable, Selectable } from 'options';
 import { EffectiveDated } from 'utils';
 
 type RaceEntry = EffectiveDated & {
@@ -15,7 +15,7 @@ export type { RaceEntry, RaceCategoryValidator };
 const initial = (asOf: string = today()): Partial<RaceEntry> => ({
     id: new Date().getTime(),
     asOf,
-    race: undefined,
+    race: asSelectable(''),
     detailed: []
 });
 


### PR DESCRIPTION
## Description

Bug where dropdown selections were still being retained when not expected. Have fixed that with all the dropdowns. Issue was the default value was being set to 'undefined' instead of either an empty selectable or null. So the change was made to all the non required fields, while the required fields just have a selectable of empty string.

## Tickets

* [CNFT1-3403](https://cdc-nbs.atlassian.net/browse/CNFT1-3403)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
