### PR TITLE
Quick fix for a bug introduced in refactoring / merge conflict resolution

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
@@ -179,7 +179,7 @@ describe('PatientSearchResultListItem', () => {
             </MemoryRouter>
         );
 
-        expect(getByText('Jane Doe')).toBeInTheDocument();
+        expect(getByText('Doe, Jane')).toBeInTheDocument();
     });
 
     it('should render each identification', () => {

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -97,7 +97,7 @@ describe('patientSearchResult functions', () => {
     it('should render other names with header and content', () => {
         const { getByText } = render(displayOtherNames(mockPatient));
         expect(getByText('Alias')).toBeInTheDocument();
-        expect(getByText('Johnny TestnullTest')).toBeInTheDocument();
+        expect(getByText('TestnullTest, Johnny')).toBeInTheDocument();
     });
 
     it('should render identifications with header and content', () => {

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -22,7 +22,7 @@ const displayOtherNames = (result: PatientSearchResult, order: 'normal' | 'rever
             {patientSearchResultNames
                 .filter((name) => !matchesLegalName(name, legalName))
                 .map((name, index) => (
-                    <div key={index}>{displayNameElement(name)}</div>
+                    <div key={index}>{displayNameElement(name, 'fullLastFirst')}</div>
                 ))}
         </div>
     );
@@ -41,7 +41,7 @@ const displayPhones = (result: PatientSearchResult): string => result.phones.joi
 const displayEmails = (result: PatientSearchResult): string => result.emails.join('\n');
 const displayPatientName = (result: PatientSearchResult): JSX.Element => (
     <div>
-        {result.legalName && displayNameElement(result.legalName)}
+        {result.legalName && displayNameElement(result.legalName, 'fullLastFirst')}
         {displayOtherNames(result, 'reverse')}
     </div>
 );

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -22,7 +22,7 @@ const displayOtherNames = (result: PatientSearchResult, order: 'normal' | 'rever
             {patientSearchResultNames
                 .filter((name) => !matchesLegalName(name, legalName))
                 .map((name, index) => (
-                    <div key={index}>{displayNameElement(name, 'fullLastFirst')}</div>
+                    <div key={index}>{displayNameElement(name)}</div>
                 ))}
         </div>
     );
@@ -41,7 +41,7 @@ const displayPhones = (result: PatientSearchResult): string => result.phones.joi
 const displayEmails = (result: PatientSearchResult): string => result.emails.join('\n');
 const displayPatientName = (result: PatientSearchResult): JSX.Element => (
     <div>
-        {result.legalName && displayNameElement(result.legalName, 'fullLastFirst')}
+        {result.legalName && displayNameElement(result.legalName)}
         {displayOtherNames(result, 'reverse')}
     </div>
 );

--- a/apps/modernization-ui/src/name/displayNameElement.spec.tsx
+++ b/apps/modernization-ui/src/name/displayNameElement.spec.tsx
@@ -7,7 +7,7 @@ describe('displayNameElement', () => {
         const name: DisplayableName = { first: 'John', last: 'Doe', type: 'Home' };
         const { getByText } = render(displayNameElement(name));
         expect(getByText('Home')).toBeInTheDocument();
-        expect(getByText('John Doe')).toBeInTheDocument();
+        expect(getByText('Doe, John')).toBeInTheDocument();
     });
 
     it('should render full name format by default with label', () => {

--- a/apps/modernization-ui/src/name/displayNameElement.tsx
+++ b/apps/modernization-ui/src/name/displayNameElement.tsx
@@ -7,7 +7,7 @@ import { DisplayableName, NameFormat } from './types';
  * @param {NameFormat} format - The format to display names in, either 'full', 'short' or 'fullLastFirst'. Default = 'full'.
  * @return {JSX.Element} The address block as JSX.
  */
-export const displayNameElement = (name: DisplayableName, format?: NameFormat): JSX.Element => {
+export const displayNameElement = (name: DisplayableName, format: NameFormat = 'fullLastFirst'): JSX.Element => {
     const nameText = displayName(format)(name);
     const nameHeader = name.type ?? undefined;
     return (


### PR DESCRIPTION
apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx

names now display as Last, First:  `displayNameElement(result.legalName, 'fullLastFirst')}`