### PR TITLE
CNFT1-3559: Update query to filter out any in an array with not equals

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -23,13 +23,13 @@ public class TextCriteriaNestedQueryResolver {
 
   public static BoolQuery notEquals(final String path, final String name, final String value) {
     return BoolQuery.of(
-        bool -> bool.should(
-            should -> should.nested(
+        bool -> bool.mustNot(
+            mustNot -> mustNot.nested(
                 nested -> nested.path(path)
                     .query(
                         query -> query.bool(
-                            field -> field.mustNot(
-                                mustNot -> mustNot.match(
+                            field -> field.must(
+                                must -> must.match(
                                     match -> match
                                         .field(name)
                                         .query(value))))))));


### PR DESCRIPTION
## Description

Currently the "not equals" Elasticsearch only works when ALL elements in the array (for name or location) don't match. This fix changes it to ANY logic, so that if at least one element doesn't match the search term, it filters out the whole item. This brings it inline with NBS 6.

For example, consider a person with 2 names, "John Lee" and "Jet Li". Currently a not equals "Lee" query was returning John Lee anyway because the second last name of "Li" failed the not equals check. This also fixes not equals for first name, address, and city.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3559)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
