### PR TITLE
[CNFT13512-Repeating-bloc-error-messages]: adding changes to validate rule files for entry fields

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.spec.ts
@@ -13,7 +13,7 @@ describe('categoryValidator', () => {
 
         const actual = categoryValidator(entries)(5, null);
 
-        await expect(actual).resolves.toBe('Race is required.');
+        await expect(actual).resolves.toBe('The race is required.');
     });
 
     it('should allow the same race category when validating the entry that contains the race category', async () => {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/categoryValidator.spec.ts
@@ -13,7 +13,7 @@ describe('categoryValidator', () => {
 
         const actual = categoryValidator(entries)(5, null);
 
-        await expect(actual).resolves.toBe('The race is required.');
+        await expect(actual).resolves.toBe('The Race is required.');
     });
 
     it('should allow the same race category when validating the entry that contains the race category', async () => {

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -80,7 +80,7 @@ describe('AddressEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The type is required')).toBeInTheDocument();
+            expect(getByText('The Type is required')).toBeInTheDocument();
         });
     });
 
@@ -93,7 +93,7 @@ describe('AddressEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The use is required')).toBeInTheDocument();
+            expect(getByText('The Use is required')).toBeInTheDocument();
         });
     });
 
@@ -106,7 +106,7 @@ describe('AddressEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The as of date is required')).toBeInTheDocument();
+            expect(getByText('The As of date is required')).toBeInTheDocument();
         });
     });
 

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -80,7 +80,7 @@ describe('AddressEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
+            expect(getByText('The type is required')).toBeInTheDocument();
         });
     });
 
@@ -93,7 +93,7 @@ describe('AddressEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Use is required.')).toBeInTheDocument();
+            expect(getByText('The use is required')).toBeInTheDocument();
         });
     });
 
@@ -106,7 +106,7 @@ describe('AddressEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
+            expect(getByText('The as of date is required')).toBeInTheDocument();
         });
     });
 

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -34,7 +34,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('As of date') }}
+                rules={{ ...validateRequiredRule('as of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Address as of"
@@ -52,7 +52,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('Type') }}
+                rules={{ ...validateRequiredRule('type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -71,7 +71,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="use"
-                rules={{ ...validateRequiredRule('Use') }}
+                rules={{ ...validateRequiredRule('use') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
@@ -90,7 +90,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="address1"
-                rules={maxLengthRule(100, 'Street address 1')}
+                rules={maxLengthRule(100, 'street address 1')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <AddressSuggestionInput
                         label="Street address 1"
@@ -113,7 +113,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="address2"
-                rules={maxLengthRule(100, 'Street address 2')}
+                rules={maxLengthRule(100, 'street address 2')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Street address 2"
@@ -132,7 +132,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="city"
-                rules={maxLengthRule(100, 'City')}
+                rules={maxLengthRule(100, 'city')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="City"
@@ -251,7 +251,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="comment"
-                rules={maxLengthRule(2000, 'Comment')}
+                rules={maxLengthRule(2000, 'comment')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Address comments"

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -34,7 +34,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('as of date') }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Address as of"
@@ -52,7 +52,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('type') }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -71,7 +71,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="use"
-                rules={{ ...validateRequiredRule('use') }}
+                rules={{ ...validateRequiredRule('Use') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
@@ -90,7 +90,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="address1"
-                rules={maxLengthRule(100, 'street address 1')}
+                rules={maxLengthRule(100, 'Street address 1')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <AddressSuggestionInput
                         label="Street address 1"
@@ -113,7 +113,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="address2"
-                rules={maxLengthRule(100, 'street address 2')}
+                rules={maxLengthRule(100, 'Street address 2')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Street address 2"
@@ -132,7 +132,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="city"
-                rules={maxLengthRule(100, 'city')}
+                rules={maxLengthRule(100, 'City')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="City"
@@ -251,7 +251,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="comment"
-                rules={maxLengthRule(2000, 'comment')}
+                rules={maxLengthRule(2000, 'Comment')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Address comments"

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -5,7 +5,7 @@ import { Input } from 'components/FormInputs/Input';
 import { SingleSelect } from 'design-system/select';
 import { useLocationCodedValues } from 'location';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { maxLengthRule } from 'validation/entry';
+import { maxLengthRule, validateRequiredRule } from 'validation/entry';
 import { AddressEntry } from '../entry';
 
 export const AddressEntryFields = () => {
@@ -34,7 +34,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ required: { value: true, message: 'As of date is required.' } }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Address as of"
@@ -52,7 +52,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ required: { value: true, message: 'Type is required.' } }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -71,7 +71,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="use"
-                rules={{ required: { value: true, message: 'Use is required.' } }}
+                rules={{ ...validateRequiredRule('Use') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
@@ -90,7 +90,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="address1"
-                rules={maxLengthRule(100)}
+                rules={maxLengthRule(100, 'Street address 1')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <AddressSuggestionInput
                         label="Street address 1"
@@ -113,7 +113,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="address2"
-                rules={maxLengthRule(100)}
+                rules={maxLengthRule(100, 'Street address 2')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Street address 2"
@@ -132,7 +132,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="city"
-                rules={maxLengthRule(100)}
+                rules={maxLengthRule(100, 'City')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="City"
@@ -251,7 +251,7 @@ export const AddressEntryFields = () => {
             <Controller
                 control={control}
                 name="comment"
-                rules={maxLengthRule(2000)}
+                rules={maxLengthRule(2000, 'Comment')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Address comments"

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
@@ -53,7 +53,7 @@ describe('IdentificationEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
+            expect(getByText('The as of date is required')).toBeInTheDocument();
         });
     });
 
@@ -67,7 +67,7 @@ describe('IdentificationEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
+            expect(getByText('The type is required')).toBeInTheDocument();
         });
     });
 
@@ -81,7 +81,7 @@ describe('IdentificationEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('ID value is required.')).toBeInTheDocument();
+            expect(getByText('The id value is required')).toBeInTheDocument();
         });
     });
 
@@ -103,9 +103,9 @@ describe('IdentificationEntryFields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('ID value is required.')).not.toBeInTheDocument();
+            expect(queryByText('The type is required')).not.toBeInTheDocument();
+            expect(queryByText('The as of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The id value is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { PatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
 import { act } from 'react-dom/test-utils';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -34,8 +34,8 @@ const Fixture = () => {
 
 describe('IdentificationEntryFields', () => {
     it('should render the proper labels', async () => {
-        const { getByLabelText } = render(<Fixture />);
-        await screen.findByText('ID value');
+        const { getByLabelText, findByText } = render(<Fixture />);
+        await findByText('ID value');
 
         expect(getByLabelText('Identification as of')).toBeInTheDocument();
         expect(getByLabelText('Type')).toBeInTheDocument();
@@ -44,8 +44,8 @@ describe('IdentificationEntryFields', () => {
     });
 
     it('should require as of', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-        await screen.findByText('ID value');
+        const { getByLabelText, getByText, findByText } = render(<Fixture />);
+        await findByText('ID value');
 
         const asOf = getByLabelText('Identification as of');
         act(() => {
@@ -53,13 +53,13 @@ describe('IdentificationEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The as of date is required')).toBeInTheDocument();
+            expect(getByText('The As of date is required')).toBeInTheDocument();
         });
     });
 
     it('should require type', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-        await screen.findByText('ID value');
+        const { getByLabelText, getByText, findByText } = render(<Fixture />);
+        await findByText('ID value');
 
         const typeInput = getByLabelText('Type');
         act(() => {
@@ -67,13 +67,13 @@ describe('IdentificationEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The type is required')).toBeInTheDocument();
+            expect(getByText('The Type is required')).toBeInTheDocument();
         });
     });
 
     it('should require id value', async () => {
-        const { getByLabelText, getByText } = render(<Fixture />);
-        await screen.findByText('ID value');
+        const { getByLabelText, getByText, findByText } = render(<Fixture />);
+        await findByText('ID value');
 
         const valueInput = getByLabelText('ID value');
         act(() => {
@@ -81,17 +81,17 @@ describe('IdentificationEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The id value is required')).toBeInTheDocument();
+            expect(getByText('The ID value is required')).toBeInTheDocument();
         });
     });
 
     it('should be valid with as of, type, and id value', async () => {
-        const { getByLabelText, queryByText } = render(<Fixture />);
+        const { getByLabelText, queryByText, findByText } = render(<Fixture />);
 
         const asOf = getByLabelText('Identification as of');
         const type = getByLabelText('Type');
         const idValue = getByLabelText('ID value');
-        await screen.findByText('ID value');
+        await findByText('ID value');
 
         act(() => {
             userEvent.paste(asOf, '01/20/2020');
@@ -103,9 +103,9 @@ describe('IdentificationEntryFields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('The type is required')).not.toBeInTheDocument();
-            expect(queryByText('The as of date is required')).not.toBeInTheDocument();
-            expect(queryByText('The id value is required')).not.toBeInTheDocument();
+            expect(queryByText('The Type is required')).not.toBeInTheDocument();
+            expect(queryByText('The As of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The ID value is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
@@ -16,7 +16,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('as of date') }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Identification as of"
@@ -34,7 +34,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('type') }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -69,7 +69,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="id"
-                rules={{ ...validateRequiredRule('id value'), ...maxLengthRule(100, 'id value') }}
+                rules={{ ...validateRequiredRule('ID value'), ...maxLengthRule(100, 'ID value') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="ID value"

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
@@ -16,7 +16,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ required: { value: true, message: 'As of date is required.' } }}
+                rules={{ ...validateRequiredRule('as of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Identification as of"
@@ -34,7 +34,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('Type') }}
+                rules={{ ...validateRequiredRule('type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -69,7 +69,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="id"
-                rules={{ required: { value: true, message: 'ID value is required.' }, ...maxLengthRule(100) }}
+                rules={{ ...validateRequiredRule('id value'), ...maxLengthRule(100, 'id value') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="ID value"

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
@@ -3,7 +3,7 @@ import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { Input } from 'components/FormInputs/Input';
 import { SingleSelect } from 'design-system/select';
 import { Controller, useFormContext } from 'react-hook-form';
-import { maxLengthRule } from 'validation/entry';
+import { maxLengthRule, validateRequiredRule } from 'validation/entry';
 import { IdentificationEntry } from '../entry';
 
 export const IdentificationEntryFields = () => {
@@ -34,7 +34,7 @@ export const IdentificationEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ required: { value: true, message: 'Type is required.' } }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
@@ -65,7 +65,7 @@ describe('Name entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
+            expect(getByText('The as of date is required')).toBeInTheDocument();
         });
     });
 
@@ -78,7 +78,7 @@ describe('Name entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
+            expect(getByText('The type is required')).toBeInTheDocument();
         });
     });
 
@@ -95,8 +95,8 @@ describe('Name entry fields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
+            expect(queryByText('The as of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The type is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
@@ -65,7 +65,7 @@ describe('Name entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The as of date is required')).toBeInTheDocument();
+            expect(getByText('The As of date is required')).toBeInTheDocument();
         });
     });
 
@@ -78,7 +78,7 @@ describe('Name entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The type is required')).toBeInTheDocument();
+            expect(getByText('The Type is required')).toBeInTheDocument();
         });
     });
 
@@ -95,8 +95,8 @@ describe('Name entry fields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('The as of date is required')).not.toBeInTheDocument();
-            expect(queryByText('The type is required')).not.toBeInTheDocument();
+            expect(queryByText('The As of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The Type is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -15,10 +15,10 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('As of date:') }}
+                rules={{ ...validateRequiredRule('as of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
-                        label="as of"
+                        label="Name as of"
                         orientation="horizontal"
                         onBlur={onBlur}
                         defaultValue={value}
@@ -33,7 +33,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('Type') }}
+                rules={{ ...validateRequiredRule('type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -69,7 +69,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="last"
-                rules={{ ...validateExtendedNameRule('Last Name') }}
+                rules={{ ...validateExtendedNameRule('last name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Last"
@@ -88,7 +88,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="secondLast"
-                rules={{ ...validateExtendedNameRule('Second Last Name') }}
+                rules={{ ...validateExtendedNameRule('second last name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second last"
@@ -107,7 +107,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="first"
-                rules={{ ...validateExtendedNameRule('First Name') }}
+                rules={{ ...validateExtendedNameRule('first name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="First"
@@ -126,7 +126,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="middle"
-                rules={{ ...validateExtendedNameRule('Middle Name') }}
+                rules={{ ...validateExtendedNameRule('middle name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Middle"
@@ -145,7 +145,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="secondMiddle"
-                rules={{ ...validateExtendedNameRule('Second Middle Name') }}
+                rules={{ ...validateExtendedNameRule('second middle name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second middle"

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -15,7 +15,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('as of date') }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Name as of"
@@ -33,7 +33,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('type') }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -69,7 +69,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="last"
-                rules={{ ...validateExtendedNameRule('last name') }}
+                rules={{ ...validateExtendedNameRule('Last name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Last"
@@ -88,7 +88,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="secondLast"
-                rules={{ ...validateExtendedNameRule('second last name') }}
+                rules={{ ...validateExtendedNameRule('Second last name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second last"
@@ -107,7 +107,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="first"
-                rules={{ ...validateExtendedNameRule('first name') }}
+                rules={{ ...validateExtendedNameRule('First name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="First"
@@ -126,7 +126,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="middle"
-                rules={{ ...validateExtendedNameRule('middle name') }}
+                rules={{ ...validateExtendedNameRule('Middle name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Middle"
@@ -145,7 +145,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="secondMiddle"
-                rules={{ ...validateExtendedNameRule('second middle name') }}
+                rules={{ ...validateExtendedNameRule('Second middle name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second middle"

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -1,7 +1,7 @@
 import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { Input } from 'components/FormInputs/Input';
 import { Controller, useFormContext } from 'react-hook-form';
-import { validNameRule } from 'validation/entry';
+import { validateExtendedNameRule, validateRequiredRule } from 'validation/entry/';
 import { NameEntry } from '../entry';
 import { usePatientNameCodedValues } from 'apps/patient/profile/names/usePatientNameCodedValues';
 import { SingleSelect } from 'design-system/select';
@@ -15,10 +15,10 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ required: { value: true, message: 'As of date is required.' } }}
+                rules={{ ...validateRequiredRule('As of date:') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
-                        label="Name as of"
+                        label="as of"
                         orientation="horizontal"
                         onBlur={onBlur}
                         defaultValue={value}
@@ -33,7 +33,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ required: { value: true, message: 'Type is required.' } }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -69,7 +69,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="last"
-                rules={validNameRule}
+                rules={{ ...validateExtendedNameRule('Last Name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Last"
@@ -88,7 +88,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="secondLast"
-                rules={validNameRule}
+                rules={{ ...validateExtendedNameRule('Second Last Name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second last"
@@ -107,7 +107,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="first"
-                rules={validNameRule}
+                rules={{ ...validateExtendedNameRule('First Name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="First"
@@ -126,7 +126,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="middle"
-                rules={validNameRule}
+                rules={{ ...validateExtendedNameRule('Middle Name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Middle"
@@ -145,7 +145,7 @@ export const NameEntryFields = () => {
             <Controller
                 control={control}
                 name="secondMiddle"
-                rules={validNameRule}
+                rules={{ ...validateExtendedNameRule('Second Middle Name') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Second middle"

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
@@ -59,7 +59,7 @@ describe('PhoneEmailEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Type is required.')).toBeInTheDocument();
+            expect(getByText('The type is required')).toBeInTheDocument();
         });
     });
 
@@ -72,7 +72,7 @@ describe('PhoneEmailEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Use is required.')).toBeInTheDocument();
+            expect(getByText('The use is required')).toBeInTheDocument();
         });
     });
 
@@ -85,7 +85,7 @@ describe('PhoneEmailEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
+            expect(getByText('The as of date is required')).toBeInTheDocument();
         });
     });
 
@@ -106,9 +106,9 @@ describe('PhoneEmailEntryFields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('Type is required.')).not.toBeInTheDocument();
-            expect(queryByText('As of date is required.')).not.toBeInTheDocument();
-            expect(queryByText('Use is required.')).not.toBeInTheDocument();
+            expect(queryByText('The type is required')).not.toBeInTheDocument();
+            expect(queryByText('The as of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The use is required')).not.toBeInTheDocument();
         });
     });
 

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
@@ -59,7 +59,7 @@ describe('PhoneEmailEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The type is required')).toBeInTheDocument();
+            expect(getByText('The Type is required')).toBeInTheDocument();
         });
     });
 
@@ -72,7 +72,7 @@ describe('PhoneEmailEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The use is required')).toBeInTheDocument();
+            expect(getByText('The Use is required')).toBeInTheDocument();
         });
     });
 
@@ -85,7 +85,7 @@ describe('PhoneEmailEntryFields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The as of date is required')).toBeInTheDocument();
+            expect(getByText('The As of date is required')).toBeInTheDocument();
         });
     });
 
@@ -106,9 +106,9 @@ describe('PhoneEmailEntryFields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('The type is required')).not.toBeInTheDocument();
-            expect(queryByText('The as of date is required')).not.toBeInTheDocument();
-            expect(queryByText('The use is required')).not.toBeInTheDocument();
+            expect(queryByText('The Type is required')).not.toBeInTheDocument();
+            expect(queryByText('The As of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The Use is required')).not.toBeInTheDocument();
         });
     });
 

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -3,7 +3,7 @@ import { DatePickerInput } from 'components/FormInputs/DatePickerInput';
 import { Input } from 'components/FormInputs/Input';
 import { SingleSelect } from 'design-system/select';
 import { Controller, useFormContext } from 'react-hook-form';
-import { maxLengthRule } from 'validation/entry';
+import { maxLengthRule, validateRequiredRule, validEmailRule } from 'validation/entry';
 import { validatePhoneNumber } from 'validation/phone';
 import { PhoneEmailEntry } from '../entry';
 
@@ -16,7 +16,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ required: { value: true, message: 'As of date is required.' } }}
+                rules={{ ...validateRequiredRule('As of') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Phone & email as of"
@@ -34,7 +34,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ required: { value: true, message: 'Type is required.' } }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -53,7 +53,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="use"
-                rules={{ required: { value: true, message: 'Use is required.' } }}
+                rules={{ ...validateRequiredRule('Use') }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
@@ -156,11 +156,7 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="email"
                 rules={{
-                    pattern: {
-                        value: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
-                        message: 'Please enter a valid email address (example: youremail@website.com)'
-                    },
-                    ...maxLengthRule(100)
+                    ...validEmailRule(100, 'Email')
                 }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
@@ -180,7 +176,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="url"
-                rules={maxLengthRule(100)}
+                rules={maxLengthRule(100, 'URL')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="URL"
@@ -199,7 +195,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="comment"
-                rules={maxLengthRule(2000)}
+                rules={maxLengthRule(2000, 'Phone & email comments')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Phone & email comments"

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -195,7 +195,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="comment"
-                rules={maxLengthRule(2000, 'phone & email comments')}
+                rules={maxLengthRule(2000, 'Phone & email comments')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Phone & email comments"

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -16,7 +16,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('As of') }}
+                rules={{ ...validateRequiredRule('as of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Phone & email as of"
@@ -34,7 +34,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('Type') }}
+                rules={{ ...validateRequiredRule('type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -53,7 +53,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="use"
-                rules={{ ...validateRequiredRule('Use') }}
+                rules={{ ...validateRequiredRule('use') }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
@@ -156,7 +156,7 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="email"
                 rules={{
-                    ...validEmailRule(100, 'Email')
+                    ...validEmailRule(100, 'email')
                 }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
@@ -195,7 +195,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="comment"
-                rules={maxLengthRule(2000, 'Phone & email comments')}
+                rules={maxLengthRule(2000, 'phone & email comments')}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input
                         label="Phone & email comments"

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -16,7 +16,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('as of date') }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Phone & email as of"
@@ -34,7 +34,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="type"
-                rules={{ ...validateRequiredRule('type') }}
+                rules={{ ...validateRequiredRule('Type') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Type"
@@ -53,7 +53,7 @@ export const PhoneEmailEntryFields = () => {
             <Controller
                 control={control}
                 name="use"
-                rules={{ ...validateRequiredRule('use') }}
+                rules={{ ...validateRequiredRule('Use') }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Use"
@@ -156,7 +156,7 @@ export const PhoneEmailEntryFields = () => {
                 control={control}
                 name="email"
                 rules={{
-                    ...validEmailRule(100, 'email')
+                    ...validEmailRule(100)
                 }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <Input

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
@@ -91,7 +91,7 @@ describe('Race entry fields', () => {
             detailed: [{ value: 'existing-detailed', name: 'existing detailed race name' }]
         };
 
-        const { getByLabelText, queryByText } = render(
+        const { getByLabelText } = render(
             <Fixture
                 entry={entry}
                 categories={[
@@ -126,7 +126,7 @@ describe('Race entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The as of date is required')).toBeInTheDocument();
+            expect(getByText('The As of date is required')).toBeInTheDocument();
         });
     });
 
@@ -140,7 +140,7 @@ describe('Race entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('The race is required.')).toBeInTheDocument();
+            expect(getByText('The Race is required.')).toBeInTheDocument();
         });
     });
 
@@ -175,8 +175,8 @@ describe('Race entry fields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('The race as of date is required')).not.toBeInTheDocument();
-            expect(queryByText('The race is required')).not.toBeInTheDocument();
+            expect(queryByText('The As of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The Race is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
@@ -113,7 +113,7 @@ describe('Race entry fields', () => {
 
         await waitFor(() => {
             expect(mockDetailResolver).toBeCalledWith('other');
-            expect(detailed).toHaveValue("");
+            expect(detailed).toHaveValue('');
         });
     });
 
@@ -126,7 +126,7 @@ describe('Race entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('As of date is required.')).toBeInTheDocument();
+            expect(getByText('The as of date is required')).toBeInTheDocument();
         });
     });
 
@@ -140,7 +140,7 @@ describe('Race entry fields', () => {
             userEvent.tab();
         });
         await waitFor(() => {
-            expect(getByText('Race is required.')).toBeInTheDocument();
+            expect(getByText('The race is required.')).toBeInTheDocument();
         });
     });
 
@@ -175,8 +175,8 @@ describe('Race entry fields', () => {
         });
 
         await waitFor(() => {
-            expect(queryByText('As of date is required')).not.toBeInTheDocument();
-            expect(queryByText('Race is required')).not.toBeInTheDocument();
+            expect(queryByText('The race as of date is required')).not.toBeInTheDocument();
+            expect(queryByText('The race is required')).not.toBeInTheDocument();
         });
     });
 });

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -5,6 +5,7 @@ import { RaceCategoryValidator, RaceEntry } from './entry';
 import { MultiSelect, SingleSelect } from 'design-system/select';
 import { Selectable } from 'options';
 import { useLayoutEffect } from 'react';
+import { validateRequiredRule } from 'validation/entry';
 
 type RaceEntryFieldsProps = {
     categories: Selectable[];
@@ -31,7 +32,7 @@ const RaceEntryFields = ({ categories, categoryValidator, isDirty }: RaceEntryFi
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ required: { value: true, message: 'As of date is required.' } }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Race as of"

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -32,7 +32,7 @@ const RaceEntryFields = ({ categories, categoryValidator, isDirty }: RaceEntryFi
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('As of date') }}
+                rules={{ ...validateRequiredRule('as of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Race as of"

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -32,7 +32,7 @@ const RaceEntryFields = ({ categories, categoryValidator, isDirty }: RaceEntryFi
             <Controller
                 control={control}
                 name="asOf"
-                rules={{ ...validateRequiredRule('as of date') }}
+                rules={{ ...validateRequiredRule('As of date') }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
                         label="Race as of"

--- a/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.spec.ts
@@ -5,14 +5,14 @@ describe('when validating the entry of a race category', () => {
     it('should pass validation when the race category is present', async () => {
         const actual = categoryRequiredValidator(5, null);
 
-        await expect(actual).resolves.toBe('Race is required.');
+        await expect(actual).resolves.toBe('The race is required.');
     });
 
     it('should fail validation when the race category is empty because it is required', async () => {
         //  A Selectable should never be empty however, something is creating them (might be react-hook-form)
         const actual = categoryRequiredValidator(5, {} as Selectable);
 
-        await expect(actual).resolves.toBe('Race is required.');
+        await expect(actual).resolves.toBe('The race is required.');
     });
 
     it('should fail validation when the race category is not present because it is required', async () => {

--- a/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.spec.ts
@@ -5,14 +5,14 @@ describe('when validating the entry of a race category', () => {
     it('should pass validation when the race category is present', async () => {
         const actual = categoryRequiredValidator(5, null);
 
-        await expect(actual).resolves.toBe('The race is required.');
+        await expect(actual).resolves.toBe('The Race is required.');
     });
 
     it('should fail validation when the race category is empty because it is required', async () => {
         //  A Selectable should never be empty however, something is creating them (might be react-hook-form)
         const actual = categoryRequiredValidator(5, {} as Selectable);
 
-        await expect(actual).resolves.toBe('The race is required.');
+        await expect(actual).resolves.toBe('The Race is required.');
     });
 
     it('should fail validation when the race category is not present because it is required', async () => {

--- a/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.ts
@@ -10,6 +10,6 @@ import { exists } from 'utils';
  * @return {Promise<string | boolean>}
  */
 const categoryRequiredValidator = (id: number, category: Selectable | null): Promise<string | boolean> =>
-    !exists(category) ? Promise.resolve('Race is required.') : Promise.resolve(true);
+    !exists(category) ? Promise.resolve('The race is required.') : Promise.resolve(true);
 
 export { categoryRequiredValidator };

--- a/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/categoryRequiredValidator.ts
@@ -10,6 +10,6 @@ import { exists } from 'utils';
  * @return {Promise<string | boolean>}
  */
 const categoryRequiredValidator = (id: number, category: Selectable | null): Promise<string | boolean> =>
-    !exists(category) ? Promise.resolve('The race is required.') : Promise.resolve(true);
+    !exists(category) ? Promise.resolve('The Race is required.') : Promise.resolve(true);
 
 export { categoryRequiredValidator };

--- a/apps/modernization-ui/src/validation/entry/index.ts
+++ b/apps/modernization-ui/src/validation/entry/index.ts
@@ -2,3 +2,5 @@ export * from './maxLengthRule';
 export * from './validNameRule';
 export * from './validPageNameRule';
 export * from './validEmailRule';
+export * from './validateExtendedNameRule';
+export * from './validateRequiredRule';

--- a/apps/modernization-ui/src/validation/entry/maxLengthRule.ts
+++ b/apps/modernization-ui/src/validation/entry/maxLengthRule.ts
@@ -9,10 +9,11 @@ type MaxLengthRule = {
  * Creates a standardized react-hook-form rule for the maximum input length.
  *
  * @param {number} value The maximum character length, defaults to 50.
+ * @param {string} name The name of the field, defaults to 'Field'.
  * @return {MaxLengthRule}
  */
-const maxLengthRule = (value = 50): MaxLengthRule => ({
-    maxLength: { value, message: `Only allows ${value} characters` }
+const maxLengthRule = (value = 50, name?: string): MaxLengthRule => ({
+    maxLength: { value, message: name ? `${name}: Only allows ${value} characters` : `Only allows ${value} characters` }
 });
 
 export { maxLengthRule };

--- a/apps/modernization-ui/src/validation/entry/maxLengthRule.ts
+++ b/apps/modernization-ui/src/validation/entry/maxLengthRule.ts
@@ -13,7 +13,10 @@ type MaxLengthRule = {
  * @return {MaxLengthRule}
  */
 const maxLengthRule = (value = 50, name?: string): MaxLengthRule => ({
-    maxLength: { value, message: name ? `${name}: Only allows ${value} characters` : `Only allows ${value} characters` }
+    maxLength: {
+        value,
+        message: name ? `The ${name} only allows ${value} characters` : `Only allows ${value} characters`
+    }
 });
 
 export { maxLengthRule };

--- a/apps/modernization-ui/src/validation/entry/validEmailRule.ts
+++ b/apps/modernization-ui/src/validation/entry/validEmailRule.ts
@@ -1,9 +1,10 @@
 import { maxLengthRule } from './maxLengthRule';
 
-const validEmailRule = (maxLength: number = 100) => ({
+const message = 'Please enter a valid email address (example: youremail@website.com)';
+const validEmailRule = (maxLength: number = 100, name?: string) => ({
     pattern: {
         value: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
-        message: 'Please enter a valid email address (example: youremail@website.com)'
+        message: name ? `${name}: ${message}` : message
     },
     ...maxLengthRule(maxLength)
 });

--- a/apps/modernization-ui/src/validation/entry/validEmailRule.ts
+++ b/apps/modernization-ui/src/validation/entry/validEmailRule.ts
@@ -4,7 +4,7 @@ const message = 'Please enter a valid email address (example: youremail@website.
 const validEmailRule = (maxLength: number = 100, name?: string) => ({
     pattern: {
         value: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
-        message: name ? `${name}: ${message}` : message
+        message: name ? `The ${name} ${message}` : message
     },
     ...maxLengthRule(maxLength)
 });

--- a/apps/modernization-ui/src/validation/entry/validEmailRule.ts
+++ b/apps/modernization-ui/src/validation/entry/validEmailRule.ts
@@ -1,10 +1,9 @@
 import { maxLengthRule } from './maxLengthRule';
 
-const message = 'Please enter a valid email address (example: youremail@website.com)';
-const validEmailRule = (maxLength: number = 100, name?: string) => ({
+const validEmailRule = (maxLength: number = 100) => ({
     pattern: {
         value: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
-        message: name ? `The ${name} ${message}` : message
+        message: 'Please enter a valid email address (example: youremail@website.com)'
     },
     ...maxLengthRule(maxLength)
 });

--- a/apps/modernization-ui/src/validation/entry/validateExtendedNameRule.ts
+++ b/apps/modernization-ui/src/validation/entry/validateExtendedNameRule.ts
@@ -1,0 +1,13 @@
+import { maxLengthRule } from './maxLengthRule';
+
+/**
+ * Creates a standardized react-hook-form rule for the entry of name values.
+ *
+ * @param {string} name The name of the field.
+ * @return {MaxLengthRule}
+ */
+const validateExtendedNameRule = (name?: string) => ({
+    ...maxLengthRule(50, name)
+});
+
+export { validateExtendedNameRule };

--- a/apps/modernization-ui/src/validation/entry/validateRequiredRule.ts
+++ b/apps/modernization-ui/src/validation/entry/validateRequiredRule.ts
@@ -1,0 +1,5 @@
+const validateRequiredRule = (name: string) => ({
+    required: { value: true, message: `${name}: is required` }
+});
+
+export { validateRequiredRule };

--- a/apps/modernization-ui/src/validation/entry/validateRequiredRule.ts
+++ b/apps/modernization-ui/src/validation/entry/validateRequiredRule.ts
@@ -1,5 +1,5 @@
 const validateRequiredRule = (name: string) => ({
-    required: { value: true, message: `${name}: is required` }
+    required: { value: true, message: `The ${name} is required` }
 });
 
 export { validateRequiredRule };


### PR DESCRIPTION
## Description

Repeating block - has to display the field labels and the associated validation message.

## Tickets

* [CNFT1-3522](https://cdc-nbs.atlassian.net/browse/CNFT1-3522)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3522]: https://cdc-nbs.atlassian.net/browse/CNFT1-3522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ