### PR TITLE
[CNFT1-3513-inline-validation-shifting-fields-fix]

### DIFF
--- a/apps/modernization-ui/src/components/Entry/entry-wrapper.module.scss
+++ b/apps/modernization-ui/src/components/Entry/entry-wrapper.module.scss
@@ -32,7 +32,7 @@
 
     &.error {
         border-left: 2px solid colors.$secondary-dark;
-        padding-left: 1rem;
+        padding-left: 1.375rem;
 
         input {
             outline: none;


### PR DESCRIPTION
## Description

adding a bit more padding left on error class to compensate for border left padding 

<img width="738" alt="Screenshot 2024-12-04 at 12 09 05 PM" src="https://github.com/user-attachments/assets/f8e3349e-d8f3-47c9-8c73-4079b432fa42">


* [CNFT1-3513](https://cdc-nbs.atlassian.net/browse/CNFT1-3513)

## Checklist before requesting a review

- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3513]: https://cdc-nbs.atlassian.net/browse/CNFT1-3513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ