### PR TITLE
[CNFT1-3627] Ensures that the error messages for date of birth validations

### DIFF
--- a/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.tsx
@@ -75,7 +75,7 @@ export const MortalityEntryFields = ({ orientation = 'horizontal' }: MortalityEn
                         name="mortality.deceasedOn"
                         shouldUnregister
                         rules={validDateRule(DECEASED_ON_LABEL)}
-                        render={({ field: { onChange, onBlur, value, name } }) => (
+                        render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                             <DatePickerInput
                                 id={name}
                                 label={DECEASED_ON_LABEL}
@@ -83,6 +83,7 @@ export const MortalityEntryFields = ({ orientation = 'horizontal' }: MortalityEn
                                 value={value}
                                 onChange={onChange}
                                 onBlur={onBlur}
+                                error={error?.message}
                             />
                         )}
                     />

--- a/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
@@ -51,7 +51,7 @@ export const SexAndBirthEntryFields = ({ orientation = 'horizontal' }: SexAndBir
                 rules={{ ...validateRequiredRule(AS_OF_DATE_LABEL), ...validDateRule(AS_OF_DATE_LABEL) }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
-                        label="Sex & birth information as of"
+                        label={AS_OF_DATE_LABEL}
                         orientation={orientation}
                         value={value}
                         onChange={onChange}
@@ -66,14 +66,15 @@ export const SexAndBirthEntryFields = ({ orientation = 'horizontal' }: SexAndBir
                 control={control}
                 name="birthAndSex.bornOn"
                 rules={validDateRule(BORN_ON_LABEL)}
-                render={({ field: { onChange, onBlur, value, name } }) => (
+                render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <DatePickerInput
-                        label={BORN_ON_LABEL}
-                        orientation={orientation}
+                        id={name}
                         value={value}
                         onChange={onChange}
                         onBlur={onBlur}
-                        id={name}
+                        label={BORN_ON_LABEL}
+                        error={error?.message}
+                        orientation={orientation}
                     />
                 )}
             />


### PR DESCRIPTION
## Description

The errors were not being passed to the "Date of death" field for display in the "Mortality" section and the "Date of birth" field in the "Sex and birth" section within "New patient - extended"

![image](https://github.com/user-attachments/assets/f0fb5d8d-26f3-4ac7-9c1b-2e37e2206a9d)


![image](https://github.com/user-attachments/assets/40416067-a0e1-46ad-b30a-1874526bb61f)


## Tickets

* [CNFT1-3627](https://cdc-nbs.atlassian.net/browse/CNFT1-3627)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3627]: https://cdc-nbs.atlassian.net/browse/CNFT1-3627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ