### PR TITLE
[FIX] disables navigation to /patient/add

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/add/useAddPatientFromSearch.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/useAddPatientFromSearch.ts
@@ -2,7 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import { PatientCriteriaEntry } from '../criteria';
 import { asNewPatientEntry } from './asNewPatientEntry';
 import { useFormContext } from 'react-hook-form';
-import { useConfiguration } from 'configuration';
 
 type Interaction = {
     add: () => void;
@@ -11,12 +10,10 @@ type Interaction = {
 const useAddPatientFromSearch = (): Interaction => {
     const navigate = useNavigate();
     const { getValues } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
-    const { features } = useConfiguration();
-    const addPatientUrl = features.patient.add.enabled ? '/patient/add' : '/add-patient';
 
     const add = () => {
         const defaults = asNewPatientEntry(getValues());
-        navigate(addPatientUrl, { state: { defaults } });
+        navigate('/add-patient', { state: { defaults } });
     };
 
     return {


### PR DESCRIPTION
## Description

Disables the navigation to `/patient/add` from patient search until the page is more complete.  A new story will be created to restore this functionality.


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
