### PR TITLE
 [CNFT1-2964]: aligning resultItems using horizontal class 

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/list/ResultItem.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/list/ResultItem.tsx
@@ -12,7 +12,11 @@ type ResultItemProps = {
 
 const ResultItem = ({ label, orientation = 'horizontal', children }: ResultItemProps) => {
     return (
-        <div className={classNames(styles.item, { [styles.vertical]: orientation === 'vertical' })}>
+        <div
+            className={classNames(styles.item, {
+                [styles.vertical]: orientation === 'vertical',
+                [styles.horizontal]: orientation === 'horizontal'
+            })}>
             <span className={styles.label}>{label}</span>
             <Value>{children}</Value>
         </div>

--- a/apps/modernization-ui/src/apps/search/layout/result/list/result-item.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/result/list/result-item.module.scss
@@ -10,6 +10,10 @@
         gap: 0.12rem;
     }
 
+    &.horizontal {
+        align-items: center;
+    }
+
     .label {
         font-size: 0.8125rem;
         font-weight: 600;


### PR DESCRIPTION
## Description

aligning resultItems using horizontal class to fix the Data in the list view, that are currently not in the same line as the label. 

## Tickets

* [CNFT1-2964](https://cdc-nbs.atlassian.net/browse/CNFT1-2964)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-2964]: https://cdc-nbs.atlassian.net/browse/CNFT1-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ