### PR TITLE
CNFT1-3520 Fix last name indexing to retain spaces and convert hyphens to spaces

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import gov.cdc.nbs.search.LocalDateWithTimeJsonDeserializer;
 import gov.cdc.nbs.search.LocalDateWithTimeJsonSerializer;
+import gov.cdc.nbs.search.WithoutHyphensJsonSerializer;
 import gov.cdc.nbs.search.WithoutSpecialCharactersJsonSerializer;
 
 import java.time.LocalDate;
@@ -89,7 +90,7 @@ public record SearchablePatient(@JsonProperty("person_uid") long identifier, @Js
       @JsonProperty("firstNmSndx") String firstSoundex,
       @JsonProperty("middleNm") @JsonSerialize(using = WithoutSpecialCharactersJsonSerializer.class,
           as = String.class) String middle,
-      @JsonProperty("lastNm") @JsonSerialize(using = WithoutSpecialCharactersJsonSerializer.class,
+      @JsonProperty("lastNm") @JsonSerialize(using = WithoutHyphensJsonSerializer.class,
           as = String.class) String last,
       @JsonProperty("lastNmSndx") String lastSoundex,
       @JsonProperty("nmPrefix") String prefix,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/WildCards.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/WildCards.java
@@ -22,6 +22,5 @@ public class WildCards {
     return value.replaceAll("([+\\-!(){}\\[\\]^\"~*?:\\\\/])", "\\\\$1");
   }
 
-  private WildCards() {
-  }
+  private WildCards() {}
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/WithoutHyphensJsonSerializer.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/WithoutHyphensJsonSerializer.java
@@ -1,0 +1,24 @@
+package gov.cdc.nbs.search;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class WithoutHyphensJsonSerializer extends JsonSerializer<String> {
+
+  @Override
+  public void serialize(
+      final String value,
+      final JsonGenerator jsonGenerator,
+      final SerializerProvider serializerProvider) throws IOException {
+    String adjusted = AdjustStrings.withoutHyphens(value);
+
+    if (adjusted == null) {
+      jsonGenerator.writeNull();
+    } else {
+      jsonGenerator.writeString(adjusted);
+    }
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -1,12 +1,13 @@
 package gov.cdc.nbs.search.criteria.text;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
 import gov.cdc.nbs.search.WildCards;
 import org.apache.commons.codec.language.Soundex;
 
 public class TextCriteriaNestedQueryResolver {
 
-  public static  BoolQuery equalTo(final String path, final String name, final String value) {
+  public static BoolQuery equalTo(final String path, final String name, final String value) {
     return BoolQuery.of(
         bool -> bool.must(
             should -> should.nested(
@@ -17,14 +18,7 @@ public class TextCriteriaNestedQueryResolver {
                                 must -> must.match(
                                     match -> match
                                         .field(name)
-                                        .query(value)
-                                )
-                            )
-                        )
-                    )
-            )
-        )
-    );
+                                        .query(value))))))));
   }
 
   public static BoolQuery notEquals(final String path, final String name, final String value) {
@@ -38,14 +32,7 @@ public class TextCriteriaNestedQueryResolver {
                                 mustNot -> mustNot.match(
                                     match -> match
                                         .field(name)
-                                        .query(value)
-                                )
-                            )
-                        )
-                    )
-            )
-        )
-    );
+                                        .query(value))))))));
   }
 
   public static BoolQuery contains(final String path, final String name, final String value) {
@@ -60,14 +47,7 @@ public class TextCriteriaNestedQueryResolver {
                                 must -> must.wildcard(
                                     match -> match
                                         .field(name)
-                                        .value(adjusted)
-                                )
-                            )
-                        )
-                    )
-            )
-        )
-    );
+                                        .value(adjusted))))))));
   }
 
   public static BoolQuery startsWith(final String path, final String name, final String value) {
@@ -77,19 +57,10 @@ public class TextCriteriaNestedQueryResolver {
             should -> should.nested(
                 nested -> nested.path(path)
                     .query(
-                        query -> query.bool(
-                            legal -> legal.must(
-                                must -> must.wildcard(
-                                    match -> match
-                                        .field(name)
-                                        .value(adjusted)
-                                )
-                            )
-                        )
-                    )
-            )
-        )
-    );
+                        query -> query.simpleQueryString(
+                            simple -> simple.fields(name)
+                                .query(adjusted)
+                                .defaultOperator(Operator.And))))));
   }
 
   public static BoolQuery soundLike(final String path, final String name, final String value) {
@@ -104,14 +75,7 @@ public class TextCriteriaNestedQueryResolver {
                                 must -> must.term(
                                     term -> term
                                         .field(name)
-                                        .value(adjusted)
-                                )
-                            )
-                        )
-                    )
-            )
-        )
-    );
+                                        .value(adjusted))))))));
   }
 
   private TextCriteriaNestedQueryResolver() {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -42,12 +42,10 @@ public class TextCriteriaNestedQueryResolver {
             should -> should.nested(
                 nested -> nested.path(path)
                     .query(
-                        query -> query.bool(
-                            field -> field.must(
-                                must -> must.wildcard(
-                                    match -> match
-                                        .field(name)
-                                        .value(adjusted))))))));
+                        query -> query.queryString(
+                            simple -> simple.fields(name)
+                                .query(adjusted)
+                                .defaultOperator(Operator.And))))));
   }
 
   public static BoolQuery startsWith(final String path, final String name, final String value) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/search/WithoutHyphensJsonSerializerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/search/WithoutHyphensJsonSerializerTest.java
@@ -1,0 +1,49 @@
+package gov.cdc.nbs.search;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class WithoutHyphensJsonSerializerTest {
+
+
+  static Stream<Arguments> values() {
+    return Stream.of(
+        arguments("smith-jones", "\"smith jones\""),
+        arguments("smith jones", "\"smith jones\""),
+        arguments(null, "null"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("values")
+  void should_retain_spaces_and_replace_hyphens_with_spaces(final String in, final String expected)
+      throws IOException {
+
+    Writer jsonWriter = new StringWriter();
+    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
+    SerializerProvider serializerProvider = new ObjectMapper().getSerializerProvider();
+
+    new WithoutHyphensJsonSerializer().serialize(
+        in,
+        jsonGenerator,
+        serializerProvider);
+
+    jsonGenerator.flush();
+
+    assertThat(jsonWriter.toString()).contains(expected);
+
+  }
+
+}

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -6,7 +6,7 @@ Feature: Searching patient's by name
     And I can "find" any "patient"
     And I have a patient
 
-  Scenario: I can find the a patient with a last name that equals a value
+  Scenario: I can find a patient with a last name that equals a value
     Given I have another patient
     And the patient has the legal name "JoeEqual" "Smith"
     And patients are available for search
@@ -16,7 +16,7 @@ Feature: Searching patient's by name
     And search result 1 has a "last name" of "Smith"
     And there are 1 patient search results
 
-  Scenario: I can find the a patient with a last name that does not equal a value
+  Scenario: I can find a patient with a last name that does not equal a value
     Given the patient has the legal name "Joe" "not-equal"
     And I have another patient
     And the patient has the legal name "JoeEqual" "Smith"
@@ -26,8 +26,8 @@ Feature: Searching patient's by name
     Then there are 1 patient search results
     And the patient is not in the search results
 
-  Scenario: I can find the a patient with a last name that contains a value
-    Given the patient has the Alias Name name "Joe" "Aerosmithy"
+  Scenario: I can find a patient with a last name that contains a value
+    Given the patient has alias Name name "Joe" "Aerosmithy"
     And I have another patient
     And the patient has the legal name "Samantha" "Smother"
     And patients are available for search
@@ -37,8 +37,8 @@ Feature: Searching patient's by name
     And search result 1 has a "last name" of "Aerosmithy"
     And there are 1 patient search results
 
-  Scenario: I can find the a patient with a last name that starts with a value
-    Given the patient has the Alias Name name "Joe" "another-value"
+  Scenario: I can find a patient with a last name that starts with a value
+    Given the patient has alias Name name "Joe" "another-value"
     And I have another patient
     And the patient has the legal name "Sam" "starts-value"
     And patients are available for search
@@ -48,7 +48,7 @@ Feature: Searching patient's by name
     And search result 1 has a "last name" of "starts-value"
     And there are 1 patient search results
 
-  Scenario: I can find the a patient with a last name that sounds like a value
+  Scenario: I can find a patient with a last name that sounds like a value
     Given I have another patient
     And the patient has the legal name "Joe" "Smooth"
     And patients are available for search
@@ -58,7 +58,7 @@ Feature: Searching patient's by name
     And search result 1 has a "last name" of "Smooth"
     And there are 1 patient search results
 
-  Scenario: I can find the a patient with a last name with multiple names that equals a value
+  Scenario: I can find a patient with a last name with multiple names that equals a value
     Given I have another patient
     And the patient has the legal name "JoeEqual" "Smith Jones"
     And patients are available for search
@@ -68,7 +68,7 @@ Feature: Searching patient's by name
     And search result 1 has a "last name" of "Smith Jones"
     And there are 1 patient search results
 
-  Scenario: I can find the a patient with a last name with hyphens that equals a value
+  Scenario: I can find a patient with a last name with hyphens that equals a value
     Given I have another patient
     And the patient has the legal name "JoeEqual" "Smith-Jones"
     And patients are available for search

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -27,7 +27,7 @@ Feature: Searching patient's by name
     And the patient is not in the search results
 
   Scenario: I can find a patient with a last name that contains a value
-    Given the patient has alias Name name "Joe" "Aerosmithy"
+    Given the patient has the Alias Name name "Joe" "Aerosmithy"
     And I have another patient
     And the patient has the legal name "Samantha" "Smother"
     And patients are available for search
@@ -38,7 +38,7 @@ Feature: Searching patient's by name
     And there are 1 patient search results
 
   Scenario: I can find a patient with a last name that starts with a value
-    Given the patient has alias Name name "Joe" "another-value"
+    Given the patient has the Alias Name name "Joe" "another-value"
     And I have another patient
     And the patient has the legal name "Sam" "starts-value"
     And patients are available for search

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -77,3 +77,25 @@ Feature: Searching patient's by name
     Then search result 1 has a "first name" of "JoeEqual"
     And search result 1 has a "last name" of "Smith-Jones"
     And there are 1 patient search results
+
+  Scenario: I can find a patient with a last name with multiple names that starts with a value
+    Given the patient has the legal name "Samantha" "Smith"
+    And I have another patient
+    And the patient has the legal name "JoeEqual" "Smith Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that starts with "Smith J"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith Jones"
+    And there are 1 patient search results
+
+  Scenario: I can find a patient with a last name with hyphens that starts with a value
+    Given the patient has the legal name "Samantha" "Smith"
+    And I have another patient
+    And the patient has the legal name "JoeEqual" "Smith-Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that starts with "Smith J"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith-Jones"
+    And there are 1 patient search results

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -57,3 +57,23 @@ Feature: Searching patient's by name
     Then search result 1 has a "first name" of "Joe"
     And search result 1 has a "last name" of "Smooth"
     And there are 1 patient search results
+
+  Scenario: I can find the a patient with a last name with multiple names that equals a value
+    Given I have another patient
+    And the patient has the legal name "JoeEqual" "Smith Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that equals "Smith Jones"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith Jones"
+    And there are 1 patient search results
+
+  Scenario: I can find the a patient with a last name with hyphens that equals a value
+    Given I have another patient
+    And the patient has the legal name "JoeEqual" "Smith-Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that equals "Smith-Jones"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith-Jones"
+    And there are 1 patient search results

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -129,7 +129,7 @@ Feature: Searching patient's by name
     When I search for patients
     Then there are 0 patient search results
 
-  Scenario: I can find a patient with a last name with hyphens that equals a value
+  Scenario: I can find a patient with a last name with hyphens that does not equal a value
     Given the patient has the legal name "JoeEqual" "Smith-Jones"
     And patients are available for search
     And I add the patient criteria for a last name that does not equal "Smith-Jones"

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -121,3 +121,17 @@ Feature: Searching patient's by name
     Then search result 1 has a "first name" of "JoeEqual"
     And search result 1 has a "last name" of "Smith-Jones"
     And there are 1 patient search results
+
+  Scenario: I can find a patient with a last name with multiple names that does not equal a value
+    Given the patient has the legal name "JoeEqual" "Smith Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that does not equal "Smith Jones"
+    When I search for patients
+    Then there are 0 patient search results
+
+  Scenario: I can find a patient with a last name with hyphens that equals a value
+    Given the patient has the legal name "JoeEqual" "Smith-Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that does not equal "Smith-Jones"
+    When I search for patients
+    Then there are 0 patient search results

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.last-name-operator.feature
@@ -99,3 +99,25 @@ Feature: Searching patient's by name
     Then search result 1 has a "first name" of "JoeEqual"
     And search result 1 has a "last name" of "Smith-Jones"
     And there are 1 patient search results
+
+  Scenario: I can find a patient with a last name with multiple names that contains a value
+    Given the patient has the legal name "Samantha" "Smith"
+    And I have another patient
+    And the patient has the legal name "JoeEqual" "Smith Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that contains "mith J"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith Jones"
+    And there are 1 patient search results
+
+  Scenario: I can find a patient with a last name with hyphens that contains a value
+    Given the patient has the legal name "Samantha" "Smith"
+    And I have another patient
+    And the patient has the legal name "JoeEqual" "Smith-Jones"
+    And patients are available for search
+    And I add the patient criteria for a last name that contains "mith j"
+    When I search for patients
+    Then search result 1 has a "first name" of "JoeEqual"
+    And search result 1 has a "last name" of "Smith-Jones"
+    And there are 1 patient search results


### PR DESCRIPTION
## Description

Fixes multi name last name searches with and without hyphens

## Tickets

* [CNFT1-3520](https://cdc-nbs.atlassian.net/browse/CNFT1-3520)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3520]: https://cdc-nbs.atlassian.net/browse/CNFT1-3520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ