### PR TITLE
[CNFT1-3372] Numeric values only

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended-form.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended-form.module.scss
@@ -14,10 +14,6 @@
         @include borders.rounded();
     }
 
-    input {
-        background-color: colors.$base-white;
-    }
-
     .formContent {
         display: flex;
         flex-direction: column;

--- a/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
@@ -6,6 +6,7 @@ import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { SingleSelect } from 'design-system/select';
 import { maxLengthRule } from 'validation/entry';
 import { Input } from 'components/FormInputs/Input';
+import { NumericInput } from 'design-system/input';
 
 export const GeneralInformationEntryFields = () => {
     const { control } = useFormContext<{ general: GeneralInformationEntry }>();
@@ -73,17 +74,15 @@ export const GeneralInformationEntryFields = () => {
                 name="general.adultsInResidence"
                 rules={{ min: { value: 0, message: 'Must be greater than 0' } }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
-                    <Input
+                    <NumericInput
                         label="Number of adults in residence"
                         orientation="horizontal"
-                        placeholder="No Data"
                         onBlur={onBlur}
                         onChange={onChange}
-                        type="number"
-                        defaultValue={value?.toString() ?? ''}
+                        value={value}
                         id={name}
                         name={name}
-                        htmlFor={name}
+                        min="0"
                         error={error?.message}
                     />
                 )}
@@ -93,17 +92,15 @@ export const GeneralInformationEntryFields = () => {
                 name="general.childrenInResidence"
                 rules={{ min: { value: 0, message: 'Must be greater than 0' } }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
-                    <Input
+                    <NumericInput
                         label="Number of children in residence"
                         orientation="horizontal"
-                        placeholder="No Data"
                         onBlur={onBlur}
                         onChange={onChange}
-                        type="number"
-                        defaultValue={value?.toString() ?? ''}
+                        value={value}
                         id={name}
                         name={name}
-                        htmlFor={name}
+                        min="0"
                         error={error?.message}
                     />
                 )}

--- a/apps/modernization-ui/src/apps/patient/data/general/asGeneral.ts
+++ b/apps/modernization-ui/src/apps/patient/data/general/asGeneral.ts
@@ -3,17 +3,30 @@ import { GeneralInformation } from '../api';
 import { GeneralInformationEntry } from '../entry';
 
 const asGeneral = (entry: GeneralInformationEntry): GeneralInformation => {
-    const { maritalStatus, primaryOccupation, educationLevel, speaksEnglish, primaryLanguage, ...remaining } = entry;
-
-    console.log(remaining);
+    const {
+        asOf,
+        maternalMaidenName,
+        adultsInResidence,
+        childrenInResidence,
+        maritalStatus,
+        primaryOccupation,
+        educationLevel,
+        speaksEnglish,
+        primaryLanguage,
+        stateHIVCase
+    } = entry;
 
     return {
+        asOf,
+        maternalMaidenName,
+        adultsInResidence,
+        childrenInResidence,
         maritalStatus: asValue(maritalStatus),
         primaryOccupation: asValue(primaryOccupation),
         educationLevel: asValue(educationLevel),
         speaksEnglish: asValue(speaksEnglish),
         primaryLanguage: asValue(primaryLanguage),
-        ...remaining
+        stateHIVCase
     };
 };
 

--- a/apps/modernization-ui/src/apps/patient/data/general/asGeneral.ts
+++ b/apps/modernization-ui/src/apps/patient/data/general/asGeneral.ts
@@ -5,6 +5,8 @@ import { GeneralInformationEntry } from '../entry';
 const asGeneral = (entry: GeneralInformationEntry): GeneralInformation => {
     const { maritalStatus, primaryOccupation, educationLevel, speaksEnglish, primaryLanguage, ...remaining } = entry;
 
+    console.log(remaining);
+
     return {
         maritalStatus: asValue(maritalStatus),
         primaryOccupation: asValue(primaryOccupation),

--- a/apps/modernization-ui/src/design-system/input/index.ts
+++ b/apps/modernization-ui/src/design-system/input/index.ts
@@ -1,0 +1,1 @@
+export { NumericInput } from './numeric';

--- a/apps/modernization-ui/src/design-system/input/numeric/NumericInput.spec.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/NumericInput.spec.tsx
@@ -1,0 +1,77 @@
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { NumericInput } from './NumericInput';
+import userEvent from '@testing-library/user-event';
+
+describe('when entering numeric values', () => {
+    it('should render with no accessibility violations', async () => {
+        const { container } = render(<NumericInput id={'testing-input'} label={'Numeric Input test'} />);
+
+        expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('should render successfully', () => {
+        const { getByRole } = render(<NumericInput id={'testing-input'} label={'Numeric Input test'} />);
+
+        const input = getByRole('spinbutton', { name: 'Numeric Input test' });
+
+        expect(input).toHaveClass('usa-input');
+        expect(input).toHaveAttribute('type', 'number');
+    });
+
+    it('should alert when value changed', () => {
+        const onChange = jest.fn();
+
+        const { getByRole } = render(
+            <NumericInput id={'testing-input'} label={'Numeric Input test'} onChange={onChange} />
+        );
+
+        const input = getByRole('spinbutton', { name: 'Numeric Input test' });
+
+        userEvent.type(input, '7');
+        userEvent.tab();
+
+        expect(onChange).toHaveBeenCalledWith(7);
+    });
+
+    it('should allow entry of numeric values', () => {
+        const { getByRole } = render(<NumericInput id={'testing-input'} label={'Numeric Input test'} />);
+
+        const input = getByRole('spinbutton', { name: 'Numeric Input test' });
+
+        userEvent.type(input, '7');
+        userEvent.tab();
+
+        expect(input).toHaveValue(7);
+    });
+
+    it('should allow pasting of numeric values', () => {
+        const { getByRole } = render(<NumericInput id={'testing-input'} label={'Numeric Input test'} />);
+
+        const input = getByRole('spinbutton', { name: 'Numeric Input test' });
+
+        userEvent.paste(input, '743');
+        userEvent.tab();
+
+        expect(input).toHaveValue(743);
+    });
+
+    it('should not allow alpha characters values', () => {
+        const { getByRole } = render(<NumericInput id={'testing-input'} label={'Numeric Input test'} />);
+
+        const input = getByRole('spinbutton', { name: 'Numeric Input test' });
+
+        userEvent.type(input, 'a');
+        userEvent.tab();
+
+        expect(input).not.toHaveValue();
+    });
+
+    it('should display given value', () => {
+        const { getByRole } = render(<NumericInput id={'testing-input'} label={'Numeric Input test'} value={5} />);
+
+        const input = getByRole('spinbutton', { name: 'Numeric Input test' });
+
+        expect(input).toHaveValue(5);
+    });
+});

--- a/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
@@ -1,0 +1,94 @@
+import {
+    ChangeEvent as ReactChangeEvent,
+    KeyboardEvent as ReactKeyboardEvent,
+    useEffect,
+    useMemo,
+    useState
+} from 'react';
+import classNames from 'classnames';
+import { EntryWrapper, Orientation, Sizing } from 'components/Entry';
+
+type NumericOnChange = (value?: number) => void;
+
+const handleKeydown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (!event.altKey && !event.ctrlKey && !event.metaKey && /Space|Key*/.test(event.code)) {
+        //  prevents spaces and letter characters from being entered but allows keyboard short cuts like (crtl-v)
+        event.preventDefault();
+    }
+};
+
+const asDisplay = (value?: string | number | null) => (value === undefined ? '' : `${value}`);
+
+type NumericInputProps = {
+    id: string;
+    label: string;
+    value?: number;
+    onChange?: NumericOnChange;
+    orientation?: Orientation;
+    sizing?: Sizing;
+    error?: string;
+    required?: boolean;
+} & Omit<JSX.IntrinsicElements['input'], 'defaultValue' | 'onChange' | 'value' | 'type'>;
+
+const NumericInput = ({
+    id,
+    name,
+    label,
+    value,
+    onChange,
+    orientation,
+    sizing,
+    error,
+    required,
+    className,
+    placeholder = 'No Data',
+    ...props
+}: NumericInputProps) => {
+    const [current, setCurrent] = useState<number | undefined>(value);
+
+    useEffect(() => {
+        onChange?.(current);
+    }, [current, onChange]);
+
+    const display = useMemo(() => asDisplay(current), [current]);
+
+    const handleChange = (event: ReactChangeEvent<HTMLInputElement>) => {
+        const next = event.target.value;
+
+        if (next === '') {
+            setCurrent(undefined);
+        } else if (Number.isNaN(next)) {
+            event.preventDefault();
+        } else {
+            const adjusted = Number(next);
+            if (!Number.isNaN(adjusted)) {
+                setCurrent(Number(next));
+            }
+        }
+    };
+
+    return (
+        <EntryWrapper
+            orientation={orientation}
+            sizing={sizing}
+            label={label}
+            htmlFor={id}
+            required={required}
+            error={error}>
+            <input
+                id={id}
+                name={name}
+                className={classNames('usa-input', className)}
+                type="number"
+                onChange={handleChange}
+                placeholder={placeholder}
+                value={display}
+                pattern="[0-9]*"
+                onKeyDown={handleKeydown}
+                {...props}
+            />
+        </EntryWrapper>
+    );
+};
+
+export { NumericInput };

--- a/apps/modernization-ui/src/design-system/input/numeric/index.ts
+++ b/apps/modernization-ui/src/design-system/input/numeric/index.ts
@@ -1,0 +1,1 @@
+export { NumericInput } from './NumericInput';


### PR DESCRIPTION
## Description

Prevents the entry of non-muerica characters by adding a `NumericInput` component. The "Number of adults in residence" and "Number of children in residence" from the General information section now use this component.

## Tickets

* [CNFT1-3372](https://cdc-nbs.atlassian.net/browse/CNFT1-3372)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3372]: https://cdc-nbs.atlassian.net/browse/CNFT1-3372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ