### PR TITLE
CNFT1-3413: Implement sizing of columns for patient search

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -10,6 +10,7 @@ import {
     displayAddresses,
     displayIdentifications
 } from 'apps/search/patient/result';
+import styles from './patient-search-result-table.module.scss';
 
 // column definitions
 const PATIENT_ID = { id: 'patientid', name: 'Patient ID' };
@@ -18,7 +19,6 @@ const DATE_OF_BIRTH = { id: 'birthday', name: 'DOB/Age' };
 const SEX = { id: 'sex', name: 'Current sex' };
 const ADDRESS = { id: 'address', name: 'Address' };
 const PHONE = { id: 'phoneNumber', name: 'Phone' };
-
 const IDENTIFICATIONS = { id: 'identification', name: 'ID' };
 const EMAIL = { id: 'email', name: 'Email' };
 
@@ -28,24 +28,26 @@ const columns: Column<PatientSearchResult>[] = [
         ...PATIENT_ID,
         fixed: true,
         sortable: true,
+        className: styles['col-patientid'],
         render: (result) => displayProfileLink(result.patient, result.shortId)
+    },
+    {
+        ...PATIENT_NAME,
+        sortable: true,
+        className: styles['col-patientname'],
+        render: displayPatientName
     },
     {
         ...DATE_OF_BIRTH,
         sortable: true,
+        className: styles['col-dob'],
         render: (result) => result.birthday && displayPatientAge(result, 'multiline')
     },
-    { ...SEX, sortable: true, render: (result) => result.gender },
-    {
-        ...PATIENT_NAME,
-        sortable: true,
-        render: displayPatientName
-    },
-    { ...ADDRESS, render: displayAddresses },
-    { ...PHONE, render: displayPhones },
-
-    { ...IDENTIFICATIONS, render: displayIdentifications },
-    { ...EMAIL, render: displayEmails }
+    { ...SEX, sortable: true, className: styles['col-sex'], render: (result) => result.gender },
+    { ...ADDRESS, className: styles['col-address'], render: displayAddresses },
+    { ...PHONE, className: styles['col-phone'], render: displayPhones },
+    { ...IDENTIFICATIONS, className: styles['col-id'], render: displayIdentifications },
+    { ...EMAIL, className: styles['col-email'], render: displayEmails }
 ];
 
 // column preferences
@@ -54,7 +56,6 @@ const preferences: ColumnPreference[] = [
     { ...PATIENT_NAME, moveable: true, toggleable: true },
     { ...DATE_OF_BIRTH, moveable: true, toggleable: true },
     { ...SEX, moveable: true, toggleable: true },
-
     { ...ADDRESS, moveable: true, toggleable: true },
     { ...PHONE, moveable: true, toggleable: true },
     { ...IDENTIFICATIONS, moveable: true, toggleable: true },

--- a/apps/modernization-ui/src/apps/search/patient/result/table/patient-search-result-table.module.scss
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/patient-search-result-table.module.scss
@@ -1,0 +1,33 @@
+.col-patientid {
+    width: 8rem;
+    min-width: 8rem !important;
+    max-width: 10rem !important;
+}
+
+.col-patientname {
+    min-width: 14rem;
+}
+
+.col-dob {
+    min-width: 7rem;
+}
+
+.col-sex {
+    min-width: 6rem;
+}
+
+.col-address {
+    min-width: 21rem;
+}
+
+.col-phone {
+    min-width: 10rem;
+}
+
+.col-id {
+    min-width: 9rem;
+}
+
+.col-email {
+    min-width: 14rem;
+}

--- a/apps/modernization-ui/src/design-system/table/DataTable.spec.tsx
+++ b/apps/modernization-ui/src/design-system/table/DataTable.spec.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react';
+import { DataTable, Column } from './DataTable';
+
+type TestData = {
+    id: number;
+    name: string;
+};
+
+const columns: Column<TestData>[] = [
+    {
+        id: 'id',
+        name: 'ID',
+        className: 'id-header',
+        render: (value) => value.id
+    },
+    {
+        id: 'name',
+        name: 'Name',
+        className: 'name-header',
+        render: (value) => value.name
+    }
+];
+
+const data: TestData[] = [
+    { id: 1, name: 'John Doe' },
+    { id: 2, name: 'Jane Smith' }
+];
+
+describe('DataTable', () => {
+    it('renders without crashing', () => {
+        render(<DataTable id="test-table" columns={columns} data={data} />);
+    });
+
+    it('renders the correct number of columns', () => {
+        const { container } = render(<DataTable id="test-table" columns={columns} data={data} />);
+        const headerCells = container.querySelectorAll('thead tr:nth-child(1) th');
+        expect(headerCells).toHaveLength(columns.length);
+    });
+
+    it('renders the correct number of rows', () => {
+        const { container } = render(<DataTable id="test-table" columns={columns} data={data} />);
+        const rows = container.querySelectorAll('tbody tr');
+        expect(rows).toHaveLength(data.length);
+    });
+
+    it('renders the correct data in cells', () => {
+        const { container } = render(<DataTable id="test-table" columns={columns} data={data} />);
+        data.forEach((row, rowIndex) => {
+            columns.forEach((column, colIndex) => {
+                const cell = container.querySelector(
+                    `tbody tr:nth-child(${rowIndex + 1}) td:nth-child(${colIndex + 1})`
+                );
+                expect(cell).toHaveTextContent(String(row[column.id as keyof TestData]));
+            });
+        });
+    });
+
+    it('renders the correct classNames in header cells', () => {
+        const { container } = render(<DataTable id="test-table" columns={columns} data={data} />);
+        columns.forEach((column, index) => {
+            const headerCell = container.querySelector(`thead tr th:nth-child(${index + 1})`);
+            expect(headerCell).toHaveClass(column.className!);
+        });
+    });
+});

--- a/apps/modernization-ui/src/design-system/table/DataTable.tsx
+++ b/apps/modernization-ui/src/design-system/table/DataTable.tsx
@@ -9,6 +9,7 @@ type Column<V> = {
     name: string;
     fixed?: boolean;
     sortable?: boolean;
+    className?: string;
     render: (value: V, index: number) => ReactNode | undefined;
 };
 
@@ -26,7 +27,9 @@ const DataTable = <V,>({ id, className, columns, data }: Props<V>) => {
                 <thead>
                     <tr>
                         {columns.map((column, index) => (
-                            <Header key={index}>{column}</Header>
+                            <Header key={index} className={column.className}>
+                                {column}
+                            </Header>
                         ))}
                     </tr>
                     <tr className={styles.border}>

--- a/apps/modernization-ui/src/design-system/table/data-table.module.scss
+++ b/apps/modernization-ui/src/design-system/table/data-table.module.scss
@@ -47,7 +47,7 @@
                 left: 0;
                 z-index: 10;
 
-                min-width: 12.5rem;
+                min-width: 8rem;
                 max-width: 12.5rem;
                 border-right-width: 1px;
                 border-right-style: solid !important;


### PR DESCRIPTION
## Description

Implement patient search column sizing for table view based on the Figma style guide, specifically minimizing the size of Patient ID column. Allow specifying a class name for columns + unit tests for DataTable.

![image](https://github.com/user-attachments/assets/9e7dcd46-2cd3-42a0-bfdc-7d1709448e3f)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3413)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
