### PR TITLE
[MU-13] Ensures that date of birth is pre-populated from search when adding a patient

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.spec.ts
@@ -1,0 +1,37 @@
+import { asBasicNewPatientEntry } from './asBasicNewPatientEntry';
+
+describe('when adding a new patient from a patient search', () => {
+    it('should populate the date of birth from the date equals criteria with a full date', () => {
+        const criteria = { bornOn: { equals: { month: 6, day: 5, year: 2025 } } };
+
+        const actual = asBasicNewPatientEntry(criteria);
+
+        expect(actual).toEqual(
+            expect.objectContaining({ personalDetails: expect.objectContaining({ bornOn: '06/05/2025' }) })
+        );
+    });
+
+    it('should populate the date of birth from the date equals criteria with only a month', () => {
+        const criteria = { bornOn: { equals: { month: 6 } } };
+
+        const actual = asBasicNewPatientEntry(criteria);
+
+        expect(actual.personalDetails?.bornOn).toBeUndefined();
+    });
+
+    it('should populate the date of birth from the date equals criteria with only a day', () => {
+        const criteria = { bornOn: { equals: { day: 5 } } };
+
+        const actual = asBasicNewPatientEntry(criteria);
+
+        expect(actual.personalDetails?.bornOn).toBeUndefined();
+    });
+
+    it('should populate the date of birth from the date equals criteria with only a year', () => {
+        const criteria = { bornOn: { equals: { year: 2025 } } };
+
+        const actual = asBasicNewPatientEntry(criteria);
+
+        expect(actual.personalDetails?.bornOn).toBeUndefined();
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.ts
@@ -1,4 +1,6 @@
 import { asSelectable } from 'options';
+import { internalizeDate } from 'date';
+import { Mapping } from 'utils';
 import {
     BasicAddressEntry,
     BasicNewPatientEntry,
@@ -8,11 +10,9 @@ import {
     BasicEthnicityRace,
     BasicIdentificationEntry
 } from './entry';
-import { Mapping } from 'utils';
-import { PatientCriteriaEntry } from 'apps/search/patient/criteria';
 import { asTextCriteriaValue, TextCriteria } from 'options/operator';
-import { internalizeDate } from 'date';
-import { isDateEqualsCriteria } from 'design-system/date/entry';
+import { resolveDate } from 'design-system/date/entry';
+import { PatientCriteriaEntry } from 'apps/search/patient/criteria';
 
 const mapOr =
     <R, S, O>(mapping: Mapping<R, S>, fallback: O) =>
@@ -42,16 +42,7 @@ const nameBasic = (initial: Partial<PatientCriteriaEntry>): NameInformationEntry
 });
 
 const personalDetailsBasic = (initial: Partial<PatientCriteriaEntry>): BasicPersonalDetailsEntry => {
-    const bornOn =
-        initial.bornOn &&
-        isDateEqualsCriteria(initial.bornOn) &&
-        initial.bornOn.equals.year &&
-        initial.bornOn.equals.month &&
-        initial.bornOn.equals.day
-            ? internalizeDate(
-                  new Date(initial.bornOn.equals.year, initial.bornOn.equals.month - 1, initial.bornOn.equals.day)
-              )
-            : undefined;
+    const bornOn = resolveDate(initial.bornOn);
 
     return {
         bornOn,

--- a/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.spec.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.spec.ts
@@ -17,12 +17,36 @@ describe('when adding a new patient from a patient search', () => {
         expect(actual).toEqual(expect.objectContaining({ lastName: 'last-name' }));
     });
 
-    it('should populate the date of birth that was searched for', () => {
-        const criteria = { dateOfBirth: '06/05/2025' };
+    it('should populate the date of birth from the date equals criteria with a full date', () => {
+        const criteria = { bornOn: { equals: { month: 6, day: 5, year: 2025 } } };
 
         const actual = asNewPatientEntry(criteria);
 
         expect(actual).toEqual(expect.objectContaining({ dateOfBirth: '06/05/2025' }));
+    });
+
+    it('should populate the date of birth from the date equals criteria with only a month', () => {
+        const criteria = { bornOn: { equals: { month: 6 } } };
+
+        const actual = asNewPatientEntry(criteria);
+
+        expect(actual.dateOfBirth).toBeUndefined();
+    });
+
+    it('should populate the date of birth from the date equals criteria with only a day', () => {
+        const criteria = { bornOn: { equals: { day: 5 } } };
+
+        const actual = asNewPatientEntry(criteria);
+
+        expect(actual.dateOfBirth).toBeUndefined();
+    });
+
+    it('should populate the date of birth from the date equals criteria with only a year', () => {
+        const criteria = { bornOn: { equals: { year: 2025 } } };
+
+        const actual = asNewPatientEntry(criteria);
+
+        expect(actual.dateOfBirth).toBeUndefined();
     });
 
     it('should populate the gender that was searched for', () => {

--- a/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/asNewPatientEntry.ts
@@ -1,10 +1,10 @@
-import { NewPatientEntry } from 'apps/patient/add';
-import { PatientCriteriaEntry, Identification, RaceEthnicity, Contact } from '../criteria';
-import { internalizeDate } from 'date';
+import { today } from 'date';
 import { asValue } from 'options';
 import { orNull } from 'utils';
-import { IdentificationEntry, EmailEntry } from 'apps/patient/add';
+import { resolveDate } from 'design-system/date/entry';
 import { TextCriteria, asTextCriteriaValue } from 'options/operator';
+import { PatientCriteriaEntry, Identification, RaceEthnicity, Contact } from 'apps/search/patient/criteria';
+import { IdentificationEntry, EmailEntry, NewPatientEntry } from 'apps/patient/add';
 
 const resolveIdentification = (entry: Identification): IdentificationEntry[] =>
     entry.identification && entry.identificationType
@@ -25,10 +25,10 @@ const resolveCriteria = (textCriteria?: TextCriteria): string | null => orNull(a
 
 const asNewPatientEntry = (criteria: Partial<PatientCriteriaEntry>): NewPatientEntry => {
     return {
-        asOf: internalizeDate(new Date()),
+        asOf: today(),
         firstName: resolveCriteria(criteria.name?.first),
         lastName: resolveCriteria(criteria.name?.last),
-        dateOfBirth: criteria.dateOfBirth,
+        dateOfBirth: resolveDate(criteria.bornOn),
         currentGender: orNull(asValue(criteria.gender)),
         streetAddress1: resolveCriteria(criteria.location?.street),
         city: resolveCriteria(criteria.location?.city),

--- a/apps/modernization-ui/src/design-system/date/entry.ts
+++ b/apps/modernization-ui/src/design-system/date/entry.ts
@@ -22,7 +22,21 @@ type DateCriteria = DateEqualsCriteria | DateBetweenCriteria;
 const isDateEqualsCriteria = (criteria: DateCriteria): criteria is DateEqualsCriteria => 'equals' in criteria;
 const isDateBetweenCriteria = (criteria: DateCriteria): criteria is DateBetweenCriteria => 'between' in criteria;
 
-export { isDateEqualsCriteria, isDateBetweenCriteria };
+/**
+ * Resolves the string representation of date equals criteria if the
+ * criteria contains a date with a month, day, and year.
+ *
+ * @param {DateCriteria | undefined} criteria The DateCriteria to resolve a date from
+ * @return {string | undefined} A MM/DD/YYYY formatted string that represents a Date.
+ */
+const resolveDate = (criteria?: DateCriteria) => {
+    if (criteria && isDateEqualsCriteria(criteria)) {
+        const date = criteria.equals;
+        return date.day && date.month && date.year ? displayDateEntry(date) : undefined;
+    }
+};
+
+export { isDateEqualsCriteria, isDateBetweenCriteria, resolveDate };
 export type { DateCriteria, DateBetweenCriteria, DateEqualsCriteria };
 
 const maybeNumber = maybeMap(Number);
@@ -69,7 +83,7 @@ const asISODate = (value?: DateEntry): string | undefined => {
 
 const asDate = (value?: DateEntry) => {
     if (value?.year && value.month && value.day) {
-        return new Date(value.year, value.month + 1, value.day);
+        return new Date(value.year, value.month - 1, value.day);
     }
 };
 

--- a/apps/modernization-ui/src/design-system/date/index.ts
+++ b/apps/modernization-ui/src/design-system/date/index.ts
@@ -1,4 +1,4 @@
-export { asDateEntry, asDate, displayDateEntry, asISODate } from './entry';
+export { asDateEntry, asDate, displayDateEntry, asISODate, resolveDate } from './entry';
 export type { DateEntry } from './entry';
 
 export { validateDate } from './validateDate';


### PR DESCRIPTION
## Description

Adds support for converting patient searches that include a full date equals criteria of the date of birth to the value of "Date of birth" on the  "New patient" page.

![mu-13](https://github.com/user-attachments/assets/5257f547-3677-46ef-9b12-e6cb047f1cef)

This is replicating the feature added for the new version of "New patient" that was added with [CNFT1-3652](https://cdc-nbs.atlassian.net/browse/CNFT1-3652)

## Tickets

* [MU-13](https://cdc-nbs.atlassian.net/browse/MU-13)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3652]: https://cdc-nbs.atlassian.net/browse/CNFT1-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MU-13]: https://cdc-nbs.atlassian.net/browse/MU-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ