### PR TITLE
CNFT1-3518: API: Escape operator special chars before passing to Elastic \search

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/WildCards.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/WildCards.java
@@ -4,18 +4,25 @@ public class WildCards {
 
   public static String startsWith(final String value) {
     return isValid(value)
-        ? value.toLowerCase().trim() + "*"
+        ? escape(value.toLowerCase().trim()) + "*"
         : null;
   }
 
   public static String contains(final String value) {
     return isValid(value)
-        ? "*" + value.toLowerCase().trim() + "*"
+        ? "*" + escape(value.toLowerCase().trim()) + "*"
         : null;
   }
 
   private static boolean isValid(final String value) {
     return value != null && !value.isEmpty();
+  }
+
+  private static String escape(final String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replaceAll("([+\\-!(){}\\[\\]^\"~*?:\\\\/])", "\\\\$1");
   }
 
   private WildCards() {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/search/WildCardsTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/search/WildCardsTest.java
@@ -51,4 +51,12 @@ class WildCardsTest {
 
     assertThat(actual).isNull();
   }
+
+  @Test
+  void should_escape_special_characters() {
+    String actual = WildCards.startsWith("value*");
+
+    assertThat(actual).isEqualTo("value\\**");
+  }
+
 }


### PR DESCRIPTION
## Description

Escape special chars so they don't get passed to Elasticsearch directly.

![image](https://github.com/user-attachments/assets/d3d8026e-b46d-443d-ad95-23744c594ced)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3518)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
