### PR TITLE
[CNT-84] - 1027 - Create Notification E2E 

### DIFF
--- a/testing/regression/cypress/e2e/features/nbs-classic/viewInvestigation.feature
+++ b/testing/regression/cypress/e2e/features/nbs-classic/viewInvestigation.feature
@@ -3,7 +3,21 @@ Feature: View Open Investigation
 Background:
     Given I am logged in as secure user and stay on classic
 
-  Scenario: Accessing and viewing an Open Investigation
+#  Scenario: Accessing and viewing an Open Investigation
+#    When I click on "Open Investigation" in the menu bar
+#    Then I should land on the "Open Investigation Queue" page
+#    Then I click and view an Investigation
+
+  Scenario: Create notification for an open investigation
     When I click on "Open Investigation" in the menu bar
-    Then I should land on the "Open Investigation Queue" page
-    Then I click and view an Investigation
+    Then Click on Patient name from open investigation queue
+    Then Click Events tab on Patient Profile Page
+    Then Click Add Investigation button on Events tab
+    Then Select condition form the dropdown in Select Condition Page
+    Then Click Submit button in Select Condition Page
+    Then Click on Case Info Tab in Add Investigation for the selected condition
+    Then Select Jurisdiction as it is mandatory field in Add Investigation for the selected condition
+    Then Select status from Case Status dropdown in Add Investigation for the selected condition
+    Then Click Submit button in Add Investigation for the selected condition
+    Then Click Create Notifications button from top action button group
+    Then Click Submit button in newly opened window Create Notification Page

--- a/testing/regression/cypress/e2e/pages/nbs-classic/openInvestigation.page.js
+++ b/testing/regression/cypress/e2e/pages/nbs-classic/openInvestigation.page.js
@@ -119,6 +119,64 @@ class OpenInvestigationPage {
     verifyUpdatedComment(expectedComment) {
       cy.get(this.updatedComment).should('contain.text', expectedComment);
     }
+
+    clickPatientName() {
+        cy.get('#parent tbody tr td a').eq(2).click()
+    }
+
+    clickEventsTab() {
+        cy.contains('Events').eq(0).click()
+    }
+
+    clickAddInvestigationBtn() {
+        cy.contains('button', 'Add investigation').eq(0).click()
+    }
+
+    selectConditionFromDropdown() {
+        cy.get('img[name="ccd_button"]').eq(0).click()
+        cy.wait(1000)
+        cy.get('#ccd').select(1, { force: true })
+        cy.get('input[name="ccd_textbox"]').eq(0).click()
+        cy.get('#ccd').select(1, { force: true })
+    }
+
+    clickSubmitBtnInSelectConditionPage() {
+        cy.get('#Submit').eq(0).click()
+    }
+
+    clickCaseInfoTab() {
+        cy.contains('Case Info').eq(0).click()
+    }
+
+    selectJurisdictionFromDropdown() {
+        cy.get('img[name="INV107_button"]').eq(0).click()
+        cy.get('#INV107').select(1, { force: true })
+        cy.get('input[name="INV107_textbox"]').eq(0).click()
+    }
+
+    selectCaseStatusFromDropdown() {
+        cy.get('img[name="INV163_button"]').eq(0).click()
+        cy.get('#INV163').select(1, { force: true })
+        cy.get('input[name="INV163_textbox"]').eq(0).click()
+        cy.get('#INV886').eq(0).click()
+    }
+
+    clickSubmitBtnInAddInvestigationPage() {
+        cy.get('#SubmitBottom').eq(0).click()
+    }
+
+    clickCreateInvestigationsBtn() {
+        cy.window().then((win) => {
+         cy.stub(win, 'open').callsFake((url) => {
+           win.location.href = url;
+         });
+       });
+       cy.get('#createNoti').eq(0).click()
+    }
+
+    clickSubmitBtnInCreateNotificationPage() {
+        cy.get('#topcreatenotId input[type="button"][value="Submit"]').eq(0).click({ force: true })
+    }
   }
   
   export const openInvestigationPage = new OpenInvestigationPage();

--- a/testing/regression/cypress/step_definitions/nbs-classic/openInvestigation.steps.js
+++ b/testing/regression/cypress/step_definitions/nbs-classic/openInvestigation.steps.js
@@ -111,3 +111,48 @@ When('the user clicks the Submit button', () => {
 Then('the Treatment Comment is updated with the text {string}', (expectedComment) => {
   openInvestigationPage.verifyUpdatedComment(expectedComment);
 });
+
+Then('Click on Patient name from open investigation queue', () => {
+  openInvestigationPage.clickPatientName();
+});
+
+Then('Click Events tab on Patient Profile Page', () => {
+  openInvestigationPage.clickEventsTab();
+});
+
+Then('Click Add Investigation button on Events tab', () => {
+  openInvestigationPage.clickAddInvestigationBtn();
+});
+
+Then('Select condition form the dropdown in Select Condition Page', () => {
+  openInvestigationPage.selectConditionFromDropdown();
+});
+
+Then('Click Submit button in Select Condition Page', () => {
+  openInvestigationPage.clickSubmitBtnInSelectConditionPage();
+});
+
+Then('Click on Case Info Tab in Add Investigation for the selected condition', () => {
+  openInvestigationPage.clickCaseInfoTab();
+});
+
+Then('Select Jurisdiction as it is mandatory field in Add Investigation for the selected condition', () => {
+  openInvestigationPage.selectJurisdictionFromDropdown();
+});
+
+Then('Select status from Case Status dropdown in Add Investigation for the selected condition', () => {
+  openInvestigationPage.selectCaseStatusFromDropdown();
+});
+
+Then('Click Submit button in Add Investigation for the selected condition', () => {
+  openInvestigationPage.clickSubmitBtnInAddInvestigationPage();
+});
+
+Then('Click Create Notifications button from top action button group', () => {
+  openInvestigationPage.clickCreateInvestigationsBtn();
+});
+
+Then('Click Submit button in newly opened window Create Notification Page', () => {
+  openInvestigationPage.clickSubmitBtnInCreateNotificationPage();
+});
+


### PR DESCRIPTION
## Description

Added end to end test case for Create notification on investigation pages.
<img width="1496" alt="Screenshot 2024-12-13 at 10 02 48 AM" src="https://github.com/user-attachments/assets/611136dd-a636-435b-beef-1d0199b21b2c" />

## Tickets

* [CNT-84](https://cdc-nbs.atlassian.net/browse/CNT-84)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
