### PR TITLE
CNFT1-3651: Fix MaskedTextInput to apply mask on change events

### DIFF
--- a/apps/modernization-ui/src/design-system/input/text/MaskedTextInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/MaskedTextInput.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent as ReactKeyboardEvent, useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { TextInput, TextInputProps } from './TextInput';
 import { masked } from './masked';
 
@@ -6,15 +6,22 @@ type MaskedTextInputProps = {
     mask: string;
 } & Omit<TextInputProps, 'maxLength'>;
 
-const MaskedTextInput = ({ mask, ...props }: MaskedTextInputProps) => {
+const MaskedTextInput = ({ mask, onChange, ...props }: MaskedTextInputProps) => {
     const applyMask = useCallback(masked(mask), [mask]);
+    const inputRef = useRef<HTMLInputElement>(null);
 
-    const handleKeyup = (event: ReactKeyboardEvent) => {
-        const input = event.target as HTMLInputElement;
-        input.value = applyMask(input.value);
+    const handleChange = (value?: string) => {
+        let next = value;
+        if (value) {
+            next = applyMask(value);
+            if (inputRef.current && next !== value) {
+                inputRef.current.value = next;
+            }
+        }
+        onChange?.(next);
     };
 
-    return <TextInput onKeyUp={handleKeyup} {...props} maxLength={mask.length} />;
+    return <TextInput onChange={handleChange} inputRef={inputRef} {...props} maxLength={mask.length} />;
 };
 
 export { MaskedTextInput };

--- a/apps/modernization-ui/src/design-system/input/text/TextInput.spec.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInput.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TextInput, TextInputProps } from './TextInput';
+import { RefObject } from 'react';
 
 const Fixture = ({ id = 'testing-text', ...remaining }: Partial<TextInputProps>) => (
     <div>
@@ -51,5 +52,19 @@ describe('when entering text values', () => {
         const input = getByRole('textbox', { name: 'Text input test' });
 
         expect(input).toHaveValue('given value');
+    });
+
+    it('should use ref value when changed', () => {
+        const mockInputRef: RefObject<HTMLInputElement> = {
+            current: document.createElement('input', { is: 'mockInputRef' })
+        };
+        const { getByRole } = render(<Fixture value={'given value'} inputRef={mockInputRef} />);
+
+        const input = getByRole('textbox', { name: 'Text input test' });
+
+        expect(input).toHaveValue('given value');
+
+        mockInputRef.current!.value = 'ref value';
+        expect(input).toHaveValue('ref value');
     });
 });

--- a/apps/modernization-ui/src/design-system/input/text/TextInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent as ReactChangeEvent, useEffect, useState } from 'react';
+import { RefObject, ChangeEvent as ReactChangeEvent, useState, useEffect } from 'react';
 import classNames from 'classnames';
 
 type TextOnChange = (value?: string) => void;
@@ -8,6 +8,7 @@ type TextInputProps = {
     type?: 'text' | 'email' | 'number' | 'password' | 'search' | 'tel' | 'url';
     inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'search';
     value?: string;
+    inputRef?: RefObject<HTMLInputElement>;
     onChange?: TextOnChange;
     onBlur?: () => void;
 } & Omit<
@@ -24,8 +25,10 @@ const TextInput = ({
     onChange,
     onBlur,
     className,
+    inputRef,
     ...props
 }: TextInputProps) => {
+    // if a ref is passed, we will ignore state
     const [current, setCurrent] = useState<string>(value ?? '');
 
     useEffect(() => {
@@ -54,7 +57,8 @@ const TextInput = ({
             onChange={handleChange}
             onBlur={onBlur}
             placeholder={placeholder}
-            value={current}
+            value={inputRef ? value || '' : current}
+            ref={inputRef}
             {...props}
         />
     );


### PR DESCRIPTION
## Description

Replace keyup with change as keyup doesn't capture paste events consistently. It also causes a delay so non-masked chars briefly appear.

This is primarily to fix the mask on phone and country code fields.

![image](https://github.com/user-attachments/assets/70f6a011-cb52-4631-85a8-e955145088c2)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3651)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
