### PR TITLE
[MU-12] Inline error not clearing when the default date is added automatically

### DIFF
--- a/apps/modernization-ui/src/design-system/date/picker/DatePicker.tsx
+++ b/apps/modernization-ui/src/design-system/date/picker/DatePicker.tsx
@@ -13,6 +13,8 @@ const handleExternalKeyUp = (event: Event) => {
     input.value = maskedAsDate(input.value);
 };
 
+const asDateOrMinimum = mapOr(asStrictISODate, '1875-01-01');
+
 const today = () => new Date().toISOString().substring(0, 10);
 
 const asDateOrToday = mapOr(asStrictISODate, today);
@@ -34,7 +36,7 @@ const DatePicker = ({ id, label, maxDate, minDate, value, onChange, onBlur, ...r
     const externalInputRef = useRef<HTMLInputElement | null>(null);
 
     const adjustedMaxValue = asDateOrToday(maxDate);
-    const adjustedMinValue = asStrictISODate(minDate);
+    const adjustedMinValue = asDateOrMinimum(minDate);
 
     useEffect(() => {
         initialize(value);
@@ -55,7 +57,7 @@ const DatePicker = ({ id, label, maxDate, minDate, value, onChange, onBlur, ...r
             onChange?.(event.target.value);
         } else {
             clear();
-            onChange?.();
+            onChange?.('');
         }
     };
 


### PR DESCRIPTION
## Description

When a date is cleared the `DatePicker` is emitting an `onChange` event with an `undefined` value.  This is causing the form be put into an invalid state and reset.  The `DatePicker` was changed to emit an empty string when the date in cleared to match the behavior of an `<input>` element.

![mu-12](https://github.com/user-attachments/assets/71d3637f-9a28-4044-9ddc-f77c91affb2d)


## Tickets

* [MU-12](https://cdc-nbs.atlassian.net/browse/MU-12)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
