### PR TITLE
change Data has been entered to Data have been entered in repeating block section

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
@@ -240,7 +240,7 @@ describe('AddPatientExtendedForm', () => {
         expect(errors).toHaveLength(5);
         // Name error
         expect(errors[0]).toHaveTextContent(
-            'Data has been entered in the Name section. Please press Add or clear the data and submit again.'
+            'Data have been entered in the Name section. Please press Add or clear the data and submit again.'
         );
         let link = within(errors[0]).getByRole('link');
         expect(link).toHaveTextContent('Name');
@@ -248,7 +248,7 @@ describe('AddPatientExtendedForm', () => {
 
         // Address
         expect(errors[1]).toHaveTextContent(
-            'Data has been entered in the Address section. Please press Add or clear the data and submit again.'
+            'Data have been entered in the Address section. Please press Add or clear the data and submit again.'
         );
         link = within(errors[1]).getByRole('link');
         expect(link).toHaveTextContent('Address');
@@ -256,7 +256,7 @@ describe('AddPatientExtendedForm', () => {
 
         // Phone & Email
         expect(errors[2]).toHaveTextContent(
-            'Data has been entered in the Phone & Email section. Please press Add or clear the data and submit again.'
+            'Data have been entered in the Phone & Email section. Please press Add or clear the data and submit again.'
         );
         link = within(errors[2]).getByRole('link');
         expect(link).toHaveTextContent('Phone & Email');
@@ -264,7 +264,7 @@ describe('AddPatientExtendedForm', () => {
 
         // Identification
         expect(errors[3]).toHaveTextContent(
-            'Data has been entered in the Identification section. Please press Add or clear the data and submit again.'
+            'Data have been entered in the Identification section. Please press Add or clear the data and submit again.'
         );
         link = within(errors[3]).getByRole('link');
         expect(link).toHaveTextContent('Identification');
@@ -272,7 +272,7 @@ describe('AddPatientExtendedForm', () => {
 
         // Race
         expect(errors[4]).toHaveTextContent(
-            'Data has been entered in the Race section. Please press Add or clear the data and submit again.'
+            'Data have been entered in the Race section. Please press Add or clear the data and submit again.'
         );
         link = within(errors[4]).getByRole('link');
         expect(link).toHaveTextContent('Race');

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.tsx
@@ -35,7 +35,7 @@ export const AddPatientExtendedForm = ({ validationErrors, setSubFormState }: Pr
         );
         return (
             <React.Fragment key={section}>
-                Data has been entered in the {linkOrText} section. Please press Add or clear the data and submit again.
+                Data have been entered in the {linkOrText} section. Please press Add or clear the data and submit again.
             </React.Fragment>
         );
     };


### PR DESCRIPTION
## Description


Change _data has been entered in X section_ to _data have been entered in X section_ as per this issue: 

https://cdc-nbs.atlassian.net/browse/CNFT1-3616


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3616)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
