### PR TITLE
[CNFT1-3423]: Adding no data and three patient profile dashes update.

### DIFF
--- a/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
@@ -88,7 +88,7 @@ export const PatientProfileSummary = ({ patient }: Props) => {
             ) : (
                 <>
                     <div className="border-bottom border-base-lighter patient-summary-title">
-                        <h2>{summary?.legalName && displayName('fullLastFirst')(summary.legalName)}</h2>
+                        <h2>{(summary?.legalName && displayName('fullLastFirst')(summary.legalName)) || '-- -- --'}</h2>
                         <span>Patient ID: {patient.shortId}</span>
                         {patient.status != 'ACTIVE' && <span className="text-red">{patient.status}</span>}
                     </div>

--- a/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
@@ -88,7 +88,7 @@ export const PatientProfileSummary = ({ patient }: Props) => {
             ) : (
                 <>
                     <div className="border-bottom border-base-lighter patient-summary-title">
-                        <h2>{(summary?.legalName && displayName('fullLastFirst')(summary.legalName)) ?? '-- -- --'}</h2>
+                        <h2>{(summary?.legalName && displayName('fullLastFirst')(summary.legalName)) ?? '---'}</h2>
                         <span>Patient ID: {patient.shortId}</span>
                         {patient.status != 'ACTIVE' && <span className="text-red">{patient.status}</span>}
                     </div>

--- a/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
@@ -88,7 +88,7 @@ export const PatientProfileSummary = ({ patient }: Props) => {
             ) : (
                 <>
                     <div className="border-bottom border-base-lighter patient-summary-title">
-                        <h2>{(summary?.legalName && displayName('fullLastFirst')(summary.legalName)) || '-- -- --'}</h2>
+                        <h2>{(summary?.legalName && displayName('fullLastFirst')(summary.legalName)) ?? '-- -- --'}</h2>
                         <span>Patient ID: {patient.shortId}</span>
                         {patient.status != 'ACTIVE' && <span className="text-red">{patient.status}</span>}
                     </div>

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.spec.tsx
@@ -7,7 +7,8 @@ import {
     displayEmails,
     displayAddresses,
     displayOtherNames,
-    displayIdentifications
+    displayIdentifications,
+    displayProfileLegalName
 } from './patientSearchResult';
 
 describe('patientSearchResult functions', () => {
@@ -75,7 +76,7 @@ describe('patientSearchResult functions', () => {
     };
 
     it('should displayPhones returns correct string', () => {
-        const {getByText} = render(displayPhones(mockPatient));
+        const { getByText } = render(displayPhones(mockPatient));
         expect(getByText('phone-use-value')).toBeInTheDocument();
         expect(getByText('270-685-4067')).toBeInTheDocument();
     });
@@ -114,5 +115,23 @@ describe('patientSearchResult functions', () => {
         expect(getByText('123-45-6789')).toBeInTheDocument();
         expect(getByText('MRN')).toBeInTheDocument();
         expect(getByText('123456')).toBeInTheDocument();
+    });
+
+    it('should displayProfileLegalName renders correctly with legal name', () => {
+        const { getByText } = render(<BrowserRouter>{displayProfileLegalName(mockPatient)}</BrowserRouter>);
+        const link = getByText('Doe, John');
+        expect(link).toHaveAttribute('href', '/patient-profile/84001/summary');
+    });
+
+    it('should displayProfileLegalName renders "No Data" when legal name is missing', () => {
+        const mockPatientWithoutLegalName = {
+            ...mockPatient,
+            legalName: null
+        };
+        const { getByText } = render(
+            <BrowserRouter>{displayProfileLegalName(mockPatientWithoutLegalName)}</BrowserRouter>
+        );
+        const link = getByText('No Data');
+        expect(link).toHaveAttribute('href', '/patient-profile/84001/summary');
     });
 });

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -9,7 +9,8 @@ const displayProfileLink = (shortId: number, displayName?: string) => {
 };
 
 const displayProfileLegalName = (result: PatientSearchResult) => {
-    const legalNameDisplay = (result.legalName && displayName('fullLastFirst')(result.legalName)) || 'No Data';
+    const legalNameDisplay =
+        result.legalName?.first || result.legalName?.last ? displayName('fullLastFirst')(result.legalName) : 'No Data';
     return displayProfileLink(result.shortId, legalNameDisplay);
 };
 


### PR DESCRIPTION
## Description

Adding No data on search and 3 dashes for no name entries on patient profile.
<img width="895" alt="Screenshot 2024-10-28 at 10 27 46 AM" src="https://github.com/user-attachments/assets/101a499f-e4a2-4c9b-9a7c-b519bde95168">
<img width="1507" alt="Screenshot 2024-10-28 at 10 28 05 AM" src="https://github.com/user-attachments/assets/6ad61d29-3b19-4630-a683-f5769a677a97">


## Tickets

* [CNFT1-3423](https://cdc-nbs.atlassian.net/browse/CNFT1-3423)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3423]: https://cdc-nbs.atlassian.net/browse/CNFT1-3423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ