### PR TITLE
CNT-111 User deletes draft investigations

### DIFF
--- a/testing/regression/cypress/e2e/features/page-library/investigations.feature
+++ b/testing/regression/cypress/e2e/features/page-library/investigations.feature
@@ -14,3 +14,7 @@ Feature: Page Builder - Page builder manage pages investigations
 	And the user enters Version Notes as "automated testing"
 	And the user clicks the Submit button to publish
 	Then success message contains the phrase "successfully published"
+
+    Scenario: User deletes draft investigations 
+	And the user clicks the Delete Draft button
+	Then success message is displayed

--- a/testing/regression/cypress/e2e/pages/page-library/investigations.page.js
+++ b/testing/regression/cypress/e2e/pages/page-library/investigations.page.js
@@ -83,6 +83,17 @@ class PageBuilderPage {
           .should('be.visible')
           .and('contain.text', 'successfully published');
       }
+
+      clickDeleteDraftButton() {
+        cy.get('input[type="button"][name="Delete Draft"][value="Delete Draft"]').eq(0).click();
+      }
+      
+      verifyDraftDeletedSuccessMessage() {
+        cy.get('div.infoBox.success').invoke('text').then((text) => {
+          expect(text).to.include('successfully  deleted.');
+        });
+      }      
+      
   }
   
   export default new PageBuilderPage();

--- a/testing/regression/cypress/step_definitions/page-library/investigations.steps.js
+++ b/testing/regression/cypress/step_definitions/page-library/investigations.steps.js
@@ -35,4 +35,14 @@ Then('I add new page', () => {
   Then('success message contains the phrase "successfully published"', () => {
     PageBuilderPage.verifySuccessMessageContains();
   });
+
+  Then('the user clicks the Delete Draft button', () => {
+    PageBuilderPage.clickDeleteDraftButton();
+  });
+
+  Then('success message is displayed', () => {
+    PageBuilderPage.verifyDraftDeletedSuccessMessage();
+  });
+  
+  
   


### PR DESCRIPTION
Classic test case automation. User deletes draft investigation.

## Description

Classic test case automation. User deletes draft investigation.
<img width="1510" alt="CNT-111" src="https://github.com/user-attachments/assets/eab8b1b6-d45b-4155-ba35-fdf73d3d8f34">


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-111)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
