### PR TITLE
[CNFT1-3446]: changing reValidate to onBlur

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -35,7 +35,7 @@ const RepeatingBlock = <V extends FieldValues>({
     formRenderer,
     viewRenderer
 }: Props<V>) => {
-    const form = useForm<V>({ mode: 'onSubmit', reValidateMode: 'onSubmit', defaultValues });
+    const form = useForm<V>({ mode: 'onSubmit', reValidateMode: 'onBlur', defaultValues });
     const { status, selected, add, edit, update, remove, view, reset, state } = useMultiValueEntryState<V>({ values });
 
     useEffect(() => {

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -75,12 +75,18 @@ describe('when one of the options is clicked', () => {
             selectedValue = value || null;
         };
 
-        const { getByRole } = render(<SingleSelectTestWrapper value={selectedValue} onChange={handleChange} />);
+        const { getByRole, rerender } = render(
+            <SingleSelectTestWrapper value={selectedValue} onChange={handleChange} />
+        );
 
         const select = getByRole('combobox', { name: 'Test Label' });
 
         userEvent.selectOptions(select, ['value-four']);
 
+        rerender(<SingleSelectTestWrapper value={selectedValue} onChange={handleChange} />);
+
+        const checked = getByRole('option', { name: 'name-four', selected: true });
+        expect(checked).toHaveTextContent('name-four');
         expect(selectedValue).toEqual({ name: 'name-four', value: 'value-four', label: 'label-four' });
     });
 });

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SingleSelect } from './SingleSelect';
-import { Selectable } from 'options/selectable';
 
 describe('when selecting a single item from a specific set of items', () => {
     it('should display the SingleSelect without a value checked', () => {
@@ -49,13 +48,7 @@ describe('when selecting a single item from a specific set of items', () => {
 
 describe('when one of the options is clicked', () => {
     it('should mark the option as checked', () => {
-        const SingleSelectTestWrapper = ({
-            value,
-            onChange
-        }: {
-            value: Selectable | null;
-            onChange: (value?: Selectable) => void;
-        }) => (
+        const { getByRole } = render(
             <SingleSelect
                 id="test-id"
                 label="Test Label"
@@ -66,27 +59,15 @@ describe('when one of the options is clicked', () => {
                     { name: 'name-four', value: 'value-four', label: 'label-four' }
                 ]}
                 name="test-name"
-                value={value}
-                onChange={onChange}
+                value={{ name: 'name-four', value: 'value-four', label: 'label-four' }}
+                onChange={jest.fn()}
             />
         );
-        let selectedValue = null;
-        const handleChange = (value?: Selectable) => {
-            selectedValue = value || null;
-        };
-
-        const { getByRole, rerender } = render(
-            <SingleSelectTestWrapper value={selectedValue} onChange={handleChange} />
-        );
-
         const select = getByRole('combobox', { name: 'Test Label' });
 
-        userEvent.selectOptions(select, ['value-four']);
+        userEvent.selectOptions(select, 'value-four');
+        const checked = getByRole('option', { selected: true });
 
-        rerender(<SingleSelectTestWrapper value={selectedValue} onChange={handleChange} />);
-
-        const checked = getByRole('option', { name: 'name-four', selected: true });
         expect(checked).toHaveTextContent('name-four');
-        expect(selectedValue).toEqual({ name: 'name-four', value: 'value-four', label: 'label-four' });
     });
 });

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SingleSelect } from './SingleSelect';
@@ -50,32 +49,38 @@ describe('when selecting a single item from a specific set of items', () => {
 
 describe('when one of the options is clicked', () => {
     it('should mark the option as checked', () => {
-        const TestComponent = () => {
-            const [selectedValue, setSelectedValue] = useState<Selectable | null>(null);
-
-            return (
-                <SingleSelect
-                    id="test-id"
-                    label="Test Label"
-                    options={[
-                        { name: 'name-one', value: 'value-one', label: 'label-one' },
-                        { name: 'name-two', value: 'value-two', label: 'label-two' },
-                        { name: 'name-three', value: 'value-three', label: 'label-three' },
-                        { name: 'name-four', value: 'value-four', label: 'label-four' }
-                    ]}
-                    name="test-name"
-                    value={selectedValue}
-                    onChange={(value?: Selectable) => setSelectedValue(value || null)}
-                />
-            );
+        const SingleSelectTestWrapper = ({
+            value,
+            onChange
+        }: {
+            value: Selectable | null;
+            onChange: (value?: Selectable) => void;
+        }) => (
+            <SingleSelect
+                id="test-id"
+                label="Test Label"
+                options={[
+                    { name: 'name-one', value: 'value-one', label: 'label-one' },
+                    { name: 'name-two', value: 'value-two', label: 'label-two' },
+                    { name: 'name-three', value: 'value-three', label: 'label-three' },
+                    { name: 'name-four', value: 'value-four', label: 'label-four' }
+                ]}
+                name="test-name"
+                value={value}
+                onChange={onChange}
+            />
+        );
+        let selectedValue = null;
+        const handleChange = (value?: Selectable) => {
+            selectedValue = value || null;
         };
 
-        const { getByRole } = render(<TestComponent />);
+        const { getByRole } = render(<SingleSelectTestWrapper value={selectedValue} onChange={handleChange} />);
 
         const select = getByRole('combobox', { name: 'Test Label' });
 
         userEvent.selectOptions(select, ['value-four']);
 
-        expect(select).toHaveValue('value-four');
+        expect(selectedValue).toEqual({ name: 'name-four', value: 'value-four', label: 'label-four' });
     });
 });

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -65,7 +65,7 @@ describe('when one of the options is clicked', () => {
                     ]}
                     name="test-name"
                     value={selectedValue}
-                    onChange={setSelectedValue}
+                    onChange={(value?: Selectable) => setSelectedValue(value || null)}
                 />
             );
         };

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -1,6 +1,8 @@
+import React, { useState } from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SingleSelect } from './SingleSelect';
+import { Selectable } from 'options/selectable';
 
 describe('when selecting a single item from a specific set of items', () => {
     it('should display the SingleSelect without a value checked', () => {
@@ -48,26 +50,32 @@ describe('when selecting a single item from a specific set of items', () => {
 
 describe('when one of the options is clicked', () => {
     it('should mark the option as checked', () => {
-        const { getByRole } = render(
-            <SingleSelect
-                id="test-id"
-                label="Test Label"
-                options={[
-                    { name: 'name-one', value: 'value-one', label: 'label-one' },
-                    { name: 'name-two', value: 'value-two', label: 'label-two' },
-                    { name: 'name-three', value: 'value-three', label: 'label-three' },
-                    { name: 'name-four', value: 'value-four', label: 'label-four' }
-                ]}
-                name="test-name"
-            />
-        );
+        const TestComponent = () => {
+            const [selectedValue, setSelectedValue] = useState<Selectable | null>(null);
+
+            return (
+                <SingleSelect
+                    id="test-id"
+                    label="Test Label"
+                    options={[
+                        { name: 'name-one', value: 'value-one', label: 'label-one' },
+                        { name: 'name-two', value: 'value-two', label: 'label-two' },
+                        { name: 'name-three', value: 'value-three', label: 'label-three' },
+                        { name: 'name-four', value: 'value-four', label: 'label-four' }
+                    ]}
+                    name="test-name"
+                    value={selectedValue}
+                    onChange={setSelectedValue}
+                />
+            );
+        };
+
+        const { getByRole } = render(<TestComponent />);
 
         const select = getByRole('combobox', { name: 'Test Label' });
 
-        userEvent.selectOptions(select, 'name-four');
+        userEvent.selectOptions(select, ['value-four']);
 
-        const checked = getByRole('option', { selected: true });
-
-        expect(checked).toHaveTextContent('name-four');
+        expect(select).toHaveValue('value-four');
     });
 });

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
@@ -57,11 +57,12 @@ const SingleSelect = ({
             required={required}
             error={error}>
             <TrussworksSelect
+                key={value?.value}
                 {...inputProps}
                 id={id}
                 validationStatus={error ? 'error' : undefined}
                 name={inputProps.name ?? id}
-                value={value?.value || ''}
+                defaultValue={value?.value}
                 placeholder="-Select-"
                 onChange={handleChange}>
                 {renderOptions(placeholder, options)}

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
@@ -48,20 +48,6 @@ const SingleSelect = ({
         }
     };
 
-    //  In order for the defaultValue to be applied the component has to be re-created when it goes from null to non null.
-    const Wrapped = () => (
-        <TrussworksSelect
-            {...inputProps}
-            id={id}
-            validationStatus={error ? 'error' : undefined}
-            name={inputProps.name ?? id}
-            defaultValue={value?.value}
-            placeholder="-Select-"
-            onChange={handleChange}>
-            {renderOptions(placeholder, options)}
-        </TrussworksSelect>
-    );
-
     return (
         <EntryWrapper
             orientation={orientation}
@@ -70,8 +56,16 @@ const SingleSelect = ({
             htmlFor={id}
             required={required}
             error={error}>
-            {value && <Wrapped />}
-            {!value && <Wrapped />}
+            <TrussworksSelect
+                {...inputProps}
+                id={id}
+                validationStatus={error ? 'error' : undefined}
+                name={inputProps.name ?? id}
+                value={value?.value || ''}
+                placeholder="-Select-"
+                onChange={handleChange}>
+                {renderOptions(placeholder, options)}
+            </TrussworksSelect>
         </EntryWrapper>
     );
 };


### PR DESCRIPTION
## Description
changing reValidate to onBlur to fix an issue where the repeating blocks inline validations were not being removed after they were corrected on blur


## Tickets

* [CNFT1-3446](https://cdc-nbs.atlassian.net/browse/CNFT1-3446)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3446]: https://cdc-nbs.atlassian.net/browse/CNFT1-3446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ