### PR TITLE
CNFT1-3538 API: Patient search: ID Type search uses "Contains"

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -278,8 +278,8 @@ class PatientDemographicQueryResolver {
                                   term -> term.field("entity_id.typeCd.keyword")
                                       .value(type)))
                               .must(
-                                  must -> must.prefix(
-                                      prefix -> prefix.field("entity_id.rootExtensionTxt").caseInsensitive(true)
+                                  must -> must.wildcard(
+                                      match -> match.field("entity_id.rootExtensionTxt").caseInsensitive(true)
                                           .value(value)))))));
     }
     return Optional.empty();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -280,7 +280,7 @@ class PatientDemographicQueryResolver {
                               .must(
                                   must -> must.wildcard(
                                       match -> match.field("entity_id.rootExtensionTxt").caseInsensitive(true)
-                                          .value(value)))))));
+                                          .value(WildCards.contains(value))))))));
     }
     return Optional.empty();
   }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -235,6 +235,17 @@ Feature: Patient Search
     When I search for patients
     Then the patient is not in the search results
 
+  Scenario: I can search for a Patient using a value that is contained in the Identification
+    Given the patient can be identified with a "MC" of "1234"
+    And I have another patient
+    And the patient can be identified with a "MC" of "1345"
+    And patients are available for search
+    And I add the patient criteria for an "identification type" equal to "MC"
+    And I add the patient criteria for an "identification value" equal to "23"
+    When I search for patients
+    Then there is only one patient search result
+    And the search results have a patient with an "identification value" equal to "1234"
+
   Scenario: BUG: CNFT1-2008 I can search for a Patient with invalid identification
     Given the patient has the legal name "Max" "Headroom"
     And the patient can be identified with a Medicare Number of "1009"


### PR DESCRIPTION
## Description

Switch to wildcard search instead of prefix search

## Tickets

* [CNFT1-3538](https://cdc-nbs.atlassian.net/browse/CNFT1-3538)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3538]: https://cdc-nbs.atlassian.net/browse/CNFT1-3538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ