### PR TITLE
Add a margin right of 4px on the input text box component in the date picker to accommodate 4px focus border

### DIFF
--- a/apps/modernization-ui/src/styles/_uswds.scss
+++ b/apps/modernization-ui/src/styles/_uswds.scss
@@ -182,6 +182,7 @@ input.usa-input--error:focus {
 .usa-date-picker__wrapper {
     .usa-date-picker__external-input {
         flex-grow: 1;
+        margin-right: 4px;
     }
     .usa-date-picker__button {
         margin: 0;


### PR DESCRIPTION
## Description

When you select a date field, a blue border appears around it, but the calendar icon to the right of it overlaps with the blue border. Moved the icon over 4px to the right to account for the focus border that appears.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3621)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
