### PR TITLE
[CNFT1-3423]: correcting content for delete modal in patient profile

### DIFF
--- a/apps/modernization-ui/src/apps/patient/profile/PatientProfile.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/PatientProfile.tsx
@@ -44,9 +44,7 @@ export const PatientProfile = () => {
                             labelPosition="right">
                             Print
                         </Button>
-                        {permissions.delete && patient && summary && (
-                            <DeletePatient patient={patient} summary={summary} />
-                        )}
+                        {permissions.delete && patient && <DeletePatient patient={patient} />}
                     </div>
                 </header>
                 <main className="main-body">

--- a/apps/modernization-ui/src/apps/patient/profile/delete/DeletePatient.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/delete/DeletePatient.spec.tsx
@@ -1,0 +1,139 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useAlert } from 'alert';
+import { useSearchNavigation } from 'apps/search';
+import { useProfileContext } from '../ProfileContext';
+import { DeletePatient } from './DeletePatient';
+import { DeletabilityResult, resolveDeletability } from './resolveDeletability';
+import { useDeletePatientMutation } from 'generated/graphql/schema';
+
+jest.mock('alert', () => ({
+    useAlert: jest.fn()
+}));
+
+jest.mock('apps/search', () => ({
+    useSearchNavigation: jest.fn()
+}));
+
+jest.mock('../ProfileContext', () => ({
+    useProfileContext: jest.fn()
+}));
+
+jest.mock('generated/graphql/schema', () => ({
+    useDeletePatientMutation: jest.fn()
+}));
+
+jest.mock('./resolveDeletability', () => ({
+    resolveDeletability: jest.fn(),
+    DeletabilityResult: {
+        Deletable: 0,
+        Associations: 1,
+        Inactive: 2
+    }
+}));
+
+const mockPatient = {
+    id: '10056284',
+    local: 'PSN10091000GA01',
+    shortId: 91000,
+    version: 10,
+    deletable: true,
+    status: 'ACTIVE',
+    summary: {
+        legalName: {
+            first: 'sdfaszxc',
+            middle: null,
+            last: ''
+        },
+        birthday: null,
+        age: null,
+        gender: 'Female'
+    }
+};
+
+describe('DeletePatient Component', () => {
+    beforeEach(() => {
+        (useAlert as jest.Mock).mockReturnValue({
+            showSuccess: jest.fn(),
+            showError: jest.fn()
+        });
+
+        (useSearchNavigation as jest.Mock).mockReturnValue({
+            go: jest.fn()
+        });
+
+        (useProfileContext as jest.Mock).mockReturnValue({
+            summary: mockPatient.summary
+        });
+
+        (useDeletePatientMutation as jest.Mock).mockReturnValue([jest.fn()]);
+    });
+
+    it('should handle the deletion flow', async () => {
+        (resolveDeletability as jest.Mock).mockReturnValue(DeletabilityResult.Deletable);
+        const { getByRole, getByText } = render(<DeletePatient patient={mockPatient} />);
+
+        const deleteButton = getByRole('button', { name: /delete patient/i });
+        userEvent.click(deleteButton);
+
+        expect(getByText('Permanently delete patient?')).toBeInTheDocument();
+        const confirmButton = getByRole('button', {
+            name: 'Yes, delete'
+        });
+        userEvent.click(confirmButton);
+    });
+
+    it('should show first name only if it is present on dialog', async () => {
+        (resolveDeletability as jest.Mock).mockReturnValue(DeletabilityResult.Deletable);
+        const { getByRole, getByText } = render(<DeletePatient patient={mockPatient} />);
+
+        const deleteButton = getByRole('button', { name: /delete patient/i });
+        userEvent.click(deleteButton);
+
+        expect(getByText('--, sdfaszxc')).toBeInTheDocument();
+    });
+
+    it('should show last name only if it is present on dialog', async () => {
+        (resolveDeletability as jest.Mock).mockReturnValue(DeletabilityResult.Deletable);
+        const mockPatientWithLastName = {
+            ...mockPatient,
+            summary: {
+                ...mockPatient.summary,
+                legalName: { ...mockPatient.summary.legalName, last: 'test last', first: '' }
+            }
+        };
+
+        (useProfileContext as jest.Mock).mockReturnValue({
+            summary: mockPatientWithLastName.summary
+        });
+
+        const { getByRole, getByText } = render(<DeletePatient patient={mockPatientWithLastName} />);
+
+        const deleteButton = getByRole('button', { name: /delete patient/i });
+        userEvent.click(deleteButton);
+
+        expect(getByText('test last, --')).toBeInTheDocument();
+    });
+
+    it('should show warning if patient has associations', () => {
+        (resolveDeletability as jest.Mock).mockReturnValue(DeletabilityResult.Has_Associations);
+
+        const { getByRole, getByText } = render(<DeletePatient patient={mockPatient} />);
+
+        const deleteButton = getByRole('button', { name: /delete patient/i });
+        userEvent.click(deleteButton);
+
+        expect(getByText('This patient file is inactive and cannot be deleted.')).toBeInTheDocument();
+    });
+
+    it('should show warning if patient is inactive', () => {
+        (resolveDeletability as jest.Mock).mockReturnValue(DeletabilityResult.Is_Inactive);
+
+        const { getByRole, getByText } = render(<DeletePatient patient={mockPatient} />);
+
+        const deleteButton = getByRole('button', { name: /delete patient/i });
+        userEvent.click(deleteButton);
+
+        expect(getByText('This patient file is inactive and cannot be deleted.')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/profile/delete/DeletePatient.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/delete/DeletePatient.tsx
@@ -1,4 +1,4 @@
-import { DeletePatientMutation, PatientSummary, useDeletePatientMutation } from 'generated/graphql/schema';
+import { DeletePatientMutation, useDeletePatientMutation } from 'generated/graphql/schema';
 import { Icon } from 'design-system/icon';
 import { Confirmation, Warning } from 'design-system/modal';
 import { useAlert } from 'alert';
@@ -11,23 +11,23 @@ import { DeletabilityResult, resolveDeletability } from './resolveDeletability';
 
 import { useSearchNavigation } from 'apps/search';
 import { Button } from 'components/button';
+import { useProfileContext } from '../ProfileContext';
 
 type Props = {
     patient: Patient;
-    summary: PatientSummary;
 };
 
-const DeletePatient = ({ patient, summary }: Props) => {
+const DeletePatient = ({ patient }: Props) => {
     const { showSuccess, showError } = useAlert();
-
     const { go } = useSearchNavigation();
+    const { summary } = useProfileContext();
 
     const deletability = resolveDeletability(patient);
 
     const handleDeleteComplete = (data: DeletePatientMutation) => {
         if (data.deletePatient.__typename === 'PatientDeleteSuccessful') {
             showSuccess({
-                message: `Deleted patient ${(summary.legalName && displayName('short')(summary.legalName)) || patient.shortId}`
+                message: `Deleted patient ${(summary?.legalName && displayName('short')(summary.legalName)) || patient.shortId}`
             });
             go();
         } else if (data.deletePatient.__typename === 'PatientDeleteFailed') {
@@ -64,12 +64,12 @@ const DeletePatient = ({ patient, summary }: Props) => {
                             confirmText="Yes, delete"
                             onConfirm={handleDeletePatient}>
                             Would you like to permanently delete patient record <strong>{patient?.shortId}</strong>
-                            {summary.legalName && (
+                            {summary?.legalName && (
                                 <>
-                                    , <strong>{displayName()(summary.legalName)}</strong>
+                                    , <strong>{displayName('fullLastFirst')(summary.legalName)}</strong>
                                 </>
                             )}
-                            ,
+                            .
                         </Confirmation>
                     </Shown>
                     <Shown when={deletability === DeletabilityResult.Has_Associations}>


### PR DESCRIPTION
## Description

1.  Delete patient modal, message displays a “,“ at the end of message. Replace “, “ with a  “.“
2. When there is no name for a patient, then the modal is displayed as:  Patient Id Number followed by ",," -> Solution: When there is no patient name then the message is displayed as “Patient ID, --,--. “
3. When there is no last name/ first name for a patient, then the modal is displayed as: "FirstName, " or "LastName," -> Solution: When there is no patient name - last name/ first name then the message is displayed as “Patient ID, test,--. “/ “Patient ID, --,test. “
4. When patient name is updated in Patient profile, Its not reflecting when deleting a patient:

Patient name was updated from “test,--” to “Something,--” but the modal is still displayed as: "test,--" -> Solution: When there is a change in the patient name then delete patient modal has to have the updated patient name.

## Tickets

* [CNFT1-3423](https://cdc-nbs.atlassian.net/browse/CNFT1-3423)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3423]: https://cdc-nbs.atlassian.net/browse/CNFT1-3423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ