### PR TITLE
[CNFT1-3656] Fixes direct patient routing rules

### DIFF
--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     implementation libs.bundles.security
     implementation libs.bundles.oidc
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway:4.1.6'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway:4.2.0'
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
 

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/PatientProfileRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/patient/profile/PatientProfileRouteLocatorConfiguration.java
@@ -30,6 +30,9 @@ import java.util.List;
 @ConditionalOnProperty(prefix = "nbs.gateway.patient.profile", name = "enabled", havingValue = "true")
 class PatientProfileRouteLocatorConfiguration {
 
+  private static final String CONTEXT_ACTION_PARAMETER = "ContextAction";
+  private static final String VALID_ACTIONS = "ViewFile|FileSummary";
+
   @Bean
   RouteLocator patientProfileLocator(
       final RouteLocatorBuilder builder,
@@ -38,12 +41,25 @@ class PatientProfileRouteLocatorConfiguration {
   ) {
     return builder.routes()
         .route(
-            "patient-profile-direct",
+            "patient-profile-direct-uid",
             route -> route
                 .order(RouteOrdering.PATIENT_PROFILE.order())
-                .query("ContextAction", "ViewFile|FileSummary")
+                .query(CONTEXT_ACTION_PARAMETER, VALID_ACTIONS)
                 .and()
-                .query("uid").or().query("MPRUid")
+                .query("uid")
+                .filters(
+                    filter -> filter.setPath(service.direct())
+                        .filters(defaults)
+                )
+                .uri(service.uri())
+        )
+        .route(
+            "patient-profile-direct-uid",
+            route -> route
+                .order(RouteOrdering.PATIENT_PROFILE.order())
+                .query(CONTEXT_ACTION_PARAMETER, VALID_ACTIONS)
+                .and()
+                .query("MPRUid")
                 .filters(
                     filter -> filter.setPath(service.direct())
                         .filters(defaults)
@@ -54,7 +70,7 @@ class PatientProfileRouteLocatorConfiguration {
             "patient-profile-resolving",
             route -> route
                 .order(RouteOrdering.PATIENT_PROFILE.order())
-                .query("ContextAction", "ViewFile|FileSummary")
+                .query(CONTEXT_ACTION_PARAMETER, VALID_ACTIONS)
                 .filters(
                     filter -> filter.setPath(service.summary())
                         .filters(defaults)

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/PatientProfileRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/patient/profile/PatientProfileRouteLocatorConfigurationTest.java
@@ -1,11 +1,16 @@
 package gov.cdc.nbs.gateway.patient.profile;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.stream.Stream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -25,53 +30,42 @@ class PatientProfileRouteLocatorConfigurationTest {
       .options(wireMockConfig().port(10001))
       .build();
 
+  @RegisterExtension
+  static WireMockExtension nbs6 = WireMockExtension.newInstance()
+      .options(wireMockConfig().port(10000))
+      .build();
+
   @Autowired
   WebTestClient webClient;
 
-  @Test
-  void should_route_to_service_when_ContextAction_is_ViewFile() {
+  @ParameterizedTest
+  @ValueSource(strings = {"ViewFile", "FileSummary"})
+  void should_route_to(final String action) {
     service.stubFor(get(urlPathMatching("/nbs/redirect/patientProfile/summary/return\\\\?.*")).willReturn(ok()));
 
     webClient
         .get().uri(
             builder -> builder
-                .path("/nbs/any")
-                .queryParam("ContextAction", "ViewFile")
+                .path("/nbs/any/path")
+                .queryParam("ContextAction", action)
                 .build()
         )
         .exchange()
         .expectStatus()
         .isOk();
-
   }
 
-  @Test
-  void should_route_to_service_when_ContextAction_is_FileSummary() {
-    service.stubFor(get(urlPathMatching("/nbs/redirect/patientProfile/summary/return\\\\?.*")).willReturn(ok()));
-
-    webClient
-        .get().uri(
-            builder -> builder
-                .path("/nbs/any")
-                .queryParam("ContextAction", "FileSummary")
-                .build()
-        )
-        .exchange()
-        .expectStatus()
-        .isOk();
-
-  }
-
-  @Test
-  void should_route_to_patient_profile_from_from_patient_name_in_an_event_search_result() {
+  @ParameterizedTest
+  @MethodSource("directParameters")
+  void should_route_directly_to_the_patient_profile(final String action, final String type) {
     service.stubFor(get(urlPathMatching("/nbs/redirect/patient/profile")).willReturn(ok()));
 
     webClient
         .get().uri(
             builder -> builder
-                .path("/nbs/PatientSearchResults1.do")
-                .queryParam("ContextAction", "ViewFile")
-                .queryParam("uid", "1051")
+                .path("/nbs/any/path")
+                .queryParam("ContextAction", action)
+                .queryParam(type, "1051")
                 .build()
         )
         .exchange()
@@ -79,16 +73,26 @@ class PatientProfileRouteLocatorConfigurationTest {
         .isOk();
   }
 
-  @Test
-  void should_route_to_patient_profile_service_from_patient_name_in_documents_requiring_review_queue() {
-    service.stubFor(get(urlPathMatching("/nbs/redirect/patient/profile")).willReturn(ok()));
+  static Stream<Arguments> directParameters() {
+    return Stream.of(
+        Arguments.arguments("ViewFile", "uid"),
+        Arguments.arguments("ViewFile", "MPRUid"),
+        Arguments.arguments("FileSummary", "uid"),
+        Arguments.arguments("FileSummary", "MPRUid")
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"uid", "MPRUid"})
+  void should_only_route_to_the_patient_profile_with_the_known_context_action(final String type) {
+    nbs6.stubFor(get(urlPathMatching("/nbs/any/path")).willReturn(ok()));
 
     webClient
         .get().uri(
             builder -> builder
-                .path("/nbs/NewLabReview1.do")
-                .queryParam("ContextAction", "ViewFile")
-                .queryParam("uid", "1051")
+                .path("/nbs/any/path")
+                .queryParam("ContextAction", "Other")
+                .queryParam(type, "1051")
                 .build()
         )
         .exchange()


### PR DESCRIPTION
## Description

The route locator for direct requests for a patient profile was including any URL that contained the parameter `MPRUid`.  This was causing event links from the "Documents Requiring Security Assignment" queue to route to the modernized patient profile over the event.

The rule was changed to correctly require a "ContextAction" of `ViewFile` or `FileSummary` along with a parameter of `uid` or `MPRUid`.

## Tickets

* [CNFT1-3656](https://cdc-nbs.atlassian.net/browse/CNFT1-3656)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3656]: https://cdc-nbs.atlassian.net/browse/CNFT1-3656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ