### PR TITLE
[CNFT1-3583] Date equals criteria validations fix

### DIFF
--- a/apps/modernization-ui/src/date/today.ts
+++ b/apps/modernization-ui/src/date/today.ts
@@ -1,5 +1,6 @@
+import { now } from 'design-system/date/clock';
 import { internalizeDate } from './InternalizeDate';
 
-const today = () => internalizeDate(new Date());
+const today = () => internalizeDate(now());
 
 export { today };

--- a/apps/modernization-ui/src/design-system/date/clock.ts
+++ b/apps/modernization-ui/src/design-system/date/clock.ts
@@ -1,0 +1,9 @@
+/**
+ * A function with a return value that is equivalent to new Date().  The main use-case of this
+ * function is to strengthen tests that rely on the current date.
+ *
+ * @return {Date} the current instant as a Date
+ */
+const now = () => new Date();
+
+export { now };

--- a/apps/modernization-ui/src/design-system/date/occursInThePast.spec.ts
+++ b/apps/modernization-ui/src/design-system/date/occursInThePast.spec.ts
@@ -1,0 +1,69 @@
+import { add, isFuture } from 'date-fns';
+import { occursInThePast } from './occursInThePast';
+import { internalizeDate } from 'date';
+
+const mockNow = jest.fn();
+
+jest.mock('./clock', () => ({
+    now: () => mockNow()
+}));
+
+describe('when validating that a DateEntry occurs in the past', () => {
+    it('should allow dates before today', () => {
+        const today = new Date('1997-10-03');
+
+        mockNow.mockReturnValue(today);
+
+        const actual = occursInThePast('Date field name')({
+            year: 1990,
+            month: 12,
+            day: 19
+        });
+
+        expect(actual).toBe(true);
+    });
+
+    it('should allow dates without a year', () => {
+        const today = new Date('1997-10-03');
+
+        mockNow.mockReturnValue(today);
+
+        const actual = occursInThePast('Date field name')({
+            month: 12,
+            day: 19
+        });
+
+        expect(actual).toBe(true);
+    });
+
+    it('should not allow future dates', () => {
+        const today = new Date('1967-07-13');
+
+        mockNow.mockReturnValue(today);
+
+        const tomorrow = add(today, { days: 1 });
+
+        const actual = occursInThePast('Date field name')({
+            year: tomorrow.getFullYear(),
+            month: tomorrow.getMonth() + 1,
+            day: tomorrow.getDate()
+        });
+
+        expect(actual).toContain(`The Date field name cannot be after ${internalizeDate(today)}`);
+    });
+
+    it('should not allow future dates with month and year only', () => {
+        const today = new Date('1967-07-13');
+
+        mockNow.mockReturnValue(today);
+
+        const tomorrow = add(today, { months: 1 });
+
+        const actual = occursInThePast('Date field name')({
+            year: tomorrow.getFullYear(),
+            month: tomorrow.getMonth() + 1
+        });
+
+        expect(actual).toContain(`The Date field name cannot be after ${internalizeDate(today)}`);
+    });
+});

--- a/apps/modernization-ui/src/design-system/date/validateDateEntry.spec.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDateEntry.spec.ts
@@ -2,7 +2,15 @@ import { internalizeDate } from 'date';
 import { validateDateEntry } from './validateDateEntry';
 import { add } from 'date-fns';
 
+const mockNow = jest.fn();
+
+jest.mock('./clock', () => ({
+    now: () => mockNow()
+}));
+
 describe('when validating a date entered in parts', () => {
+    beforeEach(() => mockNow.mockReturnValue(new Date()));
+
     describe('with a month', () => {
         it('should allow a valid month', () => {
             const actual = validateDateEntry('Date with valid month')({ month: 5 });
@@ -33,12 +41,14 @@ describe('when validating a date entered in parts', () => {
         });
 
         it('should not allow months after today', () => {
-            const today = new Date();
+            const today = new Date('2021-08-19');
 
-            const tomorrow = add(today, { days: 1 });
+            mockNow.mockReturnValue(today);
+
+            const tomorrow = add(today, { months: 1 });
 
             const actual = validateDateEntry('Date in the future')({
-                month: tomorrow.getMonth() + 2,
+                month: tomorrow.getMonth() + 1,
                 year: tomorrow.getFullYear()
             });
 
@@ -80,15 +90,16 @@ describe('when validating a date entered in parts', () => {
         });
 
         it('should not allow dates after this year', () => {
-            const today = new Date();
+            const today = new Date('2021-08-19');
 
-            const tomorrow = add(today, { days: 1 });
+            mockNow.mockReturnValue(today);
+            const tomorrow = add(today, { years: 1 });
 
             const actual = validateDateEntry('Date in the future')({
-                year: tomorrow.getFullYear() + 1
+                year: tomorrow.getFullYear()
             });
 
-            expect(actual).toContain(`The Date in the future cannot be after ${internalizeDate(today)}`);
+            expect(actual).toContain('The Date in the future should occur before or within the current year.');
         });
     });
 

--- a/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
@@ -2,10 +2,15 @@ import { getDaysInMonth } from 'date-fns';
 import { DateEntry } from './entry';
 import { occursInThePast } from './occursInThePast';
 import { validateAll } from 'validation';
+import { now } from './clock';
 
 const validateYear = (name: string) => (value: DateEntry) => {
-    if (value.year && value.year < 1875) {
-        return `The ${name} should occur after 12/31/1874.`;
+    if (value.year) {
+        if (value.year < 1875) {
+            return `The ${name} should occur after 12/31/1874.`;
+        } else if (value.year > now().getFullYear()) {
+            return `The ${name} should occur before or within the current year.`;
+        }
     }
     return true;
 };


### PR DESCRIPTION
## Description

Fixes the validation for future dates to only do the check when a `DateEntry` has a `month` and a `year` value.  The validation for only the `year` value happens before this validation is called.

- Adds a `now` function to be able to mock the current date in tests to prevent unexpected failures.
- Changes the validation message for years to closer match NBS6

## Tickets

* [CNFT1-3583](https://cdc-nbs.atlassian.net/browse/CNFT1-3583)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3583]: https://cdc-nbs.atlassian.net/browse/CNFT1-3583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ