### PR TITLE
[CNFT1-3406] adds short form patient data entry object

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/PatientCreatedPanel.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/PatientCreatedPanel.tsx
@@ -1,6 +1,6 @@
 import { Modal } from 'design-system/modal';
 import { Message } from 'design-system/message';
-import { CreatedPatient } from './extended/api';
+import { CreatedPatient } from './api';
 import { displayName } from 'name';
 import { ClassicButton } from 'classic';
 import { NavLinkButton } from 'components/button/nav/NavLinkButton';

--- a/apps/modernization-ui/src/apps/patient/add/api.ts
+++ b/apps/modernization-ui/src/apps/patient/add/api.ts
@@ -35,4 +35,7 @@ type CreatedPatient = {
     };
 };
 
-export type { NewPatient, CreatedPatient };
+type Transformer<E> = (entry: E) => NewPatient;
+type Creator = (input: NewPatient) => Promise<CreatedPatient>;
+
+export type { NewPatient, CreatedPatient, Transformer, Creator };

--- a/apps/modernization-ui/src/apps/patient/add/basic/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/entry.ts
@@ -1,0 +1,74 @@
+import { today } from 'date';
+import { AdministrativeEntry, IdentificationEntry } from 'apps/patient/data/entry';
+import { Selectable } from 'options';
+
+type NameInformationEntry = {
+    last?: string;
+    first?: string;
+    middle?: string;
+    suffix?: Selectable;
+};
+
+type OtherInformationEntry = {
+    bornOn?: string;
+    currentSex?: Selectable;
+    birthSex?: Selectable;
+    deceased?: Selectable;
+    deceasedOn?: string;
+    maritalStatus?: Selectable;
+    stateHIVCase?: string;
+};
+
+type BasicAddressEntry = {
+    address1?: string;
+    address2?: string;
+    city?: string;
+    county?: Selectable;
+    state?: Selectable;
+    zipcode?: string;
+    country?: Selectable;
+    censusTract?: string;
+};
+
+type BasicPhoneEmail = {
+    home?: string;
+    work?: { phone: string; extension?: string };
+    cell?: string;
+    email?: string;
+};
+
+type BasicEthnicityRace = {
+    ethnicity?: Selectable;
+    races?: Selectable[];
+};
+
+type BasicIdentificationEntry = Omit<IdentificationEntry, 'asOf'>;
+
+type BasicNewPatientEntry = {
+    administrative: AdministrativeEntry;
+    name?: NameInformationEntry;
+    other?: OtherInformationEntry;
+    address?: BasicAddressEntry;
+    phoneEmail?: BasicPhoneEmail;
+    ethnicityRace?: BasicEthnicityRace;
+    identifications?: BasicIdentificationEntry[];
+};
+
+export type {
+    BasicNewPatientEntry,
+    NameInformationEntry,
+    OtherInformationEntry,
+    BasicAddressEntry,
+    BasicPhoneEmail,
+    BasicEthnicityRace,
+    BasicIdentificationEntry
+};
+
+const initial = (asOf: string = today()): BasicNewPatientEntry => ({
+    administrative: {
+        asOf: asOf
+    },
+    identifications: []
+});
+
+export { initial };

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
-import { CreatedPatient } from './api';
+import { CreatedPatient } from '../api';
 import { creator } from './creator';
 import { transformer } from './transformer';
 import { ExtendedNewPatientEntry } from './entry';

--- a/apps/modernization-ui/src/apps/patient/add/extended/creator.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/creator.ts
@@ -1,6 +1,6 @@
 import { PatientProfileService } from 'generated';
 import { Creator } from './useAddExtendedPatient';
-import { NewPatient } from './api';
+import { NewPatient } from '../api';
 
 const creator: Creator = (input: NewPatient) => PatientProfileService.create({ requestBody: input });
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/transformer.ts
@@ -1,3 +1,4 @@
+import { maybeMap, maybeMapAll } from 'utils/mapping';
 import {
     asAddress,
     asAdministrative,
@@ -12,19 +13,8 @@ import {
     asGeneral
 } from 'apps/patient/data';
 import { ExtendedNewPatientEntry } from './entry';
-import { Transformer } from './useAddExtendedPatient';
-import { Mapping } from 'utils';
-import { NewPatient } from './api';
 
-const maybeMap =
-    <R, S>(mapping: Mapping<R, S>) =>
-    (value?: R): S | undefined =>
-        value ? mapping(value) : undefined;
-
-const maybeMapAll =
-    <R, S>(mapping: Mapping<R, S>) =>
-    (value?: R[]): S[] =>
-        value ? value.map(mapping) : [];
+import { NewPatient, Transformer } from 'apps/patient/add/api';
 
 const asNames = maybeMapAll(asName);
 const asAddresses = maybeMapAll(asAddress);
@@ -39,7 +29,7 @@ const maybeBirth = maybeMap(asBirth);
 const maybeMortality = maybeMap(asMortality);
 const maybeGeneral = maybeMap(asGeneral);
 
-const transformer: Transformer = (entry: ExtendedNewPatientEntry): NewPatient => {
+const transformer: Transformer<ExtendedNewPatientEntry> = (entry: ExtendedNewPatientEntry): NewPatient => {
     const administrative = mabyeAsAdministrative(entry.administrative);
     const names = asNames(entry.names);
     const addresses = asAddresses(entry.addresses);

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.spec.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import { Settings, useAddExtendedPatient } from './useAddExtendedPatient';
 import { ExtendedNewPatientEntry } from './entry';
-import { NewPatient } from './api';
+import { NewPatient } from 'apps/patient/add/api';
 import { Invalid } from './useAddExtendedPatientInteraction';
 
 const setup = (settings?: Partial<Settings>) => {

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
-import { CreatedPatient, NewPatient } from './api';
+import { CreatedPatient, NewPatient, Creator, Transformer } from 'apps/patient/add/api';
 import { ExtendedNewPatientEntry } from './entry';
 import {
     AddExtendedPatientInteraction,
@@ -46,13 +46,10 @@ const reducer = (current: Step, action: Action): Step => {
     }
 };
 
-type Transformer = (entry: ExtendedNewPatientEntry) => NewPatient;
-type Creator = (input: NewPatient) => Promise<CreatedPatient>;
-
 type State = Working | Created | Invalid;
 
 type Settings = {
-    transformer: Transformer;
+    transformer: Transformer<ExtendedNewPatientEntry>;
     creator: Creator;
 };
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatientInteraction.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatientInteraction.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext } from 'react';
-import { CreatedPatient } from './api';
+import { CreatedPatient } from 'apps/patient/add/api';
 import { ExtendedNewPatientEntry } from './entry';
 
 type Working = {

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -1,5 +1,5 @@
 import { Selectable } from 'options';
-import { EffectiveDated, HasComments, Maybe } from 'utils';
+import { EffectiveDated, HasComments } from 'utils';
 
 type LocationEntry = {
     city?: string;

--- a/apps/modernization-ui/src/utils/index.ts
+++ b/apps/modernization-ui/src/utils/index.ts
@@ -9,7 +9,8 @@ export * from './mapIf';
 
 export type { Predicate } from './predicate';
 
-type Mapping<I, O> = (input: I) => O;
+export type { Mapping } from './mapping';
+
 type Maybe<V> = V | null | undefined;
 type EffectiveDated = {
     asOf: string;
@@ -19,4 +20,4 @@ type HasComments = {
     comment?: string;
 };
 
-export type { Mapping, Maybe, EffectiveDated, HasComments };
+export type { Maybe, EffectiveDated, HasComments };

--- a/apps/modernization-ui/src/utils/mapping/index.ts
+++ b/apps/modernization-ui/src/utils/mapping/index.ts
@@ -1,0 +1,4 @@
+export { maybeMap } from './maybeMap';
+export { maybeMapAll } from './maybeMapAll';
+
+export type { Mapping } from './mapping';

--- a/apps/modernization-ui/src/utils/mapping/mapping.ts
+++ b/apps/modernization-ui/src/utils/mapping/mapping.ts
@@ -1,0 +1,3 @@
+type Mapping<I, O> = (input: I) => O;
+
+export type { Mapping };

--- a/apps/modernization-ui/src/utils/mapping/maybeMap.ts
+++ b/apps/modernization-ui/src/utils/mapping/maybeMap.ts
@@ -1,0 +1,8 @@
+import { Mapping } from './mapping';
+
+const maybeMap =
+    <R, S>(mapping: Mapping<R, S>) =>
+    (value?: R): S | undefined =>
+        value ? mapping(value) : undefined;
+
+export { maybeMap };

--- a/apps/modernization-ui/src/utils/mapping/maybeMapAll.ts
+++ b/apps/modernization-ui/src/utils/mapping/maybeMapAll.ts
@@ -1,0 +1,8 @@
+import { Mapping } from './mapping';
+
+const maybeMapAll =
+    <R, S>(mapping: Mapping<R, S>) =>
+    (value?: R[]): S[] =>
+        value ? value.map(mapping) : [];
+
+export { maybeMapAll };


### PR DESCRIPTION
## Description

Adds short form patient data entry object and refactors/ moves around some files to allow both add pages to use the same hook for patient creation in the near future.

- `mapping`, `maybeMap`, and `maybeMapAll` have been moved to the `utils` folder
- The `Transformer` and `Creator` types were moved to the `add` folder
- The `Transformer` function was made generic

These changes will make more sense with the New patient short form API integration story.

## Tickets

* [CNFT1-3406](https://cdc-nbs.atlassian.net/browse/CNFT1-3406)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3406]: https://cdc-nbs.atlassian.net/browse/CNFT1-3406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ