### PR TITLE
CNFT1-3349: Header for identifications in search

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -6,7 +6,8 @@ import {
     displayPhones,
     displayEmails,
     displayAddresses,
-    displayOtherNames
+    displayOtherNames,
+    displayIdentifications
 } from './patientSearchResult';
 
 describe('patientSearchResult functions', () => {
@@ -28,7 +29,16 @@ describe('patientSearchResult functions', () => {
                 type: 'Alias'
             }
         ],
-        identification: [],
+        identification: [
+            {
+                type: 'SSN',
+                value: '123-45-6789'
+            },
+            {
+                type: 'MRN',
+                value: '123456'
+            }
+        ],
         addresses: [
             {
                 use: 'Home',
@@ -88,5 +98,13 @@ describe('patientSearchResult functions', () => {
         const { getByText } = render(displayOtherNames(mockPatient));
         expect(getByText('Alias')).toBeInTheDocument();
         expect(getByText('Johnny TestnullTest')).toBeInTheDocument();
+    });
+
+    it('should render identifications correctly', () => {
+        const { getByText } = render(displayIdentifications(mockPatient));
+        expect(getByText('SSN')).toBeInTheDocument();
+        expect(getByText('123-45-6789')).toBeInTheDocument();
+        expect(getByText('MRN')).toBeInTheDocument();
+        expect(getByText('123456')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -2,6 +2,7 @@ import { PatientSearchResult } from 'generated/graphql/schema';
 import { displayName, displayNameElement, matchesLegalName } from 'name';
 import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
+import { ItemGroup } from 'design-system/item';
 
 const displayProfileLink = (shortId: number, displayName?: string) => {
     return <Link to={`/patient-profile/${shortId}/summary`}>{displayName || shortId}</Link>;
@@ -38,11 +39,25 @@ const displayAddresses = (result: PatientSearchResult): JSX.Element => (
 const displayPhones = (result: PatientSearchResult): string => result.phones.join('\n');
 const displayEmails = (result: PatientSearchResult): string => result.emails.join('\n');
 
+// Returns JSX that represents a list of IDs to display
+const displayIdentifications = (result: PatientSearchResult): JSX.Element => (
+    <div>
+        {result.identification.map((identification, index) => (
+            <div key={index}>
+                <ItemGroup type="other" label={identification.type}>
+                    {identification.value}
+                </ItemGroup>
+            </div>
+        ))}
+    </div>
+);
+
 export {
     displayOtherNames,
     displayProfileLink,
     displayProfileLegalName,
     displayPhones,
     displayAddresses,
-    displayEmails
+    displayEmails,
+    displayIdentifications
 };

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -7,12 +7,10 @@ import {
     displayProfileLink,
     displayOtherNames,
     displayEmails,
-    displayAddresses
+    displayAddresses,
+    displayIdentifications
 } from 'apps/search/patient/result';
 import { displayName } from 'name';
-
-const displayIdentifications = (result: PatientSearchResult): string =>
-    result.identification.map((identification) => identification.type + '\n' + identification.value).join('\n');
 
 // column definitions
 const PATIENT_ID = { id: 'patientid', name: 'Patient ID' };

--- a/apps/modernization-ui/src/design-system/item/ItemGroup.spec.tsx
+++ b/apps/modernization-ui/src/design-system/item/ItemGroup.spec.tsx
@@ -8,7 +8,7 @@ describe('ItemGroup Component', () => {
         expect(getByText('Test Children')).toBeDefined();
     });
 
-    it('renders with a label', () => {
+    it('renders with a header label', () => {
         const { getByText } = render(
             <ItemGroup label="Test Label">
                 <span>Test Child</span>
@@ -36,5 +36,25 @@ describe('ItemGroup Component', () => {
 
         const div = result.baseElement.querySelector('div.itemgroup');
         expect(div).toHaveAttribute('data-item-type', 'address');
+    });
+
+    it('renders with a <address> element when type is addressable', () => {
+        const result = render(
+            <ItemGroup type="address">
+                123 Happy St <br />
+                Farmington, NM 83640
+            </ItemGroup>
+        );
+
+        const addrElement = result.baseElement.querySelector('div.itemgroup > address');
+        expect(addrElement).toBeDefined();
+    });
+
+    it('renders with a <p> element when type is not addressable', () => {
+        const result = render(<ItemGroup type="other">Some information here</ItemGroup>);
+
+        const pElement = result.baseElement.querySelector('div.itemgroup > p');
+        expect(pElement).toBeDefined();
+        expect(pElement).toHaveAttribute('role', 'group');
     });
 });

--- a/apps/modernization-ui/src/design-system/item/ItemGroup.tsx
+++ b/apps/modernization-ui/src/design-system/item/ItemGroup.tsx
@@ -1,15 +1,20 @@
 import { ReactNode } from 'react';
 import styles from './item.module.scss';
 
-type ItemType = 'address' | 'phone' | 'name' | 'other';
+type AddressableType = 'address' | 'phone' | 'email';
+type ItemType = AddressableType | 'name' | 'other';
 
 type Props = { type?: ItemType; label?: string; children: ReactNode };
 
+const isAddressType = (type?: ItemType): type is AddressableType =>
+    type != null && ['address', 'phone', 'email'].includes(type);
+
 const ItemGroup = ({ type, label, children }: Props) => {
+    const isAddress = isAddressType(type);
     return (
         <div className={styles.itemgroup} {...(type && { 'data-item-type': type })}>
             {label && <header>{label}</header>}
-            <p>{children}</p>
+            {isAddress ? <address>{children}</address> : <p role="group">{children}</p>}
         </div>
     );
 };

--- a/apps/modernization-ui/src/design-system/item/item.module.scss
+++ b/apps/modernization-ui/src/design-system/item/item.module.scss
@@ -5,7 +5,7 @@
         font-weight: bold;
     }
     
-    p {
+    p, address {
         margin-top: 0;
         margin-bottom: 0;
         word-break: break-word;


### PR DESCRIPTION
## Description

Implement headers for identifications in search, similar to names and addresses.

![image](https://github.com/user-attachments/assets/875afa4f-f5ba-4943-a240-577e55a5b985)

**Note: Approve https://github.com/CDCgov/NEDSS-Modernization/pull/1941 first**

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3349)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
