### PR TITLE
[CNFT1-3647] New patient: restored the array based email field

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/asPersonInput.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/asPersonInput.spec.tsx
@@ -103,4 +103,36 @@ describe('when asPersonInput is given a new patient with phone numbers', () => {
             })
         );
     });
+
+    it('should include the email address when entered', () => {
+        const data = {
+            asOf: '12/17/2021',
+            identification: [],
+            phoneNumbers: [],
+            emailAddresses: [{ email: 'email-value' }]
+        };
+
+        const result = asPersonInput(data);
+        expect(result).toEqual(
+            expect.objectContaining({
+                emailAddresses: expect.arrayContaining(['email-value'])
+            })
+        );
+    });
+
+    it('should not include the email address when not entered', () => {
+        const data = {
+            asOf: '12/17/2021',
+            identification: [],
+            phoneNumbers: [],
+            emailAddresses: [{ email: '' }]
+        };
+
+        const result = asPersonInput(data);
+        expect(result).toEqual(
+            expect.objectContaining({
+                emailAddresses: []
+            })
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/add/contactFields/ContactFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/contactFields/ContactFields.tsx
@@ -1,11 +1,10 @@
 import { Grid } from '@trussworks/react-uswds';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import FormCard from 'components/FormCard/FormCard';
 import { validatePhoneNumber } from 'validation/phone';
 import { Input } from 'components/FormInputs/Input';
 import { PhoneNumberInput } from 'components/FormInputs/PhoneNumberInput/PhoneNumberInput';
 import { maxLengthRule, validEmailRule } from 'validation/entry';
-import { useEffect } from 'react';
 
 type Props = {
     id: string;
@@ -13,21 +12,12 @@ type Props = {
 };
 
 export default function ContactFields({ id, title }: Props) {
-    const { control, setValue } = useFormContext();
+    const { control } = useFormContext();
 
-    const phoneFields = useWatch({ control: control, name: 'phoneNumbers' });
-
-    useEffect(() => {
-        if (phoneFields) {
-            phoneFields.forEach((number: any, i: number) => {
-                if (number.use === 'MC') {
-                    setValue(`phoneNumbers.${i}.type`, 'CP');
-                } else {
-                    setValue(`phoneNumbers.${i}.type`, 'PH');
-                }
-            });
-        }
-    }, [JSON.stringify(phoneFields)]);
+    const { fields: emailFields } = useFieldArray({
+        control,
+        name: 'emailAddresses'
+    });
 
     return (
         <FormCard id={id} title={title}>
@@ -133,25 +123,26 @@ export default function ContactFields({ id, title }: Props) {
                     </Grid>
                 </Grid>
                 <Grid col={6}>
-                    <Controller
-                        control={control}
-                        name={`emailAddress`}
-                        rules={{
-                            ...validEmailRule(100)
-                        }}
-                        render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
-                            <Input
-                                onChange={onChange}
-                                onBlur={onBlur}
-                                type="text"
-                                label="Email"
-                                defaultValue={value}
-                                htmlFor={name}
-                                id={name}
-                                error={error?.message}
-                            />
-                        )}
-                    />
+                    {emailFields.map((item: { id: string }, index: number) => (
+                        <Controller
+                            key={item.id}
+                            control={control}
+                            name={`emailAddresses[${index}].email`}
+                            rules={validEmailRule(100)}
+                            render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
+                                <Input
+                                    onChange={onChange}
+                                    onBlur={onBlur}
+                                    type="text"
+                                    label="Email"
+                                    defaultValue={value}
+                                    htmlFor={name}
+                                    id={name}
+                                    error={error?.message}
+                                />
+                            )}
+                        />
+                    ))}
                 </Grid>
             </Grid>
         </FormCard>


### PR DESCRIPTION
This is a `release-7.8.0` compatible change for  [CNFT1-3647](https://cdc-nbs.atlassian.net/browse/CNFT1-3647) based on https://github.com/CDCgov/NEDSS-Modernization/pull/2149
---
## Description

Addresses an issue found during UAT where the email address from the "New patient" page was not being saved to the patient when the patient was added.  This applies the "New patient" that is at the path `/add-patient`.

When the "Email" field was put back it did not populate the `emailAddresses` array anymore resulting in the places that expected values there no longer receiving values.  

The better change would be to remove the `emailAddresses` array completely however, this page will be replaced soon by the "New patient" page at the path `/patient/add` which does not have this issue.  

## Tickets

* [CNFT1-3647](https://cdc-nbs.atlassian.net/browse/CNFT1-3647)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3647]: https://cdc-nbs.atlassian.net/browse/CNFT1-3647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ