### PR TITLE
CNFT1-3465 Search API: Add filters for Patient Name

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -43,12 +43,12 @@ class PatientDemographicQueryResolver {
   private static final String NAME_USE_CD = "name.nm_use_cd.keyword";
   private static final String LAST_NAME = "name.lastNm";
   private static final String LOCAL_ID = "local_id";
+  private static final String FIRST_NAME = "name.firstNm";
   private final PatientSearchSettings settings;
   private final PatientLocalIdentifierResolver resolver;
   private final PatientNameDemographicQueryResolver nameQueryResolver;
   private final PatientLocationQueryResolver locationQueryResolver;
   private final Soundex soundex;
-  private static final String FIRST_NAME = "name.firstNm";
 
 
   PatientDemographicQueryResolver(
@@ -89,7 +89,7 @@ class PatientDemographicQueryResolver {
   }
 
   private Optional<QueryVariant> applyPatientIdFilterCriteria(final PatientFilter criteria) {
-    if (criteria.getFilter() == null || criteria.getFilter().id() == null) {
+    if (criteria.getFilter().id() == null) {
       return Optional.empty();
     }
 
@@ -103,7 +103,7 @@ class PatientDemographicQueryResolver {
   }
 
   private Optional<QueryVariant> applyPatientNameFilterCriteria(final PatientFilter criteria) {
-    if (criteria.getFilter() == null || criteria.getFilter().name() == null) {
+    if (criteria.getFilter().name() == null) {
       return Optional.empty();
     }
     return Optional.ofNullable(new TextCriteria(null, null, null, criteria.getFilter().name(), null))
@@ -183,7 +183,7 @@ class PatientDemographicQueryResolver {
                                       .must(
                                           primary -> primary.match(
                                               match -> match
-                                                  .field("name.firstNm")
+                                                  .field(FIRST_NAME)
                                                   .query(name)
                                                   .boost(settings.first().primary())
 
@@ -195,7 +195,7 @@ class PatientDemographicQueryResolver {
                               .query(
                                   nonPrimary -> nonPrimary.simpleQueryString(
                                       queryString -> queryString
-                                          .fields("name.firstNm")
+                                          .fields(FIRST_NAME)
                                           .query(WildCards.startsWith(name))
                                           .boost(settings.first().nonPrimary())))))
                   .should(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -41,15 +41,25 @@ public class PatientFilter {
     private String identificationType;
   }
 
-  @Getter
-  @Setter
-  @AllArgsConstructor
-  @NoArgsConstructor
-  @EqualsAndHashCode
-  @JsonInclude(Include.NON_NULL)
-  public static class Filter {
-    private String id;
+  public record Filter(String id, String name) {
+
+    Optional<String> maybeId() {
+      return Optional.ofNullable(id());
+    }
+
+    Filter withId(final String id) {
+      return new Filter(id, name());
+    }
+
+    Optional<String> maybeName() {
+      return Optional.ofNullable(name());
+    }
+
+    Filter withName(final String name) {
+      return new Filter(id(), name);
+    }
   }
+
 
   public record NameCriteria(TextCriteria first, TextCriteria last) {
 
@@ -152,7 +162,7 @@ public class PatientFilter {
 
   public Filter getFilter() {
     if (this.filter == null) {
-      this.filter = new Filter();
+      this.filter = new Filter(null, null);
     }
     return filter;
   }
@@ -177,8 +187,22 @@ public class PatientFilter {
   }
 
   public PatientFilter withIdFilter(final String idFilter) {
-    this.filter = new Filter(idFilter);
+    if (this.filter == null) {
+      this.filter = new Filter(idFilter, null);
+    } else {
+      this.filter = this.filter.withId(idFilter);
+    }
     return this;
+  }
+
+  public PatientFilter withNameFilter(final String nameFilter) {
+    if (this.filter == null) {
+      this.filter = new Filter(null, nameFilter);
+    } else {
+      this.filter = this.filter.withName(nameFilter);
+    }
+    return this;
+
   }
 
   public PatientFilter withMorbidity(final String identifier) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -42,17 +42,8 @@ public class PatientFilter {
   }
 
   public record Filter(String id, String name) {
-
-    Optional<String> maybeId() {
-      return Optional.ofNullable(id());
-    }
-
     Filter withId(final String id) {
       return new Filter(id, name());
-    }
-
-    Optional<String> maybeName() {
-      return Optional.ofNullable(name());
     }
 
     Filter withName(final String name) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteria.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteria.java
@@ -12,8 +12,7 @@ public record TextCriteria(
     String not,
     String startsWith,
     String contains,
-    String soundsLike
-) {
+    String soundsLike) {
 
   public static TextCriteria equals(final String value) {
     return new TextCriteria(value, null, null, null, null);
@@ -55,7 +54,7 @@ public record TextCriteria(
     return maybeText(soundsLike);
   }
 
-  private static Optional<String> maybeText(String value) {
+  public static Optional<String> maybeText(String value) {
     return Optional.ofNullable(value)
         .filter(Predicate.not(String::isEmpty))
         .map(AdjustStrings::withoutHyphens);

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/search/criteria/text/TextCriteriaNestedQueryResolver.java
@@ -46,6 +46,28 @@ public class TextCriteriaNestedQueryResolver {
                                 .defaultOperator(Operator.And))))));
   }
 
+  public static BoolQuery containsInOneOfTwoFields(final String path, final String name1, final String name2,
+      final String value) {
+    String adjusted = WildCards.contains(value);
+    return BoolQuery.of(
+        bool -> bool.should(
+            should -> should.nested(
+                nested -> nested.path(path)
+                    .query(
+                        query -> query.queryString(
+                            simple -> simple.fields(name1)
+                                .query(adjusted)
+                                .defaultOperator(Operator.And)))))
+            .should(
+                should -> should.nested(
+                    nested -> nested.path(path)
+                        .query(
+                            query -> query.queryString(
+                                simple -> simple.fields(name2)
+                                    .query(adjusted)
+                                    .defaultOperator(Operator.And))))));
+  }
+
   public static BoolQuery startsWith(final String path, final String name, final String value) {
     String adjusted = WildCards.startsWith(value);
     return BoolQuery.of(

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -40,6 +40,7 @@ input LocationCriteria {
 
 input Filter {
   id: String
+  name: String
 }
 
 input PersonFilter {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -119,6 +119,13 @@ public class PatientSearchCriteriaSteps {
             .active(criteria -> criteria.withId(found.local()).withIdFilter(Long.toString(found.shortId()))));
   }
 
+  @Given("I would like to filter search results with name {string}")
+  public void i_would_like_to_filter_search_results_with_name(String name) {
+    this.patient.maybeActive().ifPresent(
+        found -> this.activeCriteria
+            .active(criteria -> criteria.withNameFilter(name)));
+  }
+
   @Given("I would like to search for a patient using multiple local IDs")
   public void i_would_like_to_search_for_a_patient_using_multiple_local_IDs() {
     this.patient.maybeActive().ifPresent(

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -61,6 +61,43 @@ Feature: Patient Search
     And search result 1 has a "last name" of "Smith"
     And there are 1 patient search results
 
+  Scenario: I can filter search results by last name
+    Given I have a patient
+    And the patient has the legal name "Joe" "Other"
+    And I have another patient
+    And the patient has the legal name "Joe" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a first name that equals "Joe"
+    And I would like to filter search results with name "mit"
+    When I search for patients
+    Then search result 1 has a "first name" of "Joe"
+    And search result 1 has a "last name" of "Smith"
+    And there are 1 patient search results
+
+  Scenario: I can filter search results by first name
+    Given I have a patient
+    And the patient has the legal name "Joe" "Smith"
+    And I have another patient
+    And the patient has the legal name "Joel" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a last name that equals "Smith"
+    And I would like to filter search results with name "oel"
+    When I search for patients
+    Then search result 1 has a "first name" of "Joel"
+    And search result 1 has a "last name" of "Smith"
+    And there are 1 patient search results
+
+  Scenario: I can filter search results by a non-existent name
+    Given I have a patient
+    And the patient has the legal name "Joe" "Smith"
+    And I have another patient
+    And the patient has the legal name "Ron" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a last name that equals "Smith"
+    And I would like to filter search results with name "Paul"
+    When I search for patients
+    Then there are 0 patient search results
+
   Scenario: I can find a patient by Patient ID using multiple local ids
     Given patients are available for search
     And I would like to search for a patient using multiple local IDs

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -61,6 +61,20 @@ Feature: Patient Search
     And search result 1 has a "last name" of "Smith"
     And there are 1 patient search results
 
+  Scenario: I can filter search results with the patient's short ID and name
+    Given I have a patient
+    And the patient has the legal name "Joe" "Other"
+    And I have another patient
+    And the patient has the legal name "Joe" "Smith"
+    And patients are available for search
+    And I add the patient criteria for a first name that equals "Joe"
+    And I would like to filter search results with the patient's short ID
+    And I would like to filter search results with name "mit"
+    When I search for patients
+    Then search result 1 has a "first name" of "Joe"
+    And search result 1 has a "last name" of "Smith"
+    And there are 1 patient search results
+
   Scenario: I can filter search results by last name
     Given I have a patient
     And the patient has the legal name "Joe" "Other"

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -205,6 +205,7 @@ export type FacilityProviders = {
 
 export type Filter = {
   id?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum Gender {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1134,6 +1134,7 @@ input LocationCriteria {
 
 input Filter {
   id: String
+  name: String
 }
 
 input PersonFilter {


### PR DESCRIPTION
## Description

Add name to the filter.  Have the name filter do an elasticsearch should on both nested fields (first and last name)

## Tickets

* [CNFT1-3465](https://cdc-nbs.atlassian.net/browse/CNFT1-3465)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3465]: https://cdc-nbs.atlassian.net/browse/CNFT1-3465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ