### PR TITLE
CNFT1-3549: Clear form value in addition to resetting field

### DIFF
--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.spec.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.spec.ts
@@ -19,6 +19,7 @@ describe('when removing search terms', () => {
 
         const after = jest.fn();
 
+        const setValue = jest.spyOn(result.current, 'setValue');
         const resetField = jest.spyOn(result.current, 'resetField');
 
         const remove = removeTerm(result.current, after);
@@ -26,7 +27,7 @@ describe('when removing search terms', () => {
         remove({ ...DEFAULT_TERM, source: 'value' });
 
         expect(after).toBeCalled();
-
+        expect(setValue).toBeCalledWith('value', null);
         expect(resetField).toBeCalledWith('value');
     });
 

--- a/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
+++ b/apps/modernization-ui/src/apps/search/terms/removeTerm.ts
@@ -26,6 +26,8 @@ const removeTerm =
             const adjusted = removeAndTrim(value as string, term.value);
             form.setValue(key, adjusted as PathValue<C, Path<C>>);
         } else {
+            // set the value to null in case there is no form element for it
+            form.setValue(key, null as PathValue<C, Path<C>>);
             form.resetField(key);
         }
 


### PR DESCRIPTION
## Description

When certain entries in the form object are present but there is no form element for them, set a null value in the form object to clear it. This fixes a bug with removing term when form element is not on the form.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3549)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
