### PR TITLE
[CNFT1-3647] New patient: restored the array based email field

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/asPersonInput.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/asPersonInput.spec.tsx
@@ -103,4 +103,36 @@ describe('when asPersonInput is given a new patient with phone numbers', () => {
             })
         );
     });
+
+    it('should include the email address when entered', () => {
+        const data = {
+            asOf: '12/17/2021',
+            identification: [],
+            phoneNumbers: [],
+            emailAddresses: [{ email: 'email-value' }]
+        };
+
+        const result = asPersonInput(data);
+        expect(result).toEqual(
+            expect.objectContaining({
+                emailAddresses: expect.arrayContaining(['email-value'])
+            })
+        );
+    });
+
+    it('should not include the email address when not entered', () => {
+        const data = {
+            asOf: '12/17/2021',
+            identification: [],
+            phoneNumbers: [],
+            emailAddresses: [{ email: '' }]
+        };
+
+        const result = asPersonInput(data);
+        expect(result).toEqual(
+            expect.objectContaining({
+                emailAddresses: []
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/contactFields/ContactFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/contactFields/ContactFields.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { Grid } from '@trussworks/react-uswds';
 import FormCard from 'components/FormCard/FormCard';
 import { Input } from 'components/FormInputs/Input';
@@ -18,21 +17,12 @@ type Props = {
 };
 
 export default function ContactFields({ id, title }: Props) {
-    const { control, setValue } = useFormContext();
+    const { control } = useFormContext();
 
-    const phoneFields = useWatch({ control: control, name: 'phoneNumbers' });
-
-    useEffect(() => {
-        if (phoneFields) {
-            phoneFields.forEach((number: any, i: number) => {
-                if (number.use === 'MC') {
-                    setValue(`phoneNumbers.${i}.type`, 'CP');
-                } else {
-                    setValue(`phoneNumbers.${i}.type`, 'PH');
-                }
-            });
-        }
-    }, [JSON.stringify(phoneFields)]);
+    const { fields: emailFields } = useFieldArray({
+        control,
+        name: 'emailAddresses'
+    });
 
     return (
         <FormCard id={id} title={title}>
@@ -117,32 +107,35 @@ export default function ContactFields({ id, title }: Props) {
                     </Grid>
                 </Grid>
                 <Grid col={6}>
-                    <Controller
-                        control={control}
-                        name={`emailAddress`}
-                        rules={maxLengthRule(100, EMAIL_LABEL)}
-                        render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
-                            <Verification
-                                control={control}
-                                name={name}
-                                constraint={maybeValidateEmail(EMAIL_LABEL)}
-                                render={({ verify, violation }) => (
-                                    <EmailField
-                                        id={name}
-                                        label={EMAIL_LABEL}
-                                        onBlur={() => {
-                                            verify();
-                                            onBlur();
-                                        }}
-                                        onChange={onChange}
-                                        value={value}
-                                        error={error?.message}
-                                        warning={violation}
-                                    />
-                                )}
-                            />
-                        )}
-                    />
+                    {emailFields.map((item: { id: string }, index: number) => (
+                        <Controller
+                            key={item.id}
+                            control={control}
+                            name={`emailAddresses[${index}].email`}
+                            rules={maxLengthRule(100, EMAIL_LABEL)}
+                            render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                                <Verification
+                                    control={control}
+                                    name={name}
+                                    constraint={maybeValidateEmail(EMAIL_LABEL)}
+                                    render={({ verify, violation }) => (
+                                        <EmailField
+                                            id={name}
+                                            label={EMAIL_LABEL}
+                                            onBlur={() => {
+                                                verify();
+                                                onBlur();
+                                            }}
+                                            onChange={onChange}
+                                            value={value}
+                                            error={error?.message}
+                                            warning={violation}
+                                        />
+                                    )}
+                                />
+                            )}
+                        />
+                    ))}
                 </Grid>
             </Grid>
         </FormCard>


### PR DESCRIPTION
## Description

Addresses an issue found during UAT where the email address from the "New patient" page was not being saved to the patient when the patient was added.  This applies the "New patient" that is at the path `/add-patient`.

## Tickets

* [CNFT1-3647](https://cdc-nbs.atlassian.net/browse/CNFT1-3647)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
