### PR TITLE
[CNFT1-3634] Return link location

### DIFF
--- a/apps/modernization-ui/src/system/return-message/ReturnMessage.spec.tsx
+++ b/apps/modernization-ui/src/system/return-message/ReturnMessage.spec.tsx
@@ -24,6 +24,6 @@ describe('when displaying a ReturnMessage', () => {
         const returnLink = getByRole('link', { name: 'Return to NBS' });
 
         expect(returnLink).toBeInTheDocument();
-        expect(returnLink).toHaveAttribute('href', '/nbs/HomePage.do?method=loadHomePage');
+        expect(returnLink).toHaveAttribute('href', '/nbs/login');
     });
 });

--- a/apps/modernization-ui/src/system/return-message/ReturnMessage.tsx
+++ b/apps/modernization-ui/src/system/return-message/ReturnMessage.tsx
@@ -10,7 +10,7 @@ const ReturnMessage = ({ title, children }: Props) => (
     <div className={styles.return}>
         <h1>{title}</h1>
         <div className={styles.message}>{children}</div>
-        <a href="/nbs/HomePage.do?method=loadHomePage">Return to NBS</a>
+        <a href="/nbs/login">Return to NBS</a>
     </div>
 );
 

--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -62,5 +62,5 @@ tasks.withType(JavaExec).configureEach {
 
 tasks.named("bootRun") {
     // Enables the local profile when run from the command line
-    systemProperty 'spring.profiles.active', 'default,development'
+    systemProperty 'spring.profiles.active', 'default,development,local'
 }

--- a/apps/nbs-gateway/src/main/resources/application-development.yml
+++ b/apps/nbs-gateway/src/main/resources/application-development.yml
@@ -1,9 +1,5 @@
 nbs:
   security:
-    oidc:
-      client:
-        id: nbs-development
-        secret: ${OIDC_CLIENT_SECRET}
     log:
       level: INFO
   gateway:


### PR DESCRIPTION
## Description

Changes the "Return to NBS" link to go to `/nbs/login` to ensure that a user is logged in to NBS6.

## Tickets

* [CNFT1-3634](https://cdc-nbs.atlassian.net/browse/CNFT1-3634)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3634]: https://cdc-nbs.atlassian.net/browse/CNFT1-3634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ