### PR TITLE
[CNFT1-3208] Home page name searching contains support

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteria.java
@@ -7,22 +7,19 @@ import gov.cdc.nbs.time.json.FormattedLocalDateJsonSerializer;
 import java.time.LocalDate;
 
 record SimplePatientSearchCriteria(
-    String lastName,
-    String firstName,
-    @JsonSerialize(using = FormattedLocalDateJsonSerializer.class)
-    LocalDate dateOfBirth,
-    Option gender,
-    String id,
-    String morbidity,
-    String document,
-    String stateCase,
-    String abcCase,
-    String cityCountyCase,
-    String notification,
-    String labReport,
-    String accessionNumber,
-    String investigation,
-    String treatment,
-    String vaccination
-) {
+        SimplePatientSearchNameCriteria name,
+        @JsonSerialize(using = FormattedLocalDateJsonSerializer.class) LocalDate dateOfBirth,
+        Option gender,
+        String id,
+        String morbidity,
+        String document,
+        String stateCase,
+        String abcCase,
+        String cityCountyCase,
+        String notification,
+        String labReport,
+        String accessionNumber,
+        String investigation,
+        String treatment,
+        String vaccination) {
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchNameCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchNameCriteria.java
@@ -1,0 +1,7 @@
+package gov.cdc.nbs.search.redirect.simple;
+
+import gov.cdc.nbs.search.criteria.text.TextCriteria;
+
+record SimplePatientSearchNameCriteria(TextCriteria first, TextCriteria last) {
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimpleSearchRedirectionController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/redirect/simple/SimpleSearchRedirectionController.java
@@ -46,7 +46,7 @@ class SimpleSearchRedirectionController {
     return UriComponentsBuilder.fromPath(searchRedirect.base())
         .path("/simple/{type}/{criteria}")
         .build()
-        .expand(search.type(),search.criteria())
+        .expand(search.type(), search.criteria())
         .toUri();
 
   }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaResolverTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimplePatientSearchCriteriaResolverTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.search.redirect.simple;
 
 import gov.cdc.nbs.message.enums.Gender;
 import gov.cdc.nbs.option.Option;
+import gov.cdc.nbs.search.criteria.text.TextCriteria;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,7 +19,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class SimplePatientSearchCriteriaResolverTest {
 
   @Test
-  void should_resolve_first_name() {
+  void should_resolve_first_name_starting_with_value() {
     Map<String, String> parameters = Map.of("patientSearchVO.firstName", "first-name-value");
 
 
@@ -27,12 +28,30 @@ class SimplePatientSearchCriteriaResolverTest {
     assertThat(resolved).hasValueSatisfying(
         actual -> assertThat(actual)
             .asInstanceOf(type(SimplePatientSearchCriteria.class))
-            .returns("first-name-value", SimplePatientSearchCriteria::firstName)
+            .extracting(SimplePatientSearchCriteria::name)
+            .extracting(SimplePatientSearchNameCriteria::first)
+            .returns("first-name-value", TextCriteria::startsWith)
     );
   }
 
   @Test
-  void should_resolve_last_name() {
+  void should_resolve_first_name_containing_value() {
+    Map<String, String> parameters = Map.of("patientSearchVO.firstName", "%first-name-value");
+
+
+    Optional<SimplePatientSearchCriteria> resolved = new SimplePatientSearchCriteriaResolver().resolve(parameters);
+
+    assertThat(resolved).hasValueSatisfying(
+        actual -> assertThat(actual)
+            .asInstanceOf(type(SimplePatientSearchCriteria.class))
+            .extracting(SimplePatientSearchCriteria::name)
+            .extracting(SimplePatientSearchNameCriteria::first)
+            .returns("first-name-value", TextCriteria::contains)
+    );
+  }
+
+  @Test
+  void should_resolve_last_name_starting_with_value() {
     Map<String, String> parameters = Map.of("patientSearchVO.lastName", "last-name-value");
 
 
@@ -41,7 +60,25 @@ class SimplePatientSearchCriteriaResolverTest {
     assertThat(resolved).hasValueSatisfying(
         actual -> assertThat(actual)
             .asInstanceOf(type(SimplePatientSearchCriteria.class))
-            .returns("last-name-value", SimplePatientSearchCriteria::lastName)
+            .extracting(SimplePatientSearchCriteria::name)
+            .extracting(SimplePatientSearchNameCriteria::last)
+            .returns("last-name-value", TextCriteria::startsWith)
+    );
+  }
+
+  @Test
+  void should_resolve_last_name_contains_value() {
+    Map<String, String> parameters = Map.of("patientSearchVO.lastName", "%last-name-value");
+
+
+    Optional<SimplePatientSearchCriteria> resolved = new SimplePatientSearchCriteriaResolver().resolve(parameters);
+
+    assertThat(resolved).hasValueSatisfying(
+        actual -> assertThat(actual)
+            .asInstanceOf(type(SimplePatientSearchCriteria.class))
+            .extracting(SimplePatientSearchCriteria::name)
+            .extracting(SimplePatientSearchNameCriteria::last)
+            .returns("last-name-value", TextCriteria::contains)
     );
   }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimpleSearchRedirectSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimpleSearchRedirectSteps.java
@@ -94,11 +94,35 @@ public class SimpleSearchRedirectSteps {
   }
 
   @Then("the search parameters include a(n) {string} of {string}")
-  public void the_search_parameters_include_date_of_birth_as(final String property, final String value)
+  public void the_search_parameters_include(final String property, final String value)
       throws Exception {
     JsonPathResultMatchers path = matchingPath(property);
 
     this.decrypted.active().andDo(print()).andExpect(path.value(equalToIgnoringCase(value)));
+  }
+
+  @Then("the search parameters include a(n) {string} that starts with {string}")
+  public void the_search_parameters_include_the_criteria_that_starts_with(final String property, final String value)
+      throws Exception {
+    JsonPathResultMatchers path = criteriaMatchingPath(property, "startsWith");
+
+    this.decrypted.active().andDo(print()).andExpect(path.value(equalToIgnoringCase(value)));
+  }
+
+  @Then("the search parameters include a(n) {string} that contains {string}")
+  public void the_search_parameters_include_the_criteria_that_contains(final String property, final String value)
+      throws Exception {
+    JsonPathResultMatchers path = criteriaMatchingPath(property, "contains");
+
+    this.decrypted.active().andDo(print()).andExpect(path.value(equalToIgnoringCase(value)));
+  }
+
+  private JsonPathResultMatchers criteriaMatchingPath(final String field, final String property) {
+    return switch (field.toLowerCase()) {
+      case "first name" -> jsonPath("$.name.first.%s", property);
+      case "last name" -> jsonPath("$.name.last.%s",property);
+      default -> throw new IllegalStateException("Unexpected simple search parameter value: " + field.toLowerCase());
+    };
   }
 
   @Then("the search parameters include a(n) {eventTypeId} with the ID {string}")
@@ -138,11 +162,9 @@ public class SimpleSearchRedirectSteps {
   private JsonPathResultMatchers matchingPath(final String field) {
     return switch (field.toLowerCase()) {
       case "date of birth" -> jsonPath("$.dateOfBirth");
-      case "first name" -> jsonPath("$.firstName");
-      case "last name" -> jsonPath("$.lastName");
       case "gender" -> jsonPath("$.gender.value");
       case "patient id" -> jsonPath("$.id");
-      default -> throw new IllegalStateException("Unexpected Page Summary value: " + field.toLowerCase());
+      default -> throw new IllegalStateException("Unexpected simple search parameter value: " + field.toLowerCase());
     };
   }
 

--- a/apps/modernization-api/src/test/resources/features/search/redirect/SimpleSearchRedirect.feature
+++ b/apps/modernization-api/src/test/resources/features/search/redirect/SimpleSearchRedirect.feature
@@ -7,14 +7,14 @@ Feature: Searching from the NBS home page
   Scenario: NBS home page search redirects to Patient search
     Given I want a simple search for a "Date Of Birth" of "2000-01-07"
     And I want a simple search for a "First name" of "Firstly"
-    And I want a simple search for a "Last name" of "Lastly"
+    And I want a simple search for a "Last name" of "%Lastly"
     And I want a simple search for a "Gender" of "F"
     And I want a simple search for a "Patient ID" of "100056"
     When I perform a search from the NBS Home screen
     Then I am redirected to Advanced Search
     And the search parameters include a "Date of Birth" of "01/07/2000"
-    And the search parameters include a "First Name" of "Firstly"
-    And the search parameters include a "Last Name" of "Lastly"
+    And the search parameters include a "First Name" that starts with "Firstly"
+    And the search parameters include a "Last Name" that contains "Lastly"
     And the search parameters include a "Gender" of "F"
     And the search parameters include a "Patient ID" of "100056"
     And the search type is patients

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -16,7 +16,7 @@ export const BasicInformation = () => {
         <SearchCriteria>
             <Controller
                 control={control}
-                name="lastName"
+                name="name.last"
                 rules={validNameRule}
                 render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <OperatorInput
@@ -31,7 +31,7 @@ export const BasicInformation = () => {
             />
             <Controller
                 control={control}
-                name="firstName"
+                name="name.first"
                 rules={validNameRule}
                 render={({ field: { onChange, value, name }, fieldState: { error } }) => (
                     <OperatorInput

--- a/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.spec.ts
@@ -2,7 +2,7 @@ import { asNewPatientEntry } from './asNewPatientEntry';
 
 describe('when adding a new patient from a patient search', () => {
     it('should populate the first name that was searched for', () => {
-        const criteria = { firstName: { contains: 'first-name' } };
+        const criteria = { name: { first: { contains: 'first-name' } } };
 
         const actual = asNewPatientEntry(criteria);
 
@@ -10,7 +10,7 @@ describe('when adding a new patient from a patient search', () => {
     });
 
     it('should populate the last name that was searched for', () => {
-        const criteria = { lastName: { equals: 'last-name' } };
+        const criteria = { name: { last: { equals: 'last-name' } } };
 
         const actual = asNewPatientEntry(criteria);
 

--- a/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.ts
@@ -26,8 +26,8 @@ const resolveName = (textCriteria?: TextCriteria | string): string | null => orN
 const asNewPatientEntry = (criteria: Partial<PatientCriteriaEntry>): NewPatientEntry => {
     return {
         asOf: internalizeDate(new Date()),
-        firstName: resolveName(criteria.firstName),
-        lastName: resolveName(criteria.lastName),
+        firstName: resolveName(criteria.name?.first),
+        lastName: resolveName(criteria.name?.last),
         dateOfBirth: criteria.dateOfBirth,
         currentGender: orNull(asValue(criteria.gender)),
         streetAddress1: orNull(criteria.address),

--- a/apps/modernization-ui/src/apps/search/patient/criteria.ts
+++ b/apps/modernization-ui/src/apps/search/patient/criteria.ts
@@ -11,9 +11,13 @@ const statusOptions: Selectable[] = [
 
 export { statusOptions };
 
+type NameCriteria = {
+    first?: TextCriteria;
+    last?: TextCriteria;
+};
+
 type BasicInformation = {
-    lastName?: TextCriteria;
-    firstName?: TextCriteria;
+    name?: NameCriteria;
     dateOfBirth?: string;
     gender?: Selectable;
     id?: string;
@@ -58,7 +62,7 @@ type EventIds = {
 
 type PatientCriteriaEntry = BasicInformation & Address & Contact & RaceEthnicity & Identification & EventIds;
 
-export type { PatientCriteriaEntry, BasicInformation, Identification, RaceEthnicity, Contact };
+export type { PatientCriteriaEntry, BasicInformation, Identification, RaceEthnicity, Contact, NameCriteria };
 
 const initial: PatientCriteriaEntry = {
     status: [ACTIVE]

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
@@ -27,7 +27,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
 
     it('should resolve terms with last name', () => {
         const input: PatientCriteriaEntry = {
-            lastName: { equals: 'last-name-value' },
+            name: { last: { equals: 'last-name-value' } },
             status: []
         };
 
@@ -42,7 +42,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
 
     it('should resolve terms with first name', () => {
         const input: PatientCriteriaEntry = {
-            firstName: { equals: 'first-name-value' },
+            name: { first: { equals: 'first-name-value' } },
             status: []
         };
 

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.ts
@@ -14,12 +14,12 @@ const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
         }
     };
 
-    if (entry.lastName) {
-        pushCriteria('lastName', 'LAST NAME', entry.lastName);
+    if (entry.name?.last) {
+        pushCriteria('lastName', 'LAST NAME', entry.name.last);
     }
 
-    if (entry.firstName) {
-        pushCriteria('firstName', 'FIRST NAME', entry.firstName);
+    if (entry.name?.first) {
+        pushCriteria('firstName', 'FIRST NAME', entry.name.first);
     }
 
     if (entry.dateOfBirth) {

--- a/apps/modernization-ui/src/apps/search/patient/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/transformer.spec.ts
@@ -18,7 +18,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
 
     it('should transform with last name', () => {
         const input: PatientCriteriaEntry = {
-            lastName: { equals: 'last-name-value' },
+            name: { last: { equals: 'last-name-value' } },
             status: []
         };
 
@@ -29,7 +29,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
 
     it('should transform with first name', () => {
         const input: PatientCriteriaEntry = {
-            firstName: { equals: 'first-name-value' },
+            name: { first: { equals: 'first-name-value' } },
             status: []
         };
 

--- a/apps/modernization-ui/src/apps/search/patient/transformer.ts
+++ b/apps/modernization-ui/src/apps/search/patient/transformer.ts
@@ -3,7 +3,6 @@ import { RecordStatus, PersonFilter, IdentificationCriteria } from 'generated/gr
 import { asValue, asValues } from 'options/selectable';
 import { PatientCriteriaEntry } from './criteria';
 import { externalizeDate } from 'date';
-import { asTextCriteria } from 'options/operator';
 
 const resolveIdentification = (data: PatientCriteriaEntry): IdentificationCriteria | undefined =>
     data.identification && data.identificationType
@@ -15,8 +14,7 @@ const resolveIdentification = (data: PatientCriteriaEntry): IdentificationCriter
 
 export const transform = (data: PatientCriteriaEntry): PersonFilter => {
     const {
-        lastName,
-        firstName,
+        name,
         id,
         address,
         city,
@@ -37,10 +35,7 @@ export const transform = (data: PatientCriteriaEntry): PersonFilter => {
         ...remaining
     } = data;
     return {
-        name: {
-            last: asTextCriteria(lastName),
-            first: asTextCriteria(firstName)
-        },
+        name,
         id,
         address,
         city,


### PR DESCRIPTION
## Description

Adds operator support to the Home page search for "Last name" and "First name".  By default the value entered into the "Last name" or "First name" fields will result in a starts with search for the respective field.  If the value starts with `%` it will results in a contains search for the respective field.

- A "Last name" with the value "bri" results in patients with a last name that starts with "bri"
- A "Last name" with the value "%bri" results in patients with a last name that contains "bri"
- A "First name" with the value "aro" results in patients with a last name that starts with "aro"
- A "First name" with the value "%aro" results in patients with a last name that contains "aro"

## Tickets

* [CNFT1-3208](https://cdc-nbs.atlassian.net/browse/CNFT1-3208)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3208]: https://cdc-nbs.atlassian.net/browse/CNFT1-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ