### PR TITLE
Convert null emails to blanks

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/email/PatientSearchResultEmailFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/email/PatientSearchResultEmailFinder.java
@@ -10,14 +10,14 @@ class PatientSearchResultEmailFinder {
 
   private static final String QUERY = """
       select distinct
-          [email_address].email_address as [email]
+          IsNull([email_address].email_address, '') as [email]
       from Entity_locator_participation [locator]
-            
+
           join Tele_locator [email_address] on
                   [email_address].[tele_locator_uid] = [locator].[locator_uid]
               and [email_address].record_status_cd = [locator].[record_status_cd]
-            
-            
+
+
       where   [locator].entity_uid = ?
           and [locator].[class_cd] = 'TELE'
           and [locator].cd = 'NET'
@@ -36,7 +36,6 @@ class PatientSearchResultEmailFinder {
     return this.template.query(
         QUERY,
         statement -> statement.setLong(PATIENT_PARAMETER, patient),
-        (rs, row) -> rs.getString(EMAIL_COLUMN)
-    );
+        (rs, row) -> rs.getString(EMAIL_COLUMN));
   }
 }


### PR DESCRIPTION
## Description

Fixes blank search results with error:
```
The field at path '/findPatientsByFilter/content[11]/emails[0]' was declared as a non null type, but the code involved in retrieving data has wrongly returned a null value.
```

Notes: could fetch just non null values but figured it was beneficial to see if blanks and nulls are being inserted into the db erroneously.

## Tickets

* [CNFT1-3538](https://cdc-nbs.atlassian.net/browse/CNFT1-3538)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3538]: https://cdc-nbs.atlassian.net/browse/CNFT1-3538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ