### PR TITLE
CNFT1-3421 API: Loosen cd,use_cd fields for Search to enable HL7 ingestion without error

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/PatientSummaryFinder.java
@@ -45,20 +45,19 @@ class PatientSummaryFinder {
 
   Optional<PatientSummary> find(final long identifier, final Instant asOf) {
     return this.factory.selectDistinct(
-            this.tables.patient().personParentUid.id,
-            this.tables.prefix().codeShortDescTxt,
-            this.tables.name().firstNm,
-            this.tables.name().middleNm,
-            this.tables.name().lastNm,
-            this.tables.name().nmSuffix,
-            this.tables.patient().currSexCd,
-            this.tables.patient().birthTime,
-            this.tables.ethnicity().codeShortDescTxt,
-            this.tables.phoneNumber().phoneNbrTxt,
-            this.tables.phoneUse().codeShortDescTxt,
-            this.tables.email().emailAddress,
-            this.tables.emailUse().codeShortDescTxt
-        ).from(this.tables.patient())
+        this.tables.patient().personParentUid.id,
+        this.tables.prefix().codeShortDescTxt,
+        this.tables.name().firstNm,
+        this.tables.name().middleNm,
+        this.tables.name().lastNm,
+        this.tables.name().nmSuffix,
+        this.tables.patient().currSexCd,
+        this.tables.patient().birthTime,
+        this.tables.ethnicity().codeShortDescTxt,
+        this.tables.phoneNumber().phoneNbrTxt,
+        this.tables.phoneUse().codeShortDescTxt,
+        this.tables.email().emailAddress,
+        this.tables.emailUse().codeShortDescTxt).from(this.tables.patient())
         //  Most effective Legal name for the as of
         .leftJoin(this.tables.name()).on(
             this.tables.name().id.personUid.eq(this.tables.patient().id),
@@ -71,9 +70,7 @@ class PatientSummaryFinder {
                         EFF_NAME.id.personUid.eq(this.tables.name().id.personUid),
                         EFF_NAME.recordStatusCd.eq(this.tables.name().recordStatusCd),
                         EFF_NAME.nmUseCd.eq(this.tables.name().nmUseCd),
-                        EFF_NAME.asOfDate.loe(asOf)
-                    )
-            ),
+                        EFF_NAME.asOfDate.loe(asOf))),
             this.tables.name().id.personNameSeq.eq(
                 JPAExpressions.select(SEQ_NAME.id.personNameSeq.max())
                     .from(SEQ_NAME)
@@ -81,46 +78,35 @@ class PatientSummaryFinder {
                         SEQ_NAME.id.personUid.eq(this.tables.name().id.personUid),
                         SEQ_NAME.recordStatusCd.eq(this.tables.name().recordStatusCd),
                         SEQ_NAME.nmUseCd.eq(this.tables.name().nmUseCd),
-                        SEQ_NAME.asOfDate.eq(this.tables.name().asOfDate)
-                    )
-            )
-        )
+                        SEQ_NAME.asOfDate.eq(this.tables.name().asOfDate))))
         .leftJoin(this.tables.prefix()).on(
             this.tables.prefix().id.codeSetNm.eq(NAME_PREFIX_CODE_SET),
-            this.tables.prefix().id.code.eq(this.tables.name().nmPrefix)
-        )
+            this.tables.prefix().id.code.eq(this.tables.name().nmPrefix))
         //
         .leftJoin(this.tables.ethnicity()).on(
             this.tables.ethnicity().id.codeSetNm.eq(ETHNIC_GROUP_CODE_SET),
-            this.tables.ethnicity().id.code.eq(this.tables.patient().ethnicity.ethnicGroupInd)
-        )
+            this.tables.ethnicity().id.code.eq(this.tables.patient().ethnicity.ethnicGroupInd))
         //  Most effective Phone number for the as of
         .leftJoin(this.tables.phone()).on(
             this.tables.phone().id.entityUid.eq(this.tables.patient().id),
             this.tables.phone().recordStatusCd.eq(ACTIVE_CODE),
-            this.tables.phone().cd.ne(EMAIL_CODE),
+            this.tables.phone().cd.isNull().or(this.tables.phone().cd.ne(EMAIL_CODE)),
             this.tables.phone().asOfDate.eq(
                 JPAExpressions.select(EFF_PHONE.asOfDate.max())
                     .from(EFF_PHONE)
                     .join(EFF_PHONE_CHILD).on(
                         EFF_PHONE_CHILD.id.eq(EFF_PHONE.id.entityUid),
-                        EFF_PHONE_CHILD.personParentUid.id.eq(this.tables.patient().personParentUid.id)
-                    )
+                        EFF_PHONE_CHILD.personParentUid.id.eq(this.tables.patient().personParentUid.id))
                     .where(
                         EFF_PHONE.id.entityUid.eq(this.tables.phone().id.entityUid),
-                        EFF_PHONE.cd.eq(this.tables.phone().cd),
-                        EFF_PHONE.asOfDate.loe(asOf)
-                    )
-            )
-        )
+                        this.tables.phone().cd.isNull().or(EFF_PHONE.cd.eq(this.tables.phone().cd)),
+                        EFF_PHONE.asOfDate.loe(asOf))))
         .leftJoin(this.tables.phoneNumber()).on(
             this.tables.phoneNumber().id.eq(this.tables.phone().id.locatorUid),
-            this.tables.phoneNumber().phoneNbrTxt.isNotNull()
-        )
+            this.tables.phoneNumber().phoneNbrTxt.isNotNull())
         .leftJoin(this.tables.phoneUse()).on(
             this.tables.phoneUse().id.codeSetNm.eq("EL_USE_TELE_PAT"),
-            this.tables.phoneUse().id.code.eq(this.tables.phone().useCd)
-        )
+            this.tables.phoneUse().id.code.eq(this.tables.phone().useCd))
         //  Most effective email for the as of
         .leftJoin(this.tables.net()).on(
             this.tables.net().id.entityUid.eq(this.tables.patient().id),
@@ -132,28 +118,21 @@ class PatientSummaryFinder {
                     //  email addresses associated with a child patient have their own as of dates
                     .join(EFF_EMAIL_CHILD).on(
                         EFF_EMAIL_CHILD.id.eq(EFF_EMAIL.id.entityUid),
-                        EFF_EMAIL_CHILD.personParentUid.id.eq(this.tables.patient().personParentUid.id)
-                    )
+                        EFF_EMAIL_CHILD.personParentUid.id.eq(this.tables.patient().personParentUid.id))
                     .where(
                         EFF_EMAIL.id.entityUid.eq(this.tables.net().id.entityUid),
                         EFF_EMAIL.cd.eq(this.tables.net().cd),
-                        EFF_EMAIL.asOfDate.loe(asOf)
-                    )
-            )
-        )
+                        EFF_EMAIL.asOfDate.loe(asOf))))
         .leftJoin(this.tables.email()).on(
             this.tables.email().id.eq(this.tables.net().id.locatorUid),
-            this.tables.email().emailAddress.isNotNull()
-        )
+            this.tables.email().emailAddress.isNotNull())
         .leftJoin(this.tables.emailUse()).on(
             this.tables.emailUse().id.codeSetNm.eq("EL_USE_TELE_PAT"),
-            this.tables.emailUse().id.code.eq(this.tables.net().useCd)
-        )
+            this.tables.emailUse().id.code.eq(this.tables.net().useCd))
         .where(this.tables.patient().id.eq(identifier), this.tables.patient().cd.eq(PATIENT_CODE))
         .fetch()
         .stream()
         .map(tuple -> this.mapper.map(asOf, tuple))
-        .collect(Accumulator.accumulating(PatientSummary::patient, this.merger::merge))
-        ;
+        .collect(Accumulator.accumulating(PatientSummary::patient, this.merger::merge));
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/address/PatientSummaryAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/summary/address/PatientSummaryAddressFinder.java
@@ -14,11 +14,11 @@ class PatientSummaryAddressFinder {
       select
           coalesce(
                 [type].code_short_desc_txt,
-                [locators].cd
+                IsNull([locators].cd, '')
           )                               as [type],
           coalesce(
                 [use].code_short_desc_txt,
-                [locators].[use_cd]
+                IsNull([locators].[use_cd],'')
           )                               as [use],
           [address].street_addr1          as [address_1],
           [address].street_addr2          as [address_2],
@@ -36,7 +36,7 @@ class PatientSummaryAddressFinder {
           left join  NBS_SRTE..Code_value_general [type] on
                   [type].code_set_nm = 'EL_TYPE_PST_PAT'
               and [type].code = [locators].cd
-    
+
           left join NBS_SRTE..Code_value_general [use] on
                   [use].code_set_nm = 'EL_USE_PST_PAT'
               and [use].code = [locators].[use_cd]
@@ -51,7 +51,7 @@ class PatientSummaryAddressFinder {
 
       where   [locators].entity_uid = ?
           and [locators].[class_cd] = 'PST'
-          and [locators].[use_cd] not in ('BIR', 'DTH', 'H')
+          and ([locators].[use_cd] IS NULL OR [locators].[use_cd] not in ('BIR', 'DTH', 'H'))
           and [locators].[record_status_cd] = 'ACTIVE'
       """;
   private static final int PATIENT_PARAMETER = 1;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/address/PatientSearchResultAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/address/PatientSearchResultAddressFinder.java
@@ -12,49 +12,49 @@ import java.util.Collection;
 class PatientSearchResultAddressFinder {
 
   private static final String QUERY = """
-        select
-            coalesce(
-                [type].code_short_desc_txt,
-                [locators].cd
-            )                               as [type],
-            coalesce(
-                [use].code_short_desc_txt,
-                [locators].[use_cd]
-            )                               as [use],
-            [address].street_addr1          as [address_1],
-            [address].street_addr2          as [address_2],
-            [address].city_desc_txt         as [city],
-            [state].state_nm                as [state],
-            [address].zip_cd                as [zipcode],
-            [country].code_short_desc_txt   as [country],
-            [county].code_desc_txt          as [county]
-        from Entity_locator_participation [locators]
+      select
+          coalesce(
+              [type].code_short_desc_txt,
+              [locators].cd
+          )                               as [type],
+          coalesce(
+              [use].code_short_desc_txt,
+              [locators].[use_cd]
+          )                               as [use],
+          [address].street_addr1          as [address_1],
+          [address].street_addr2          as [address_2],
+          [address].city_desc_txt         as [city],
+          [state].state_nm                as [state],
+          [address].zip_cd                as [zipcode],
+          [country].code_short_desc_txt   as [country],
+          [county].code_desc_txt          as [county]
+      from Entity_locator_participation [locators]
 
-            join Postal_locator [address] on
-                    [address].[postal_locator_uid] = [locators].[locator_uid]
-                and [address].record_status_cd = [locators].record_status_cd
+          join Postal_locator [address] on
+                  [address].[postal_locator_uid] = [locators].[locator_uid]
+              and [address].record_status_cd = [locators].record_status_cd
 
-            left join  NBS_SRTE..Code_value_general [type] on
-                    [type].code_set_nm = 'EL_TYPE_PST_PAT'
-                and [type].code = [locators].cd
-        
-            left join NBS_SRTE..Code_value_general [use] on
-                    [use].code_set_nm = 'EL_USE_PST_PAT'
-                and [use].code = [locators].[use_cd]
+          left join  NBS_SRTE..Code_value_general [type] on
+                  [type].code_set_nm = 'EL_TYPE_PST_PAT'
+              and [type].code = [locators].cd
 
-            left join NBS_SRTE..State_county_code_value [county] on [county].code = [address].cnty_cd
+          left join NBS_SRTE..Code_value_general [use] on
+                  [use].code_set_nm = 'EL_USE_PST_PAT'
+              and [use].code = [locators].[use_cd]
 
-            left join NBS_SRTE..State_code [state] on
-                    [state].state_cd = [address].state_cd
+          left join NBS_SRTE..State_county_code_value [county] on [county].code = [address].cnty_cd
 
-            left join NBS_SRTE..Country_code [country] on
-                    [country].code = [address].cntry_cd
+          left join NBS_SRTE..State_code [state] on
+                  [state].state_cd = [address].state_cd
 
-        where   [locators].entity_uid = ?
-            and [locators].[class_cd] = 'PST'
-            and [locators].[use_cd] not in ('BIR', 'DTH')
-            and [locators].[record_status_cd] = 'ACTIVE'
-        """;
+          left join NBS_SRTE..Country_code [country] on
+                  [country].code = [address].cntry_cd
+
+      where   [locators].entity_uid = ?
+          and [locators].[class_cd] = 'PST'
+          and ([locators].[use_cd] IS NULL OR [locators].[use_cd] not in ('BIR', 'DTH'))
+          and [locators].[record_status_cd] = 'ACTIVE'
+      """;
   private static final int PATIENT_PARAMETER = 1;
 
   private final JdbcTemplate template;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
@@ -32,7 +32,7 @@ public class SearchablePatientAddressFinder {
               left join NBS_SRTE..Country_code [srte_country] on [srte_country].code = [address].cntry_cd
           where   [locators].entity_uid = ?
               and [locators].[class_cd] = 'PST'
-              and ([locators].use_cd IS NULL) OR [locators].use_cd not in ('BIR', 'DTH'))
+              and ([locators].use_cd IS NULL OR [locators].use_cd not in ('BIR', 'DTH'))
           """;
   private static final int PATIENT_PARAMETER = 1;
   private static final int ADDRESS_1_COLUMN = 1;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
@@ -32,7 +32,7 @@ public class SearchablePatientAddressFinder {
               left join NBS_SRTE..Country_code [srte_country] on [srte_country].code = [address].cntry_cd
           where   [locators].entity_uid = ?
               and [locators].[class_cd] = 'PST'
-              and [locators].use_cd not in ('BIR', 'DTH')
+              and ([locators].use_cd IS NULL) OR [locators].use_cd not in ('BIR', 'DTH'))
           """;
   private static final int PATIENT_PARAMETER = 1;
   private static final int ADDRESS_1_COLUMN = 1;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultDetailedPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultDetailedPhoneFinder.java
@@ -16,7 +16,7 @@ class PatientSearchResultDetailedPhoneFinder {
         )                               as [type],
         coalesce(
             [use].code_short_desc_txt,
-            [locators].[use_cd]
+            IsNull([locators].[use_cd],'')
         )                               as [use],
         IsNull([locators].cd, '')       as [type_cd],
         [locators].use_cd               as [use_cd],

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultDetailedPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultDetailedPhoneFinder.java
@@ -12,25 +12,25 @@ class PatientSearchResultDetailedPhoneFinder {
       select distinct
         coalesce(
           [type].code_short_desc_txt,
-          [locators].cd
+          IsNull([locators].cd, '')
         )                               as [type],
         coalesce(
             [use].code_short_desc_txt,
             [locators].[use_cd]
         )                               as [use],
-        [locators].cd                   as [type_cd],
+        IsNull([locators].cd, '')       as [type_cd],
         [locators].use_cd               as [use_cd],
         [phone_number].phone_nbr_txt    as [phone_number]
       from Entity_locator_participation [locators]
-      
+
           join Tele_locator [phone_number] on
                   [phone_number].[tele_locator_uid] = [locators].[locator_uid]
               and [phone_number].record_status_cd   = [locators].[record_status_cd]
-      
+
           left join  NBS_SRTE..Code_value_general [type] on
                   [type].code_set_nm = 'EL_TYPE_TELE_PAT'
               and [type].code = [locators].cd
-      
+
           left join NBS_SRTE..Code_value_general [use] on
                   [use].code_set_nm = 'EL_USE_TELE_PAT'
               and [use].code = [locators].[use_cd]
@@ -38,7 +38,7 @@ class PatientSearchResultDetailedPhoneFinder {
 
       where   [locators].entity_uid = ?
           and [locators].[class_cd] = 'TELE'
-          and [locators].cd <> 'NET'
+          and ([locators].cd is null or [locators].cd <> 'NET')
           and [locators].record_status_cd = 'ACTIVE'
       """;
   private static final int PATIENT_PARAMETER = 1;
@@ -55,7 +55,6 @@ class PatientSearchResultDetailedPhoneFinder {
     return this.template.query(
         QUERY,
         statement -> statement.setLong(PATIENT_PARAMETER, patient),
-        mapper
-    );
+        mapper);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultPhoneFinder.java
@@ -13,7 +13,7 @@ class PatientSearchResultPhoneFinder {
               [phone_number].phone_nbr_txt    as [phone_number],
               [phone_number].extension_txt    as [extension],
               IsNull([locators].cd, '')       as [type_cd],
-              [locators].use_cd               as [use_cd]
+              IsNull([locators].use_cd,'')    as [use_cd]
           from Entity_locator_participation [locators]
 
               join Tele_locator [phone_number] on

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultPhoneFinder.java
@@ -12,7 +12,7 @@ class PatientSearchResultPhoneFinder {
           select distinct
               [phone_number].phone_nbr_txt    as [phone_number],
               [phone_number].extension_txt    as [extension],
-              [locators].cd                   as [type_cd],
+              IsNull([locators].cd, '')       as [type_cd],
               [locators].use_cd               as [use_cd]
           from Entity_locator_participation [locators]
 
@@ -24,7 +24,7 @@ class PatientSearchResultPhoneFinder {
 
           where   [locators].entity_uid = ?
               and [locators].[class_cd] = 'TELE'
-              and [locators].cd <> 'NET'
+              and ([locators].cd is null or [locators].cd <> 'NET')
               and [locators].record_status_cd = 'ACTIVE'
       """;
   private static final int PATIENT_PARAMETER = 1;

--- a/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/summary/PatientProfileSummary.tsx
@@ -96,8 +96,8 @@ export const PatientProfileSummary = ({ patient }: Props) => {
                         <div className="grouped">
                             <SummaryItem label="Current sex">{maybeRender(summary.gender, asText)}</SummaryItem>
                             <SummaryItem label="Phone"> {maybeRender(summary.phone, asPhones)}</SummaryItem>
-                            <SummaryItem label={addressLabel(summary.home)}>
-                                {maybeRender(summary.home, asAddress)}
+                            <SummaryItem label={addressLabel(summary.home) ?? 'Address'}>
+                                {maybeRender(summary.home ?? summary.address[0], asAddress)}
                             </SummaryItem>
                             <SummaryItem label="Race">{maybeRender(summary.races, allAsText)}</SummaryItem>
                             <SummaryItem label="Date of birth">{asBirthday(summary)}</SummaryItem>


### PR DESCRIPTION
## Description

The queries seem to only have a problem with  null values.  They are happy to return codes that don't exist.  So check for null in the conditionals and return blanks for the interface fields that are non-null.  In the case of 'TELE' have the null condition default to a phone (vs an email)

## Tickets

* [CNFT1-3421](https://cdc-nbs.atlassian.net/browse/CNFT1-3421)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3421]: https://cdc-nbs.atlassian.net/browse/CNFT1-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ