### PR TITLE
CNFT1-3522: updating label to just Information as of

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
@@ -203,7 +203,7 @@ describe('AddPatientExtendedForm', () => {
         const expected = internalizeDate(new Date());
 
         await waitFor(() => {
-            expect(getByLabelText('Information as of date')).toHaveValue('05/07/1977');
+            expect(getByLabelText('Information as of')).toHaveValue('05/07/1977');
 
             expect(getByLabelText('Name as of')).toHaveValue(expected);
 

--- a/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.spec.tsx
@@ -1,7 +1,6 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { AdministrativeEntryFields } from './AdministrativeEntryFields';
 import { FormProvider, useForm } from 'react-hook-form';
-import { ReactNode } from 'react';
 import userEvent from '@testing-library/user-event';
 import { NewPatientEntry } from 'apps/patient/add';
 
@@ -18,21 +17,21 @@ describe('Administrative', () => {
     it('should render all input fields', () => {
         const { getByLabelText } = render(<Fixture />);
 
-        expect(getByLabelText('Information as of date')).toBeInTheDocument();
+        expect(getByLabelText('Information as of')).toBeInTheDocument();
         expect(getByLabelText('General comments')).toBeInTheDocument();
     });
 
     it('should require as of', () => {
         const { getByLabelText } = render(<Fixture />);
 
-        expect(getByLabelText('Information as of date')).toBeInTheDocument();
+        expect(getByLabelText('Information as of')).toBeInTheDocument();
         expect(getByLabelText('General comments')).toBeInTheDocument();
     });
 
     it('should require as of date', async () => {
         const { getByLabelText, queryByText } = render(<Fixture />);
         const errorMessage = 'As of date is required.';
-        const dateInput = getByLabelText('Information as of date');
+        const dateInput = getByLabelText('Information as of');
 
         expect(queryByText(errorMessage)).not.toBeInTheDocument();
         act(() => {

--- a/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.tsx
@@ -15,7 +15,7 @@ export const AdministrativeEntryFields = () => {
                 rules={{ required: { value: true, message: 'As of date is required.' } }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
-                        label="Information as of date"
+                        label="Information as of"
                         orientation="horizontal"
                         defaultValue={value}
                         onBlur={onBlur}


### PR DESCRIPTION
## Description

UI: New patient- Extended: Administrative: "Information as of date" field name has to be updated to "Information as of"

## Tickets

* [CNFT1-3522](https://cdc-nbs.atlassian.net/browse/CNFT1-3522)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3522]: https://cdc-nbs.atlassian.net/browse/CNFT1-3522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ