### PR TITLE
CNFT1-3557: Chips for multiple patient IDs

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.spec.tsx
@@ -25,4 +25,9 @@ describe('when Basic information renders', () => {
         const inputs = container.getElementsByTagName('input');
         expect(inputs.length).toBe(8);
     });
+
+    it('should have helper text for patient ID', () => {
+        const { getByText } = setup();
+        expect(getByText('Separate IDs by commas, semicolons, or spaces')).toBeInTheDocument();
+    });
 });

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -85,6 +85,7 @@ export const BasicInformation = () => {
                         defaultValue={value}
                         type="text"
                         label="Patient ID"
+                        helperText="Separate IDs by commas, semicolons, or spaces"
                         name={name}
                         htmlFor={name}
                         id={name}

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
@@ -36,7 +36,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'lastName',
+                    source: 'name.last',
                     title: 'LAST NAME',
                     name: 'last-name-value',
                     value: 'last-name-value',
@@ -57,7 +57,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'lastName',
+                    source: 'name.last',
                     title: 'LAST NAME',
                     name: 'last-name-value',
                     value: 'last-name-value',
@@ -78,7 +78,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'lastName',
+                    source: 'name.last',
                     title: 'LAST NAME',
                     name: 'last-name-value',
                     value: 'last-name-value',
@@ -99,7 +99,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'lastName',
+                    source: 'name.last',
                     title: 'LAST NAME',
                     name: 'last-name-value',
                     value: 'last-name-value',
@@ -120,7 +120,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'lastName',
+                    source: 'name.last',
                     title: 'LAST NAME',
                     name: 'last-name-value',
                     value: 'last-name-value',
@@ -141,7 +141,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'firstName',
+                    source: 'name.first',
                     title: 'FIRST NAME',
                     name: 'first-name-value',
                     value: 'first-name-value',
@@ -162,7 +162,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'firstName',
+                    source: 'name.first',
                     title: 'FIRST NAME',
                     name: 'first-name-value',
                     value: 'first-name-value',
@@ -183,7 +183,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'firstName',
+                    source: 'name.first',
                     title: 'FIRST NAME',
                     name: 'first-name-value',
                     value: 'first-name-value',
@@ -204,7 +204,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'firstName',
+                    source: 'name.first',
                     title: 'FIRST NAME',
                     name: 'first-name-value',
                     value: 'first-name-value',
@@ -225,7 +225,7 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'firstName',
+                    source: 'name.first',
                     title: 'FIRST NAME',
                     name: 'first-name-value',
                     value: 'first-name-value',
@@ -257,7 +257,9 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
         const actual = patientTermsResolver(input);
 
         expect(actual).toEqual(
-            expect.arrayContaining([{ source: 'id', title: 'PATIENT ID', name: 'id-value', value: 'id-value' }])
+            expect.arrayContaining([
+                { source: 'id', title: 'PATIENT ID', name: 'id-value', value: 'id-value', partial: true }
+            ])
         );
     });
 });
@@ -274,7 +276,7 @@ describe('when the PatientCriteria contains Address criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'address',
+                    source: 'location.street',
                     title: 'STREET ADDRESS',
                     name: 'address-value',
                     value: 'address-value',
@@ -295,7 +297,7 @@ describe('when the PatientCriteria contains Address criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'address',
+                    source: 'location.street',
                     title: 'STREET ADDRESS',
                     name: 'address-value',
                     value: 'address-value',
@@ -316,7 +318,7 @@ describe('when the PatientCriteria contains Address criteria', () => {
         expect(actual).toEqual(
             expect.arrayContaining([
                 {
-                    source: 'address',
+                    source: 'location.street',
                     title: 'STREET ADDRESS',
                     name: 'address-value',
                     value: 'address-value',
@@ -336,7 +338,7 @@ describe('when the PatientCriteria contains Address criteria', () => {
 
         expect(actual).toEqual(
             expect.arrayContaining([
-                { source: 'city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Equals' }
+                { source: 'location.city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Equals' }
             ])
         );
     });
@@ -351,7 +353,8 @@ describe('when the PatientCriteria contains Address criteria', () => {
 
         expect(actual).toEqual(
             expect.arrayContaining([
-                { source: 'city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Not equal' }
+                // eslint-disable-next-line prettier/prettier
+                { source: 'location.city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Not equal' }
             ])
         );
     });
@@ -366,7 +369,8 @@ describe('when the PatientCriteria contains Address criteria', () => {
 
         expect(actual).toEqual(
             expect.arrayContaining([
-                { source: 'city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Contains' }
+                // eslint-disable-next-line prettier/prettier
+                { source: 'location.city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Contains' }
             ])
         );
     });

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.spec.ts
@@ -262,6 +262,23 @@ describe('when the PatientCriteria contains Basic Information criteria', () => {
             ])
         );
     });
+
+    it('should resolve multiple terms with patient id', () => {
+        const input: PatientCriteriaEntry = {
+            id: '123,456; 789',
+            status: []
+        };
+
+        const actual = patientTermsResolver(input);
+
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                { source: 'id', title: 'PATIENT ID', name: '123', value: '123', partial: true },
+                { source: 'id', title: 'PATIENT ID', name: '456', value: '456', partial: true },
+                { source: 'id', title: 'PATIENT ID', name: '789', value: '789', partial: true }
+            ])
+        );
+    });
 });
 
 describe('when the PatientCriteria contains Address criteria', () => {
@@ -353,7 +370,6 @@ describe('when the PatientCriteria contains Address criteria', () => {
 
         expect(actual).toEqual(
             expect.arrayContaining([
-                // eslint-disable-next-line prettier/prettier
                 { source: 'location.city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Not equal' }
             ])
         );
@@ -369,7 +385,6 @@ describe('when the PatientCriteria contains Address criteria', () => {
 
         expect(actual).toEqual(
             expect.arrayContaining([
-                // eslint-disable-next-line prettier/prettier
                 { source: 'location.city', title: 'CITY', name: 'city-value', value: 'city-value', operator: 'Contains' }
             ])
         );

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.ts
@@ -1,6 +1,7 @@
 import { Term, fromSelectable, fromValue } from 'apps/search/terms';
 import { PatientCriteriaEntry } from './criteria';
 import { asTextCriteriaValue, TextCriteria, asTextCriteriaOperator } from 'options/operator';
+import { splitStringByCommonDelimiters } from 'utils';
 
 const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
     const terms: Term[] = [];
@@ -19,12 +20,20 @@ const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
         }
     };
 
+    const pushPatientIDs = (source: string, title: string, value: string) => {
+        console.log('pushPatientIDs value', value);
+        // splitStringByCommonDelimiters(value).forEach((id) => {
+        //     terms.push(fromValue(source, title)(id));
+        // });
+        terms.push(...splitStringByCommonDelimiters(value).map((id) => fromValue(source, title)(id)));
+    };
+
     if (entry.name?.last) {
-        pushCriteria('lastName', 'LAST NAME', entry.name.last);
+        pushCriteria('name.last', 'LAST NAME', entry.name.last);
     }
 
     if (entry.name?.first) {
-        pushCriteria('firstName', 'FIRST NAME', entry.name.first);
+        pushCriteria('name.first', 'FIRST NAME', entry.name.first);
     }
 
     if (entry.dateOfBirth) {
@@ -36,7 +45,7 @@ const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
     }
 
     if (entry.id) {
-        terms.push(fromValue('id', 'PATIENT ID')(entry.id));
+        pushPatientIDs('id', 'PATIENT ID', entry.id);
     }
 
     if (entry.location?.street) {

--- a/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.ts
+++ b/apps/modernization-ui/src/apps/search/patient/patientTermsResolver.ts
@@ -7,8 +7,7 @@ const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
     const terms: Term[] = [];
 
     const pushCriteria = (source: string, title: string, value?: TextCriteria) => {
-        // note: we will eventually want to use asTextCriteria here and get the operator i.e. "contains"
-        // to populate the operator field in the term
+        // get the operator i.e. "contains" to populate the operator field in the term
         const stringValue = asTextCriteriaValue(value);
         const operator = asTextCriteriaOperator(value);
         if (stringValue) {
@@ -21,11 +20,8 @@ const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
     };
 
     const pushPatientIDs = (source: string, title: string, value: string) => {
-        console.log('pushPatientIDs value', value);
-        // splitStringByCommonDelimiters(value).forEach((id) => {
-        //     terms.push(fromValue(source, title)(id));
-        // });
-        terms.push(...splitStringByCommonDelimiters(value).map((id) => fromValue(source, title)(id)));
+        // push multiple terms if the value contains common delimiters
+        terms.push(...splitStringByCommonDelimiters(value).map((id) => fromValue(source, title)(id, undefined, true)));
     };
 
     if (entry.name?.last) {
@@ -57,11 +53,11 @@ const patientTermsResolver = (entry: PatientCriteriaEntry): Term[] => {
     }
 
     if (entry.location?.street) {
-        pushCriteria('address', 'STREET ADDRESS', entry.location?.street);
+        pushCriteria('location.street', 'STREET ADDRESS', entry.location?.street);
     }
 
     if (entry.location?.city) {
-        pushCriteria('city', 'CITY', entry.location?.city);
+        pushCriteria('location.city', 'CITY', entry.location?.city);
     }
 
     if (entry.state) {

--- a/apps/modernization-ui/src/apps/search/terms/fromSelectable.ts
+++ b/apps/modernization-ui/src/apps/search/terms/fromSelectable.ts
@@ -7,8 +7,7 @@ const fromSelectable =
         source,
         title,
         name,
-        value,
-        partial: false
+        value
     });
 
 export { fromSelectable };

--- a/apps/modernization-ui/src/apps/search/terms/fromSelectable.ts
+++ b/apps/modernization-ui/src/apps/search/terms/fromSelectable.ts
@@ -7,7 +7,8 @@ const fromSelectable =
         source,
         title,
         name,
-        value
+        value,
+        partial: false
     });
 
 export { fromSelectable };

--- a/apps/modernization-ui/src/apps/search/terms/fromValue.ts
+++ b/apps/modernization-ui/src/apps/search/terms/fromValue.ts
@@ -1,9 +1,10 @@
-const fromValue = (source: string, title: string) => (value: string, operator?: string) => ({
+const fromValue = (source: string, title: string) => (value: string, operator?: string, partial?: boolean) => ({
     source,
     title,
     name: value,
     value,
-    operator
+    operator,
+    partial: !!partial
 });
 
 export { fromValue };

--- a/apps/modernization-ui/src/apps/search/terms/fromValue.ts
+++ b/apps/modernization-ui/src/apps/search/terms/fromValue.ts
@@ -4,7 +4,7 @@ const fromValue = (source: string, title: string) => (value: string, operator?: 
     name: value,
     value,
     operator,
-    partial: !!partial
+    partial
 });
 
 export { fromValue };

--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.spec.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.spec.ts
@@ -68,4 +68,43 @@ describe('when removing search terms', () => {
 
         expect(actual).toEqual(expect.objectContaining({ values: [asSelectable('one'), asSelectable('two')] }));
     });
+
+    it('should remove a term from a string when partial is true', () => {
+        const { result } = renderHook(() => useForm<{ value?: string }>());
+
+        result.current.setValue('value', 'one, two, three');
+
+        const after = jest.fn();
+
+        const remove = removeTerm(result.current, after);
+
+        act(() => {
+            remove({ ...DEFAULT_TERM, source: 'value', value: 'two', partial: true });
+        });
+
+        expect(after).toBeCalled();
+
+        const actual = result.current.getValues();
+
+        expect(actual).toEqual(expect.objectContaining({ value: 'one, , three' }));
+    });
+
+    // it should handle a nested object path
+    it('it should handle a nested object path', () => {
+        const { result } = renderHook(() => useForm<{ nested: { value?: string } }>());
+
+        result.current.setValue('nested.value', 'current-value');
+
+        const after = jest.fn();
+        const resetField = jest.spyOn(result.current, 'resetField');
+
+        const remove = removeTerm(result.current, after);
+
+        act(() => {
+            remove({ ...DEFAULT_TERM, source: 'nested.value' });
+        });
+
+        expect(after).toBeCalled();
+        expect(resetField).toBeCalledWith('nested.value');
+    });
 });

--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.spec.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.spec.ts
@@ -3,6 +3,14 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { removeTerm } from './removeTerm';
 import { asSelectable, Selectable } from 'options';
 
+const DEFAULT_TERM = {
+    source: 'source',
+    title: 'title-value',
+    name: 'name-value',
+    value: 'current-value',
+    partial: false
+};
+
 describe('when removing search terms', () => {
     it('should remove a term with a single value', () => {
         const { result } = renderHook(() => useForm<{ value?: string }>());
@@ -15,12 +23,13 @@ describe('when removing search terms', () => {
 
         const remove = removeTerm(result.current, after);
 
-        remove({ source: 'value', title: 'title-value', name: 'name-value', value: 'current-value' });
+        remove({ ...DEFAULT_TERM, source: 'value' });
 
         expect(after).toBeCalled();
 
         expect(resetField).toBeCalledWith('value');
     });
+
     it('should remove a term with multi values', () => {
         const { result } = renderHook(() => useForm<{ values?: string[] }>());
 
@@ -31,7 +40,7 @@ describe('when removing search terms', () => {
         const remove = removeTerm(result.current, after);
 
         act(() => {
-            remove({ source: 'values', title: 'title-value', name: 'name-value', value: 'current-value' });
+            remove({ ...DEFAULT_TERM, source: 'values' });
         });
 
         expect(after).toBeCalled();
@@ -50,7 +59,7 @@ describe('when removing search terms', () => {
         const remove = removeTerm(result.current, after);
 
         act(() => {
-            remove({ source: 'values', title: 'title-value', name: 'name-value', value: 'current-value' });
+            remove({ ...DEFAULT_TERM, source: 'values' });
         });
 
         expect(after).toBeCalled();

--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
@@ -1,6 +1,7 @@
 import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form';
 import { Term } from './terms';
 import { selectField } from 'utils/util';
+import { removeAndTrim } from 'utils';
 
 const isSelectableNotMatching = (value: string) => (item: any) => 'value' in item && item.value !== value;
 
@@ -21,8 +22,8 @@ const removeTerm =
             const adjusted = value.filter(doesNotEqual(term.value));
             form.setValue(key, adjusted);
         } else if (term.partial && typeof value === 'string') {
-            // extract and remove term from string: "123, 456" -> remove 123 -> ", 456"
-            const adjusted = (value as string).replace(term.value, '');
+            // extract and remove term from string: "123, 456" -> remove 123 and surrounding delimiters -> "456"
+            const adjusted = removeAndTrim(value as string, term.value);
             form.setValue(key, adjusted as PathValue<C, Path<C>>);
         } else {
             form.resetField(key);

--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
@@ -16,9 +16,15 @@ const removeTerm =
         const value = formValues[key];
 
         if (Array.isArray(value)) {
-            //  this will most likey be a Selectable
+            //  this will most likely be a Selectable
             const adjusted = value.filter(doesNotEqual(term.value));
             form.setValue(key, adjusted);
+        } else if (term.partial && typeof value === 'string') {
+            // extract and remove term from string: "123, 456" -> remove 123 -> ", 456"
+            // eslint-disable-next-line no-debugger
+            debugger;
+            const newValue = value.replace(term.value, '');
+            form.setValue(key, newValue);
         } else {
             form.resetField(key);
         }

--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
@@ -1,5 +1,6 @@
-import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form';
 import { Term } from './terms';
+import { selectField } from 'utils/util';
 
 const isSelectableNotMatching = (value: string) => (item: any) => 'value' in item && item.value !== value;
 
@@ -13,18 +14,16 @@ const removeTerm =
 
         const key = term.source as Path<C>;
 
-        const value = formValues[key];
+        const value = selectField(formValues, key) as PathValue<C, Path<C>>;
 
         if (Array.isArray(value)) {
-            //  this will most likely be a Selectable
+            // this will most likely be a Selectable
             const adjusted = value.filter(doesNotEqual(term.value));
             form.setValue(key, adjusted);
         } else if (term.partial && typeof value === 'string') {
             // extract and remove term from string: "123, 456" -> remove 123 -> ", 456"
-            // eslint-disable-next-line no-debugger
-            debugger;
-            const newValue = value.replace(term.value, '');
-            form.setValue(key, newValue);
+            const adjusted = (value as string).replace(term.value, '');
+            form.setValue(key, adjusted as PathValue<C, Path<C>>);
         } else {
             form.resetField(key);
         }

--- a/apps/modernization-ui/src/apps/search/terms/terms.ts
+++ b/apps/modernization-ui/src/apps/search/terms/terms.ts
@@ -4,6 +4,7 @@ type Term = {
     name: string;
     value: string;
     operator?: string;
+    partial: boolean;
 };
 
 export type { Term };

--- a/apps/modernization-ui/src/apps/search/terms/terms.ts
+++ b/apps/modernization-ui/src/apps/search/terms/terms.ts
@@ -4,7 +4,7 @@ type Term = {
     name: string;
     value: string;
     operator?: string;
-    partial: boolean;
+    partial?: boolean;
 };
 
 export type { Term };

--- a/apps/modernization-ui/src/apps/search/useSearchResults.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResults.spec.tsx
@@ -74,7 +74,7 @@ const setup = (props?: Partial<SearchResultSettings<Criteria, APIParameters, Res
     const defaultTransformer = (criteria: Criteria) => ({ search: criteria.name });
     const defaultResultResolver = () => Promise.resolve({ total: 0, content: [], page: 0, size: 7 });
     const defaultTermResolver = () => [
-        { source: 'default-source', title: 'title-value', name: 'name-value', value: 'value-vlaue' }
+        { source: 'default-source', title: 'title-value', name: 'name-value', value: 'value-value', partial: false }
     ];
     //
     const transformer = props?.transformer ?? defaultTransformer;
@@ -176,7 +176,9 @@ describe('when searching using useSearchResults', () => {
     it('should change the criteria when searching', async () => {
         const transformer = jest.fn(() => ({ search: 'name-value' }));
 
-        const terms = [{ source: 'mock-source', title: 'Mocked Title', name: 'Mocked Name', value: 'mock' }];
+        const terms = [
+            { source: 'mock-source', title: 'Mocked Title', name: 'Mocked Name', value: 'mock', partial: false }
+        ];
 
         const termResolver = jest.fn(() => terms);
 

--- a/apps/modernization-ui/src/components/Entry/vertical-entry-wrapper.module.scss
+++ b/apps/modernization-ui/src/components/Entry/vertical-entry-wrapper.module.scss
@@ -3,7 +3,6 @@
 .entry {
     flex-direction: column;
     gap: 0.5rem;
-    padding-top: 0.5rem;
 }
 
 label {

--- a/apps/modernization-ui/src/utils/index.ts
+++ b/apps/modernization-ui/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './exists';
 export * from './focusedTarget';
 export * from './mapIf';
 export * from './isEmpty';
+export * from './text';
 
 export type { Predicate } from './predicate';
 

--- a/apps/modernization-ui/src/utils/text.spec.ts
+++ b/apps/modernization-ui/src/utils/text.spec.ts
@@ -1,4 +1,4 @@
-import { splitStringByCommonDelimiters } from './text';
+import { splitStringByCommonDelimiters, trimCommonDelimiters } from './text';
 
 describe('splitStringByCommonDelimiters', () => {
     it('should split a string by commas', () => {
@@ -34,5 +34,22 @@ describe('splitStringByCommonDelimiters', () => {
     it('should handle string with only delimiters', () => {
         const result = splitStringByCommonDelimiters(', ; ');
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('trimCommonDelimiters', () => {
+    it('should remove leading and trailing common delimiters', () => {
+        const result = trimCommonDelimiters(',; a, b; c; ');
+        expect(result).toEqual('a, b; c');
+    });
+
+    it('should handle empty string', () => {
+        const result = trimCommonDelimiters('');
+        expect(result).toEqual('');
+    });
+
+    it('should handle string with only delimiters', () => {
+        const result = trimCommonDelimiters(', ; ');
+        expect(result).toEqual('');
     });
 });

--- a/apps/modernization-ui/src/utils/text.spec.ts
+++ b/apps/modernization-ui/src/utils/text.spec.ts
@@ -1,0 +1,38 @@
+import { splitStringByCommonDelimiters } from './text';
+
+describe('splitStringByCommonDelimiters', () => {
+    it('should split a string by commas', () => {
+        const result = splitStringByCommonDelimiters('a,b,c');
+        expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should split a string by semicolons', () => {
+        const result = splitStringByCommonDelimiters('a;b;c');
+        expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should split a string by whitespace', () => {
+        const result = splitStringByCommonDelimiters('a b c');
+        expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should split a string by mixed delimiters', () => {
+        const result = splitStringByCommonDelimiters('a, b; c');
+        expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should handle leading and trailing whitespace', () => {
+        const result = splitStringByCommonDelimiters('  a, b; c  ');
+        expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should handle empty string', () => {
+        const result = splitStringByCommonDelimiters('');
+        expect(result).toHaveLength(0);
+    });
+
+    it('should handle string with only delimiters', () => {
+        const result = splitStringByCommonDelimiters(', ; ');
+        expect(result).toHaveLength(0);
+    });
+});

--- a/apps/modernization-ui/src/utils/text.ts
+++ b/apps/modernization-ui/src/utils/text.ts
@@ -13,3 +13,24 @@ export function splitStringByCommonDelimiters(text: string): string[] {
             .filter((s) => s.length > 0) ?? []
     );
 }
+
+/**
+ * Trim common delimiters from the beginning and end of a string.
+ * @param {string} text The text to trim
+ * @return {string} the updated string
+ */
+export function trimCommonDelimiters(text: string): string {
+    // remove any common delimiters at beginning or end of string
+    return text?.replace(new RegExp(`^[${COMMON_DELIMITERS.join('')}]+|[${COMMON_DELIMITERS.join('')}]+$`, 'g'), '');
+}
+
+/**
+ * Remove the specified value from a string and trim common delimiters.
+ * @param {string} text The text to trim
+ * @param {string} value The value to remove
+ * @return {string} the updated string
+ */
+export function removeAndTrim(text: string, value: string) {
+    if (!text) return '';
+    return trimCommonDelimiters(text.replace(value, ''));
+}

--- a/apps/modernization-ui/src/utils/text.ts
+++ b/apps/modernization-ui/src/utils/text.ts
@@ -1,0 +1,15 @@
+export const COMMON_DELIMITERS = [',', ';', '\\s'];
+
+/**
+ * Split a string by common delimiters
+ * @param {string} text The text to split
+ * @return {string[]} An array of strings split by common delimiters, or an empty array if the text is empty or contains only delimiters
+ */
+export function splitStringByCommonDelimiters(text: string): string[] {
+    return (
+        text
+            ?.split(/[,;\s]+/g)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0) ?? []
+    );
+}

--- a/apps/modernization-ui/src/utils/util.spec.ts
+++ b/apps/modernization-ui/src/utils/util.spec.ts
@@ -1,0 +1,52 @@
+import { selectField } from './util';
+
+describe('selectField', () => {
+    it('should return the value at the given path', () => {
+        const obj = { a: { b: { c: 42 } } };
+        const path = 'a.b.c';
+        const result = selectField(obj, path);
+        expect(result).toBe(42);
+    });
+
+    it('should return undefined for an invalid path', () => {
+        const obj = { a: { b: { c: 42 } } };
+        const path = 'a.b.d';
+        const result = selectField(obj, path);
+        expect(result).toBeUndefined();
+    });
+
+    it('should return the object itself for an empty path', () => {
+        const obj = { a: { b: { c: 42 } } };
+        const path = '';
+        const result = selectField(obj, path);
+        expect(result).toBe(obj);
+    });
+
+    it('should return the nested object for a non-terminal path', () => {
+        const obj = { a: { b: { c: 42 } } };
+        const path = 'a.b';
+        const result = selectField(obj, path);
+        expect(result).toStrictEqual({ c: 42 });
+    });
+
+    it('should return undefined for an undefined object', () => {
+        const obj = undefined;
+        const path = 'a.b.c';
+        const result = selectField(obj!, path);
+        expect(result).toBeUndefined();
+    });
+
+    it('should handle paths with array indices', () => {
+        const obj = { a: [{ b: 42 }] };
+        const path = 'a.0.b';
+        const result = selectField(obj, path);
+        expect(result).toBe(42);
+    });
+
+    it('should return undefined for out of bounds array indices', () => {
+        const obj = { a: [{ b: 42 }] };
+        const path = 'a.1.b';
+        const result = selectField(obj, path);
+        expect(result).toBeUndefined();
+    });
+});

--- a/apps/modernization-ui/src/utils/util.ts
+++ b/apps/modernization-ui/src/utils/util.ts
@@ -29,3 +29,16 @@ export const calculateAge = (birthday: Date) => {
 
     return `${Math.abs(ageDate.getUTCFullYear() - 1970)} years`;
 };
+
+/**
+ * Given an object, selects the value at the given path, using dot notation.
+ * Example: selectField({ a: { b: { c: 42 } } }, 'a.b.c') returns 42
+ * @param {object} obj The object for which to select the field
+ * @param {string} path The path to the field, using dot notation ('foo.bar.baz')
+ * @return {unknown} The original object if path is empty, or the field located at the specified path.
+ */
+export const selectField = (obj: { [key: string]: any }, path: string) => {
+    if (!path) return obj;
+    const keys = path.split('.');
+    return keys.reduce((acc, part) => acc && acc[part], obj);
+};


### PR DESCRIPTION
## Description

- Implement splitting of patient ID for chips
- Add help text for patient ID field
- Fixes issue with chips for name (first and last) and location (street and city), nested properties were not being respected and thus these items weren't being removed when X was clicked

![image](https://github.com/user-attachments/assets/c3dcc89d-71fd-445e-bd1f-b7757ce8d533)

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3557)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
