### PR TITLE
CNFT1-3312 API: Update API to handle Operators for Last Name

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -32,6 +32,8 @@ class PatientDemographicQueryResolver {
   private static final String IDENTIFICATIONS = "entity_id";
   private static final String BIRTHDAY = "birth_time";
   private static final String ADDRESSES = "address";
+  private static final String NAME_USE_CD = "name.nm_use_cd.keyword";
+  private static final String LAST_NAME = "name.lastNm";
   private final PatientSearchSettings settings;
   private final PatientLocalIdentifierResolver resolver;
   private final Soundex soundex;
@@ -118,7 +120,7 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .must(
                                           primary -> primary.match(
@@ -176,12 +178,12 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .must(
                                           primary -> primary.match(
                                               match -> match
-                                                  .field("name.lastNm")
+                                                  .field(LAST_NAME)
                                                   .query(name)
                                                   .boost(settings.first().primary())))))))
                   .should(
@@ -191,7 +193,7 @@ class PatientDemographicQueryResolver {
                               .query(
                                   query -> query.simpleQueryString(
                                       nonPrimary -> nonPrimary
-                                          .fields("name.lastNm")
+                                          .fields(LAST_NAME)
                                           .query(WildCards.startsWith(name))
                                           .boost(settings.first().nonPrimary())))))
                   .should(
@@ -223,12 +225,12 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .must(
                                           primary -> primary.match(
                                               match -> match
-                                                  .field("name.lastNm")
+                                                  .field(LAST_NAME)
                                                   .query(name)
                                                   .boost(settings.first().primary())))))))));
 
@@ -242,12 +244,12 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .must(
                                           primary -> primary.simpleQueryString(
                                               nonPrimary -> nonPrimary
-                                                  .fields("name.lastNm")
+                                                  .fields(LAST_NAME)
                                                   .query(WildCards.startsWith(name))
                                                   .boost(settings.first().nonPrimary())))))))));
       case "contains" -> Optional.of(
@@ -260,11 +262,11 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .must(
                                           primary -> primary.wildcard(
-                                              nonPrimary -> nonPrimary.field("name.lastNm")
+                                              nonPrimary -> nonPrimary.field(LAST_NAME)
                                                   .value(WildCards.contains(name))
                                                   .boost(settings.first().nonPrimary())))))))));
       case "sounds_like" -> Optional.of(
@@ -277,7 +279,7 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .must(
                                           primary -> primary.term(
@@ -294,12 +296,12 @@ class PatientDemographicQueryResolver {
                               query -> query.bool(
                                   legal -> legal.filter(
                                       filter -> filter.term(
-                                          term -> term.field("name.nm_use_cd.keyword")
+                                          term -> term.field(NAME_USE_CD)
                                               .value("L")))
                                       .mustNot(
                                           primary -> primary.match(
                                               match -> match
-                                                  .field("name.lastNm")
+                                                  .field(LAST_NAME)
                                                   .query(name)
                                                   .boost(settings.first().primary())))))))));
       default -> Optional.empty();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -22,6 +22,7 @@ import gov.cdc.nbs.search.WildCards;
 import gov.cdc.nbs.search.criteria.date.DateCriteria;
 import gov.cdc.nbs.search.criteria.date.DateCriteria.Between;
 import gov.cdc.nbs.search.criteria.date.DateCriteria.Equals;
+import gov.cdc.nbs.search.criteria.name.NameCriteria;
 import gov.cdc.nbs.time.FlexibleInstantConverter;
 
 @Component
@@ -154,7 +155,7 @@ class PatientDemographicQueryResolver {
   }
 
   private Optional<QueryVariant> applyLastNameCriteria(final PatientFilter criteria) {
-    if (criteria.getLastNameOperator() != null) {
+    if (criteria.getLastNameCriteria() != null) {
       return applyLastNameWithOperatorCriteria(criteria);
     }
 
@@ -211,8 +212,9 @@ class PatientDemographicQueryResolver {
   }
 
   private Optional<QueryVariant> applyLastNameWithOperatorCriteria(final PatientFilter criteria) {
-    String name = AdjustStrings.withoutHyphens(criteria.getLastName());
-    String operator = criteria.getLastNameOperator().toLowerCase();
+    NameCriteria nameCriteria = criteria.getLastNameCriteria();
+    String name = AdjustStrings.withoutHyphens(nameCriteria.name());
+    String operator = nameCriteria.operator().toLowerCase();
 
     return switch (operator) {
       case "equal" -> Optional.of(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -1,10 +1,5 @@
 package gov.cdc.nbs.patient.search;
 
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.stream.Stream;
-import org.apache.commons.codec.language.Soundex;
-import org.springframework.stereotype.Component;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
@@ -22,8 +17,13 @@ import gov.cdc.nbs.search.WildCards;
 import gov.cdc.nbs.search.criteria.date.DateCriteria;
 import gov.cdc.nbs.search.criteria.date.DateCriteria.Between;
 import gov.cdc.nbs.search.criteria.date.DateCriteria.Equals;
-import gov.cdc.nbs.search.criteria.name.NameCriteria;
 import gov.cdc.nbs.time.FlexibleInstantConverter;
+import org.apache.commons.codec.language.Soundex;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 @Component
 class PatientDemographicQueryResolver {
@@ -37,31 +37,44 @@ class PatientDemographicQueryResolver {
   private static final String LAST_NAME = "name.lastNm";
   private final PatientSearchSettings settings;
   private final PatientLocalIdentifierResolver resolver;
+  private final PatientNameDemographicQueryResolver nameQueryResolver;
   private final Soundex soundex;
 
   PatientDemographicQueryResolver(
       final PatientSearchSettings settings,
-      final PatientLocalIdentifierResolver resolver) {
+      final PatientLocalIdentifierResolver resolver,
+      final PatientNameDemographicQueryResolver nameQueryResolver
+  ) {
     this.settings = settings;
     this.resolver = resolver;
+    this.nameQueryResolver = nameQueryResolver;
     this.soundex = new Soundex();
   }
 
   Stream<Query> resolve(final PatientFilter criteria) {
-    return Stream.of(
-        applyPatientIdentifierCriteria(criteria),
-        applyFirstNameCriteria(criteria),
-        applyLastNameCriteria(criteria),
-        applyPhoneNumberCriteria(criteria),
-        applyEmailCriteria(criteria),
-        applyIdentificationCriteria(criteria),
-        applyDateOfBirthCriteria(criteria),
-        applyStreetAddressCriteria(criteria),
-        applyCityCriteria(criteria),
-        applyDateOfBirthHighRangeCriteria(criteria),
-        applyDateOfBirthLowRangeCriteria(criteria),
-        applyZipcodeCriteria(criteria)).flatMap(Optional::stream)
+    return Stream.concat(
+            resolveDemographicCriteria(criteria),
+            nameQueryResolver.resolve(criteria)
+        )
         .map(QueryVariant::_toQuery);
+  }
+
+  private Stream<QueryVariant> resolveDemographicCriteria(final PatientFilter criteria) {
+    return Stream.of(
+            applyPatientIdentifierCriteria(criteria),
+            applyFirstNameCriteria(criteria),
+            applyLastNameCriteria(criteria),
+            applyPhoneNumberCriteria(criteria),
+            applyEmailCriteria(criteria),
+            applyIdentificationCriteria(criteria),
+            applyDateOfBirthCriteria(criteria),
+            applyStreetAddressCriteria(criteria),
+            applyCityCriteria(criteria),
+            applyDateOfBirthHighRangeCriteria(criteria),
+            applyDateOfBirthLowRangeCriteria(criteria),
+            applyZipcodeCriteria(criteria)
+        )
+        .flatMap(Optional::stream);
   }
 
   private Optional<QueryVariant> applyPatientIdentifierCriteria(final PatientFilter criteria) {
@@ -114,32 +127,43 @@ class PatientDemographicQueryResolver {
       return Optional.of(
           BoolQuery.of(
               bool -> bool.should(
-                  should -> should.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .must(
-                                          primary -> primary.match(
-                                              match -> match
-                                                  .field("name.firstNm")
-                                                  .query(name)
-                                                  .boost(settings.first().primary())
+                      should -> should.nested(
+                          nested -> nested.path(NAMES)
+                              .scoreMode(ChildScoreMode.Max)
+                              .query(
+                                  query -> query.bool(
+                                      legal -> legal.filter(
+                                              filter -> filter.term(
+                                                  term -> term.field(NAME_USE_CD)
+                                                      .value("L")))
+                                          .must(
+                                              primary -> primary.match(
+                                                  match -> match
+                                                      .field("name.firstNm")
+                                                      .query(name)
+                                                      .boost(settings.first().primary())
 
-                                          )))))).should(
-                                              should -> should.nested(
-                                                  nested -> nested.path(NAMES)
-                                                      .scoreMode(ChildScoreMode.Avg)
-                                                      .query(
-                                                          nonPrimary -> nonPrimary.simpleQueryString(
-                                                              queryString -> queryString
-                                                                  .fields("name.firstNm")
-                                                                  .query(WildCards.startsWith(name))
-                                                                  .boost(settings.first().nonPrimary())))))
+                                              )
+                                          )
+                                  )
+                              )
+                      )
+                  )
+                  .should(
+                      should -> should.nested(
+                          nested -> nested.path(NAMES)
+                              .scoreMode(ChildScoreMode.Avg)
+                              .query(
+                                  nonPrimary -> nonPrimary.simpleQueryString(
+                                      queryString -> queryString
+                                          .fields("name.firstNm")
+                                          .query(WildCards.startsWith(name))
+                                          .boost(settings.first().nonPrimary()
+                                          )
+                                  )
+                              )
+                      )
+                  )
                   .should(
                       should -> should.nested(
                           nested -> nested.path(NAMES)
@@ -149,16 +173,18 @@ class PatientDemographicQueryResolver {
                                   query -> query.term(
                                       term -> term
                                           .field("name.firstNmSndx.keyword")
-                                          .value(encoded)))))));
+                                          .value(encoded)
+                                  )
+                              )
+                      )
+                  )
+          )
+      );
     }
     return Optional.empty();
   }
 
   private Optional<QueryVariant> applyLastNameCriteria(final PatientFilter criteria) {
-    if (criteria.getLastNameCriteria() != null) {
-      return applyLastNameWithOperatorCriteria(criteria);
-    }
-
     String name = AdjustStrings.withoutHyphens(criteria.getLastName());
 
     if (name != null && !name.isBlank()) {
@@ -172,21 +198,21 @@ class PatientDemographicQueryResolver {
       return Optional.of(
           BoolQuery.of(
               bool -> bool.should(
-                  should -> should.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .must(
-                                          primary -> primary.match(
-                                              match -> match
-                                                  .field(LAST_NAME)
-                                                  .query(name)
-                                                  .boost(settings.first().primary())))))))
+                      should -> should.nested(
+                          nested -> nested.path(NAMES)
+                              .scoreMode(ChildScoreMode.Max)
+                              .query(
+                                  query -> query.bool(
+                                      legal -> legal.filter(
+                                              filter -> filter.term(
+                                                  term -> term.field(NAME_USE_CD)
+                                                      .value("L")))
+                                          .must(
+                                              primary -> primary.match(
+                                                  match -> match
+                                                      .field(LAST_NAME)
+                                                      .query(name)
+                                                      .boost(settings.first().primary())))))))
                   .should(
                       should -> should.nested(
                           nested -> nested.path(NAMES)
@@ -209,105 +235,6 @@ class PatientDemographicQueryResolver {
                                           .value(encoded)))))));
     }
     return Optional.empty();
-  }
-
-  private Optional<QueryVariant> applyLastNameWithOperatorCriteria(final PatientFilter criteria) {
-    NameCriteria nameCriteria = criteria.getLastNameCriteria();
-    String name = AdjustStrings.withoutHyphens(nameCriteria.name());
-    String operator = nameCriteria.operator().toLowerCase();
-
-    return switch (operator) {
-      case "equal" -> Optional.of(
-          BoolQuery.of(
-              bool -> bool.must(
-                  must -> must.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .must(
-                                          primary -> primary.match(
-                                              match -> match
-                                                  .field(LAST_NAME)
-                                                  .query(name)
-                                                  .boost(settings.first().primary())))))))));
-
-      case "starts_with" -> Optional.of(
-          BoolQuery.of(
-              bool -> bool.must(
-                  must -> must.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .must(
-                                          primary -> primary.simpleQueryString(
-                                              nonPrimary -> nonPrimary
-                                                  .fields(LAST_NAME)
-                                                  .query(WildCards.startsWith(name))
-                                                  .boost(settings.first().nonPrimary())))))))));
-      case "contains" -> Optional.of(
-          BoolQuery.of(
-              bool -> bool.must(
-                  must -> must.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .must(
-                                          primary -> primary.wildcard(
-                                              nonPrimary -> nonPrimary.field(LAST_NAME)
-                                                  .value(WildCards.contains(name))
-                                                  .boost(settings.first().nonPrimary())))))))));
-      case "sounds_like" -> Optional.of(
-          BoolQuery.of(
-              bool -> bool.must(
-                  must -> must.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .must(
-                                          primary -> primary.term(
-                                              term -> term
-                                                  .field("name.lastNmSndx.keyword")
-                                                  .value(soundex.encode(name.trim()))))))))));
-      case "not_equal" -> Optional.of(
-          BoolQuery.of(
-              bool -> bool.must(
-                  must -> must.nested(
-                      nested -> nested.path(NAMES)
-                          .scoreMode(ChildScoreMode.Max)
-                          .query(
-                              query -> query.bool(
-                                  legal -> legal.filter(
-                                      filter -> filter.term(
-                                          term -> term.field(NAME_USE_CD)
-                                              .value("L")))
-                                      .mustNot(
-                                          primary -> primary.match(
-                                              match -> match
-                                                  .field(LAST_NAME)
-                                                  .query(name)
-                                                  .boost(settings.first().primary())))))))));
-      default -> Optional.empty();
-    };
   }
 
   private Optional<QueryVariant> applyPhoneNumberCriteria(final PatientFilter criteria) {
@@ -364,9 +291,9 @@ class PatientDemographicQueryResolver {
                   .query(
                       query -> query.bool(
                           bool -> bool.filter(
-                              filter -> filter.term(
-                                  term -> term.field("entity_id.typeCd.keyword")
-                                      .value(type)))
+                                  filter -> filter.term(
+                                      term -> term.field("entity_id.typeCd.keyword")
+                                          .value(type)))
                               .must(
                                   must -> must.prefix(
                                       prefix -> prefix.field("entity_id.rootExtensionTxt").caseInsensitive(true)
@@ -502,11 +429,11 @@ class PatientDemographicQueryResolver {
 
       QueryVariant q = zipcode.length() < 5
           ? PrefixQuery.of(
-              prefix -> prefix.field("address.zip")
-                  .value(zipcode))
+          prefix -> prefix.field("address.zip")
+              .value(zipcode))
           : MatchQuery.of(
-              match -> match.field("address.zip")
-                  .query(zipcode));
+          match -> match.field("address.zip")
+              .query(zipcode));
 
       return Optional.of(
           NestedQuery.of(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.search.criteria.date.DateCriteria;
-import gov.cdc.nbs.search.criteria.name.NameCriteria;
+import gov.cdc.nbs.search.criteria.text.TextCriteria;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -41,10 +41,20 @@ public class PatientFilter {
     private String identificationType;
   }
 
+  public record NameCriteria(TextCriteria last){
+
+    Optional<TextCriteria> maybeLast() {
+      return Optional.ofNullable(last());
+    }
+
+    NameCriteria withLast(final TextCriteria last){
+      return new NameCriteria(last);
+    }
+  }
 
   private String id;
+  private NameCriteria name;
   private String lastName;
-  private NameCriteria lastNameCriteria;
   private String firstName;
   private String race;
   private Identification identification;
@@ -212,7 +222,7 @@ public class PatientFilter {
     return Optional.ofNullable(labReport);
   }
 
-  public PatientFilter withAccessiontNumber(final String identifier) {
+  public PatientFilter withAccessionNumber(final String identifier) {
     this.accessionNumber = identifier;
     return this;
   }
@@ -250,6 +260,20 @@ public class PatientFilter {
 
   public PatientFilter withBornBetween(final LocalDate from, final LocalDate to) {
     this.bornOn = DateCriteria.between(from, to);
+    return this;
+  }
+
+  public Optional<NameCriteria> maybeName() {
+    return Optional.ofNullable(this.name);
+  }
+
+  public PatientFilter withLastName(final TextCriteria criteria) {
+    if(this.name == null) {
+
+      this.name = new NameCriteria(criteria);
+    } else {
+      this.name = this.name.withLast(criteria);
+    }
     return this;
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -43,6 +43,7 @@ public class PatientFilter {
 
   private String id;
   private String lastName;
+  private String lastNameOperator;
   private String firstName;
   private String race;
   private Identification identification;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.search.criteria.date.DateCriteria;
+import gov.cdc.nbs.search.criteria.name.NameCriteria;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -43,7 +44,7 @@ public class PatientFilter {
 
   private String id;
   private String lastName;
-  private String lastNameOperator;
+  private NameCriteria lastNameCriteria;
   private String firstName;
   private String race;
   private Identification identification;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientNameDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientNameDemographicQueryResolver.java
@@ -1,0 +1,63 @@
+package gov.cdc.nbs.patient.search;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryVariant;
+import gov.cdc.nbs.search.criteria.text.TextCriteria;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static gov.cdc.nbs.search.criteria.text.TextCriteriaNestedQueryResolver.*;
+
+@Component
+class PatientNameDemographicQueryResolver {
+  private static final String NAMES = "name";
+  private static final String LAST_NAME = "name.lastNm";
+  private static final String LAST_NAME_SOUNDEX = "name.lastNmSndx.keyword";
+
+  Stream<QueryVariant> resolve(final PatientFilter criteria) {
+    return criteria.maybeName().stream().flatMap(this::resolveNameCriteria);
+  }
+
+  private Stream<QueryVariant> resolveNameCriteria(final PatientFilter.NameCriteria criteria) {
+    return Stream.of(
+            applyLastNameEquals(criteria),
+            applyLastNameNotEquals(criteria),
+            applyLastNameContains(criteria),
+            applyLastNameStartsWith(criteria),
+            applyLastNameSoundsLike(criteria)
+        )
+        .flatMap(Optional::stream);
+  }
+
+  private Optional<QueryVariant> applyLastNameEquals(final PatientFilter.NameCriteria criteria) {
+    return criteria.maybeLast()
+        .map(TextCriteria::equals)
+        .map(value -> equalTo(NAMES, LAST_NAME, value));
+  }
+
+  private Optional<QueryVariant> applyLastNameNotEquals(final PatientFilter.NameCriteria criteria) {
+    return criteria.maybeLast()
+        .map(TextCriteria::not)
+        .map(value -> notEquals(NAMES, LAST_NAME, value));
+  }
+
+  private Optional<QueryVariant> applyLastNameContains(final PatientFilter.NameCriteria criteria) {
+    return criteria.maybeLast()
+        .map(TextCriteria::contains)
+        .map(value -> contains(NAMES, LAST_NAME, value));
+  }
+
+  private Optional<QueryVariant> applyLastNameStartsWith(final PatientFilter.NameCriteria criteria) {
+    return criteria.maybeLast()
+        .map(TextCriteria::startsWith)
+        .map(value -> startsWith(NAMES, LAST_NAME, value));
+  }
+
+  private Optional<QueryVariant> applyLastNameSoundsLike(final PatientFilter.NameCriteria criteria) {
+    return criteria.maybeLast()
+        .map(TextCriteria::soundsLike)
+        .map(value -> soundLike(NAMES, LAST_NAME_SOUNDEX, value));
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientNameDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientNameDemographicQueryResolver.java
@@ -32,31 +32,31 @@ class PatientNameDemographicQueryResolver {
 
   private Optional<QueryVariant> applyLastNameEquals(final PatientFilter.NameCriteria criteria) {
     return criteria.maybeLast()
-        .map(TextCriteria::equals)
+        .flatMap(TextCriteria::maybeEquals)
         .map(value -> equalTo(NAMES, LAST_NAME, value));
   }
 
   private Optional<QueryVariant> applyLastNameNotEquals(final PatientFilter.NameCriteria criteria) {
     return criteria.maybeLast()
-        .map(TextCriteria::not)
+        .flatMap(TextCriteria::maybeNot)
         .map(value -> notEquals(NAMES, LAST_NAME, value));
   }
 
   private Optional<QueryVariant> applyLastNameContains(final PatientFilter.NameCriteria criteria) {
     return criteria.maybeLast()
-        .map(TextCriteria::contains)
+        .flatMap(TextCriteria::maybeContains)
         .map(value -> contains(NAMES, LAST_NAME, value));
   }
 
   private Optional<QueryVariant> applyLastNameStartsWith(final PatientFilter.NameCriteria criteria) {
     return criteria.maybeLast()
-        .map(TextCriteria::startsWith)
+        .flatMap(TextCriteria::maybeStartsWith)
         .map(value -> startsWith(NAMES, LAST_NAME, value));
   }
 
   private Optional<QueryVariant> applyLastNameSoundsLike(final PatientFilter.NameCriteria criteria) {
     return criteria.maybeLast()
-        .map(TextCriteria::soundsLike)
+        .flatMap(TextCriteria::maybeSoundsLike)
         .map(value -> soundLike(NAMES, LAST_NAME_SOUNDEX, value));
   }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/name/NameCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/name/NameCriteria.java
@@ -1,0 +1,7 @@
+package gov.cdc.nbs.search.criteria.name;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NameCriteria(String name, String operator) {
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/name/NameCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/name/NameCriteria.java
@@ -1,7 +1,0 @@
-package gov.cdc.nbs.search.criteria.name;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public record NameCriteria(String name, String operator) {
-}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteria.java
@@ -1,6 +1,10 @@
 package gov.cdc.nbs.search.criteria.text;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import gov.cdc.nbs.search.AdjustStrings;
+
+import java.util.Optional;
+import java.util.function.Predicate;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record TextCriteria(
@@ -31,4 +35,29 @@ public record TextCriteria(
     return new TextCriteria(null, null, null, null, value);
   }
 
+  public Optional<String> maybeEquals() {
+    return maybeText(equals);
+  }
+
+  public Optional<String> maybeNot() {
+    return maybeText(not);
+  }
+
+  public Optional<String> maybeStartsWith() {
+    return maybeText(startsWith);
+  }
+
+  public Optional<String> maybeContains() {
+    return maybeText(contains);
+  }
+
+  public Optional<String> maybeSoundsLike() {
+    return maybeText(soundsLike);
+  }
+
+  private static Optional<String> maybeText(String value) {
+    return Optional.ofNullable(value)
+        .filter(Predicate.not(String::isEmpty))
+        .map(AdjustStrings::withoutHyphens);
+  }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteria.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.search.criteria.text;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TextCriteria(
+    String equals,
+    String not,
+    String startsWith,
+    String contains,
+    String soundsLike
+) {
+
+  public static TextCriteria equals(final String value) {
+    return new TextCriteria(value, null, null, null, null);
+  }
+
+  public static TextCriteria not(final String value) {
+    return new TextCriteria(null, value, null, null, null);
+  }
+
+  public static TextCriteria startsWith(final String value) {
+    return new TextCriteria(null, null, value, null, null);
+  }
+
+  public static TextCriteria contains(final String value) {
+    return new TextCriteria(null, null, null, value, null);
+  }
+
+  public static TextCriteria soundsLike(final String value) {
+    return new TextCriteria(null, null, null, null, value);
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -1,14 +1,12 @@
 package gov.cdc.nbs.search.criteria.text;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
-import gov.cdc.nbs.search.AdjustStrings;
 import gov.cdc.nbs.search.WildCards;
 import org.apache.commons.codec.language.Soundex;
 
 public class TextCriteriaNestedQueryResolver {
 
   public static  BoolQuery equalTo(final String path, final String name, final String value) {
-    String adjusted = AdjustStrings.withoutHyphens(value);
     return BoolQuery.of(
         bool -> bool.must(
             should -> should.nested(
@@ -19,7 +17,7 @@ public class TextCriteriaNestedQueryResolver {
                                 must -> must.match(
                                     match -> match
                                         .field(name)
-                                        .query(adjusted)
+                                        .query(value)
                                 )
                             )
                         )
@@ -30,7 +28,6 @@ public class TextCriteriaNestedQueryResolver {
   }
 
   public static BoolQuery notEquals(final String path, final String name, final String value) {
-    String adjusted = AdjustStrings.withoutHyphens(value);
     return BoolQuery.of(
         bool -> bool.should(
             should -> should.nested(
@@ -41,7 +38,7 @@ public class TextCriteriaNestedQueryResolver {
                                 mustNot -> mustNot.match(
                                     match -> match
                                         .field(name)
-                                        .query(adjusted)
+                                        .query(value)
                                 )
                             )
                         )
@@ -52,7 +49,7 @@ public class TextCriteriaNestedQueryResolver {
   }
 
   public static BoolQuery contains(final String path, final String name, final String value) {
-    String adjusted = WildCards.contains(AdjustStrings.withoutHyphens(value));
+    String adjusted = WildCards.contains(value);
     return BoolQuery.of(
         bool -> bool.should(
             should -> should.nested(
@@ -74,7 +71,7 @@ public class TextCriteriaNestedQueryResolver {
   }
 
   public static BoolQuery startsWith(final String path, final String name, final String value) {
-    String adjusted = WildCards.startsWith(AdjustStrings.withoutHyphens(value));
+    String adjusted = WildCards.startsWith(value);
     return BoolQuery.of(
         bool -> bool.should(
             should -> should.nested(
@@ -96,7 +93,7 @@ public class TextCriteriaNestedQueryResolver {
   }
 
   public static BoolQuery soundLike(final String path, final String name, final String value) {
-    String adjusted = Holder.soundex.encode(AdjustStrings.withoutHyphens(value));
+    String adjusted = Holder.soundex.encode(value);
     return BoolQuery.of(
         bool -> bool.should(
             should -> should.nested(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -1,0 +1,128 @@
+package gov.cdc.nbs.search.criteria.text;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import gov.cdc.nbs.search.AdjustStrings;
+import gov.cdc.nbs.search.WildCards;
+import org.apache.commons.codec.language.Soundex;
+
+public class TextCriteriaNestedQueryResolver {
+
+  public static  BoolQuery equalTo(final String path, final String name, final String value) {
+    String adjusted = AdjustStrings.withoutHyphens(value);
+    return BoolQuery.of(
+        bool -> bool.must(
+            should -> should.nested(
+                nested -> nested.path(path)
+                    .query(
+                        query -> query.bool(
+                            field -> field.must(
+                                must -> must.match(
+                                    match -> match
+                                        .field(name)
+                                        .query(adjusted)
+                                )
+                            )
+                        )
+                    )
+            )
+        )
+    );
+  }
+
+  public static BoolQuery notEquals(final String path, final String name, final String value) {
+    String adjusted = AdjustStrings.withoutHyphens(value);
+    return BoolQuery.of(
+        bool -> bool.should(
+            should -> should.nested(
+                nested -> nested.path(path)
+                    .query(
+                        query -> query.bool(
+                            field -> field.mustNot(
+                                mustNot -> mustNot.match(
+                                    match -> match
+                                        .field(name)
+                                        .query(adjusted)
+                                )
+                            )
+                        )
+                    )
+            )
+        )
+    );
+  }
+
+  public static BoolQuery contains(final String path, final String name, final String value) {
+    String adjusted = WildCards.contains(AdjustStrings.withoutHyphens(value));
+    return BoolQuery.of(
+        bool -> bool.should(
+            should -> should.nested(
+                nested -> nested.path(path)
+                    .query(
+                        query -> query.bool(
+                            field -> field.must(
+                                must -> must.wildcard(
+                                    match -> match
+                                        .field(name)
+                                        .value(adjusted)
+                                )
+                            )
+                        )
+                    )
+            )
+        )
+    );
+  }
+
+  public static BoolQuery startsWith(final String path, final String name, final String value) {
+    String adjusted = WildCards.startsWith(AdjustStrings.withoutHyphens(value));
+    return BoolQuery.of(
+        bool -> bool.should(
+            should -> should.nested(
+                nested -> nested.path(path)
+                    .query(
+                        query -> query.bool(
+                            legal -> legal.must(
+                                must -> must.wildcard(
+                                    match -> match
+                                        .field(name)
+                                        .value(adjusted)
+                                )
+                            )
+                        )
+                    )
+            )
+        )
+    );
+  }
+
+  public static BoolQuery soundLike(final String path, final String name, final String value) {
+    String adjusted = Holder.soundex.encode(AdjustStrings.withoutHyphens(value));
+    return BoolQuery.of(
+        bool -> bool.should(
+            should -> should.nested(
+                nested -> nested.path(path)
+                    .query(
+                        query -> query.bool(
+                            legal -> legal.must(
+                                must -> must.term(
+                                    term -> term
+                                        .field(name)
+                                        .value(adjusted)
+                                )
+                            )
+                        )
+                    )
+            )
+        )
+    );
+  }
+
+  private TextCriteriaNestedQueryResolver() {
+    //  static
+  }
+
+  private static class Holder {
+    private static final Soundex soundex = new Soundex();
+  }
+
+}

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -22,11 +22,6 @@ input TextCriteria {
   soundsLike: String
 }
 
-input NameCriteria {
-  name: String!
-  operator: NameOperator!
-}
-
 input IdentificationCriteria {
   identificationNumber: String
   identificationType: String
@@ -41,7 +36,6 @@ input PersonFilter {
   id: String
   name: PatientNameCriteria
   lastName: String
-  lastNameCriteria: NameCriteria
   firstName: String
   race: String
   identification: IdentificationCriteria
@@ -90,14 +84,6 @@ enum Operator {
   EQUAL
   BEFORE
   AFTER
-}
-
-enum NameOperator {
-  EQUAL
-  NOT_EQUAL
-  STARTS_WITH
-  CONTAINS
-  SOUNDS_LIKE
 }
 
 type PatientSearchResultIdentification {

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -14,6 +14,14 @@ input DateCriteria {
   between: DateBetweenCriteria
 }
 
+input TextCriteria {
+  equals: String
+  not: String
+  startsWith:String
+  contains: String
+  soundsLike: String
+}
+
 input NameCriteria {
   name: String!
   operator: NameOperator!
@@ -25,8 +33,13 @@ input IdentificationCriteria {
   assigningAuthority: String
 }
 
+input PatientNameCriteria {
+  last: TextCriteria
+}
+
 input PersonFilter {
   id: String
+  name: PatientNameCriteria
   lastName: String
   lastNameCriteria: NameCriteria
   firstName: String

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -23,6 +23,7 @@ input IdentificationCriteria {
 input PersonFilter {
   id: String
   lastName: String
+  lastNameOperator: NameOperator
   firstName: String
   race: String
   identification: IdentificationCriteria
@@ -71,6 +72,14 @@ enum Operator {
   EQUAL
   BEFORE
   AFTER
+}
+
+enum NameOperator {
+  EQUAL
+  NOT_EQUAL
+  STARTS_WITH
+  CONTAINS
+  SOUNDS_LIKE
 }
 
 type PatientSearchResultIdentification {

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -14,6 +14,11 @@ input DateCriteria {
   between: DateBetweenCriteria
 }
 
+input NameCriteria {
+  name: String!
+  operator: NameOperator!
+}
+
 input IdentificationCriteria {
   identificationNumber: String
   identificationType: String
@@ -23,7 +28,7 @@ input IdentificationCriteria {
 input PersonFilter {
   id: String
   lastName: String
-  lastNameOperator: NameOperator
+  lastNameCriteria: NameCriteria
   firstName: String
   race: String
   identification: IdentificationCriteria

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -24,8 +24,7 @@ public class PatientSearchCriteriaSteps {
   @Given("I add the patient criteria for a(n) {string} equal to {string}")
   public void i_add_the_patient_criteria_for_a_field_that_is_value(
       final String field,
-      final String value
-  ) {
+      final String value) {
 
     if (field == null || field.isEmpty()) {
       return;
@@ -38,12 +37,12 @@ public class PatientSearchCriteriaSteps {
   private PatientFilter applyCriteria(
       final String field,
       final String value,
-      final PatientFilter criteria
-  ) {
+      final PatientFilter criteria) {
     switch (field.toLowerCase()) {
       case "patient id" -> criteria.setId(value);
       case "first name" -> criteria.setFirstName(value);
       case "last name" -> criteria.setLastName(value);
+      case "last name operator" -> criteria.setLastNameOperator(value);
       case "disable soundex" -> criteria.setDisableSoundex(value.equals("true"));
       case "phone number" -> criteria.setPhoneNumber(value);
       case "email", "email address" -> criteria.setEmail(value);
@@ -86,28 +85,24 @@ public class PatientSearchCriteriaSteps {
   @Given("I add the patient criteria for patient's born on the {nth} day of the month")
   public void i_would_like_to_search_for_a_patient_born_on_a_specific_day_of_the_month(final int value) {
     this.patient.maybeActive().ifPresent(
-        found -> this.activeCriteria.active(criteria -> criteria.withBornOnDay(value))
-    );
+        found -> this.activeCriteria.active(criteria -> criteria.withBornOnDay(value)));
   }
 
   @Given("I add the patient criteria for patient's born in the month of {month}")
   public void i_would_like_to_search_for_a_patient_born_on_a_specific_month(final Month month) {
     this.patient.maybeActive().ifPresent(
-        found -> this.activeCriteria.active(criteria -> criteria.withBornOnMonth(month.getValue()))
-    );
+        found -> this.activeCriteria.active(criteria -> criteria.withBornOnMonth(month.getValue())));
   }
 
   @Given("I add the patient criteria for patient's born in the year {int}")
   public void i_would_like_to_search_for_a_patient_born_on_a_specific_year(final int year) {
     this.patient.maybeActive().ifPresent(
-        found -> this.activeCriteria.active(criteria -> criteria.withBornOnYear(year))
-    );
+        found -> this.activeCriteria.active(criteria -> criteria.withBornOnYear(year)));
   }
 
   @Given("I add the patient criteria for patient's born between {localDate} and {localDate}")
   public void i_would_like_to_search_for_a_patient_born_between(final LocalDate from, final LocalDate to) {
     this.patient.maybeActive().ifPresent(
-        found -> this.activeCriteria.active(criteria -> criteria.withBornBetween(from,to))
-    );
+        found -> this.activeCriteria.active(criteria -> criteria.withBornBetween(from, to)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -3,7 +3,7 @@ package gov.cdc.nbs.patient.search;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.message.enums.Gender;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
-import gov.cdc.nbs.search.criteria.name.NameCriteria;
+import gov.cdc.nbs.search.criteria.text.TextCriteria;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
 
@@ -43,7 +43,6 @@ public class PatientSearchCriteriaSteps {
       case "patient id" -> criteria.setId(value);
       case "first name" -> criteria.setFirstName(value);
       case "last name" -> criteria.setLastName(value);
-      case "last name operator" -> criteria.setLastNameCriteria(new NameCriteria(criteria.getLastName(), value));
       case "disable soundex" -> criteria.setDisableSoundex(value.equals("true"));
       case "phone number" -> criteria.setPhoneNumber(value);
       case "email", "email address" -> criteria.setEmail(value);
@@ -105,5 +104,30 @@ public class PatientSearchCriteriaSteps {
   public void i_would_like_to_search_for_a_patient_born_between(final LocalDate from, final LocalDate to) {
     this.patient.maybeActive().ifPresent(
         found -> this.activeCriteria.active(criteria -> criteria.withBornBetween(from, to)));
+  }
+
+  @Given("I add the patient criteria for a last name that equals {string}")
+  public void i_add_the_patient_criteria_for_a_last_name_that_equals(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withLastName(TextCriteria.equals(value)));
+  }
+
+  @Given("I add the patient criteria for a last name that does not equal {string}")
+  public void i_add_the_patient_criteria_for_a_last_name_that_does_not_equal(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withLastName(TextCriteria.not(value)));
+  }
+
+  @Given("I add the patient criteria for a last name that contains {string}")
+  public void i_add_the_patient_criteria_for_a_last_name_that_contains(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withLastName(TextCriteria.contains(value)));
+  }
+
+  @Given("I add the patient criteria for a last name that starts with {string}")
+  public void i_add_the_patient_criteria_for_a_last_name_that_starts_with(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withLastName(TextCriteria.startsWith(value)));
+  }
+
+  @Given("I add the patient criteria for a last name that sounds like {string}")
+  public void i_add_the_patient_criteria_for_a_last_name_that_sounds_like(final String value) {
+    this.activeCriteria.active(criteria -> criteria.withLastName(TextCriteria.soundsLike(value)));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.patient.search;
 import gov.cdc.nbs.entity.enums.RecordStatus;
 import gov.cdc.nbs.message.enums.Gender;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.search.criteria.name.NameCriteria;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
 
@@ -42,7 +43,7 @@ public class PatientSearchCriteriaSteps {
       case "patient id" -> criteria.setId(value);
       case "first name" -> criteria.setFirstName(value);
       case "last name" -> criteria.setLastName(value);
-      case "last name operator" -> criteria.setLastNameOperator(value);
+      case "last name operator" -> criteria.setLastNameCriteria(new NameCriteria(criteria.getLastName(), value));
       case "disable soundex" -> criteria.setDisableSoundex(value.equals("true"));
       case "phone number" -> criteria.setPhoneNumber(value);
       case "email", "email address" -> criteria.setEmail(value);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchEventIdSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchEventIdSteps.java
@@ -140,6 +140,6 @@ public class PatientSearchEventIdSteps {
     this.activeAccessionNumber.maybeActive()
         .map(AccessionIdentifier::local)
         .ifPresent(
-            identifier -> this.activeCriteria.active(criteria -> criteria.withAccessiontNumber(identifier)));
+            identifier -> this.activeCriteria.active(criteria -> criteria.withAccessionNumber(identifier)));
   }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -1,60 +1,59 @@
-@patient @patient-search
-Feature: Patient Search by Last name operator
+@patient-search @patient-search-results
+Feature: Searching patient's by name
 
   Background:
     Given I am logged into NBS
     And I can "find" any "patient"
-    And I want patients sorted by "relevance" "desc"
     And I have a patient
-    And the patient has the legal name "JoeEqual" "Smith"
-    And I have another patient
-    And the patient has the legal name "JoeSoundsLike" "Smyth"
-    And I have another patient
-    And the patient has the legal name "JoeStartsWith" "Smiths"
-    And I have another patient
-    And the patient has the legal name "JoeContains" "Aerosmithy"
-    And patients are available for search
 
-  Scenario: I can find the most relevant patient when searching by last name with operator equals
-    And I add the patient criteria for a "last name" equal to "Smith"
-    And I add the patient criteria for a "last name operator" equal to "EQUAL"
+  Scenario: I can find the a patient with a last name that equals a value
+    Given I have another patient
+    And the patient has the legal name "JoeEqual" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a last name that equals "Smith"
     When I search for patients
     Then search result 1 has a "first name" of "JoeEqual"
     And search result 1 has a "last name" of "Smith"
     And there are 1 patient search results
 
-  Scenario: I can find the most relevant patient when searching by last name with operator starts with
-    And I add the patient criteria for a "last name" equal to "Smith"
-    And I add the patient criteria for a "last name operator" equal to "STARTS_WITH"
+  Scenario: I can find the a patient with a last name that does not equal a value
+    Given the patient has the legal name "Joe" "not-equal"
+    And I have another patient
+    And the patient has the legal name "JoeEqual" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a last name that does not equal "Smith"
     When I search for patients
-    Then search result 1 has a "first name" of "JoeEqual"
-    And search result 1 has a "last name" of "Smith"
-    Then search result 2 has a "first name" of "JoeStartsWith"
-    And search result 2 has a "last name" of "Smiths"
-    And there are 2 patient search results    
+    Then there are 1 patient search results
+    And the patient is not in the search results
 
-  Scenario: I can find the most relevant patient when searching by last name with operator sounds like
-    And I add the patient criteria for a "last name" equal to "Smith"
-    And I add the patient criteria for a "last name operator" equal to "SOUNDS_LIKE"
+  Scenario: I can find the a patient with a last name that contains a value
+    Given the patient has the Alias Name name "Joe" "Aerosmithy"
+    And I have another patient
+    And the patient has the legal name "Samantha" "Smother"
+    And patients are available for search
+    And I add the patient criteria for a last name that contains "smith"
     When I search for patients
-    Then search result 1 has a "first name" of "JoeEqual"
-    Then search result 2 has a "first name" of "JoeSoundsLike"
-    And there are 2 patient search results   
+    Then search result 1 has a "first name" of "Joe"
+    And search result 1 has a "last name" of "Aerosmithy"
+    And there are 1 patient search results
 
-  Scenario: I can find the most relevant patient when searching by last name with operator not equal
-    And I add the patient criteria for a "last name" equal to "Smith"
-    And I add the patient criteria for a "last name operator" equal to "NOT_EQUAL"
+  Scenario: I can find the a patient with a last name that starts with a value
+    Given the patient has the Alias Name name "Joe" "another-value"
+    And I have another patient
+    And the patient has the legal name "Sam" "starts-value"
+    And patients are available for search
+    And I add the patient criteria for a last name that starts with "starts"
     When I search for patients
-    Then search result 1 has a "last name" of "Smyth"
-    Then search result 2 has a "last name" of "Smiths"
-    Then search result 3 has a "last name" of "Aerosmithy"
-    And there are 3 patient search results   
+    Then search result 1 has a "first name" of "Sam"
+    And search result 1 has a "last name" of "starts-value"
+    And there are 1 patient search results
 
-  Scenario: I can find the most relevant patient when searching by last name with operator contains
-    And I add the patient criteria for a "last name" equal to "Smith"
-    And I add the patient criteria for a "last name operator" equal to "CONTAINS"
+  Scenario: I can find the a patient with a last name that sounds like a value
+    Given I have another patient
+    And the patient has the legal name "Joe" "Smooth"
+    And patients are available for search
+    And I add the patient criteria for a last name that sounds like "Smith"
     When I search for patients
-    Then search result 1 has a "last name" of "Smith"
-    Then search result 2 has a "last name" of "Smiths"
-    Then search result 3 has a "last name" of "Aerosmithy"
-    And there are 3 patient search results   
+    Then search result 1 has a "first name" of "Joe"
+    And search result 1 has a "last name" of "Smooth"
+    And there are 1 patient search results

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -1,0 +1,60 @@
+@patient @patient-search
+Feature: Patient Search by Last name operator
+
+  Background:
+    Given I am logged into NBS
+    And I can "find" any "patient"
+    And I want patients sorted by "relevance" "desc"
+    And I have a patient
+    And the patient has the legal name "JoeEqual" "Smith"
+    And I have another patient
+    And the patient has the legal name "JoeSoundsLike" "Smyth"
+    And I have another patient
+    And the patient has the legal name "JoeStartsWith" "Smiths"
+    And I have another patient
+    And the patient has the legal name "JoeContains" "Aerosmithy"
+    And patients are available for search
+
+  Scenario: I can find the most relevant patient when searching by last name with operator equals
+    And I add the patient criteria for a "last name" equal to "Smith"
+    And I add the patient criteria for a "last name operator" equal to "EQUAL"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith"
+    And there are 1 patient search results
+
+  Scenario: I can find the most relevant patient when searching by last name with operator starts with
+    And I add the patient criteria for a "last name" equal to "Smith"
+    And I add the patient criteria for a "last name operator" equal to "STARTS_WITH"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith"
+    Then search result 2 has a "first name" of "JoeStartsWith"
+    And search result 2 has a "last name" of "Smiths"
+    And there are 2 patient search results    
+
+  Scenario: I can find the most relevant patient when searching by last name with operator sounds like
+    And I add the patient criteria for a "last name" equal to "Smith"
+    And I add the patient criteria for a "last name operator" equal to "SOUNDS_LIKE"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    Then search result 2 has a "first name" of "JoeSoundsLike"
+    And there are 2 patient search results   
+
+  Scenario: I can find the most relevant patient when searching by last name with operator not equal
+    And I add the patient criteria for a "last name" equal to "Smith"
+    And I add the patient criteria for a "last name operator" equal to "NOT_EQUAL"
+    When I search for patients
+    Then search result 1 has a "last name" of "Smyth"
+    Then search result 2 has a "last name" of "Smiths"
+    Then search result 3 has a "last name" of "Aerosmithy"
+    And there are 3 patient search results   
+
+  Scenario: I can find the most relevant patient when searching by last name with operator contains
+    And I add the patient criteria for a "last name" equal to "Smith"
+    And I add the patient criteria for a "last name operator" equal to "CONTAINS"
+    When I search for patients
+    Then search result 1 has a "last name" of "Smith"
+    Then search result 2 has a "last name" of "Smiths"
+    Then search result 3 has a "last name" of "Aerosmithy"
+    And there are 3 patient search results   

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -629,6 +629,14 @@ export type MutationUpdatePatientRaceArgs = {
   input: RaceInput;
 };
 
+export enum NameOperator {
+  Contains = 'CONTAINS',
+  Equal = 'EQUAL',
+  NotEqual = 'NOT_EQUAL',
+  SoundsLike = 'SOUNDS_LIKE',
+  StartsWith = 'STARTS_WITH'
+}
+
 export enum NameUseCd {
   /**  Alias Name */
   A = 'A',
@@ -1673,6 +1681,7 @@ export type PersonFilter = {
   investigation?: InputMaybe<Scalars['String']['input']>;
   labReport?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
+  lastNameOperator?: InputMaybe<NameOperator>;
   morbidity?: InputMaybe<Scalars['String']['input']>;
   mortalityStatus?: InputMaybe<Scalars['String']['input']>;
   notification?: InputMaybe<Scalars['String']['input']>;
@@ -3462,8 +3471,8 @@ export function useAddressTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AddressTypesQuery, AddressTypesQueryVariables>(AddressTypesDocument, options);
         }
-export function useAddressTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AddressTypesQuery, AddressTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAddressTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AddressTypesQuery, AddressTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AddressTypesQuery, AddressTypesQueryVariables>(AddressTypesDocument, options);
         }
 export type AddressTypesQueryHookResult = ReturnType<typeof useAddressTypesQuery>;
@@ -3502,8 +3511,8 @@ export function useAddressUsesLazyQuery(baseOptions?: Apollo.LazyQueryHookOption
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AddressUsesQuery, AddressUsesQueryVariables>(AddressUsesDocument, options);
         }
-export function useAddressUsesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AddressUsesQuery, AddressUsesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAddressUsesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AddressUsesQuery, AddressUsesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AddressUsesQuery, AddressUsesQueryVariables>(AddressUsesDocument, options);
         }
 export type AddressUsesQueryHookResult = ReturnType<typeof useAddressUsesQuery>;
@@ -3542,8 +3551,8 @@ export function useAssigningAuthoritiesLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>(AssigningAuthoritiesDocument, options);
         }
-export function useAssigningAuthoritiesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAssigningAuthoritiesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AssigningAuthoritiesQuery, AssigningAuthoritiesQueryVariables>(AssigningAuthoritiesDocument, options);
         }
 export type AssigningAuthoritiesQueryHookResult = ReturnType<typeof useAssigningAuthoritiesQuery>;
@@ -3584,8 +3593,8 @@ export function useCountiesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<C
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<CountiesQuery, CountiesQueryVariables>(CountiesDocument, options);
         }
-export function useCountiesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CountiesQuery, CountiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useCountiesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CountiesQuery, CountiesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<CountiesQuery, CountiesQueryVariables>(CountiesDocument, options);
         }
 export type CountiesQueryHookResult = ReturnType<typeof useCountiesQuery>;
@@ -3624,8 +3633,8 @@ export function useCountriesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<CountriesQuery, CountriesQueryVariables>(CountriesDocument, options);
         }
-export function useCountriesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CountriesQuery, CountriesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useCountriesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CountriesQuery, CountriesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<CountriesQuery, CountriesQueryVariables>(CountriesDocument, options);
         }
 export type CountriesQueryHookResult = ReturnType<typeof useCountriesQuery>;
@@ -3664,8 +3673,8 @@ export function useDegreesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<De
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<DegreesQuery, DegreesQueryVariables>(DegreesDocument, options);
         }
-export function useDegreesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<DegreesQuery, DegreesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useDegreesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<DegreesQuery, DegreesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<DegreesQuery, DegreesQueryVariables>(DegreesDocument, options);
         }
 export type DegreesQueryHookResult = ReturnType<typeof useDegreesQuery>;
@@ -3704,8 +3713,8 @@ export function useDetailedEthnicitiesLazyQuery(baseOptions?: Apollo.LazyQueryHo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>(DetailedEthnicitiesDocument, options);
         }
-export function useDetailedEthnicitiesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useDetailedEthnicitiesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<DetailedEthnicitiesQuery, DetailedEthnicitiesQueryVariables>(DetailedEthnicitiesDocument, options);
         }
 export type DetailedEthnicitiesQueryHookResult = ReturnType<typeof useDetailedEthnicitiesQuery>;
@@ -3746,8 +3755,8 @@ export function useDetailedRacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<DetailedRacesQuery, DetailedRacesQueryVariables>(DetailedRacesDocument, options);
         }
-export function useDetailedRacesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<DetailedRacesQuery, DetailedRacesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useDetailedRacesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<DetailedRacesQuery, DetailedRacesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<DetailedRacesQuery, DetailedRacesQueryVariables>(DetailedRacesDocument, options);
         }
 export type DetailedRacesQueryHookResult = ReturnType<typeof useDetailedRacesQuery>;
@@ -3786,8 +3795,8 @@ export function useEducationLevelsLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<EducationLevelsQuery, EducationLevelsQueryVariables>(EducationLevelsDocument, options);
         }
-export function useEducationLevelsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<EducationLevelsQuery, EducationLevelsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useEducationLevelsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<EducationLevelsQuery, EducationLevelsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<EducationLevelsQuery, EducationLevelsQueryVariables>(EducationLevelsDocument, options);
         }
 export type EducationLevelsQueryHookResult = ReturnType<typeof useEducationLevelsQuery>;
@@ -3826,8 +3835,8 @@ export function useEthnicGroupsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<EthnicGroupsQuery, EthnicGroupsQueryVariables>(EthnicGroupsDocument, options);
         }
-export function useEthnicGroupsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<EthnicGroupsQuery, EthnicGroupsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useEthnicGroupsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<EthnicGroupsQuery, EthnicGroupsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<EthnicGroupsQuery, EthnicGroupsQueryVariables>(EthnicGroupsDocument, options);
         }
 export type EthnicGroupsQueryHookResult = ReturnType<typeof useEthnicGroupsQuery>;
@@ -3866,8 +3875,8 @@ export function useEthnicityUnknownReasonsLazyQuery(baseOptions?: Apollo.LazyQue
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>(EthnicityUnknownReasonsDocument, options);
         }
-export function useEthnicityUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useEthnicityUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<EthnicityUnknownReasonsQuery, EthnicityUnknownReasonsQueryVariables>(EthnicityUnknownReasonsDocument, options);
         }
 export type EthnicityUnknownReasonsQueryHookResult = ReturnType<typeof useEthnicityUnknownReasonsQuery>;
@@ -3907,8 +3916,8 @@ export function useFindAllConditionCodesLazyQuery(baseOptions?: Apollo.LazyQuery
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>(FindAllConditionCodesDocument, options);
         }
-export function useFindAllConditionCodesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllConditionCodesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllConditionCodesQuery, FindAllConditionCodesQueryVariables>(FindAllConditionCodesDocument, options);
         }
 export type FindAllConditionCodesQueryHookResult = ReturnType<typeof useFindAllConditionCodesQuery>;
@@ -3953,8 +3962,8 @@ export function useFindAllEthnicityValuesLazyQuery(baseOptions?: Apollo.LazyQuer
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>(FindAllEthnicityValuesDocument, options);
         }
-export function useFindAllEthnicityValuesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllEthnicityValuesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllEthnicityValuesQuery, FindAllEthnicityValuesQueryVariables>(FindAllEthnicityValuesDocument, options);
         }
 export type FindAllEthnicityValuesQueryHookResult = ReturnType<typeof useFindAllEthnicityValuesQuery>;
@@ -4013,8 +4022,8 @@ export function useFindAllJurisdictionsLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>(FindAllJurisdictionsDocument, options);
         }
-export function useFindAllJurisdictionsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllJurisdictionsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllJurisdictionsQuery, FindAllJurisdictionsQueryVariables>(FindAllJurisdictionsDocument, options);
         }
 export type FindAllJurisdictionsQueryHookResult = ReturnType<typeof useFindAllJurisdictionsQuery>;
@@ -4060,8 +4069,8 @@ export function useFindAllOutbreaksLazyQuery(baseOptions?: Apollo.LazyQueryHookO
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>(FindAllOutbreaksDocument, options);
         }
-export function useFindAllOutbreaksSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllOutbreaksSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllOutbreaksQuery, FindAllOutbreaksQueryVariables>(FindAllOutbreaksDocument, options);
         }
 export type FindAllOutbreaksQueryHookResult = ReturnType<typeof useFindAllOutbreaksQuery>;
@@ -4106,8 +4115,8 @@ export function useFindAllPatientIdentificationTypesLazyQuery(baseOptions?: Apol
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>(FindAllPatientIdentificationTypesDocument, options);
         }
-export function useFindAllPatientIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllPatientIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllPatientIdentificationTypesQuery, FindAllPatientIdentificationTypesQueryVariables>(FindAllPatientIdentificationTypesDocument, options);
         }
 export type FindAllPatientIdentificationTypesQueryHookResult = ReturnType<typeof useFindAllPatientIdentificationTypesQuery>;
@@ -4152,8 +4161,8 @@ export function useFindAllProgramAreasLazyQuery(baseOptions?: Apollo.LazyQueryHo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>(FindAllProgramAreasDocument, options);
         }
-export function useFindAllProgramAreasSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllProgramAreasSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllProgramAreasQuery, FindAllProgramAreasQueryVariables>(FindAllProgramAreasDocument, options);
         }
 export type FindAllProgramAreasQueryHookResult = ReturnType<typeof useFindAllProgramAreasQuery>;
@@ -4198,8 +4207,8 @@ export function useFindAllRaceValuesLazyQuery(baseOptions?: Apollo.LazyQueryHook
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>(FindAllRaceValuesDocument, options);
         }
-export function useFindAllRaceValuesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllRaceValuesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllRaceValuesQuery, FindAllRaceValuesQueryVariables>(FindAllRaceValuesDocument, options);
         }
 export type FindAllRaceValuesQueryHookResult = ReturnType<typeof useFindAllRaceValuesQuery>;
@@ -4245,8 +4254,8 @@ export function useFindAllUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindAllUsersQuery, FindAllUsersQueryVariables>(FindAllUsersDocument, options);
         }
-export function useFindAllUsersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindAllUsersQuery, FindAllUsersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindAllUsersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindAllUsersQuery, FindAllUsersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindAllUsersQuery, FindAllUsersQueryVariables>(FindAllUsersDocument, options);
         }
 export type FindAllUsersQueryHookResult = ReturnType<typeof useFindAllUsersQuery>;
@@ -4308,8 +4317,8 @@ export function useFindContactsNamedByPatientLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>(FindContactsNamedByPatientDocument, options);
         }
-export function useFindContactsNamedByPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindContactsNamedByPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindContactsNamedByPatientQuery, FindContactsNamedByPatientQueryVariables>(FindContactsNamedByPatientDocument, options);
         }
 export type FindContactsNamedByPatientQueryHookResult = ReturnType<typeof useFindContactsNamedByPatientQuery>;
@@ -4348,8 +4357,8 @@ export function useFindDistinctCodedResultsLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>(FindDistinctCodedResultsDocument, options);
         }
-export function useFindDistinctCodedResultsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDistinctCodedResultsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDistinctCodedResultsQuery, FindDistinctCodedResultsQueryVariables>(FindDistinctCodedResultsDocument, options);
         }
 export type FindDistinctCodedResultsQueryHookResult = ReturnType<typeof useFindDistinctCodedResultsQuery>;
@@ -4388,8 +4397,8 @@ export function useFindDistinctResultedTestLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>(FindDistinctResultedTestDocument, options);
         }
-export function useFindDistinctResultedTestSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDistinctResultedTestSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDistinctResultedTestQuery, FindDistinctResultedTestQueryVariables>(FindDistinctResultedTestDocument, options);
         }
 export type FindDistinctResultedTestQueryHookResult = ReturnType<typeof useFindDistinctResultedTestQuery>;
@@ -4443,8 +4452,8 @@ export function useFindDocumentsForPatientLazyQuery(baseOptions?: Apollo.LazyQue
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>(FindDocumentsForPatientDocument, options);
         }
-export function useFindDocumentsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDocumentsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDocumentsForPatientQuery, FindDocumentsForPatientQueryVariables>(FindDocumentsForPatientDocument, options);
         }
 export type FindDocumentsForPatientQueryHookResult = ReturnType<typeof useFindDocumentsForPatientQuery>;
@@ -4508,8 +4517,8 @@ export function useFindDocumentsRequiringReviewForPatientLazyQuery(baseOptions?:
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>(FindDocumentsRequiringReviewForPatientDocument, options);
         }
-export function useFindDocumentsRequiringReviewForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindDocumentsRequiringReviewForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindDocumentsRequiringReviewForPatientQuery, FindDocumentsRequiringReviewForPatientQueryVariables>(FindDocumentsRequiringReviewForPatientDocument, options);
         }
 export type FindDocumentsRequiringReviewForPatientQueryHookResult = ReturnType<typeof useFindDocumentsRequiringReviewForPatientQuery>;
@@ -4573,8 +4582,8 @@ export function useFindInvestigationsByFilterLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>(FindInvestigationsByFilterDocument, options);
         }
-export function useFindInvestigationsByFilterSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindInvestigationsByFilterSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindInvestigationsByFilterQuery, FindInvestigationsByFilterQueryVariables>(FindInvestigationsByFilterDocument, options);
         }
 export type FindInvestigationsByFilterQueryHookResult = ReturnType<typeof useFindInvestigationsByFilterQuery>;
@@ -4633,8 +4642,8 @@ export function useFindInvestigationsForPatientLazyQuery(baseOptions?: Apollo.La
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>(FindInvestigationsForPatientDocument, options);
         }
-export function useFindInvestigationsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindInvestigationsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindInvestigationsForPatientQuery, FindInvestigationsForPatientQueryVariables>(FindInvestigationsForPatientDocument, options);
         }
 export type FindInvestigationsForPatientQueryHookResult = ReturnType<typeof useFindInvestigationsForPatientQuery>;
@@ -4716,8 +4725,8 @@ export function useFindLabReportsByFilterLazyQuery(baseOptions?: Apollo.LazyQuer
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>(FindLabReportsByFilterDocument, options);
         }
-export function useFindLabReportsByFilterSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindLabReportsByFilterSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindLabReportsByFilterQuery, FindLabReportsByFilterQueryVariables>(FindLabReportsByFilterDocument, options);
         }
 export type FindLabReportsByFilterQueryHookResult = ReturnType<typeof useFindLabReportsByFilterQuery>;
@@ -4788,8 +4797,8 @@ export function useFindLabReportsForPatientLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>(FindLabReportsForPatientDocument, options);
         }
-export function useFindLabReportsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindLabReportsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindLabReportsForPatientQuery, FindLabReportsForPatientQueryVariables>(FindLabReportsForPatientDocument, options);
         }
 export type FindLabReportsForPatientQueryHookResult = ReturnType<typeof useFindLabReportsForPatientQuery>;
@@ -4852,8 +4861,8 @@ export function useFindMorbidityReportsForPatientLazyQuery(baseOptions?: Apollo.
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>(FindMorbidityReportsForPatientDocument, options);
         }
-export function useFindMorbidityReportsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindMorbidityReportsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindMorbidityReportsForPatientQuery, FindMorbidityReportsForPatientQueryVariables>(FindMorbidityReportsForPatientDocument, options);
         }
 export type FindMorbidityReportsForPatientQueryHookResult = ReturnType<typeof useFindMorbidityReportsForPatientQuery>;
@@ -4915,8 +4924,8 @@ export function useFindPatientNamedByContactLazyQuery(baseOptions?: Apollo.LazyQ
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>(FindPatientNamedByContactDocument, options);
         }
-export function useFindPatientNamedByContactSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindPatientNamedByContactSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindPatientNamedByContactQuery, FindPatientNamedByContactQueryVariables>(FindPatientNamedByContactDocument, options);
         }
 export type FindPatientNamedByContactQueryHookResult = ReturnType<typeof useFindPatientNamedByContactQuery>;
@@ -5270,8 +5279,8 @@ export function useFindPatientProfileLazyQuery(baseOptions?: Apollo.LazyQueryHoo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindPatientProfileQuery, FindPatientProfileQueryVariables>(FindPatientProfileDocument, options);
         }
-export function useFindPatientProfileSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindPatientProfileQuery, FindPatientProfileQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindPatientProfileSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindPatientProfileQuery, FindPatientProfileQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindPatientProfileQuery, FindPatientProfileQueryVariables>(FindPatientProfileDocument, options);
         }
 export type FindPatientProfileQueryHookResult = ReturnType<typeof useFindPatientProfileQuery>;
@@ -5357,8 +5366,8 @@ export function useFindPatientsByFilterLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>(FindPatientsByFilterDocument, options);
         }
-export function useFindPatientsByFilterSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindPatientsByFilterSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindPatientsByFilterQuery, FindPatientsByFilterQueryVariables>(FindPatientsByFilterDocument, options);
         }
 export type FindPatientsByFilterQueryHookResult = ReturnType<typeof useFindPatientsByFilterQuery>;
@@ -5412,8 +5421,8 @@ export function useFindTreatmentsForPatientLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>(FindTreatmentsForPatientDocument, options);
         }
-export function useFindTreatmentsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindTreatmentsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindTreatmentsForPatientQuery, FindTreatmentsForPatientQueryVariables>(FindTreatmentsForPatientDocument, options);
         }
 export type FindTreatmentsForPatientQueryHookResult = ReturnType<typeof useFindTreatmentsForPatientQuery>;
@@ -5467,8 +5476,8 @@ export function useFindVaccinationsForPatientLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>(FindVaccinationsForPatientDocument, options);
         }
-export function useFindVaccinationsForPatientSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useFindVaccinationsForPatientSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<FindVaccinationsForPatientQuery, FindVaccinationsForPatientQueryVariables>(FindVaccinationsForPatientDocument, options);
         }
 export type FindVaccinationsForPatientQueryHookResult = ReturnType<typeof useFindVaccinationsForPatientQuery>;
@@ -5507,8 +5516,8 @@ export function useGenderUnknownReasonsLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>(GenderUnknownReasonsDocument, options);
         }
-export function useGenderUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGenderUnknownReasonsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GenderUnknownReasonsQuery, GenderUnknownReasonsQueryVariables>(GenderUnknownReasonsDocument, options);
         }
 export type GenderUnknownReasonsQueryHookResult = ReturnType<typeof useGenderUnknownReasonsQuery>;
@@ -5547,8 +5556,8 @@ export function useGendersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Ge
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GendersQuery, GendersQueryVariables>(GendersDocument, options);
         }
-export function useGendersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GendersQuery, GendersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGendersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GendersQuery, GendersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GendersQuery, GendersQueryVariables>(GendersDocument, options);
         }
 export type GendersQueryHookResult = ReturnType<typeof useGendersQuery>;
@@ -5587,8 +5596,8 @@ export function useIdentificationTypesLazyQuery(baseOptions?: Apollo.LazyQueryHo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<IdentificationTypesQuery, IdentificationTypesQueryVariables>(IdentificationTypesDocument, options);
         }
-export function useIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<IdentificationTypesQuery, IdentificationTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useIdentificationTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<IdentificationTypesQuery, IdentificationTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<IdentificationTypesQuery, IdentificationTypesQueryVariables>(IdentificationTypesDocument, options);
         }
 export type IdentificationTypesQueryHookResult = ReturnType<typeof useIdentificationTypesQuery>;
@@ -5627,8 +5636,8 @@ export function useMaritalStatusesLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<MaritalStatusesQuery, MaritalStatusesQueryVariables>(MaritalStatusesDocument, options);
         }
-export function useMaritalStatusesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<MaritalStatusesQuery, MaritalStatusesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useMaritalStatusesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<MaritalStatusesQuery, MaritalStatusesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<MaritalStatusesQuery, MaritalStatusesQueryVariables>(MaritalStatusesDocument, options);
         }
 export type MaritalStatusesQueryHookResult = ReturnType<typeof useMaritalStatusesQuery>;
@@ -5667,8 +5676,8 @@ export function useNameTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<NameTypesQuery, NameTypesQueryVariables>(NameTypesDocument, options);
         }
-export function useNameTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<NameTypesQuery, NameTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useNameTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<NameTypesQuery, NameTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<NameTypesQuery, NameTypesQueryVariables>(NameTypesDocument, options);
         }
 export type NameTypesQueryHookResult = ReturnType<typeof useNameTypesQuery>;
@@ -5707,8 +5716,8 @@ export function usePhoneTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PhoneTypesQuery, PhoneTypesQueryVariables>(PhoneTypesDocument, options);
         }
-export function usePhoneTypesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PhoneTypesQuery, PhoneTypesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePhoneTypesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PhoneTypesQuery, PhoneTypesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PhoneTypesQuery, PhoneTypesQueryVariables>(PhoneTypesDocument, options);
         }
 export type PhoneTypesQueryHookResult = ReturnType<typeof usePhoneTypesQuery>;
@@ -5747,8 +5756,8 @@ export function usePhoneUsesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PhoneUsesQuery, PhoneUsesQueryVariables>(PhoneUsesDocument, options);
         }
-export function usePhoneUsesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PhoneUsesQuery, PhoneUsesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePhoneUsesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PhoneUsesQuery, PhoneUsesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PhoneUsesQuery, PhoneUsesQueryVariables>(PhoneUsesDocument, options);
         }
 export type PhoneUsesQueryHookResult = ReturnType<typeof usePhoneUsesQuery>;
@@ -5787,8 +5796,8 @@ export function usePreferredGendersLazyQuery(baseOptions?: Apollo.LazyQueryHookO
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PreferredGendersQuery, PreferredGendersQueryVariables>(PreferredGendersDocument, options);
         }
-export function usePreferredGendersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PreferredGendersQuery, PreferredGendersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePreferredGendersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PreferredGendersQuery, PreferredGendersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PreferredGendersQuery, PreferredGendersQueryVariables>(PreferredGendersDocument, options);
         }
 export type PreferredGendersQueryHookResult = ReturnType<typeof usePreferredGendersQuery>;
@@ -5827,8 +5836,8 @@ export function usePrefixesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<P
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PrefixesQuery, PrefixesQueryVariables>(PrefixesDocument, options);
         }
-export function usePrefixesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PrefixesQuery, PrefixesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePrefixesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PrefixesQuery, PrefixesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PrefixesQuery, PrefixesQueryVariables>(PrefixesDocument, options);
         }
 export type PrefixesQueryHookResult = ReturnType<typeof usePrefixesQuery>;
@@ -5867,8 +5876,8 @@ export function usePrimaryLanguagesLazyQuery(baseOptions?: Apollo.LazyQueryHookO
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>(PrimaryLanguagesDocument, options);
         }
-export function usePrimaryLanguagesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePrimaryLanguagesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PrimaryLanguagesQuery, PrimaryLanguagesQueryVariables>(PrimaryLanguagesDocument, options);
         }
 export type PrimaryLanguagesQueryHookResult = ReturnType<typeof usePrimaryLanguagesQuery>;
@@ -5907,8 +5916,8 @@ export function usePrimaryOccupationsLazyQuery(baseOptions?: Apollo.LazyQueryHoo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>(PrimaryOccupationsDocument, options);
         }
-export function usePrimaryOccupationsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function usePrimaryOccupationsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<PrimaryOccupationsQuery, PrimaryOccupationsQueryVariables>(PrimaryOccupationsDocument, options);
         }
 export type PrimaryOccupationsQueryHookResult = ReturnType<typeof usePrimaryOccupationsQuery>;
@@ -5947,8 +5956,8 @@ export function useRaceCategoriesLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<RaceCategoriesQuery, RaceCategoriesQueryVariables>(RaceCategoriesDocument, options);
         }
-export function useRaceCategoriesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<RaceCategoriesQuery, RaceCategoriesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useRaceCategoriesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<RaceCategoriesQuery, RaceCategoriesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<RaceCategoriesQuery, RaceCategoriesQueryVariables>(RaceCategoriesDocument, options);
         }
 export type RaceCategoriesQueryHookResult = ReturnType<typeof useRaceCategoriesQuery>;
@@ -5988,8 +5997,8 @@ export function useStatesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Sta
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<StatesQuery, StatesQueryVariables>(StatesDocument, options);
         }
-export function useStatesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<StatesQuery, StatesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useStatesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<StatesQuery, StatesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<StatesQuery, StatesQueryVariables>(StatesDocument, options);
         }
 export type StatesQueryHookResult = ReturnType<typeof useStatesQuery>;
@@ -6028,8 +6037,8 @@ export function useSuffixesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<S
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<SuffixesQuery, SuffixesQueryVariables>(SuffixesDocument, options);
         }
-export function useSuffixesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SuffixesQuery, SuffixesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useSuffixesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SuffixesQuery, SuffixesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<SuffixesQuery, SuffixesQueryVariables>(SuffixesDocument, options);
         }
 export type SuffixesQueryHookResult = ReturnType<typeof useSuffixesQuery>;

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -629,6 +629,11 @@ export type MutationUpdatePatientRaceArgs = {
   input: RaceInput;
 };
 
+export type NameCriteria = {
+  name: Scalars['String']['input'];
+  operator: NameOperator;
+};
+
 export enum NameOperator {
   Contains = 'CONTAINS',
   Equal = 'EQUAL',
@@ -1681,7 +1686,7 @@ export type PersonFilter = {
   investigation?: InputMaybe<Scalars['String']['input']>;
   labReport?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
-  lastNameOperator?: InputMaybe<NameOperator>;
+  lastNameCriteria?: InputMaybe<NameCriteria>;
   morbidity?: InputMaybe<Scalars['String']['input']>;
   mortalityStatus?: InputMaybe<Scalars['String']['input']>;
   notification?: InputMaybe<Scalars['String']['input']>;

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -629,19 +629,6 @@ export type MutationUpdatePatientRaceArgs = {
   input: RaceInput;
 };
 
-export type NameCriteria = {
-  name: Scalars['String']['input'];
-  operator: NameOperator;
-};
-
-export enum NameOperator {
-  Contains = 'CONTAINS',
-  Equal = 'EQUAL',
-  NotEqual = 'NOT_EQUAL',
-  SoundsLike = 'SOUNDS_LIKE',
-  StartsWith = 'STARTS_WITH'
-}
-
 export enum NameUseCd {
   /**  Alias Name */
   A = 'A',
@@ -1301,6 +1288,10 @@ export type PatientNameChangeResult = {
   sequence: Scalars['Int']['output'];
 };
 
+export type PatientNameCriteria = {
+  last?: InputMaybe<TextCriteria>;
+};
+
 export type PatientNameDegree = {
   __typename?: 'PatientNameDegree';
   description: Scalars['String']['output'];
@@ -1686,9 +1677,9 @@ export type PersonFilter = {
   investigation?: InputMaybe<Scalars['String']['input']>;
   labReport?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
-  lastNameCriteria?: InputMaybe<NameCriteria>;
   morbidity?: InputMaybe<Scalars['String']['input']>;
   mortalityStatus?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<PatientNameCriteria>;
   notification?: InputMaybe<Scalars['String']['input']>;
   phoneNumber?: InputMaybe<Scalars['String']['input']>;
   race?: InputMaybe<Scalars['String']['input']>;
@@ -2075,6 +2066,14 @@ export enum Suffix {
   Sr = 'SR',
   V = 'V'
 }
+
+export type TextCriteria = {
+  contains?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  soundsLike?: InputMaybe<Scalars['String']['input']>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type TracedCondition = {
   __typename?: 'TracedCondition';

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1108,9 +1108,12 @@ input DateCriteria {
   between: DateBetweenCriteria
 }
 
-input NameCriteria {
-  name: String!
-  operator: NameOperator!
+input TextCriteria {
+  equals: String
+  not: String
+  startsWith:String
+  contains: String
+  soundsLike: String
 }
 
 input IdentificationCriteria {
@@ -1119,10 +1122,14 @@ input IdentificationCriteria {
   assigningAuthority: String
 }
 
+input PatientNameCriteria {
+  last: TextCriteria
+}
+
 input PersonFilter {
   id: String
+  name: PatientNameCriteria
   lastName: String
-  lastNameCriteria: NameCriteria
   firstName: String
   race: String
   identification: IdentificationCriteria
@@ -1171,14 +1178,6 @@ enum Operator {
   EQUAL
   BEFORE
   AFTER
-}
-
-enum NameOperator {
-  EQUAL
-  NOT_EQUAL
-  STARTS_WITH
-  CONTAINS
-  SOUNDS_LIKE
 }
 
 type PatientSearchResultIdentification {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1108,6 +1108,11 @@ input DateCriteria {
   between: DateBetweenCriteria
 }
 
+input NameCriteria {
+  name: String!
+  operator: NameOperator!
+}
+
 input IdentificationCriteria {
   identificationNumber: String
   identificationType: String
@@ -1117,7 +1122,7 @@ input IdentificationCriteria {
 input PersonFilter {
   id: String
   lastName: String
-  lastNameOperator: NameOperator
+  lastNameCriteria: NameCriteria
   firstName: String
   race: String
   identification: IdentificationCriteria

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1117,6 +1117,7 @@ input IdentificationCriteria {
 input PersonFilter {
   id: String
   lastName: String
+  lastNameOperator: NameOperator
   firstName: String
   race: String
   identification: IdentificationCriteria
@@ -1165,6 +1166,14 @@ enum Operator {
   EQUAL
   BEFORE
   AFTER
+}
+
+enum NameOperator {
+  EQUAL
+  NOT_EQUAL
+  STARTS_WITH
+  CONTAINS
+  SOUNDS_LIKE
 }
 
 type PatientSearchResultIdentification {


### PR DESCRIPTION
## Description

Add new field `name` with a patient name type `input PatientNameCriteria {
  last: TextCriteria
}` that is a generic type of 
`input TextCriteria {
  equals: String
  not: String
  startsWith:String
  contains: String
  soundsLike: String
}`.
  If that field is populated diverge from old code (for backwards compatibility) and call the new searches wrt each operator.

## Tickets

* [CNFT1-3312](https://cdc-nbs.atlassian.net/browse/CNFT1-3312)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3312]: https://cdc-nbs.atlassian.net/browse/CNFT1-3312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ