### PR TITLE
CNFT1-3610: Search results pluralize fix

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { SearchTerms } from './SearchTerms';
+import { useSkipLink } from 'SkipLink/SkipLinkContext';
+import { useSearchInteraction } from 'apps/search';
+import { focusedTarget } from 'utils/focusedTarget';
+import { Term } from 'apps/search/terms';
+
+const mockSkipTo = jest.fn();
+const mockFocusedTarget = jest.fn();
+const mockWithout = jest.fn();
+
+jest.mock('SkipLink/SkipLinkContext');
+jest.mock('apps/search');
+jest.mock('utils/focusedTarget');
+
+const terms: Term[] = [
+    { title: 'Term1', name: 'term1', source: 'term1', value: '1' },
+    { title: 'Term2', name: 'term2', source: 'term2', value: '2' }
+];
+
+describe('SearchTerms', () => {
+    beforeEach(() => {
+        (useSkipLink as jest.Mock).mockReturnValue({ skipTo: mockSkipTo });
+        (focusedTarget as jest.Mock).mockImplementation(mockFocusedTarget);
+        (useSearchInteraction as jest.Mock).mockReturnValue({ without: mockWithout });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the correct number of results', () => {
+        const { getByText } = render(<SearchTerms total={2} terms={terms} />);
+        expect(getByText('2 results for:')).toBeInTheDocument();
+    });
+
+    it('renders the singular form of results when total is 1', () => {
+        const { getByText } = render(<SearchTerms total={1} terms={terms} />);
+        expect(getByText('1 result for:')).toBeInTheDocument();
+    });
+
+    it('renders the correct terms', () => {
+        const { getByText } = render(<SearchTerms total={2} terms={terms} />);
+        expect(getByText('Term1: term1')).toBeInTheDocument();
+        expect(getByText('Term2: term2')).toBeInTheDocument();
+    });
+
+    it('calls skipTo and focusedTarget on mount', async () => {
+        render(<SearchTerms total={2} terms={terms} />);
+
+        await waitFor(() => {
+            expect(mockSkipTo).toHaveBeenCalledWith('resultsCount');
+            expect(mockFocusedTarget).toHaveBeenCalledWith('resultsCount');
+        });
+    });
+
+    it('calls without function when chip close button is clicked', () => {
+        const { getAllByRole } = render(<SearchTerms total={2} terms={terms} />);
+        const closeButton = getAllByRole('img')[0];
+        fireEvent.click(closeButton);
+        expect(mockWithout).toHaveBeenCalledWith(terms[0]);
+    });
+
+    it('has correct aria-label', () => {
+        const { getByLabelText } = render(<SearchTerms total={2} terms={terms} />);
+        const resultsCountDiv = getByLabelText('2 Results have been found');
+        expect(resultsCountDiv).toBeInTheDocument();
+    });
+
+    it('has correct aria-label singular form when total is 1', () => {
+        const { getByLabelText } = render(<SearchTerms total={1} terms={terms} />);
+        const resultsCountDiv = getByLabelText('1 Result has been found');
+        expect(resultsCountDiv).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -4,7 +4,7 @@ import { useSearchInteraction } from 'apps/search';
 import { Term } from 'apps/search/terms';
 
 import { useSkipLink } from 'SkipLink/SkipLinkContext';
-import { focusedTarget } from 'utils';
+import { focusedTarget, pluralize } from 'utils';
 
 import styles from './search-terms.module.scss';
 
@@ -15,6 +15,9 @@ type Props = {
 
 const SearchTerms = ({ total, terms }: Props) => {
     const { skipTo } = useSkipLink();
+    const resultsText = pluralize('Result', total);
+    const verbText = pluralize('has', total, 'have');
+    const ariaLabel = `${total} ${resultsText} ${verbText} been found`;
 
     useEffect(() => {
         skipTo('resultsCount');
@@ -24,9 +27,11 @@ const SearchTerms = ({ total, terms }: Props) => {
     const { without } = useSearchInteraction();
 
     return (
-        <div className={styles.terms} tabIndex={0} id="resultsCount" aria-label={`${total} Results have been found`}>
+        <div className={styles.terms} tabIndex={0} id="resultsCount" aria-label={ariaLabel}>
             <div className={styles.term}>
-                <h2>{total} results for:</h2>
+                <h2>
+                    {total} {resultsText.toLowerCase()} for:
+                </h2>
                 {terms.map((term, index) => (
                     <Chip
                         key={index}

--- a/apps/modernization-ui/src/utils/text.spec.ts
+++ b/apps/modernization-ui/src/utils/text.spec.ts
@@ -1,4 +1,4 @@
-import { splitStringByCommonDelimiters, trimCommonDelimiters } from './text';
+import { pluralize, splitStringByCommonDelimiters, trimCommonDelimiters } from './text';
 
 describe('splitStringByCommonDelimiters', () => {
     it('should split a string by commas', () => {
@@ -51,5 +51,22 @@ describe('trimCommonDelimiters', () => {
     it('should handle string with only delimiters', () => {
         const result = trimCommonDelimiters(', ; ');
         expect(result).toEqual('');
+    });
+});
+
+describe('pluralize', () => {
+    it('should return singular form for count of 1', () => {
+        const result = pluralize('item', 1);
+        expect(result).toEqual('item');
+    });
+
+    it('should return plural form for count greater than 1', () => {
+        const result = pluralize('item', 2);
+        expect(result).toEqual('items');
+    });
+
+    it('should return custom plural form', () => {
+        const result = pluralize('person', 2, 'people');
+        expect(result).toEqual('people');
     });
 });

--- a/apps/modernization-ui/src/utils/text.ts
+++ b/apps/modernization-ui/src/utils/text.ts
@@ -34,3 +34,15 @@ export function removeAndTrim(text: string, value: string) {
     if (!text) return '';
     return trimCommonDelimiters(text.replace(value, ''));
 }
+
+/**
+ * Pluralize a word based on a count. If count is 1 returns the singular form.
+ * Optionally provide a plural form for words that do not pluralize by adding 's'.
+ * @param {string} singular The word to pluralize.
+ * @param {number} count The count to determine singular or plural.
+ * @param {string} plural The plural form of the word. Defaults to adding 's' to the singular form.
+ * @returns The singular or plural form of the word.
+ */
+export function pluralize(singular: string, count: number, plural?: string) {
+    return count === 1 ? singular : plural || `${singular}s`;
+}

--- a/apps/modernization-ui/src/utils/text.ts
+++ b/apps/modernization-ui/src/utils/text.ts
@@ -41,7 +41,7 @@ export function removeAndTrim(text: string, value: string) {
  * @param {string} singular The word to pluralize.
  * @param {number} count The count to determine singular or plural.
  * @param {string} plural The plural form of the word. Defaults to adding 's' to the singular form.
- * @returns The singular or plural form of the word.
+ * @return {string} The singular or plural form of the word.
  */
 export function pluralize(singular: string, count: number, plural?: string) {
     return count === 1 ? singular : plural || `${singular}s`;


### PR DESCRIPTION
## Description

Pluralize "results" for text and aria-label. Create `pluralize()` function for use across the app in other places.

![image](https://github.com/user-attachments/assets/34289662-ddd7-43e1-a1db-03817598dc68)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3610)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
