### PR TITLE
[FIX] Strengthen date tests

### DIFF
--- a/apps/modernization-ui/src/design-system/date/validateDate.spec.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDate.spec.ts
@@ -2,14 +2,24 @@ import { internalizeDate } from 'date';
 import { add } from 'date-fns';
 import { validateDate } from './validateDate';
 
+const mockNow = jest.fn();
+
+jest.mock('./clock', () => ({
+    now: () => mockNow()
+}));
+
 describe('when validating a date entered at text', () => {
+    beforeEach(() => {
+        mockNow.mockReturnValue(new Date('2020-01-25T00:00:00'));
+    });
+
     describe('with an invalid format', () => {
         it.each(['', 'not a date', '01152014', '1/1/2021'])(
             "should not allow a value in an incorrect format: '%s' ",
             (value) => {
                 const actual = validateDate('Date with an invalid format')(value);
 
-                expect(actual).toContain(`The Date with an invalid format should be in the format MM/DD/YYYY`);
+                expect(actual).toContain('The Date with an invalid format should be in the format MM/DD/YYYY');
             }
         );
 
@@ -17,7 +27,7 @@ describe('when validating a date entered at text', () => {
             const actual = validateDate('Date with an invalid month')('15/31/2000');
 
             expect(actual).toContain(
-                `The Date with an invalid month should have a month between 1 (January) and 12 (December)`
+                'The Date with an invalid month should have a month between 1 (January) and 12 (December)'
             );
         });
 
@@ -25,7 +35,7 @@ describe('when validating a date entered at text', () => {
             const actual = validateDate('Date with an invalid month')('00/31/2000');
 
             expect(actual).toContain(
-                `The Date with an invalid month should have a month between 1 (January) and 12 (December)`
+                'The Date with an invalid month should have a month between 1 (January) and 12 (December)'
             );
         });
     });
@@ -34,23 +44,19 @@ describe('when validating a date entered at text', () => {
         it('should not allow a day greater than the days in the month', () => {
             const actual = validateDate('Date with too many days')('02/30/2000');
 
-            expect(actual).toContain(`The Date with too many days should have at most 29 days`);
+            expect(actual).toContain('The Date with too many days should have at most 29 days');
         });
 
         it('should not allow dates before the year 1875', () => {
             const actual = validateDate('Date with an invalid year')('12/31/1874');
 
-            expect(actual).toContain(`The Date with an invalid year should occur after 12/31/1874`);
+            expect(actual).toContain('The Date with an invalid year should occur after 12/31/1874');
         });
 
         it('should not allow future dates', () => {
-            const today = new Date();
+            const actual = validateDate('Date field name')('01/27/2020');
 
-            const tomorrow = internalizeDate(add(today, { days: 1 }));
-
-            const actual = validateDate('Date field name')(tomorrow);
-
-            expect(actual).toContain(`The Date field name cannot be after ${internalizeDate(today)}`);
+            expect(actual).toContain('The Date field name cannot be after 01/25/2020');
         });
     });
 });

--- a/apps/modernization-ui/src/design-system/date/validateDateEntry.spec.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDateEntry.spec.ts
@@ -9,7 +9,9 @@ jest.mock('./clock', () => ({
 }));
 
 describe('when validating a date entered in parts', () => {
-    beforeEach(() => mockNow.mockReturnValue(new Date()));
+    beforeEach(() => {
+        mockNow.mockReturnValue(new Date('2020-01-25T00:00:00'));
+    });
 
     describe('with a month', () => {
         it('should allow a valid month', () => {
@@ -22,7 +24,7 @@ describe('when validating a date entered in parts', () => {
             const actual = validateDateEntry('Date with an invalid month')({ month: 13 });
 
             expect(actual).toContain(
-                `The Date with an invalid month should have a month between 1 (January) and 12 (December)`
+                'The Date with an invalid month should have a month between 1 (January) and 12 (December)'
             );
         });
 
@@ -30,29 +32,27 @@ describe('when validating a date entered in parts', () => {
             const actual = validateDateEntry('Date with an invalid month')({ month: 0 });
 
             expect(actual).toContain(
-                `The Date with an invalid month should have a month between 1 (January) and 12 (December)`
+                'The Date with an invalid month should have a month between 1 (January) and 12 (December)'
             );
         });
 
         it('should not allow a day greater than the days in the month', () => {
             const actual = validateDateEntry('Date with too many days')({ year: 2000, month: 2, day: 30 });
 
-            expect(actual).toContain(`The Date with too many days should have at most 29 days`);
+            expect(actual).toContain('The Date with too many days should have at most 29 days');
         });
 
         it('should not allow months after today', () => {
-            const today = new Date('2021-08-19');
+            const today = new Date('2017-05-23T00:00:00');
 
-            mockNow.mockReturnValue(today);
-
-            const tomorrow = add(today, { months: 1 });
+            mockNow.mockReturnValue(new Date('2017-05-23T00:00:00'));
 
             const actual = validateDateEntry('Date in the future')({
-                month: tomorrow.getMonth() + 1,
-                year: tomorrow.getFullYear()
+                month: 6,
+                year: 2017
             });
 
-            expect(actual).toContain(`The Date in the future cannot be after ${internalizeDate(today)}`);
+            expect(actual).toContain('The Date in the future cannot be after 05/23/2017');
         });
     });
 
@@ -66,13 +66,13 @@ describe('when validating a date entered in parts', () => {
         it('should not allow a day less than 1', () => {
             const actual = validateDateEntry('Date with an invalid day')({ day: 0 });
 
-            expect(actual).toContain(`The Date with an invalid day should be at least the first day of the month`);
+            expect(actual).toContain('The Date with an invalid day should be at least the first day of the month');
         });
 
         it('should not allow a day greater than 31', () => {
             const actual = validateDateEntry('Date with an invalid day')({ day: 32 });
 
-            expect(actual).toContain(`The Date with an invalid day should have at most 31 days`);
+            expect(actual).toContain('The Date with an invalid day should have at most 31 days');
         });
     });
 
@@ -86,7 +86,7 @@ describe('when validating a date entered in parts', () => {
         it('should not allow dates before the year 1875', () => {
             const actual = validateDateEntry('Date with an invalid year')({ year: 1874 });
 
-            expect(actual).toContain(`The Date with an invalid year should occur after 12/31/1874`);
+            expect(actual).toContain('The Date with an invalid year should occur after 12/31/1874');
         });
 
         it('should not allow dates after this year', () => {
@@ -105,19 +105,17 @@ describe('when validating a date entered in parts', () => {
 
     describe('with a year, month, and day', () => {
         it('should not allow future dates', () => {
-            const today = new Date();
-
-            const tomorrow = add(today, { days: 1 });
+            mockNow.mockReturnValue(new Date('2021-08-19T00:00:00'));
 
             const next = {
-                year: tomorrow.getFullYear(),
-                month: tomorrow.getMonth() + 1,
-                day: tomorrow.getDate()
+                year: 2021,
+                month: 8,
+                day: 20
             };
 
             const actual = validateDateEntry('Date in the future')(next);
 
-            expect(actual).toContain(`The Date in the future cannot be after ${internalizeDate(today)}`);
+            expect(actual).toContain('The Date in the future cannot be after 08/19/2021');
         });
     });
 });


### PR DESCRIPTION
## Description

Changes the `validateDate` and `validateDateEntry` tests to not rely on the current date.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
