### PR TITLE
[CNFT1-3339]-adding dash for first last names and tests

### DIFF
--- a/apps/modernization-ui/src/name/displayName.spec.ts
+++ b/apps/modernization-ui/src/name/displayName.spec.ts
@@ -100,7 +100,7 @@ describe('when given a partial name', () => {
 
         const actual = displayName('fullLastFirst')(name);
 
-        expect(actual).toBe('Ted');
+        expect(actual).toBe('--, Ted');
     });
 
     it('should display the last name with fullLastFirst format', () => {
@@ -110,6 +110,6 @@ describe('when given a partial name', () => {
 
         const actual = displayName('fullLastFirst')(name);
 
-        expect(actual).toBe('Logan');
+        expect(actual).toBe('Logan, --');
     });
 });

--- a/apps/modernization-ui/src/name/displayName.ts
+++ b/apps/modernization-ui/src/name/displayName.ts
@@ -39,8 +39,8 @@ const displayFullName = ({ first, middle, last, suffix }: DisplayableName) => {
 };
 
 const displayFullNameLastFirst = ({ first, middle, last, suffix }: DisplayableName) => {
-    const firstMiddle = [first, middle].filter(exists).join(' ');
-    const name = [last, firstMiddle].filter(exists).join(', ');
+    const firstMiddle = [first || '--', middle].filter(exists).join(' ');
+    const name = [last || '--', firstMiddle].filter(exists).join(', ');
     return [name, suffix].filter(exists).join(', ');
 };
 


### PR DESCRIPTION
## Description

Adding dash for when there is no first or last name

## Tickets

* [CNFT1-3339](https://cdc-nbs.atlassian.net/browse/CNFT1-3339)

<img width="617" alt="Screen Shot 2024-10-22 at 8 24 01 AM" src="https://github.com/user-attachments/assets/789e10aa-8920-4d04-9c21-9ec33712b99f">
<img width="983" alt="Screen Shot 2024-10-22 at 8 24 41 AM" src="https://github.com/user-attachments/assets/bed48535-d3b6-4d76-a382-82acb23dce1a">

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3339]: https://cdc-nbs.atlassian.net/browse/CNFT1-3339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ