### PR TITLE
[CNFT1-3577] Repeating block pending state

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/entry.ts
@@ -1,5 +1,6 @@
 import { today } from 'date';
-import { AdministrativeEntry, IdentificationEntry } from 'apps/patient/data/entry';
+import { IdentificationEntry } from 'apps/patient/data';
+import { AdministrativeEntry } from 'apps/patient/data/entry';
 import { Selectable } from 'options';
 
 type NameInformationEntry = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
@@ -1,7 +1,7 @@
 import { asSelectable, findByValue, Selectable } from 'options';
 import { PatientNameCodedValues } from 'apps/patient/profile/names/usePatientNameCodedValues';
-import { IdentificationEntry, PhoneEmailEntry } from 'apps/patient/data/entry';
-import { RaceEntry, AddressEntry, NameEntry } from 'apps/patient/data';
+import { IdentificationEntry } from 'apps/patient/data/entry';
+import { RaceEntry, AddressEntry, NameEntry, PhoneEmailEntry } from 'apps/patient/data';
 import { NewPatientEntry } from 'apps/patient/add';
 import { ExtendedNewPatientEntry } from './entry';
 import { CodedValue } from 'coded';

--- a/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
@@ -1,7 +1,7 @@
 import { asSelectable, findByValue, Selectable } from 'options';
 import { PatientNameCodedValues } from 'apps/patient/profile/names/usePatientNameCodedValues';
-import { IdentificationEntry } from 'apps/patient/data/entry';
-import { RaceEntry, AddressEntry, NameEntry, PhoneEmailEntry } from 'apps/patient/data';
+
+import { RaceEntry, AddressEntry, NameEntry, PhoneEmailEntry, IdentificationEntry } from 'apps/patient/data';
 import { NewPatientEntry } from 'apps/patient/add';
 import { ExtendedNewPatientEntry } from './entry';
 import { CodedValue } from 'coded';

--- a/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
@@ -1,8 +1,8 @@
 import { asSelectable, findByValue, Selectable } from 'options';
 import { PatientNameCodedValues } from 'apps/patient/profile/names/usePatientNameCodedValues';
-import { AddressEntry, IdentificationEntry, PhoneEmailEntry } from 'apps/patient/data/entry';
-import { RaceEntry } from 'apps/patient/data/race/entry';
-import { NewPatientEntry } from 'apps/patient/add/NewPatientEntry';
+import { IdentificationEntry, PhoneEmailEntry } from 'apps/patient/data/entry';
+import { RaceEntry, AddressEntry, NameEntry } from 'apps/patient/data';
+import { NewPatientEntry } from 'apps/patient/add';
 import { ExtendedNewPatientEntry } from './entry';
 import { CodedValue } from 'coded';
 import { isEmpty, Mapping } from 'utils';
@@ -11,7 +11,6 @@ import { HOME as HOME_ADDRESS } from 'options/address/uses';
 import { HOUSE } from 'options/address/types';
 import { CELL_PHONE, PHONE, EMAIL } from 'options/phone/types';
 import { HOME as HOME_PHONE, MOBILE_CONTACT, PRIMARY_WORKPLACE } from 'options/phone/uses';
-import { NameEntry } from 'apps/patient/data/name';
 
 const mapOr =
     <R, S, O>(mapping: Mapping<R, S>, fallback: O) =>

--- a/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/asExtendedNewPatientEntry.ts
@@ -1,6 +1,6 @@
 import { asSelectable, findByValue, Selectable } from 'options';
 import { PatientNameCodedValues } from 'apps/patient/profile/names/usePatientNameCodedValues';
-import { AddressEntry, IdentificationEntry, NameEntry, PhoneEmailEntry } from 'apps/patient/data/entry';
+import { AddressEntry, IdentificationEntry, PhoneEmailEntry } from 'apps/patient/data/entry';
 import { RaceEntry } from 'apps/patient/data/race/entry';
 import { NewPatientEntry } from 'apps/patient/add/NewPatientEntry';
 import { ExtendedNewPatientEntry } from './entry';
@@ -11,6 +11,7 @@ import { HOME as HOME_ADDRESS } from 'options/address/uses';
 import { HOUSE } from 'options/address/types';
 import { CELL_PHONE, PHONE, EMAIL } from 'options/phone/types';
 import { HOME as HOME_PHONE, MOBILE_CONTACT, PRIMARY_WORKPLACE } from 'options/phone/uses';
+import { NameEntry } from 'apps/patient/data/name';
 
 const mapOr =
     <R, S, O>(mapping: Mapping<R, S>, fallback: O) =>

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -1,7 +1,6 @@
 import { today } from 'date';
 import {
     AdministrativeEntry,
-    NameEntry,
     AddressEntry,
     PhoneEmailEntry,
     IdentificationEntry,
@@ -11,6 +10,7 @@ import {
     GeneralInformationEntry
 } from 'apps/patient/data/entry';
 import { EthnicityEntry, initial as initialEthnicity } from 'apps/patient/data/ethnicity';
+import { NameEntry } from 'apps/patient/data/name';
 import { RaceEntry } from 'apps/patient/data/race';
 
 type ExtendedNewPatientEntry = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -1,7 +1,6 @@
 import { today } from 'date';
 import {
     AdministrativeEntry,
-    PhoneEmailEntry,
     IdentificationEntry,
     SexEntry,
     BirthEntry,
@@ -10,7 +9,7 @@ import {
 } from 'apps/patient/data/entry';
 import { EthnicityEntry, initial as initialEthnicity } from 'apps/patient/data/ethnicity';
 
-import { AddressEntry, NameEntry, RaceEntry } from 'apps/patient/data';
+import { AddressEntry, NameEntry, RaceEntry, PhoneEmailEntry } from 'apps/patient/data';
 
 type ExtendedNewPatientEntry = {
     administrative?: AdministrativeEntry;

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -1,7 +1,6 @@
 import { today } from 'date';
 import {
     AdministrativeEntry,
-    IdentificationEntry,
     SexEntry,
     BirthEntry,
     MortalityEntry,
@@ -9,7 +8,7 @@ import {
 } from 'apps/patient/data/entry';
 import { EthnicityEntry, initial as initialEthnicity } from 'apps/patient/data/ethnicity';
 
-import { AddressEntry, NameEntry, RaceEntry, PhoneEmailEntry } from 'apps/patient/data';
+import { NameEntry, AddressEntry, PhoneEmailEntry, IdentificationEntry, RaceEntry } from 'apps/patient/data';
 
 type ExtendedNewPatientEntry = {
     administrative?: AdministrativeEntry;

--- a/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/entry.ts
@@ -1,7 +1,6 @@
 import { today } from 'date';
 import {
     AdministrativeEntry,
-    AddressEntry,
     PhoneEmailEntry,
     IdentificationEntry,
     SexEntry,
@@ -10,8 +9,8 @@ import {
     GeneralInformationEntry
 } from 'apps/patient/data/entry';
 import { EthnicityEntry, initial as initialEthnicity } from 'apps/patient/data/ethnicity';
-import { NameEntry } from 'apps/patient/data/name';
-import { RaceEntry } from 'apps/patient/data/race';
+
+import { AddressEntry, NameEntry, RaceEntry } from 'apps/patient/data';
 
 type ExtendedNewPatientEntry = {
     administrative?: AdministrativeEntry;

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.tsx
@@ -1,26 +1,12 @@
-import { AddressEntry } from 'apps/patient/data/entry';
-import { today } from 'date';
-import { Column } from 'design-system/table';
-import { AddressView } from './AddressView';
-import { AddressEntryFields } from 'apps/patient/data/address/AddressEntryFields';
-import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
 import { ReactNode } from 'react';
+import { Column } from 'design-system/table';
+import { RepeatingBlock } from 'design-system/entry/multi-value';
+import { AddressEntry, AddressEntryFields, initial } from 'apps/patient/data/address';
 import { asAddressTypeUse } from 'apps/patient/data/address/utils';
 
-const defaultValue: Partial<AddressEntry> = {
-    asOf: today(),
-    type: null,
-    use: null,
-    address1: '',
-    address2: '',
-    city: '',
-    state: null,
-    zipcode: '',
-    county: null,
-    country: null,
-    censusTract: '',
-    comment: ''
-};
+import { AddressView } from './AddressView';
+
+const defaultValue: Partial<AddressEntry> = initial();
 
 type Props = {
     id: string;

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressView.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressView.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { AddressEntry } from 'apps/patient/data/entry';
+import { AddressEntry } from 'apps/patient/data';
 import { AddressView } from './AddressView';
 
 const entry: AddressEntry = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressView.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressView.tsx
@@ -1,4 +1,4 @@
-import { AddressEntry } from 'apps/patient/data/entry';
+import { AddressEntry } from 'apps/patient/data';
 import { ValueView } from 'design-system/data-display/ValueView';
 
 type Props = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
@@ -1,17 +1,11 @@
-import { IdentificationEntry } from 'apps/patient/data/entry';
-import { IdentificationEntryFields } from 'apps/patient/data/identification/IdentificationEntryFields';
-import { today } from 'date';
-import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
-import { Column } from 'design-system/table';
-import { IdentificationView } from './IdentificationView';
 import { ReactNode } from 'react';
+import { Column } from 'design-system/table';
+import { RepeatingBlock } from 'design-system/entry/multi-value';
+import { IdentificationEntryFields, IdentificationEntry, initial } from 'apps/patient/data/identification';
+import { IdentificationView } from './IdentificationView';
 
-const defaultValue: Partial<IdentificationEntry> = {
-    asOf: today(),
-    type: null,
-    issuer: null,
-    id: ''
-};
+const defaultValue: Partial<IdentificationEntry> = initial();
+
 type Props = {
     id: string;
     values?: IdentificationEntry[];

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationView.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationView.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { IdentificationEntry } from 'apps/patient/data/entry';
+import { IdentificationEntry } from 'apps/patient/data';
 import { IdentificationView } from './IdentificationView';
 
 const entry: IdentificationEntry = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationView.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationView.tsx
@@ -1,4 +1,4 @@
-import { IdentificationEntry } from 'apps/patient/data/entry';
+import { IdentificationEntry } from 'apps/patient/data';
 import { ValueView } from 'design-system/data-display/ValueView';
 
 type Props = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameEntryView.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameEntryView.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { NameEntry } from 'apps/patient/data/entry';
+import { NameEntry } from 'apps/patient/data/name';
 import { NameEntryView } from './NameEntryView';
 import { asSelectable } from 'options/selectable';
 

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameEntryView.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameEntryView.tsx
@@ -1,4 +1,4 @@
-import { NameEntry } from 'apps/patient/data/entry';
+import { NameEntry } from 'apps/patient/data/name';
 import { ValueView } from 'design-system/data-display/ValueView';
 
 type Props = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
@@ -1,23 +1,10 @@
-import { NameEntry } from 'apps/patient/data/entry';
-import { NameEntryFields } from 'apps/patient/data/name/NameEntryFields';
-import { today } from 'date';
-import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
-import { Column } from 'design-system/table';
-import { NameEntryView } from './NameEntryView';
 import { ReactNode } from 'react';
+import { Column } from 'design-system/table';
+import { RepeatingBlock } from 'design-system/entry/multi-value';
+import { NameEntry, NameEntryFields, initial } from 'apps/patient/data/name';
+import { NameEntryView } from './NameEntryView';
 
-const defaultValue: Partial<NameEntry> = {
-    asOf: today(),
-    type: null,
-    prefix: null,
-    first: '',
-    middle: '',
-    secondMiddle: '',
-    last: '',
-    secondLast: '',
-    suffix: null,
-    degree: null
-};
+const defaultValue: Partial<NameEntry> = initial();
 
 const columns: Column<NameEntry>[] = [
     { id: 'nameAsOf', name: 'As of', render: (v) => v.asOf },

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
@@ -1,22 +1,11 @@
-import { PhoneEmailEntry } from 'apps/patient/data/entry';
-import { PhoneEmailEntryFields } from 'apps/patient/data/phoneEmail/PhoneEmailEntryFields';
-import { today } from 'date';
-import { RepeatingBlock } from 'design-system/entry/multi-value/RepeatingBlock';
-import { Column } from 'design-system/table';
-import { PhoneEntryView } from './PhoneEntryView';
 import { ReactNode } from 'react';
+import { RepeatingBlock } from 'design-system/entry/multi-value';
+import { Column } from 'design-system/table';
+import { PhoneEmailEntry, PhoneEmailEntryFields, initial } from 'apps/patient/data/phoneEmail';
+import { PhoneEntryView } from './PhoneEntryView';
 
-const defaultValue: Partial<PhoneEmailEntry> = {
-    asOf: today(),
-    type: null,
-    use: null,
-    countryCode: '',
-    phoneNumber: '',
-    extension: '',
-    email: '',
-    url: '',
-    comment: ''
-};
+const defaultValue: Partial<PhoneEmailEntry> = initial();
+
 type Props = {
     id: string;
     values?: PhoneEmailEntry[];

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneEntryView.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneEntryView.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { PhoneEmailEntry } from 'apps/patient/data/entry';
+import { PhoneEmailEntry } from 'apps/patient/data';
 import { PhoneEntryView } from './PhoneEntryView';
 
 const mockPatientPhoneCodedValues = {

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneEntryView.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneEntryView.tsx
@@ -1,4 +1,4 @@
-import { PhoneEmailEntry } from 'apps/patient/data/entry';
+import { PhoneEmailEntry } from 'apps/patient/data';
 import { ValueView } from 'design-system/data-display/ValueView';
 
 type Props = {

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -1,9 +1,8 @@
-import { render, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
 import { FormProvider, useForm } from 'react-hook-form';
-import { AddressEntry } from '../entry';
-import { AddressEntryFields } from './AddressEntryFields';
 import userEvent from '@testing-library/user-event';
+import { render, waitFor, act } from '@testing-library/react';
+import { AddressEntry } from './entry';
+import { AddressEntryFields } from './AddressEntryFields';
 
 const mockPatientAddressCodedValues = {
     types: [{ name: 'House', value: 'H' }],

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -1,13 +1,13 @@
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { EntryFieldsProps } from 'design-system/entry';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { SingleSelect } from 'design-system/select';
-import { maxLengthRule, validateRequiredRule } from 'validation/entry';
+import { EntryFieldsProps } from 'design-system/entry';
 import { usePatientAddressCodedValues } from 'apps/patient/profile/addresses/usePatientAddressCodedValues';
-import { Input } from 'components/FormInputs/Input';
 import { useLocationCodedValues } from 'location';
+import { maxLengthRule, validateRequiredRule } from 'validation/entry';
+import { Input } from 'components/FormInputs/Input';
 import { AddressSuggestion, AddressSuggestionInput } from 'address/suggestion';
-import { AddressEntry } from 'apps/patient/data/entry';
+import { AddressEntry } from './entry';
 
 const AS_OF_DATE_LABEL = 'Address as of';
 const TYPE_LABEL = 'Type';

--- a/apps/modernization-ui/src/apps/patient/data/address/asAddress.ts
+++ b/apps/modernization-ui/src/apps/patient/data/address/asAddress.ts
@@ -1,6 +1,6 @@
 import { asValue } from 'options';
 import { Address } from '../api';
-import { AddressEntry } from '../entry';
+import { AddressEntry } from './entry';
 import { exists, orUndefined } from 'utils';
 
 const asAddress = (entry: AddressEntry): Address | undefined => {

--- a/apps/modernization-ui/src/apps/patient/data/address/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/address/entry.ts
@@ -1,0 +1,36 @@
+import { today } from 'date';
+import { Selectable } from 'options';
+import { EffectiveDated, HasComments } from 'utils';
+
+type AddressEntry = EffectiveDated &
+    HasComments & {
+        type: Selectable | null;
+        use: Selectable | null;
+        address1?: string;
+        address2?: string;
+        city?: string;
+        county?: Selectable | null;
+        state?: Selectable | null;
+        zipcode?: string;
+        country?: Selectable | null;
+        censusTract?: string;
+    };
+
+export type { AddressEntry };
+
+const initial = (asOf: string = today()): Partial<AddressEntry> => ({
+    asOf,
+    type: undefined,
+    use: undefined,
+    address1: '',
+    address2: '',
+    city: '',
+    state: undefined,
+    zipcode: '',
+    county: undefined,
+    country: undefined,
+    censusTract: '',
+    comment: ''
+});
+
+export { initial };

--- a/apps/modernization-ui/src/apps/patient/data/address/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/address/index.ts
@@ -1,0 +1,5 @@
+export { initial } from './entry';
+export type { AddressEntry } from './entry';
+
+export { AddressEntryFields } from './AddressEntryFields';
+export { asAddress } from './asAddress';

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -10,17 +10,6 @@ type LocationEntry = {
 
 type AdministrativeEntry = EffectiveDated & HasComments;
 
-type PhoneEmailEntry = EffectiveDated &
-    HasComments & {
-        type: Selectable | null;
-        use: Selectable | null;
-        countryCode?: string;
-        phoneNumber?: string;
-        extension?: string;
-        email?: string;
-        url?: string;
-    };
-
 type IdentificationEntry = EffectiveDated & {
     type: Selectable | null;
     id: string | null;
@@ -60,12 +49,4 @@ type GeneralInformationEntry = EffectiveDated & {
     stateHIVCase?: string;
 };
 
-export type {
-    AdministrativeEntry,
-    PhoneEmailEntry,
-    IdentificationEntry,
-    SexEntry,
-    BirthEntry,
-    MortalityEntry,
-    GeneralInformationEntry
-};
+export type { AdministrativeEntry, IdentificationEntry, SexEntry, BirthEntry, MortalityEntry, GeneralInformationEntry };

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -10,18 +10,6 @@ type LocationEntry = {
 
 type AdministrativeEntry = EffectiveDated & HasComments;
 
-type NameEntry = EffectiveDated & {
-    type: Selectable | null;
-    prefix?: Maybe<Selectable>;
-    first?: string;
-    middle?: string;
-    secondMiddle?: string;
-    last?: string;
-    secondLast?: string;
-    suffix?: Maybe<Selectable>;
-    degree?: Maybe<Selectable>;
-};
-
 type AddressEntry = EffectiveDated &
     HasComments & {
         type: Selectable | null;
@@ -88,7 +76,6 @@ type GeneralInformationEntry = EffectiveDated & {
 
 export type {
     AdministrativeEntry,
-    NameEntry,
     AddressEntry,
     PhoneEmailEntry,
     IdentificationEntry,

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -10,12 +10,6 @@ type LocationEntry = {
 
 type AdministrativeEntry = EffectiveDated & HasComments;
 
-type IdentificationEntry = EffectiveDated & {
-    type: Selectable | null;
-    id: string | null;
-    issuer?: Maybe<Selectable>;
-};
-
 type SexEntry = EffectiveDated & {
     current?: Selectable;
     unknownReason?: Selectable;
@@ -49,4 +43,4 @@ type GeneralInformationEntry = EffectiveDated & {
     stateHIVCase?: string;
 };
 
-export type { AdministrativeEntry, IdentificationEntry, SexEntry, BirthEntry, MortalityEntry, GeneralInformationEntry };
+export type { AdministrativeEntry, SexEntry, BirthEntry, MortalityEntry, GeneralInformationEntry };

--- a/apps/modernization-ui/src/apps/patient/data/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/entry.ts
@@ -10,20 +10,6 @@ type LocationEntry = {
 
 type AdministrativeEntry = EffectiveDated & HasComments;
 
-type AddressEntry = EffectiveDated &
-    HasComments & {
-        type: Selectable | null;
-        use: Selectable | null;
-        address1?: string;
-        address2?: string;
-        city?: string;
-        county?: Maybe<Selectable>;
-        state?: Maybe<Selectable>;
-        zipcode?: string;
-        country?: Maybe<Selectable>;
-        censusTract?: string;
-    };
-
 type PhoneEmailEntry = EffectiveDated &
     HasComments & {
         type: Selectable | null;
@@ -76,7 +62,6 @@ type GeneralInformationEntry = EffectiveDated & {
 
 export type {
     AdministrativeEntry,
-    AddressEntry,
     PhoneEmailEntry,
     IdentificationEntry,
     SexEntry,

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
@@ -1,10 +1,9 @@
-import { render, waitFor } from '@testing-library/react';
-import { PatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
-import { act } from 'react-dom/test-utils';
 import { FormProvider, useForm } from 'react-hook-form';
-import { IdentificationEntry } from '../entry';
-import { IdentificationEntryFields } from './IdentificationEntryFields';
+import { render, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { PatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
+import { IdentificationEntry } from './entry';
+import { IdentificationEntryFields } from './IdentificationEntryFields';
 
 const mockPatientIdentificationCodedValues: PatientIdentificationCodedValues = {
     types: [{ name: 'Account number', value: 'AN' }],

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
@@ -1,11 +1,11 @@
 import { Controller, useFormContext } from 'react-hook-form';
-import { EntryFieldsProps } from 'design-system/entry';
-import { usePatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
+import { Input } from 'components/FormInputs/Input';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { maxLengthRule, validateRequiredRule } from 'validation/entry';
-import { Input } from 'components/FormInputs/Input';
+import { EntryFieldsProps } from 'design-system/entry';
 import { SingleSelect } from 'design-system/select';
-import { IdentificationEntry } from '../entry';
+import { usePatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
+import { IdentificationEntry } from './entry';
 
 const AS_OF_DATE_LABEL = 'Identification as of';
 const TYPE_LABEL = 'Type';

--- a/apps/modernization-ui/src/apps/patient/data/identification/asIdentification.ts
+++ b/apps/modernization-ui/src/apps/patient/data/identification/asIdentification.ts
@@ -1,6 +1,6 @@
 import { asValue } from 'options';
 import { Identification } from '../api';
-import { IdentificationEntry } from '../entry';
+import { IdentificationEntry } from './entry';
 import { exists } from 'utils';
 
 const asIdentification = (entry: IdentificationEntry): Identification | undefined => {

--- a/apps/modernization-ui/src/apps/patient/data/identification/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/identification/entry.ts
@@ -1,0 +1,20 @@
+import { today } from 'date';
+import { Selectable } from 'options';
+import { EffectiveDated } from 'utils';
+
+type IdentificationEntry = EffectiveDated & {
+    type: Selectable | null;
+    id: string | null;
+    issuer?: Selectable | null;
+};
+
+export type { IdentificationEntry };
+
+const initial = (asOf: string = today()): Partial<IdentificationEntry> => ({
+    asOf,
+    type: undefined,
+    issuer: undefined,
+    id: ''
+});
+
+export { initial };

--- a/apps/modernization-ui/src/apps/patient/data/identification/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/identification/index.ts
@@ -1,0 +1,5 @@
+export { initial } from './entry';
+export type { IdentificationEntry } from './entry';
+
+export { IdentificationEntryFields } from './IdentificationEntryFields';
+export { asIdentification } from './asIdentification';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -9,7 +9,8 @@ export { asAddress } from './address';
 export type { PhoneEmailEntry } from './phoneEmail';
 export { asPhoneEmail } from './phoneEmail';
 
-export { asIdentification } from './identification/asIdentification';
+export type { IdentificationEntry } from './identification';
+export { asIdentification } from './identification';
 
 export type { RaceEntry } from './race';
 export { asRace } from './race';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -1,9 +1,16 @@
 export { asAdministrative } from './administrative/asAdministrative';
-export { asName } from './name/asName';
-export { asAddress } from './address/asAddress';
+
+export type { NameEntry } from './name/';
+export { asName } from './name';
+
+export type { AddressEntry } from './address';
+export { asAddress } from './address';
+
+export type { RaceEntry } from './race';
+export { asRace } from './race';
+
 export { asPhoneEmail } from './phoneEmail/asPhoneEmail';
 export { asIdentification } from './identification/asIdentification';
-export { asRace } from './race/asRace';
 export { asEthnicity } from './ethnicity/asEthnicity';
 export { asMortality } from './mortality/asMortality';
 export { asSex } from './sexAndBirth/asSex';

--- a/apps/modernization-ui/src/apps/patient/data/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/index.ts
@@ -6,11 +6,14 @@ export { asName } from './name';
 export type { AddressEntry } from './address';
 export { asAddress } from './address';
 
+export type { PhoneEmailEntry } from './phoneEmail';
+export { asPhoneEmail } from './phoneEmail';
+
+export { asIdentification } from './identification/asIdentification';
+
 export type { RaceEntry } from './race';
 export { asRace } from './race';
 
-export { asPhoneEmail } from './phoneEmail/asPhoneEmail';
-export { asIdentification } from './identification/asIdentification';
 export { asEthnicity } from './ethnicity/asEthnicity';
 export { asMortality } from './mortality/asMortality';
 export { asSex } from './sexAndBirth/asSex';

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
@@ -1,8 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { NameEntry } from '../entry';
+import { act, render, waitFor } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { NameEntry } from './entry';
 import { NameEntryFields } from './NameEntryFields';
 
 const mockPatientNameCodedValues = {

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -4,7 +4,7 @@ import { SingleSelect } from 'design-system/select';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { EntryFieldsProps } from 'design-system/entry';
 import { validateExtendedNameRule, validateRequiredRule } from 'validation/entry/';
-import { NameEntry } from 'apps/patient/data/entry';
+import { NameEntry } from './entry';
 import { usePatientNameCodedValues } from 'apps/patient/profile/names/usePatientNameCodedValues';
 
 const AS_OF_DATE_LABEL = 'Name as of';

--- a/apps/modernization-ui/src/apps/patient/data/name/asName.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/name/asName.spec.ts
@@ -1,4 +1,4 @@
-import { asName } from '..';
+import { asName } from './asName';
 
 describe('when mapping a name entry to a format accepted by the API', () => {
     it('should include the as of date', () => {

--- a/apps/modernization-ui/src/apps/patient/data/name/asName.ts
+++ b/apps/modernization-ui/src/apps/patient/data/name/asName.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-redeclare */
 import { asValue } from 'options';
-import { NameEntry } from '../entry';
+import { NameEntry } from './entry';
 import { Name } from '../api';
 import { exists, orUndefined } from 'utils';
 

--- a/apps/modernization-ui/src/apps/patient/data/name/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/name/entry.ts
@@ -1,0 +1,32 @@
+import { today } from 'date';
+import { Selectable } from 'options';
+import { EffectiveDated } from 'utils';
+
+type NameEntry = EffectiveDated & {
+    type: Selectable | null;
+    prefix?: Selectable | null;
+    first?: string;
+    middle?: string;
+    secondMiddle?: string;
+    last?: string;
+    secondLast?: string;
+    suffix?: Selectable | null;
+    degree?: Selectable | null;
+};
+
+export type { NameEntry };
+
+const initial = (asOf: string = today()): Partial<NameEntry> => ({
+    asOf,
+    type: undefined,
+    prefix: undefined,
+    first: '',
+    middle: '',
+    secondMiddle: '',
+    last: '',
+    secondLast: '',
+    suffix: undefined,
+    degree: undefined
+});
+
+export { initial };

--- a/apps/modernization-ui/src/apps/patient/data/name/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/name/index.ts
@@ -1,0 +1,5 @@
+export { initial } from './entry';
+export type { NameEntry } from './entry';
+
+export { NameEntryFields } from './NameEntryFields';
+export { asName } from './asName';

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
@@ -1,9 +1,8 @@
-import { render, waitFor, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
-import { FormProvider, useForm } from 'react-hook-form';
-import { PhoneEmailEntry } from '../entry';
-import { PhoneEmailEntryFields } from './PhoneEmailEntryFields';
+import { render, waitFor, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { PhoneEmailEntry } from './entry';
+import { PhoneEmailEntryFields } from './PhoneEmailEntryFields';
 
 const mockPatientPhoneCodedValues = {
     types: [{ name: 'Phone', value: 'PH' }],

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -1,12 +1,12 @@
 import { Controller, useFormContext } from 'react-hook-form';
-import { usePatientPhoneCodedValues } from 'apps/patient/profile/phoneEmail/usePatientPhoneCodedValues';
 import { DatePickerInput, validDateRule } from 'design-system/date';
-import { Input } from 'components/FormInputs/Input';
 import { SingleSelect } from 'design-system/select';
+import { Input } from 'components/FormInputs/Input';
 import { maxLengthRule, validateRequiredRule, validEmailRule } from 'validation/entry';
 import { validatePhoneNumber } from 'validation/phone';
-import { PhoneEmailEntry } from 'apps/patient/data/entry';
 import { EntryFieldsProps } from 'design-system/entry';
+import { usePatientPhoneCodedValues } from 'apps/patient/profile/phoneEmail/usePatientPhoneCodedValues';
+import { PhoneEmailEntry } from './entry';
 
 const AS_OF_DATE_LABEL = 'Phone & email as of';
 const TYPE_LABEL = 'Type';

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/asPhoneEmail.ts
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/asPhoneEmail.ts
@@ -1,6 +1,6 @@
 import { asValue } from 'options';
 import { PhoneEmail } from '../api';
-import { PhoneEmailEntry } from '../entry';
+import { PhoneEmailEntry } from './entry';
 import { exists, orUndefined } from 'utils';
 
 const asPhoneEmail = (entry: PhoneEmailEntry): PhoneEmail | undefined => {

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/entry.ts
@@ -1,0 +1,30 @@
+import { today } from 'date';
+import { Selectable } from 'options';
+import { EffectiveDated, HasComments } from 'utils';
+
+type PhoneEmailEntry = EffectiveDated &
+    HasComments & {
+        type: Selectable | null;
+        use: Selectable | null;
+        countryCode?: string;
+        phoneNumber?: string;
+        extension?: string;
+        email?: string;
+        url?: string;
+    };
+
+export type { PhoneEmailEntry };
+
+const initial = (asOf: string = today()): Partial<PhoneEmailEntry> => ({
+    asOf,
+    type: undefined,
+    use: undefined,
+    countryCode: '',
+    phoneNumber: '',
+    extension: '',
+    email: '',
+    url: '',
+    comment: ''
+});
+
+export { initial };

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/index.ts
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/index.ts
@@ -1,0 +1,5 @@
+export { initial } from './entry';
+export type { PhoneEmailEntry } from './entry';
+
+export { PhoneEmailEntryFields } from './PhoneEmailEntryFields';
+export { asPhoneEmail } from './asPhoneEmail';

--- a/apps/modernization-ui/src/apps/patient/data/race/entry.ts
+++ b/apps/modernization-ui/src/apps/patient/data/race/entry.ts
@@ -15,7 +15,7 @@ export type { RaceEntry, RaceCategoryValidator };
 const initial = (asOf: string = today()): Partial<RaceEntry> => ({
     id: new Date().getTime(),
     asOf,
-    race: null,
+    race: undefined,
     detailed: []
 });
 


### PR DESCRIPTION
## Description

When the placeholder option of “- Select -” is picked the value of the property becomes `undefined`.  The initial values of the `Selectable` properties were set to `null` making the form library evaluate the forms as dirty.  The initial value of the `Selectable` properties of `NameEntry`, `AddressEntry`, `PhoneEmailEntry`, `IdentificationEntry`, and `RaceEntry`types were changed from `null` to `undefined`

Why so many changes?  The entry types were moved to the folder for the specific type along with the function that creates the initial value.

## Tickets

* [CNFT1-3577](https://cdc-nbs.atlassian.net/browse/CNFT1-3577)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3577]: https://cdc-nbs.atlassian.net/browse/CNFT1-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ