### PR TITLE
[CNFT1-3620]adding scroll to top upon having errors with repeating blocks and user clicking save(extended)

### DIFF
--- a/apps/modernization-ui/src/address/suggestion/AddressSuggestionInput.tsx
+++ b/apps/modernization-ui/src/address/suggestion/AddressSuggestionInput.tsx
@@ -101,7 +101,6 @@ const AddressSuggestionInput = (props: Props): ReactElement => {
                 autoComplete="off"
                 sizing="compact"
                 orientation={orientation}
-                sizing={props.sizing}
                 error={props.error}
                 onChange={handleOnChange}
                 onBlur={props.onBlur}

--- a/apps/modernization-ui/src/address/suggestion/AddressSuggestionInput.tsx
+++ b/apps/modernization-ui/src/address/suggestion/AddressSuggestionInput.tsx
@@ -99,8 +99,8 @@ const AddressSuggestionInput = (props: Props): ReactElement => {
                 defaultValue={props.defaultValue}
                 placeholder={props.placeholder}
                 autoComplete="off"
-                sizing="compact"
                 orientation={orientation}
+                sizing={props.sizing || "compact"}
                 error={props.error}
                 onChange={handleOnChange}
                 onBlur={props.onBlur}

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -58,7 +58,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
 
     return (
         <div className={styles.addPatientForm}>
-            <div className={styles.formContent}>
+            <div className={styles.formContent} id="extended-form-errors">
                 {validationErrors && (
                     <AlertMessage title="Please fix the following errors:" type="error">
                         {renderErrorMessages()}

--- a/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
+++ b/apps/modernization-ui/src/apps/patient/add/extended/useAddExtendedPatient.ts
@@ -66,6 +66,8 @@ const useAddExtendedPatient = (): AddExtendedPatientInteraction => {
                 subFormDirtyState.race
             ) {
                 dispatch({ type: 'invalidate', validationErrors: { dirtySections: subFormDirtyState } });
+                const form = document.getElementById('extended-form-errors');
+                form?.scrollIntoView({ behavior: 'smooth', block: 'start' });
             } else {
                 dispatch({ type: 'validated' });
             }


### PR DESCRIPTION


https://github.com/user-attachments/assets/d98ee822-14b5-4a8b-91df-01a3b744d1ee

## Description

Ensuring user is scrolled to top of the extended form to visualize errors when the user clicks on the save button when there are existing errors in any of the repeating blocks after having interacted with them.
## Tickets

* [CNFT1-3620](https://cdc-nbs.atlassian.net/browse/CNFT1-3620)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3620]: https://cdc-nbs.atlassian.net/browse/CNFT1-3620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ