### PR TITLE
[FIX] removes duplicate props

### DIFF
--- a/apps/modernization-ui/src/address/suggestion/AddressSuggestionInput.tsx
+++ b/apps/modernization-ui/src/address/suggestion/AddressSuggestionInput.tsx
@@ -1,9 +1,8 @@
-import { Input } from 'components/FormInputs/Input';
+import { ReactElement, KeyboardEvent, useRef, useState, useEffect } from 'react';
+import { TextInputField, TextInputFieldProps } from 'design-system/input/text';
 import { Suggestions } from 'suggestion/Suggestions';
 import { AddressSuggestion, useAddressAutocomplete } from './useAddressAutocomplete';
-import { ReactElement, KeyboardEvent, ChangeEvent, useRef, useState, useEffect } from 'react';
 import { LocationCodedValues } from 'location';
-import { Orientation, Sizing } from 'components/Entry';
 
 const renderSuggestion = (suggestion: AddressSuggestion) => (
     <>
@@ -23,21 +22,10 @@ type Props = {
     id: string;
     locations: LocationCodedValues;
     criteria?: Criteria;
-    label?: string;
-    className?: string;
-    placeholder?: string;
-    defaultValue?: string;
-    flexBox?: boolean;
-    orientation?: Orientation;
-    sizing?: Sizing;
-    error?: string;
-    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-    onBlur?: (event: ChangeEvent<HTMLInputElement>) => void;
     onSelection?: (suggestion: AddressSuggestion) => void;
-};
+} & TextInputFieldProps;
 
 const AddressSuggestionInput = (props: Props): ReactElement => {
-    const orientation = props.flexBox ? 'horizontal' : props.orientation;
     const suggestionRef = useRef<HTMLUListElement>(null);
 
     const { suggestions, suggest, reset } = useAddressAutocomplete({ locations: props.locations });
@@ -64,13 +52,11 @@ const AddressSuggestionInput = (props: Props): ReactElement => {
         }
     };
 
-    const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-        const search = event.target.value;
-
-        suggest({ search, ...adjustedCriteria });
+    const handleOnChange = (value?: string) => {
+        suggest({ search: value ?? '', ...adjustedCriteria });
 
         if (props.onChange) {
-            props.onChange(event);
+            props.onChange(value);
         }
     };
 
@@ -90,17 +76,13 @@ const AddressSuggestionInput = (props: Props): ReactElement => {
 
     return (
         <>
-            <Input
+            <TextInputField
                 id={props.id}
                 label={props.label}
-                htmlFor={props.label}
-                type="text"
                 className={props.className}
-                defaultValue={props.defaultValue}
+                value={props.value}
                 placeholder={props.placeholder}
-                autoComplete="off"
-                sizing="compact"
-                orientation={orientation}
+                orientation={props.orientation}
                 sizing={props.sizing}
                 error={props.error}
                 onChange={handleOnChange}

--- a/apps/modernization-ui/src/apps/patient/add/addressFields/AddressFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/addressFields/AddressFields.tsx
@@ -51,7 +51,7 @@ export default function AddressFields({ id, title, coded }: Props) {
                                     locations={coded}
                                     criteria={{ zip: enteredZip, city: enteredCity, state: selectedState }}
                                     label="Street address 1"
-                                    defaultValue={value}
+                                    value={value}
                                     onChange={onChange}
                                     onSelection={handleSuggestionSelection}
                                     error={error?.message}

--- a/apps/modernization-ui/src/apps/patient/add/basic/address/BasicAddressFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/address/BasicAddressFields.tsx
@@ -1,13 +1,13 @@
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { useLocationCodedValues } from 'location';
 import { AddressSuggestion, AddressSuggestionInput } from 'address/suggestion';
 import { validCensusTractRule, CensusTractInputField } from 'apps/patient/data/address';
 import { Input } from 'components/FormInputs/Input';
 import { EntryFieldsProps } from 'design-system/entry';
 import { SingleSelect } from 'design-system/select';
 import { validZipCodeRule, ZipCodeInputField } from 'libs/demographics/location';
-import { useLocationCodedValues } from 'location';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { maxLengthRule } from 'validation/entry';
-import { BasicNewPatientEntry } from '../entry';
+import { BasicNewPatientEntry } from 'apps/patient/add/basic/entry';
 
 const STREET_ADDRESS_LABEL = 'Street address 1';
 const STREET_ADDRESS_2_LABEL = 'Street address 2';
@@ -57,7 +57,7 @@ export const BasicAddressFields = ({ orientation = 'horizontal' }: AddressEntryF
                             state: selectedState?.value ?? undefined,
                             zip: enteredZip ?? undefined
                         }}
-                        defaultValue={value ?? ''}
+                        value={value}
                         onChange={onChange}
                         onBlur={onBlur}
                         onSelection={handleSuggestionSelection}

--- a/apps/modernization-ui/src/apps/patient/add/basic/phoneEmail/BasicPhoneEmailFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/phoneEmail/BasicPhoneEmailFields.tsx
@@ -120,7 +120,6 @@ export const BasicPhoneEmailFields = ({
                                 value={value}
                                 sizing={sizing}
                                 orientation={orientation}
-                                sizing="compact"
                                 error={error?.message}
                                 warning={violation}
                             />

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -121,7 +121,7 @@ export const AddressEntryFields = ({ orientation = 'horizontal' }: AddressEntryF
                             state: selectedState?.value ?? undefined,
                             zip: enteredZip ?? undefined
                         }}
-                        defaultValue={value ?? ''}
+                        value={value}
                         onChange={onChange}
                         onBlur={onBlur}
                         onSelection={handleSuggestionSelection}

--- a/apps/modernization-ui/src/apps/patient/profile/addresses/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/addresses/AddressEntryFields.tsx
@@ -104,7 +104,7 @@ export const AddressEntryFields = () => {
                             state: selectedState ?? undefined,
                             zip: enteredZip ?? undefined
                         }}
-                        defaultValue={value ?? ''}
+                        value={value ?? undefined}
                         onChange={onChange}
                         onBlur={onBlur}
                         onSelection={handleSuggestionSelection}


### PR DESCRIPTION
## Description

Removes some duplicate properties that were introduced when a PR was merged.  It also changes `AddressSuggestionInput` to use the `TextInputField`.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
