### PR TITLE
Add character limit 8 num chars to the Extension field in add patient short form.

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/contactFields/ContactFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/contactFields/ContactFields.tsx
@@ -124,6 +124,8 @@ export default function ContactFields({ id, title }: Props) {
                                     defaultValue={value}
                                     htmlFor={name}
                                     id={name}
+                                    mask="________"
+                                    pattern="^\+?\d{1,8}$"
                                     error={error?.message}
                                 />
                             )}


### PR DESCRIPTION
## Description

limits the Extension field to 8 numeric characters with mask and regex pattern. 8 digits in short form only for now, extended form is a different story. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3562)

