### PR TITLE
[CNFT1-3581] Ensure a patient's state is saved from New Patient

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useCreatePatientMutation } from 'generated/graphql/schema';
 import { Button, Form, Grid, Icon, ModalRef } from '@trussworks/react-uswds';
@@ -18,15 +19,14 @@ import { orNull } from 'utils';
 import { DefaultNewPatentEntry, initialEntry, NewPatientEntry } from 'apps/patient/add';
 import { usePreFilled } from 'apps/patient/add/usePreFilled';
 import { useConfiguration } from 'configuration';
-import { asValue } from 'options';
 import { useBasicExtendedTransition } from './useBasicExtendedTransition';
 import { DataEntryMenu } from './DataEntryMenu';
 import { Shown } from 'conditional-render';
 import { PatientCreatedPanel } from './PatientCreatedPanel';
+import { CreatedPatient } from './api';
 
 import './AddPatient.scss';
-import { CreatedPatient } from './api';
-import { useNavigate } from 'react-router-dom';
+
 // The process of creating a patient is broken into steps once input is valid and the form has been submitted.
 //
 //      1.  Check Missing Fields
@@ -57,7 +57,7 @@ const withVerifiedAddress = (entry: NewPatientEntry, address: VerifiableAdddress
     ...entry,
     streetAddress1: address.address1,
     city: address.city,
-    state: asValue(address.state),
+    state: address.state,
     zip: address.zip
 });
 
@@ -83,10 +83,6 @@ const AddPatient = () => {
 
     const { toExtended } = useBasicExtendedTransition();
 
-    useEffect(() => {
-        reset(prefilled);
-    }, [prefilled]);
-
     const methods = useForm<NewPatientEntry, DefaultNewPatentEntry>({
         defaultValues: initialEntry(),
         mode: 'onBlur'
@@ -94,9 +90,12 @@ const AddPatient = () => {
 
     const {
         handleSubmit,
-        reset,
         formState: { errors }
     } = methods;
+
+    useEffect(() => {
+        methods.reset(prefilled);
+    }, [prefilled, methods.reset]);
 
     const formHasErrors = Object.keys(errors).length > 0;
 

--- a/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
@@ -94,7 +94,7 @@ const AddPatient = () => {
     } = methods;
 
     useEffect(() => {
-        methods.reset(prefilled);
+        methods.reset(prefilled, { keepDefaultValues: true });
     }, [prefilled, methods.reset]);
 
     const formHasErrors = Object.keys(errors).length > 0;

--- a/apps/modernization-ui/src/apps/patient/add/NewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/NewPatientEntry.ts
@@ -14,7 +14,7 @@ type AddressEntry = {
     streetAddress1: Maybe<string>;
     streetAddress2: Maybe<string>;
     city: Maybe<string>;
-    state?: Selectable;
+    state?: Selectable | null;
     zip: Maybe<string>;
     county?: Selectable;
     censusTract: Maybe<string>;

--- a/apps/modernization-ui/src/apps/patient/add/addressFields/AddressFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/addressFields/AddressFields.tsx
@@ -24,12 +24,12 @@ export default function AddressFields({ id, title, coded }: Props) {
 
     const counties = coded.counties.byState(selectedState?.value);
 
-    function handleSuggestionSelection(selected: AddressSuggestion) {
+    const handleSuggestionSelection = (selected: AddressSuggestion) => {
         setValue('streetAddress1', selected.address1);
         setValue('city', selected.city);
         setValue('state', selected.state?.value);
         setValue('zip', selected.zip);
-    }
+    };
 
     return (
         <FormCard id={id} title={title}>

--- a/apps/modernization-ui/src/apps/patient/add/usePreFilled.ts
+++ b/apps/modernization-ui/src/apps/patient/add/usePreFilled.ts
@@ -1,53 +1,18 @@
-import { internalizeDate } from 'date';
-import { EncryptionControllerService } from 'generated';
-import { DefaultNewPatentEntry, NewPatientEntry } from 'apps/patient/add';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { orNull } from 'utils';
+import { DefaultNewPatentEntry, NewPatientEntry } from 'apps/patient/add';
 
 const usePreFilled = (initial: DefaultNewPatentEntry): NewPatientEntry => {
     const location = useLocation();
     const [prefilled, setPrefilled] = useState<NewPatientEntry>(initial);
 
     useEffect(() => {
-        if (location?.state?.criteria) {
-            decrypt(location.state.criteria).then(withCriteria(initial)).then(setPrefilled);
-        } else if (location?.state?.defaults) {
+        if (location?.state?.defaults) {
             setPrefilled(location?.state?.defaults);
         }
     }, [location?.state?.criteria, location?.state?.defaults]);
 
     return prefilled;
 };
-
-const withCriteria =
-    (initial: DefaultNewPatentEntry) =>
-    (filter: any): NewPatientEntry => ({
-        ...initial,
-        firstName: orNull(filter?.firstName),
-        lastName: orNull(filter?.lastName),
-        dateOfBirth: internalizeDate(filter.dateOfBirth),
-        currentGender: orNull(filter?.gender),
-        streetAddress1: orNull(filter?.address),
-        city: orNull(filter?.city),
-        state: orNull(filter?.state),
-        zip: orNull(filter?.zip),
-        ethnicity: orNull(filter?.ethnicity),
-        homePhone: orNull(filter?.phoneNumber),
-        race: filter?.race ? [filter.race] : [],
-        identification: [
-            {
-                type: filter?.identification?.identificationType,
-                value: filter?.identification?.identificationNumber,
-                authority: null
-            }
-        ],
-        emailAddresses: [{ email: orNull(filter?.email) }]
-    });
-
-const decrypt = (criteria: string) =>
-    EncryptionControllerService.decrypt({
-        requestBody: criteria
-    });
 
 export { usePreFilled };

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -1,8 +1,26 @@
 import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { SingleSelect } from './SingleSelect';
 
 describe('when selecting a single item from a specific set of items', () => {
+    it('should render with no accessibility violations', async () => {
+        const { container } = render(
+            <SingleSelect
+                id="test-id"
+                label="Test Label"
+                options={[
+                    { name: 'name-one', value: 'value-one', label: 'label-one' },
+                    { name: 'name-two', value: 'value-two', label: 'label-two' },
+                    { name: 'name-three', value: 'value-three', label: 'label-three' },
+                    { name: 'name-four', value: 'value-four', label: 'label-four' }
+                ]}
+            />
+        );
+
+        expect(await axe(container)).toHaveNoViolations();
+    });
+
     it('should display the SingleSelect without a value checked', () => {
         const { queryByRole } = render(
             <SingleSelect
@@ -14,7 +32,6 @@ describe('when selecting a single item from a specific set of items', () => {
                     { name: 'name-three', value: 'value-three', label: 'label-three' },
                     { name: 'name-four', value: 'value-four', label: 'label-four' }
                 ]}
-                name="test-name"
                 placeholder="place-holder-value"
             />
         );
@@ -35,7 +52,6 @@ describe('when selecting a single item from a specific set of items', () => {
                     { name: 'name-three', value: 'value-three', label: 'label-three' },
                     { name: 'name-four', value: 'value-four', label: 'label-four' }
                 ]}
-                name="test-name"
                 value={{ name: 'name-three', value: 'value-three', label: 'label-three' }}
             />
         );
@@ -58,7 +74,6 @@ describe('when one of the options is clicked', () => {
                     { name: 'name-three', value: 'value-three', label: 'label-three' },
                     { name: 'name-four', value: 'value-four', label: 'label-four' }
                 ]}
-                name="test-name"
                 value={{ name: 'name-four', value: 'value-four', label: 'label-four' }}
                 onChange={jest.fn()}
             />

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
@@ -1,11 +1,15 @@
 import { ChangeEvent } from 'react';
-import { Select as TrussworksSelect } from '@trussworks/react-uswds';
 import { EntryWrapper, Orientation, Sizing } from 'components/Entry';
 import { Selectable, findByValue } from 'options';
+import classNames from 'classnames';
 
 const renderOptions = (options: Selectable[], placeholder?: string) => (
     <>
-        {placeholder && <option value="">{placeholder}</option>}
+        {placeholder && (
+            <option key={-1} value="">
+                {placeholder}
+            </option>
+        )}
         {options?.map((item, index) => (
             <option key={index} value={item.value}>
                 {item.name}
@@ -30,6 +34,7 @@ type Props = {
 const SingleSelect = ({
     id,
     label,
+    className,
     helperText,
     options,
     value,
@@ -59,17 +64,17 @@ const SingleSelect = ({
             htmlFor={id}
             required={required}
             error={error}>
-            <TrussworksSelect
-                key={value?.value}
-                {...inputProps}
+            <select
+                key={value?.value ?? ''}
                 id={id}
-                validationStatus={error ? 'error' : undefined}
+                className={classNames('usa-select', className)}
                 name={inputProps.name ?? id}
-                defaultValue={value?.value}
-                placeholder="-Select-"
-                onChange={handleChange}>
+                value={value?.value}
+                placeholder={placeholder}
+                onChange={handleChange}
+                {...inputProps}>
                 {renderOptions(options, placeholder)}
-            </TrussworksSelect>
+            </select>
         </EntryWrapper>
     );
 };


### PR DESCRIPTION
## Description

The value for the state was being converted from a `Selectable` to a `string` during address verification which caused the value to be excluded when making the request to add the patient.  Even though address verification was turned off the pass-through function was where the `Selectable` to `string` conversion was happening.

- Removed the code from `usePrefilled` that supported Advanced Search which greatly simplifies it
- Removed the Trussworks Select element from `SingleSelect` as it was only a wrapper for a `<select>` with the USWDS styling.

## Tickets

* [CNFT1-3581](https://cdc-nbs.atlassian.net/browse/CNFT1-3581)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3581]: https://cdc-nbs.atlassian.net/browse/CNFT1-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ