### PR TITLE
[CNFT1-3599] removes specified UTC timezone

### DIFF
--- a/apps/modernization-ui/src/date/InternalizeDate.spec.ts
+++ b/apps/modernization-ui/src/date/InternalizeDate.spec.ts
@@ -1,12 +1,21 @@
 import { internalizeDate } from './InternalizeDate';
 
 describe('when a date value is given', () => {
-    it('should transform an ISO 8601 formatted date string into a string formatted as M/d/y', () => {
-        expect(internalizeDate('2025-04-06')).toBe('04/06/2025');
+    describe('as text', () => {
+        it('should transform an ISO 8601 formatted date string into a string formatted as M/d/y', () => {
+            expect(internalizeDate('2025-04-06')).toBe('04/06/2025');
+        });
+
+        it('should transform an ISO 8601 formatted date time string into a string formatted as M/d/y', () => {
+            expect(internalizeDate('2025-04-06T11:13:19.010Z')).toBe('04/06/2025');
+        });
     });
 
-    it('should transform an ISO 8601 formatted date time string into a string formatted as M/d/y', () => {
-        expect(internalizeDate('2025-04-06T11:13:19.010Z')).toBe('04/06/2025');
+    describe('as a Date', () => {
+        it('should transform the Date into a string formatted as M/d/y', () => {
+            const value = new Date('2025-04-06T11:13:19.010Z');
+            expect(internalizeDate(value)).toBe('04/06/2025');
+        });
     });
 
     it('should not transform a null date', () => {

--- a/apps/modernization-ui/src/date/InternalizeDate.ts
+++ b/apps/modernization-ui/src/date/InternalizeDate.ts
@@ -10,7 +10,6 @@ function internalizeDate(input: string | Date | null | undefined) {
         return internalizeDate(parseISO(input));
     } else if (input instanceof Date) {
         return input.toLocaleDateString('en-US', {
-            timeZone: 'UTC',
             day: '2-digit',
             month: '2-digit',
             year: 'numeric'


### PR DESCRIPTION
## Description

The `internalizeDate` function was formatting dates using the UTC timezone, it should use the current timezone of the user.

## Tickets

* [CNFT1-3599](https://cdc-nbs.atlassian.net/browse/CNFT1-3599)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
