### PR TITLE
[CNFT1-3666] Patient add feedback

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/AddPatient.tsx
@@ -276,7 +276,8 @@ const AddPatient = () => {
                                     <Button
                                         className="add-patient-button"
                                         type={'button'}
-                                        onClick={handleSubmit(evaluateMissingFields)}>
+                                        onClick={handleSubmit(evaluateMissingFields)}
+                                        disabled={entryState.step === 'create'}>
                                         Save changes
                                     </Button>
                                 </div>

--- a/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
@@ -1,19 +1,19 @@
+import { useLocation } from 'react-router-dom';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Button } from 'components/button';
 import { AddPatientLayout, DataEntryLayout } from 'apps/patient/add/layout';
-import styles from './add-patient-basic.module.scss';
 import { sections } from './sections';
 import { AddPatientBasicForm } from './AddPatientBasicForm';
-import { FormProvider, useForm } from 'react-hook-form';
 import { BasicNewPatientEntry } from './entry';
 import { useAddBasicPatient } from './useAddBasicPatient';
 import { Shown } from 'conditional-render';
 import { PatientCreatedPanel } from '../PatientCreatedPanel';
-import { useMemo } from 'react';
 import { useAddPatientBasicDefaults } from './useAddPatientBasicDefaults';
-import { useLocation } from 'react-router-dom';
 import { useSearchFromAddPatient } from 'apps/search/patient/add/useSearchFromAddPatient';
 import { useConfiguration } from 'configuration';
-import { useBasicExtendedTransition } from '../useBasicExtendedTransition';
+import { useBasicExtendedTransition } from 'apps/patient/add/useBasicExtendedTransition';
+
+import styles from './add-patient-basic.module.scss';
 
 export const AddPatientBasic = () => {
     const { initialize } = useAddPatientBasicDefaults();
@@ -27,11 +27,6 @@ export const AddPatientBasic = () => {
 
     const { toExtendedNew } = useBasicExtendedTransition();
 
-    const created = useMemo(
-        () => (interaction.status === 'created' ? interaction.created : undefined),
-        [interaction.status]
-    );
-
     const handleSave = form.handleSubmit(interaction.create);
 
     const { toSearch } = useSearchFromAddPatient();
@@ -41,10 +36,12 @@ export const AddPatientBasic = () => {
     };
     const handleExtended = form.handleSubmit(toExtendedNew);
 
+    const working = !form.formState.isValid || interaction.status !== 'waiting';
+
     return (
         <DataEntryLayout>
             <Shown when={interaction.status === 'created'}>
-                {created && <PatientCreatedPanel created={created} />}
+                {interaction.status === 'created' && <PatientCreatedPanel created={interaction.created} />}
             </Shown>
             <FormProvider {...form}>
                 <AddPatientLayout
@@ -58,14 +55,14 @@ export const AddPatientBasic = () => {
                                     onClick={handleExtended}
                                     outline
                                     className="add-patient-button"
-                                    disabled={!form.formState.isValid}>
+                                    disabled={working}>
                                     Add extended data
                                 </Button>
                             )}
                             <Button onClick={handleCancel} outline>
                                 Cancel
                             </Button>
-                            <Button type="submit" onClick={handleSave} disabled={!form.formState.isValid}>
+                            <Button type="submit" onClick={handleSave} disabled={working}>
                                 Save
                             </Button>
                         </div>

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
@@ -1,23 +1,23 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
-import { CreatedPatient } from '../api';
-import { ExtendedNewPatientEntry } from './entry';
-import { AddExtendedPatientInteractionProvider } from './useAddExtendedPatientInteraction';
-import { useAddExtendedPatient } from './useAddExtendedPatient';
-import { useShowCancelModal } from './useShowCancelModal';
-import { useNavigationBlock } from 'navigation/useNavigationBlock';
-import { useAddPatientExtendedDefaults } from './useAddPatientExtendedDefaults';
 import { Button } from 'components/button';
 import { Shown } from 'conditional-render';
+import { useNavigationBlock } from 'navigation/useNavigationBlock';
+import { CreatedPatient } from 'apps/patient/add/api';
+import { DataEntryMenu } from 'apps/patient/add/DataEntryMenu';
 import { PatientCreatedPanel } from 'apps/patient/add/PatientCreatedPanel';
+import { useBasicExtendedTransition } from 'apps/patient/add/useBasicExtendedTransition';
+import { AddPatientExtendedInPageNav } from './nav/AddPatientExtendedNav';
+import { ExtendedNewPatientEntry } from './entry';
 import { AddPatientExtendedForm } from './AddPatientExtendedForm';
 import { CancelAddPatientExtendedPanel } from './CancelAddPatientExtendedPanel';
-import { AddPatientExtendedInPageNav } from './nav/AddPatientExtendedNav';
+import { useAddPatientExtendedDefaults } from './useAddPatientExtendedDefaults';
+import { useAddExtendedPatient } from './useAddExtendedPatient';
+import { AddExtendedPatientInteractionProvider } from './useAddExtendedPatientInteraction';
+import { useShowCancelModal } from './useShowCancelModal';
 
 import styles from './add-patient-extended.module.scss';
-import { useBasicExtendedTransition } from 'apps/patient/add/useBasicExtendedTransition';
-import { DataEntryMenu } from 'apps/patient/add/DataEntryMenu';
 
 export const AddPatientExtended = () => {
     const interaction = useAddExtendedPatient();
@@ -36,6 +36,8 @@ export const AddPatientExtended = () => {
         mode: 'onBlur',
         reValidateMode: 'onBlur'
     });
+
+    const working = !form.formState.isValid || interaction.status !== 'waiting';
 
     const handleSave = form.handleSubmit(interaction.create);
 
@@ -84,7 +86,7 @@ export const AddPatientExtended = () => {
                                 <Button onClick={handleCancel} outline>
                                     Cancel
                                 </Button>
-                                <Button onClick={handleSave} disabled={!form.formState.isValid}>
+                                <Button onClick={handleSave} disabled={working}>
                                     Save
                                 </Button>
                             </div>


### PR DESCRIPTION
## Description

When the API call to add a patient takes a while there is no indication to the user that the patient is being created.  The "Save" button remains enabled allowing a user to create multiple patients with the same demographics.  

The "Save" button was changed to be disabled while the API is being called on the "New patient" and "New patient - extended" pages to prevent multi-submission.

![CNFT1-3666](https://github.com/user-attachments/assets/d0637991-0b50-47a7-9095-eae07bb21f5e)


## Tickets

* [CNFT1-3666](https://cdc-nbs.atlassian.net/browse/CNFT1-3666)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3666]: https://cdc-nbs.atlassian.net/browse/CNFT1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-3666]: https://cdc-nbs.atlassian.net/browse/CNFT1-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ