### PR TITLE
Cnft1 3444 UI update search results list view to display details of page age

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
@@ -49,7 +49,7 @@ describe('PatientSearchResultListItem', () => {
                 <PatientSearchResultListItem result={patient} />
             </MemoryRouter>
         );
-        expect(getByText('07/05/1995')).toBeInTheDocument();
+        expect(getByText('07/05/1995 (29 years)', { trim: true })).toBeInTheDocument();
     });
 
     it('should render the sex', () => {
@@ -136,11 +136,13 @@ describe('PatientSearchResultListItem', () => {
             emails: [],
             names: [],
             identification: [],
-            detailedPhones: [{
-              number: 'phone-number-value',
-              type: '',
-              use: ''
-            }]
+            detailedPhones: [
+                {
+                    number: 'phone-number-value',
+                    type: '',
+                    use: ''
+                }
+            ]
         };
 
         const { getByText } = render(

--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.tsx
@@ -1,5 +1,4 @@
 import { PatientSearchResult } from 'generated/graphql/schema';
-import { internalizeDate } from 'date';
 
 import { Result, ResultItem, ResultItemGroup } from 'apps/search/layout/result/list';
 import {
@@ -7,7 +6,8 @@ import {
     displayOtherNames,
     displayEmails,
     displayAddresses,
-    displayProfileLegalName
+    displayProfileLegalName,
+    displayPatientAge
 } from 'apps/search/patient/result';
 
 type Props = {
@@ -20,7 +20,7 @@ const PatientSearchResultListItem = ({ result }: Props) => (
             <ResultItem label="Patient name" orientation="vertical">
                 {displayProfileLegalName(result)}
             </ResultItem>
-            <ResultItem label="Date of birth">{internalizeDate(result.birthday)}</ResultItem>
+            <ResultItem label="DOB/Age">{result.birthday && displayPatientAge(result, 'singleline')}</ResultItem>
             <ResultItem label="Current sex">{result.gender}</ResultItem>
             <ResultItem label="Patient ID">{result.shortId}</ResultItem>
         </ResultItemGroup>

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -3,6 +3,7 @@ import { displayName, displayNameElement, matchesLegalName } from 'name';
 import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
 import { ItemGroup } from 'design-system/item';
+import { internalizeDate } from 'date';
 
 const displayProfileLink = (shortId: number, displayName?: string) => {
     return <Link to={`/patient-profile/${shortId}/summary`}>{displayName || shortId}</Link>;
@@ -56,6 +57,7 @@ const displayPatientName = (result: PatientSearchResult): JSX.Element => (
         {displayOtherNames(result, 'reverse')}
     </div>
 );
+const displayPatientAge = (result: PatientSearchResult): JSX.Element => <div>{internalizeDate(result.birthday)}</div>;
 
 // Returns JSX that represents a list of IDs to display
 const displayIdentifications = (result: PatientSearchResult): JSX.Element => (
@@ -72,6 +74,7 @@ const displayIdentifications = (result: PatientSearchResult): JSX.Element => (
 
 export {
     displayPatientName,
+    displayPatientAge,
     displayOtherNames,
     displayProfileLink,
     displayProfileLegalName,

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -4,6 +4,7 @@ import { displayAddress } from 'address/display';
 import { Link } from 'react-router-dom';
 import { ItemGroup } from 'design-system/item';
 import { internalizeDate } from 'date';
+import { displayAgeAsOfToday } from 'date/displayAge';
 
 const displayProfileLink = (shortId: number, displayName?: string) => {
     return <Link to={`/patient-profile/${shortId}/summary`}>{displayName || shortId}</Link>;
@@ -57,7 +58,13 @@ const displayPatientName = (result: PatientSearchResult): JSX.Element => (
         {displayOtherNames(result, 'reverse')}
     </div>
 );
-const displayPatientAge = (result: PatientSearchResult): JSX.Element => <div>{internalizeDate(result.birthday)}</div>;
+const displayPatientAge = (result: PatientSearchResult): JSX.Element => (
+    <div>
+        {internalizeDate(result.birthday)}
+        <br />
+        {displayAgeAsOfToday(result.birthday)}
+    </div>
+);
 
 // Returns JSX that represents a list of IDs to display
 const displayIdentifications = (result: PatientSearchResult): JSX.Element => (

--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -58,11 +58,12 @@ const displayPatientName = (result: PatientSearchResult): JSX.Element => (
         {displayOtherNames(result, 'reverse')}
     </div>
 );
-const displayPatientAge = (result: PatientSearchResult): JSX.Element => (
+const displayPatientAge = (result: PatientSearchResult, variant: 'singleline' | 'multiline'): JSX.Element => (
     <div>
         {internalizeDate(result.birthday)}
-        <br />
+        {variant === 'multiline' ? <br /> : ' ('}
         {displayAgeAsOfToday(result.birthday)}
+        {variant === 'singleline' && ')'}
     </div>
 );
 

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -33,7 +33,7 @@ const columns: Column<PatientSearchResult>[] = [
     {
         ...DATE_OF_BIRTH,
         sortable: true,
-        render: displayPatientAge
+        render: (result) => result.birthday && displayPatientAge(result)
     },
     { ...SEX, sortable: true, render: (result) => result.gender },
     {

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -1,10 +1,10 @@
 import { PatientSearchResult } from 'generated/graphql/schema';
 import { Column, DataTable } from 'design-system/table';
 import { ColumnPreference, useColumnPreferences } from 'design-system/table/preferences';
-import { internalizeDate } from 'date';
 import {
     displayPhones,
     displayPatientName,
+    displayPatientAge,
     displayProfileLink,
     displayEmails,
     displayAddresses,
@@ -14,7 +14,7 @@ import {
 // column definitions
 const PATIENT_ID = { id: 'patientid', name: 'Patient ID' };
 const PATIENT_NAME = { id: 'patientname', name: 'Patient name' };
-const DATE_OF_BIRTH = { id: 'birthday', name: 'Date of birth' };
+const DATE_OF_BIRTH = { id: 'birthday', name: 'DOB/Age' };
 const SEX = { id: 'sex', name: 'Current sex' };
 const ADDRESS = { id: 'address', name: 'Address' };
 const PHONE = { id: 'phoneNumber', name: 'Phone' };
@@ -33,7 +33,7 @@ const columns: Column<PatientSearchResult>[] = [
     {
         ...DATE_OF_BIRTH,
         sortable: true,
-        render: (result) => internalizeDate(result.birthday)
+        render: displayPatientAge
     },
     { ...SEX, sortable: true, render: (result) => result.gender },
     {

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -33,7 +33,7 @@ const columns: Column<PatientSearchResult>[] = [
     {
         ...DATE_OF_BIRTH,
         sortable: true,
-        render: (result) => result.birthday && displayPatientAge(result)
+        render: (result) => result.birthday && displayPatientAge(result, 'multiline')
     },
     { ...SEX, sortable: true, render: (result) => result.gender },
     {


### PR DESCRIPTION
## Description

Includes [Cnft1 3018 UI update search results table view to display details of page age ](https://github.com/CDCgov/NEDSS-Modernization/pull/2026) changes and updates the list view as well.

## Tickets

https://cdc-nbs.atlassian.net/browse/CNFT1-3444

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
