### PR TITLE
setting up the ability to provide default sort in the sorting prefere…

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -12,6 +12,7 @@ import { PatientCriteriaEntry, initial as defaultValues } from './criteria';
 import { PatientSearchActions } from './PatientSearchActions';
 import { PatientCriteria } from './PatientCriteria/PatientCriteria';
 import { usePatientSearch } from './usePatientSearch';
+import { Direction } from 'sorting';
 
 const PatientSearch = () => {
     const form = useForm<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>({
@@ -24,7 +25,13 @@ const PatientSearch = () => {
 
     return (
         <ColumnPreferenceProvider id="search.patients.preferences.columns" defaults={preferences}>
-            <SortingPreferenceProvider id="search.patients.preferences.sorting" available={sorting}>
+            <SortingPreferenceProvider
+                id="search.patients.preferences.sorting"
+                available={sorting}
+                defaultSort={{
+                    property: 'patientname',
+                    direction: Direction.Descending
+                }}>
                 <SearchInteractionProvider interaction={interaction}>
                     <FormProvider {...form}>
                         <SearchLayout

--- a/apps/modernization-ui/src/design-system/sorting/preferences/useSortingPreferences.tsx
+++ b/apps/modernization-ui/src/design-system/sorting/preferences/useSortingPreferences.tsx
@@ -63,9 +63,10 @@ type Props = {
     id: string;
     children: ReactNode;
     available?: SortingSelectable[];
+    defaultSort?: ActiveSorting;
 };
 
-const SortingPreferenceProvider = ({ id, children, available = [] }: Props) => {
+const SortingPreferenceProvider = ({ id, children, available = [], defaultSort }: Props) => {
     const [state, dispatch] = useReducer(reducer, { status: 'unsorted' });
 
     const { value, save, remove } = useLocalStorage<ActiveSorting>({ key: id });
@@ -74,6 +75,8 @@ const SortingPreferenceProvider = ({ id, children, available = [] }: Props) => {
         if (value) {
             //  use the stored sorting
             dispatch({ type: 'load', active: value });
+        } else if (defaultSort) {
+            dispatch({ type: 'load', active: defaultSort });
         }
     }, [value]);
 


### PR DESCRIPTION


Setting up defaultSort in SortingPreferenceProvider to have the patient name column sorted by default and displaying the proper styles for the sorted column.

## Tickets

* [CNFT1-3635](https://cdc-nbs.atlassian.net/browse/CNFT1-3635)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3635]: https://cdc-nbs.atlassian.net/browse/CNFT1-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ