### PR TITLE
[CNFT1-3408] basic add patient api integration

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/entry.ts
@@ -30,9 +30,11 @@ type BasicAddressEntry = {
     censusTract?: string;
 };
 
+type BasicWorkPhone = { phone: string; extension?: string };
+
 type BasicPhoneEmail = {
     home?: string;
-    work?: { phone: string; extension?: string };
+    work?: BasicWorkPhone;
     cell?: string;
     email?: string;
 };
@@ -59,6 +61,7 @@ export type {
     NameInformationEntry,
     OtherInformationEntry,
     BasicAddressEntry,
+    BasicWorkPhone,
     BasicPhoneEmail,
     BasicEthnicityRace,
     BasicIdentificationEntry

--- a/apps/modernization-ui/src/apps/patient/add/basic/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/transformer.spec.ts
@@ -1,0 +1,585 @@
+import { BasicNewPatientEntry } from './entry';
+import { transformer } from './transformer';
+
+describe('when transforming entered basic patient data', () => {
+    it('should transform general information to a format accepted by the API', () => {
+        const entry: BasicNewPatientEntry = {
+            administrative: { asOf: '04/13/2017', comment: 'entered-value' }
+        };
+
+        const actual = transformer(entry);
+
+        expect(actual).toEqual(
+            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'entered-value' } })
+        );
+    });
+
+    describe('that contains Name information ', () => {
+        it('should transform last name to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '11/07/2019' },
+                name: {
+                    last: 'last-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    names: expect.arrayContaining([
+                        {
+                            asOf: '11/07/2019',
+                            type: 'L',
+                            last: 'last-value'
+                        }
+                    ])
+                })
+            );
+        });
+
+        it('should transform first name to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '11/07/2019' },
+                name: {
+                    first: 'first-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    names: expect.arrayContaining([
+                        {
+                            asOf: '11/07/2019',
+                            type: 'L',
+                            first: 'first-value'
+                        }
+                    ])
+                })
+            );
+        });
+
+        it('should transform middle name to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '11/07/2019' },
+                name: {
+                    middle: 'middle-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    names: expect.arrayContaining([
+                        {
+                            asOf: '11/07/2019',
+                            type: 'L',
+                            middle: 'middle-value'
+                        }
+                    ])
+                })
+            );
+        });
+
+        it('should transform suffix to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '11/07/2019' },
+                name: {
+                    suffix: { value: 'suffix-value', name: 'suffix-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    names: expect.arrayContaining([
+                        {
+                            asOf: '11/07/2019',
+                            type: 'L',
+                            suffix: 'suffix-value'
+                        }
+                    ])
+                })
+            );
+        });
+    });
+
+    describe('that contains Other information ', () => {
+        it('should transform birth values to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                other: {
+                    bornOn: '08/05/1990',
+                    birthSex: { value: 'birth-sex-value', name: 'birth-sex-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    birth: expect.objectContaining({ asOf: '04/13/2017', bornOn: '08/05/1990', sex: 'birth-sex-value' })
+                })
+            );
+        });
+
+        it('should transform gender values to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                other: {
+                    currentSex: { value: 'current-sex-value', name: 'current-sex-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    gender: expect.objectContaining({ asOf: '04/13/2017', current: 'current-sex-value' })
+                })
+            );
+        });
+
+        it('should transform mortality values to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                other: {
+                    deceased: { value: 'deceased-value', name: 'deceased-name' },
+                    deceasedOn: '05/08/1790'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    mortality: expect.objectContaining({
+                        asOf: '04/13/2017',
+                        deceasedOn: '05/08/1790',
+                        deceased: 'deceased-value'
+                    })
+                })
+            );
+        });
+
+        it('should transform general values to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                other: {
+                    maritalStatus: { value: 'marital-status-value', name: 'marital-status-name' },
+                    stateHIVCase: 'state-hiv-case-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    general: expect.objectContaining({
+                        asOf: '04/13/2017',
+                        maritalStatus: 'marital-status-value',
+                        stateHIVCase: 'state-hiv-case-value'
+                    })
+                })
+            );
+        });
+    });
+
+    describe('that contains Address', () => {
+        it('should transform Street address 1 to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    address1: 'address-1-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            address1: 'address-1-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform Street address 2 to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    address2: 'address-2-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+
+                            address2: 'address-2-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform city to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    city: 'city-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            city: 'city-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform country to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    county: { value: 'county-value', name: 'county-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            county: 'county-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform zipcode to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    zipcode: 'zipcode-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            zipcode: 'zipcode-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform state to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    state: { value: 'state-value', name: 'state-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            state: 'state-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform country to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    country: { value: 'country-value', name: 'country-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            country: 'country-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform census tract to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                address: {
+                    censusTract: 'census-tract-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    addresses: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'H',
+                            use: 'H',
+                            censusTract: 'census-tract-value'
+                        })
+                    ])
+                })
+            );
+        });
+    });
+
+    describe('that contains Phone & email ', () => {
+        it('should transform home phone to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                phoneEmail: {
+                    home: 'home-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    phoneEmails: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'PH',
+                            use: 'H',
+                            phoneNumber: 'home-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform work phone to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                phoneEmail: {
+                    work: { phone: 'work-phone-value' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    phoneEmails: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'PH',
+                            use: 'WP',
+                            phoneNumber: 'work-phone-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform work phone with extension to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                phoneEmail: {
+                    work: { phone: 'work-phone-value', extension: 'extension-value' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    phoneEmails: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'PH',
+                            use: 'WP',
+                            phoneNumber: 'work-phone-value',
+                            extension: 'extension-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform cell phone to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                phoneEmail: {
+                    cell: 'cell-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    phoneEmails: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'CP',
+                            use: 'MC',
+                            phoneNumber: 'cell-value'
+                        })
+                    ])
+                })
+            );
+        });
+
+        it('should transform email address to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                phoneEmail: {
+                    email: 'email-value'
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    phoneEmails: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '04/13/2017',
+                            type: 'NET',
+                            use: 'H',
+                            email: 'email-value'
+                        })
+                    ])
+                })
+            );
+        });
+    });
+
+    describe('that contains Ethnicity and race information ', () => {
+        it('should transform ethnicity to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                ethnicityRace: {
+                    ethnicity: { value: 'ethnicity-value', name: 'ethnicity-name' }
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    ethnicity: {
+                        asOf: '04/13/2017',
+                        ethnicGroup: 'ethnicity-value',
+                        detailed: []
+                    }
+                })
+            );
+        });
+
+        it('should transform each race into a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '04/13/2017' },
+                ethnicityRace: {
+                    races: [
+                        { value: 'race-one-value', name: 'race-one-name' },
+                        { value: 'race-two-value', name: 'race-two-name' }
+                    ]
+                }
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    races: expect.arrayContaining([
+                        { asOf: '04/13/2017', race: 'race-one-value', detailed: [] },
+                        { asOf: '04/13/2017', race: 'race-two-value', detailed: [] }
+                    ])
+                })
+            );
+        });
+    });
+
+    describe('that contains Identifications ', () => {
+        it('should transform identifications to a format accepted by the API', () => {
+            const entry: BasicNewPatientEntry = {
+                administrative: { asOf: '11/07/2019' },
+                identifications: [
+                    {
+                        id: 'id-value',
+                        type: { value: 'identification-type-value', name: 'identification-type-name' },
+                        issuer: { value: 'issuer-value', name: 'issuer-name' }
+                    }
+                ]
+            };
+
+            const actual = transformer(entry);
+
+            expect(actual).toEqual(
+                expect.objectContaining({
+                    identifications: expect.arrayContaining([
+                        expect.objectContaining({
+                            asOf: '11/07/2019',
+                            id: 'id-value',
+                            type: 'identification-type-value',
+                            issuer: 'issuer-value'
+                        })
+                    ])
+                })
+            );
+        });
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/add/basic/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/transformer.ts
@@ -1,0 +1,286 @@
+import { exists, isEmpty, orUndefined } from 'utils';
+import { Mapping, maybeMap, maybeMapAll } from 'utils/mapping';
+import { asValue, Selectable } from 'options';
+import { LEGAL } from 'options/name/types';
+import { HOME as HOME_ADDRESS } from 'options/address/uses';
+import { HOUSE } from 'options/address/types';
+import { CELL_PHONE, PHONE, EMAIL } from 'options/phone/types';
+import { HOME as HOME_PHONE, MOBILE_CONTACT, PRIMARY_WORKPLACE } from 'options/phone/uses';
+import { Race } from 'apps/patient/data/race/api';
+import { NewPatient } from 'apps/patient/add/api';
+import {
+    Address,
+    Birth,
+    Ethnicity,
+    GeneralInformation,
+    Identification,
+    Mortality,
+    Name,
+    PhoneEmail,
+    Sex
+} from 'apps/patient/data/api';
+
+import { asAdministrative } from 'apps/patient/data';
+
+import {
+    BasicAddressEntry,
+    BasicEthnicityRace,
+    BasicIdentificationEntry,
+    BasicNewPatientEntry,
+    BasicPhoneEmail,
+    NameInformationEntry,
+    OtherInformationEntry
+} from './entry';
+
+const maybeMapEach =
+    <R, S>(...mappings: Mapping<R, S>[]) =>
+    (value?: R): NonNullable<S>[] => {
+        if (value) {
+            return mappings.reduce((previous, current) => {
+                const mapped = current(value);
+                return mapped ? [...previous, mapped] : previous;
+            }, [] as NonNullable<S>[]);
+        }
+
+        return [];
+    };
+
+const maybeAsBirth = (asOf: string) => maybeMap(asBirth(asOf));
+const maybeAsGender = (asOf: string) => maybeMap(asGender(asOf));
+const maybeAsMortality = (asOf: string) => maybeMap(asMortality(asOf));
+const maybeAsGeneral = (asOf: string) => maybeMap(asGeneral(asOf));
+const maybeAsEthnicity = (asOf: string) => maybeMap(asEthnicity(asOf));
+
+const asNames = (asOf: string) => maybeMapEach(asName(asOf));
+const asAddresses = (asOf: string) => maybeMapEach(asAddress(asOf));
+const asRaces = (asOf: string) => maybeMapAll(asRace(asOf));
+const asPhones = (asOf: string) => maybeMapEach(asHomePhone(asOf), asWorkPone(asOf), asCellPhone(asOf), asEmail(asOf));
+
+const asIdentifications = (asOf: string) => maybeMapAll(asIdentification(asOf));
+
+const transformer = (entry: BasicNewPatientEntry): NewPatient => {
+    const administrative = asAdministrative(entry.administrative);
+
+    const { asOf } = administrative;
+
+    const names = asNames(asOf)(entry.name);
+    const birth = maybeAsBirth(asOf)(entry.other);
+    const gender = maybeAsGender(asOf)(entry.other);
+    const mortality = maybeAsMortality(asOf)(entry.other);
+    const general = maybeAsGeneral(asOf)(entry.other);
+    const addresses = asAddresses(asOf)(entry.address);
+    const ethnicity = maybeAsEthnicity(asOf)(entry.ethnicityRace);
+    const races = asRaces(asOf)(entry.ethnicityRace?.races);
+    const phoneEmails = asPhones(asOf)(entry.phoneEmail);
+    const identifications = asIdentifications(asOf)(entry.identifications);
+
+    return {
+        administrative,
+        names,
+        birth,
+        gender,
+        mortality,
+        general,
+        addresses,
+        ethnicity,
+        races,
+        phoneEmails,
+        identifications
+    };
+};
+
+const asName =
+    (asOf: string) =>
+    (entry: NameInformationEntry): Name | undefined => {
+        if (!isEmpty(entry)) {
+            const { first, middle, last, suffix } = entry;
+            return {
+                asOf,
+                type: LEGAL.value,
+                first: orUndefined(first),
+                middle: orUndefined(middle),
+                last: orUndefined(last),
+                suffix: asValue(suffix)
+            };
+        }
+    };
+
+const asBirth =
+    (asOf: string) =>
+    (entry: OtherInformationEntry): Birth | undefined => {
+        const { bornOn, birthSex } = entry;
+
+        if (bornOn || birthSex) {
+            return {
+                asOf,
+                bornOn,
+                sex: asValue(birthSex)
+            };
+        }
+    };
+
+const asGender =
+    (asOf: string) =>
+    (entry: OtherInformationEntry): Sex | undefined => {
+        const { currentSex } = entry;
+
+        if (currentSex) {
+            return {
+                asOf,
+                current: asValue(currentSex)
+            };
+        }
+    };
+
+const asMortality =
+    (asOf: string) =>
+    (entry: OtherInformationEntry): Mortality | undefined => {
+        const { deceased, deceasedOn } = entry;
+
+        if (deceased || deceasedOn) {
+            return {
+                asOf,
+                deceasedOn,
+                deceased: asValue(deceased)
+            };
+        }
+    };
+
+const asGeneral =
+    (asOf: string) =>
+    (entry: OtherInformationEntry): GeneralInformation | undefined => {
+        const { maritalStatus, stateHIVCase } = entry;
+        if (maritalStatus || stateHIVCase) {
+            return {
+                asOf,
+                stateHIVCase,
+                maritalStatus: asValue(maritalStatus)
+            };
+        }
+    };
+
+const asAddress =
+    (asOf: string) =>
+    (entry: BasicAddressEntry): Address | undefined => {
+        if (!isEmpty(entry)) {
+            const { state, county, country, address1, address2, city, zipcode, censusTract } = entry;
+
+            return {
+                asOf,
+                type: HOUSE.value,
+                use: HOME_ADDRESS.value,
+                county: asValue(county),
+                state: asValue(state),
+                country: asValue(country),
+                address1: orUndefined(address1),
+                address2: orUndefined(address2),
+                city: orUndefined(city),
+                zipcode: orUndefined(zipcode),
+                censusTract: orUndefined(censusTract)
+            };
+        }
+    };
+
+const asEthnicity =
+    (asOf: string) =>
+    (entry: BasicEthnicityRace): Ethnicity | undefined => {
+        const { ethnicity } = entry;
+
+        if (exists(ethnicity)) {
+            return {
+                asOf,
+                ethnicGroup: asValue(ethnicity),
+                detailed: []
+            };
+        }
+    };
+
+const asRace =
+    (asOf: string) =>
+    (entry: Selectable): Race | undefined => {
+        if (exists(entry)) {
+            return {
+                asOf,
+                race: asValue(entry),
+                detailed: []
+            };
+        }
+    };
+
+const asHomePhone =
+    (asOf: string) =>
+    (entry: BasicPhoneEmail): PhoneEmail | undefined => {
+        const { home } = entry;
+
+        if (home) {
+            return {
+                asOf,
+                type: PHONE.value,
+                use: HOME_PHONE.value,
+                phoneNumber: home
+            };
+        }
+    };
+
+const asWorkPone =
+    (asOf: string) =>
+    (entry: BasicPhoneEmail): PhoneEmail | undefined => {
+        const { work } = entry;
+
+        if (!isEmpty(entry.work)) {
+            return {
+                asOf,
+                type: PHONE.value,
+                use: PRIMARY_WORKPLACE.value,
+                phoneNumber: work?.phone,
+                extension: work?.extension
+            };
+        }
+    };
+
+const asCellPhone =
+    (asOf: string) =>
+    (entry: BasicPhoneEmail): PhoneEmail | undefined => {
+        const { cell } = entry;
+
+        if (cell) {
+            return {
+                asOf,
+                type: CELL_PHONE.value,
+                use: MOBILE_CONTACT.value,
+                phoneNumber: cell
+            };
+        }
+    };
+
+const asEmail =
+    (asOf: string) =>
+    (entry: BasicPhoneEmail): PhoneEmail | undefined => {
+        const { email } = entry;
+
+        if (email) {
+            return {
+                asOf,
+                type: EMAIL.value,
+                use: HOME_PHONE.value,
+                email
+            };
+        }
+    };
+
+const asIdentification =
+    (asOf: string) =>
+    (entry: BasicIdentificationEntry): Identification | undefined => {
+        const { type, issuer, id } = entry;
+
+        if (exists(type)) {
+            return {
+                asOf,
+                type: asValue(type),
+                id,
+                issuer: asValue(issuer)
+            };
+        }
+    };
+
+export { transformer };

--- a/apps/modernization-ui/src/apps/patient/add/basic/useAddBasicPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/useAddBasicPatient.ts
@@ -1,0 +1,16 @@
+import { AddPatientInteraction, useAddPatient, creator } from 'apps/patient/add';
+import { BasicNewPatientEntry } from './entry';
+import { transformer } from './transformer';
+
+/**
+ * Allows creation of a patient from a BasicNewPatientEntry object.
+ *
+ * @return {AddPatientInteraction}
+ */
+const useAddBasicPatient = (): AddPatientInteraction<BasicNewPatientEntry> => {
+    const interaction = useAddPatient({ transformer, creator });
+
+    return interaction;
+};
+
+export { useAddBasicPatient };

--- a/apps/modernization-ui/src/apps/patient/add/creator.ts
+++ b/apps/modernization-ui/src/apps/patient/add/creator.ts
@@ -1,6 +1,6 @@
 import { PatientProfileService } from 'generated';
-import { Creator } from './useAddExtendedPatient';
-import { NewPatient } from '../api';
+import { Creator } from './extended/useAddExtendedPatient';
+import { NewPatient } from './api';
 
 const creator: Creator = (input: NewPatient) => PatientProfileService.create({ requestBody: input });
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
@@ -2,8 +2,6 @@ import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
 import { CreatedPatient } from '../api';
-import { creator } from './creator';
-import { transformer } from './transformer';
 import { ExtendedNewPatientEntry } from './entry';
 import { AddExtendedPatientInteractionProvider } from './useAddExtendedPatientInteraction';
 import { useAddExtendedPatient } from './useAddExtendedPatient';
@@ -22,7 +20,7 @@ import styles from './add-patient-extended.module.scss';
 import { useBasicExtendedTransition } from 'apps/patient/add/useBasicExtendedTransition';
 
 export const AddPatientExtended = () => {
-    const interaction = useAddExtendedPatient({ transformer, creator });
+    const interaction = useAddExtendedPatient();
     const { initialize } = useAddPatientExtendedDefaults();
     const { value: bypassModal } = useShowCancelModal();
     const { toBasic } = useBasicExtendedTransition();

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.spec.ts
@@ -1,23 +1,12 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import { Settings, useAddExtendedPatient } from './useAddExtendedPatient';
+import { useAddExtendedPatient } from './useAddExtendedPatient';
 import { ExtendedNewPatientEntry } from './entry';
-import { NewPatient } from 'apps/patient/add/api';
-import { Invalid } from './useAddExtendedPatientInteraction';
 
-const setup = (settings?: Partial<Settings>) => {
-    const transformer = settings?.transformer ?? jest.fn();
-    const creator = settings?.creator ?? jest.fn();
-
-    return renderHook(() => useAddExtendedPatient({ transformer, creator }));
+const setup = () => {
+    return renderHook(() => useAddExtendedPatient());
 };
 
 describe('when adding patients with extended data', () => {
-    it('should default to waiting', () => {
-        const { result } = setup();
-
-        expect(result.current.status).toEqual('waiting');
-    });
-
     it('should validate name sub form is not dirty when attempting to create', async () => {
         const { result } = setup();
 
@@ -31,12 +20,15 @@ describe('when adding patients with extended data', () => {
         });
 
         expect(result.current.status).toBe('invalid');
-        const validationErrors = (result.current as Invalid).validationErrors;
-        expect(validationErrors.dirtySections.name).toBeTruthy();
-        expect(validationErrors.dirtySections.address).toBeFalsy();
-        expect(validationErrors.dirtySections.phone).toBeFalsy();
-        expect(validationErrors.dirtySections.identification).toBeFalsy();
-        expect(validationErrors.dirtySections.race).toBeFalsy();
+
+        if (result.current.status === 'invalid') {
+            const { validationErrors } = result.current;
+            expect(validationErrors.dirtySections.name).toBeTruthy();
+            expect(validationErrors.dirtySections.address).toBeFalsy();
+            expect(validationErrors.dirtySections.phone).toBeFalsy();
+            expect(validationErrors.dirtySections.identification).toBeFalsy();
+            expect(validationErrors.dirtySections.race).toBeFalsy();
+        }
     });
 
     it('should validate address sub form is not dirty when attempting to create', async () => {
@@ -50,15 +42,16 @@ describe('when adding patients with extended data', () => {
             result.current.setSubFormState({ address: true });
             result.current.create(entry);
         });
-
         expect(result.current.status).toBe('invalid');
 
-        const validationErrors = (result.current as Invalid).validationErrors;
-        expect(validationErrors.dirtySections.name).toBeFalsy();
-        expect(validationErrors.dirtySections.address).toBeTruthy();
-        expect(validationErrors.dirtySections.phone).toBeFalsy();
-        expect(validationErrors.dirtySections.identification).toBeFalsy();
-        expect(validationErrors.dirtySections.race).toBeFalsy();
+        if (result.current.status === 'invalid') {
+            const { validationErrors } = result.current;
+            expect(validationErrors.dirtySections.name).toBeFalsy();
+            expect(validationErrors.dirtySections.address).toBeTruthy();
+            expect(validationErrors.dirtySections.phone).toBeFalsy();
+            expect(validationErrors.dirtySections.identification).toBeFalsy();
+            expect(validationErrors.dirtySections.race).toBeFalsy();
+        }
     });
 
     it('should validate phone sub form is not dirty when attempting to create', async () => {
@@ -72,14 +65,16 @@ describe('when adding patients with extended data', () => {
             result.current.setSubFormState({ phone: true });
             result.current.create(entry);
         });
-
         expect(result.current.status).toBe('invalid');
-        const validationErrors = (result.current as Invalid).validationErrors;
-        expect(validationErrors.dirtySections.name).toBeFalsy();
-        expect(validationErrors.dirtySections.address).toBeFalsy();
-        expect(validationErrors.dirtySections.phone).toBeTruthy();
-        expect(validationErrors.dirtySections.identification).toBeFalsy();
-        expect(validationErrors.dirtySections.race).toBeFalsy();
+
+        if (result.current.status === 'invalid') {
+            const { validationErrors } = result.current;
+            expect(validationErrors.dirtySections.name).toBeFalsy();
+            expect(validationErrors.dirtySections.address).toBeFalsy();
+            expect(validationErrors.dirtySections.phone).toBeTruthy();
+            expect(validationErrors.dirtySections.identification).toBeFalsy();
+            expect(validationErrors.dirtySections.race).toBeFalsy();
+        }
     });
 
     it('should validate identification sub form is not dirty when attempting to create', async () => {
@@ -95,12 +90,15 @@ describe('when adding patients with extended data', () => {
         });
 
         expect(result.current.status).toBe('invalid');
-        const validationErrors = (result.current as Invalid).validationErrors;
-        expect(validationErrors.dirtySections.name).toBeFalsy();
-        expect(validationErrors.dirtySections.address).toBeFalsy();
-        expect(validationErrors.dirtySections.phone).toBeFalsy();
-        expect(validationErrors.dirtySections.identification).toBeTruthy();
-        expect(validationErrors.dirtySections.race).toBeFalsy();
+
+        if (result.current.status === 'invalid') {
+            const { validationErrors } = result.current;
+            expect(validationErrors.dirtySections.name).toBeFalsy();
+            expect(validationErrors.dirtySections.address).toBeFalsy();
+            expect(validationErrors.dirtySections.phone).toBeFalsy();
+            expect(validationErrors.dirtySections.identification).toBeTruthy();
+            expect(validationErrors.dirtySections.race).toBeFalsy();
+        }
     });
 
     it('should validate race sub form is not dirty when attempting to create', async () => {
@@ -116,43 +114,14 @@ describe('when adding patients with extended data', () => {
         });
 
         expect(result.current.status).toBe('invalid');
-        const validationErrors = (result.current as Invalid).validationErrors;
-        expect(validationErrors.dirtySections.name).toBeFalsy();
-        expect(validationErrors.dirtySections.address).toBeFalsy();
-        expect(validationErrors.dirtySections.phone).toBeFalsy();
-        expect(validationErrors.dirtySections.identification).toBeFalsy();
-        expect(validationErrors.dirtySections.race).toBeTruthy();
-    });
 
-    it('should transition to created when creation is completed', async () => {
-        const input: NewPatient = { administrative: { asOf: '04/13/2017', comment: 'transformed' } };
-
-        const transformer = jest.fn();
-
-        transformer.mockReturnValue(input);
-
-        const creator = jest.fn();
-
-        creator.mockResolvedValue({ id: 101, shortId: 691 });
-
-        const { result } = setup({ transformer, creator });
-
-        const entry: ExtendedNewPatientEntry = {
-            administrative: { asOf: '04/13/2017', comment: 'entered' }
-        };
-
-        await act(async () => {
-            result.current.create(entry);
-        });
-
-        expect(transformer).toHaveBeenCalledWith(
-            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'entered' } })
-        );
-
-        expect(creator).toHaveBeenCalledWith(
-            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'transformed' } })
-        );
-
-        expect(result.current.status).toEqual('created');
+        if (result.current.status === 'invalid') {
+            const { validationErrors } = result.current;
+            expect(validationErrors.dirtySections.name).toBeFalsy();
+            expect(validationErrors.dirtySections.address).toBeFalsy();
+            expect(validationErrors.dirtySections.phone).toBeFalsy();
+            expect(validationErrors.dirtySections.identification).toBeFalsy();
+            expect(validationErrors.dirtySections.race).toBeTruthy();
+        }
     });
 });

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatientInteraction.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatientInteraction.tsx
@@ -21,12 +21,14 @@ type ValidationErrors = {
     dirtySections: SubFormDirtyState;
 };
 
-type AddExtendedPatientInteraction = (Working | Created | Invalid) & {
+type AddExtendedPatientState = Working | Created | Invalid;
+
+type AddExtendedPatientInteraction = AddExtendedPatientState & {
     create: (entry: ExtendedNewPatientEntry) => void;
     setSubFormState: (subFormState: Partial<SubFormDirtyState>) => void;
 };
 
-export type { AddExtendedPatientInteraction, Working, Created, Invalid };
+export type { AddExtendedPatientInteraction, AddExtendedPatientState };
 
 const AddExtendedPatientInteractionContext = createContext<AddExtendedPatientInteraction | undefined>(undefined);
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatientInteraction.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatientInteraction.tsx
@@ -1,32 +1,25 @@
 import { createContext, ReactNode, useContext } from 'react';
-import { CreatedPatient } from 'apps/patient/add/api';
+import { AddPatientInteraction } from 'apps/patient/add';
 import { ExtendedNewPatientEntry } from './entry';
-
-type Working = {
-    status: 'waiting' | 'working';
-};
-
-type Created = {
-    status: 'created';
-    created: CreatedPatient;
-};
+import { Created, Working } from '../useAddPatient';
 
 type Invalid = {
     status: 'invalid';
     validationErrors: ValidationErrors;
 };
+
+type AddExtendedPatientState = Working | Created | Invalid;
+
 type SubFormDirtyState = { address: boolean; phone: boolean; identification: boolean; name: boolean; race: boolean };
 
 type ValidationErrors = {
     dirtySections: SubFormDirtyState;
 };
 
-type AddExtendedPatientState = Working | Created | Invalid;
-
-type AddExtendedPatientInteraction = AddExtendedPatientState & {
-    create: (entry: ExtendedNewPatientEntry) => void;
-    setSubFormState: (subFormState: Partial<SubFormDirtyState>) => void;
-};
+type AddExtendedPatientInteraction = AddExtendedPatientState &
+    Pick<AddPatientInteraction<ExtendedNewPatientEntry>, 'create'> & {
+        setSubFormState: (subFormState: Partial<SubFormDirtyState>) => void;
+    };
 
 export type { AddExtendedPatientInteraction, AddExtendedPatientState };
 

--- a/apps/modernization-ui/src/apps/patient/add/index.ts
+++ b/apps/modernization-ui/src/apps/patient/add/index.ts
@@ -2,3 +2,4 @@ export * from './NewPatientEntry';
 export { routing } from './PatientAddRouting';
 export type { AddPatientState, AddPatientInteraction, AddPatientSettings } from './useAddPatient';
 export { useAddPatient } from './useAddPatient';
+export { creator } from './creator';

--- a/apps/modernization-ui/src/apps/patient/add/index.ts
+++ b/apps/modernization-ui/src/apps/patient/add/index.ts
@@ -1,2 +1,4 @@
 export * from './NewPatientEntry';
 export { routing } from './PatientAddRouting';
+export type { AddPatientState, AddPatientInteraction, AddPatientSettings } from './useAddPatient';
+export { useAddPatient } from './useAddPatient';

--- a/apps/modernization-ui/src/apps/patient/add/useAddPatient.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/useAddPatient.spec.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { AddPatientSettings, useAddPatient } from './useAddPatient';
+import { NewPatient } from './api';
+
+type Example = {};
+
+const setup = (settings?: Partial<AddPatientSettings<Example>>) => {
+    const transformer = settings?.transformer ?? jest.fn();
+    const creator = settings?.creator ?? jest.fn();
+
+    return renderHook(() => useAddPatient({ transformer, creator }));
+};
+
+describe('when adding patients with extended data', () => {
+    it('should default to waiting', () => {
+        const { result } = setup();
+
+        expect(result.current.status).toEqual('waiting');
+    });
+
+    it('should transition to created when creation is completed', async () => {
+        const input: NewPatient = { administrative: { asOf: '04/13/2017', comment: 'transformed' } };
+
+        const transformer = jest.fn();
+
+        transformer.mockReturnValue(input);
+
+        const creator = jest.fn();
+
+        creator.mockResolvedValue({ id: 101, shortId: 691 });
+
+        const { result } = setup({ transformer, creator });
+
+        const entry: Example = {
+            administrative: { asOf: '04/13/2017', comment: 'entered' }
+        };
+
+        await act(async () => {
+            result.current.create(entry);
+        });
+
+        expect(transformer).toHaveBeenCalledWith(
+            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'entered' } })
+        );
+
+        expect(creator).toHaveBeenCalledWith(
+            expect.objectContaining({ administrative: { asOf: '04/13/2017', comment: 'transformed' } })
+        );
+
+        expect(result.current.status).toEqual('created');
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/add/useAddPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/useAddPatient.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { CreatedPatient, Creator, NewPatient, Transformer } from './api';
+
+type Step<I> =
+    | { status: 'requesting'; entry: I }
+    | { status: 'creating'; input: NewPatient }
+    | { status: 'created'; created: CreatedPatient }
+    | { status: 'waiting' };
+
+type Action<I> =
+    | { type: 'request'; entry: I }
+    | { type: 'create'; input: NewPatient }
+    | { type: 'complete'; created: CreatedPatient }
+    | { type: 'wait' };
+
+const reducer = <I>(current: Step<I>, action: Action<I>): Step<I> => {
+    switch (action.type) {
+        case 'request': {
+            return { status: 'requesting', entry: action.entry };
+        }
+        case 'create': {
+            return { status: 'creating', input: action.input };
+        }
+        case 'complete': {
+            return { status: 'created', created: action.created };
+        }
+        default: {
+            return current;
+        }
+    }
+};
+
+type Working = {
+    status: 'waiting' | 'working';
+};
+
+type Created = {
+    status: 'created';
+    created: CreatedPatient;
+};
+
+type AddPatientState = Working | Created;
+
+type AddPatientInteraction<I> = AddPatientState & {
+    create: (entry: I) => void;
+};
+
+type AddPatientSettings<E> = {
+    transformer: Transformer<E>;
+    creator: Creator;
+};
+
+const useAddPatient = <E>({ transformer, creator }: AddPatientSettings<E>): AddPatientInteraction<E> => {
+    const [step, dispatch] = useReducer(reducer<E>, { status: 'waiting' });
+
+    useEffect(() => {
+        if (step.status === 'requesting') {
+            const input = transformer(step.entry);
+            dispatch({ type: 'create', input });
+        } else if (step.status === 'creating') {
+            creator(step.input).then((created) => dispatch({ type: 'complete', created }));
+        }
+    }, [step.status, dispatch]);
+
+    const state: AddPatientState = useMemo(() => evaluateState(step), [step]);
+
+    const create = useCallback((entry: E) => dispatch({ type: 'request', entry }), [dispatch]);
+
+    return {
+        ...state,
+        create
+    };
+};
+
+const evaluateState = <I>(step: Step<I>): AddPatientState => {
+    switch (step.status) {
+        case 'creating':
+        case 'requesting': {
+            return { status: 'working' };
+        }
+        case 'created': {
+            return { status: 'created', created: step.created };
+        }
+        default: {
+            return { status: step.status };
+        }
+    }
+};
+
+export type { AddPatientState, AddPatientInteraction, AddPatientSettings };
+export { useAddPatient };

--- a/apps/modernization-ui/src/apps/patient/add/useAddPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/useAddPatient.ts
@@ -50,6 +50,15 @@ type AddPatientSettings<E> = {
     creator: Creator;
 };
 
+/**
+ * Allows creation of a patient from an entry object.
+ *
+ * By default the status will be "waiting", when create is invoked the status will change to
+ * "working" until the patient has been created.  Once patient is created the status will
+ * change to "created" and the "created" property will contain the CreatedPatient.
+ *
+ * @return {AddPatientInteraction}
+ */
 const useAddPatient = <E>({ transformer, creator }: AddPatientSettings<E>): AddPatientInteraction<E> => {
     const [step, dispatch] = useReducer(reducer<E>, { status: 'waiting' });
 
@@ -87,5 +96,5 @@ const evaluateState = <I>(step: Step<I>): AddPatientState => {
     }
 };
 
-export type { AddPatientState, AddPatientInteraction, AddPatientSettings };
+export type { AddPatientState, AddPatientInteraction, AddPatientSettings, Working, Created };
 export { useAddPatient };

--- a/apps/modernization-ui/src/options/address/types.ts
+++ b/apps/modernization-ui/src/options/address/types.ts
@@ -1,0 +1,5 @@
+import { asSelectable } from 'options/selectable';
+
+const HOUSE = asSelectable('H', 'House');
+
+export { HOUSE };

--- a/apps/modernization-ui/src/options/address/uses.ts
+++ b/apps/modernization-ui/src/options/address/uses.ts
@@ -1,0 +1,5 @@
+import { asSelectable } from 'options/selectable';
+
+const HOME = asSelectable('H', 'Home');
+
+export { HOME };

--- a/apps/modernization-ui/src/options/name/types.ts
+++ b/apps/modernization-ui/src/options/name/types.ts
@@ -1,0 +1,5 @@
+import { asSelectable } from 'options';
+
+const LEGAL = asSelectable('L', 'Legal');
+
+export { LEGAL };

--- a/apps/modernization-ui/src/options/phone/types.ts
+++ b/apps/modernization-ui/src/options/phone/types.ts
@@ -1,0 +1,7 @@
+import { asSelectable } from 'options/selectable';
+
+const PHONE = asSelectable('PH', 'Phone');
+const CELL_PHONE = asSelectable('CP', 'Cellular phone');
+const EMAIL = asSelectable('NET', 'Email address');
+
+export { PHONE, CELL_PHONE, EMAIL };

--- a/apps/modernization-ui/src/options/phone/uses.ts
+++ b/apps/modernization-ui/src/options/phone/uses.ts
@@ -1,0 +1,7 @@
+import { asSelectable } from 'options/selectable';
+
+const HOME = asSelectable('H', 'Home');
+const MOBILE_CONTACT = asSelectable('MC', 'Mobile contact');
+const PRIMARY_WORKPLACE = asSelectable('WP', 'Primary work place');
+
+export { HOME, MOBILE_CONTACT, PRIMARY_WORKPLACE };

--- a/apps/modernization-ui/src/utils/isEmpty.ts
+++ b/apps/modernization-ui/src/utils/isEmpty.ts
@@ -1,9 +1,9 @@
 import { exists } from './exists';
 
 /* eslint-disable no-redeclare */
-function isEmpty<T extends object>(obj: T): boolean;
+function isEmpty<T>(obj: T): boolean;
 function isEmpty(obj: null | undefined): true;
-function isEmpty<T extends object>(obj: T | null | undefined): boolean {
+function isEmpty<T>(obj: T | null | undefined): boolean {
     for (const key in obj) {
         if (Object.hasOwn(obj, key)) {
             const value = obj[key];


### PR DESCRIPTION
## Description

Adds the `useAddBasicPatient` hook to allow adding a patient with the patient create API using a `BasicNewPatientEntry`.  The API interaction was extracted from `useAddExtendedPatient`into `useAddPatient` so that it could be used by both `useAddBasicPatient` and `useAddExtendedPatient`.  The extra validation for pending input remains in `useAddExtendedPatient`.  

- a `transformer` function was introduced to map a `BasicNewPatientEntry` to a `NewPatient` to send as a request to the patient create API
- The `creator` function was moved up to the `add` folder to be used by both `basic` and `extended`

## Tickets

* [CNFT1-3408](https://cdc-nbs.atlassian.net/browse/CNFT1-3408)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3408]: https://cdc-nbs.atlassian.net/browse/CNFT1-3408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ