### PR TITLE
CNFT1-3464 Search API: Add filters for Patient ID

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -85,12 +85,11 @@ class PatientDemographicQueryResolver {
   }
 
   private Optional<QueryVariant> applyPatientIdFilterCriteria(final PatientFilter criteria) {
-    String idFilter = criteria.getIdFilter();
-    if (idFilter == null) {
+    if (criteria.getFilter() == null || criteria.getFilter().getId() == null) {
       return Optional.empty();
-
     }
-    String adjusted = WildCards.contains(idFilter);
+
+    String adjusted = WildCards.contains(criteria.getFilter().getId());
     return Optional.of(BoolQuery.of(
         bool -> bool.must(
             query -> query.queryString(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -177,11 +177,7 @@ public class PatientFilter {
   }
 
   public PatientFilter withIdFilter(final String idFilter) {
-    if (this.filter == null) {
-      this.filter = new Filter(idFilter);
-    } else {
-      this.filter.id = idFilter;
-    }
+    this.filter = new Filter(idFilter);
     return this;
   }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -111,6 +111,7 @@ public class PatientFilter {
   private String investigation;
   private String labReport;
   private String accessionNumber;
+  private String idFilter;
 
   private boolean disableSoundex;
   @JsonIgnore
@@ -155,6 +156,11 @@ public class PatientFilter {
 
   public PatientFilter withId(final String id) {
     this.id = id;
+    return this;
+  }
+
+  public PatientFilter withIdFilter(final String idFilter) {
+    this.idFilter = idFilter;
     return this;
   }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -41,6 +41,16 @@ public class PatientFilter {
     private String identificationType;
   }
 
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @EqualsAndHashCode
+  @JsonInclude(Include.NON_NULL)
+  public static class Filter {
+    private String id;
+  }
+
   public record NameCriteria(TextCriteria first, TextCriteria last) {
 
     Optional<TextCriteria> maybeLast() {
@@ -111,7 +121,7 @@ public class PatientFilter {
   private String investigation;
   private String labReport;
   private String accessionNumber;
-  private String idFilter;
+  private Filter filter;
 
   private boolean disableSoundex;
   @JsonIgnore
@@ -140,6 +150,13 @@ public class PatientFilter {
     return identification;
   }
 
+  public Filter getFilter() {
+    if (this.filter == null) {
+      this.filter = new Filter();
+    }
+    return filter;
+  }
+
   public List<RecordStatus> adjustedStatus() {
     return adjustedStatus == null ? List.copyOf(this.recordStatus) : List.copyOf(this.adjustedStatus);
   }
@@ -160,7 +177,11 @@ public class PatientFilter {
   }
 
   public PatientFilter withIdFilter(final String idFilter) {
-    this.idFilter = idFilter;
+    if (this.filter == null) {
+      this.filter = new Filter(idFilter);
+    } else {
+      this.filter.id = idFilter;
+    }
     return this;
   }
 

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -73,6 +73,7 @@ input PersonFilter {
   accessionNumber: String
   disableSoundex: Boolean
   recordStatus: [RecordStatus!]!
+  idFilter: String
 }
 
 enum Gender {

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -38,6 +38,10 @@ input LocationCriteria {
   city: TextCriteria
 }
 
+input Filter {
+  id: String
+}
+
 input PersonFilter {
   id: String
   name: PatientNameCriteria
@@ -73,7 +77,7 @@ input PersonFilter {
   accessionNumber: String
   disableSoundex: Boolean
   recordStatus: [RecordStatus!]!
-  idFilter: String
+  filter: Filter
 }
 
 enum Gender {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -112,6 +112,13 @@ public class PatientSearchCriteriaSteps {
         found -> this.activeCriteria.active(criteria -> criteria.withId(found.local()).withIdFilter("XXXXX")));
   }
 
+  @Given("I would like to filter search results with the patient's short ID")
+  public void i_would_like_to_filter_search_results_with_the_patients_short_id() {
+    this.patient.maybeActive().ifPresent(
+        found -> this.activeCriteria
+            .active(criteria -> criteria.withId(found.local()).withIdFilter(Long.toString(found.shortId()))));
+  }
+
   @Given("I would like to search for a patient using multiple local IDs")
   public void i_would_like_to_search_for_a_patient_using_multiple_local_IDs() {
     this.patient.maybeActive().ifPresent(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -91,6 +91,27 @@ public class PatientSearchCriteriaSteps {
         found -> this.activeCriteria.active(criteria -> criteria.withId(found.local())));
   }
 
+  @Given("I would like to search for a patient using a local ID and a good equals id filter")
+  public void i_would_like_to_search_for_a_patient_using_a_local_ID_and_good_id_filter_that_equals_the_id() {
+    this.patient.maybeActive().ifPresent(
+        found -> this.activeCriteria
+            .active(criteria -> criteria.withId(found.local()).withIdFilter(Long.toString(found.shortId()))));
+  }
+
+  @Given("I would like to search for a patient using a local ID and a good contains id filter")
+  public void i_would_like_to_search_for_a_patient_using_a_local_ID_and_good_id_filter_that_contains_the_id() {
+    this.patient.maybeActive().ifPresent(
+        found -> this.activeCriteria
+            .active(
+                criteria -> criteria.withId(found.local()).withIdFilter(Long.toString(found.shortId()).substring(1))));
+  }
+
+  @Given("I would like to search for a patient using a local ID and a bad id filter")
+  public void i_would_like_to_search_for_a_patient_using_a_local_ID_and_id_filter_that_does_not_exist() {
+    this.patient.maybeActive().ifPresent(
+        found -> this.activeCriteria.active(criteria -> criteria.withId(found.local()).withIdFilter("XXXXX")));
+  }
+
   @Given("I would like to search for a patient using multiple local IDs")
   public void i_would_like_to_search_for_a_patient_using_multiple_local_IDs() {
     this.patient.maybeActive().ifPresent(

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -28,6 +28,26 @@ Feature: Patient Search
     Then the patient is in the search results
     And there is only one patient search result
 
+  Scenario: I can find a patient by Patient ID using the local id and an id filter that equals the id
+    Given patients are available for search
+    And I would like to search for a patient using a local ID and a good equals id filter
+    When I search for patients
+    Then the patient is in the search results
+    And there is only one patient search result
+
+  Scenario: I can find a patient by Patient ID using the local id and an id filter the contains the id
+    Given patients are available for search
+    And I would like to search for a patient using a local ID and a good contains id filter
+    When I search for patients
+    Then the patient is in the search results
+    And there is only one patient search result
+
+  Scenario: I can't find a patient by Patient ID using a good local id and a bad id filter
+    Given patients are available for search
+    And I would like to search for a patient using a local ID and a bad id filter
+    When I search for patients
+    Then there are 0 patient search results
+
   Scenario: I can find a patient by Patient ID using multiple local ids
     Given patients are available for search
     And I would like to search for a patient using multiple local IDs

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -48,6 +48,19 @@ Feature: Patient Search
     When I search for patients
     Then there are 0 patient search results
 
+  Scenario: I can filter search results with the patient's short ID
+    Given I have a patient
+    And the patient has the legal name "Joe" "Other"
+    And I have another patient
+    And the patient has the legal name "Joe" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a first name that equals "Joe"
+    And I would like to filter search results with the patient's short ID
+    When I search for patients
+    Then search result 1 has a "first name" of "Joe"
+    And search result 1 has a "last name" of "Smith"
+    And there are 1 patient search results
+
   Scenario: I can find a patient by Patient ID using multiple local ids
     Given patients are available for search
     And I would like to search for a patient using multiple local IDs

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -1679,6 +1679,7 @@ export type PersonFilter = {
   firstName?: InputMaybe<Scalars['String']['input']>;
   gender?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
+  idFilter?: InputMaybe<Scalars['String']['input']>;
   identification?: InputMaybe<IdentificationCriteria>;
   investigation?: InputMaybe<Scalars['String']['input']>;
   labReport?: InputMaybe<Scalars['String']['input']>;

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -203,6 +203,10 @@ export type FacilityProviders = {
   sendingFacility?: Maybe<SendingFacility>;
 };
 
+export type Filter = {
+  id?: InputMaybe<Scalars['String']['input']>;
+};
+
 export enum Gender {
   F = 'F',
   M = 'M',
@@ -1676,10 +1680,10 @@ export type PersonFilter = {
   document?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   ethnicity?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<Filter>;
   firstName?: InputMaybe<Scalars['String']['input']>;
   gender?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
-  idFilter?: InputMaybe<Scalars['String']['input']>;
   identification?: InputMaybe<IdentificationCriteria>;
   investigation?: InputMaybe<Scalars['String']['input']>;
   labReport?: InputMaybe<Scalars['String']['input']>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1167,6 +1167,7 @@ input PersonFilter {
   accessionNumber: String
   disableSoundex: Boolean
   recordStatus: [RecordStatus!]!
+  idFilter: String
 }
 
 enum Gender {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1132,6 +1132,10 @@ input LocationCriteria {
   city: TextCriteria
 }
 
+input Filter {
+  id: String
+}
+
 input PersonFilter {
   id: String
   name: PatientNameCriteria
@@ -1167,7 +1171,7 @@ input PersonFilter {
   accessionNumber: String
   disableSoundex: Boolean
   recordStatus: [RecordStatus!]!
-  idFilter: String
+  filter: Filter
 }
 
 enum Gender {


### PR DESCRIPTION
## Description

Make the new `idFilter` field a should (wildcard) query on `local_id`.  The existing id searches are exact match term queries on `local_id`

## Tickets

* [CNFT1-3464](https://cdc-nbs.atlassian.net/browse/CNFT1-3464)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3464]: https://cdc-nbs.atlassian.net/browse/CNFT1-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ