### PR TITLE
CNFT1-3560: Equals operator enhance strictness in exact matches

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -9,16 +9,15 @@ public class TextCriteriaNestedQueryResolver {
 
   public static BoolQuery equalTo(final String path, final String name, final String value) {
     return BoolQuery.of(
-        bool -> bool.must(
+        bool -> bool.should(
             should -> should.nested(
                 nested -> nested.path(path)
                     .query(
-                        query -> query.bool(
-                            field -> field.must(
-                                must -> must.match(
-                                    match -> match
-                                        .field(name)
-                                        .query(value))))))));
+                        query -> query.queryString(
+                            simple -> simple.fields(name)
+                                .query(value)
+                                .defaultOperator(Operator.And)
+                                .quoteFieldSuffix(".exact"))))));
   }
 
   public static BoolQuery notEquals(final String path, final String name, final String value) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -13,11 +13,10 @@ public class TextCriteriaNestedQueryResolver {
             should -> should.nested(
                 nested -> nested.path(path)
                     .query(
-                        query -> query.queryString(
-                            simple -> simple.fields(name)
-                                .query(value)
-                                .defaultOperator(Operator.And)
-                                .quoteFieldSuffix(".exact"))))));
+                        query -> query.term(
+                            term -> term.field(name + ".keyword")
+                                .value(value)
+                                .caseInsensitive(true))))));
   }
 
   public static BoolQuery notEquals(final String path, final String name, final String value) {


### PR DESCRIPTION
## Description

Fixes the tokenization problems with street addresses so that "123 Happy St" must match exactly. This includes similar behavior for name and city.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3560)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
