### PR TITLE
[CNFT1-3682] populate soundex values for names

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/BasicPatientCreator.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/BasicPatientCreator.java
@@ -6,6 +6,7 @@ import gov.cdc.nbs.message.patient.input.PatientInput;
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.PatientIdentifierGenerator;
 import gov.cdc.nbs.patient.RequestContext;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,17 +17,20 @@ import java.time.Instant;
 @Component
 public class BasicPatientCreator {
 
+    private final SoundexResolver resolver;
     private final PatientIdentifierGenerator patientIdentifierGenerator;
     private final IdGeneratorService idGeneratorService;
     private final EntityManager entityManager;
     private final PatientCreatedEmitter emitter;
 
     BasicPatientCreator(
+        final SoundexResolver resolver,
         final PatientIdentifierGenerator patientIdentifierGenerator,
         final IdGeneratorService idGenerator,
         final EntityManager entityManager,
         final PatientCreatedEmitter emitter
     ) {
+        this.resolver = resolver;
         this.patientIdentifierGenerator = patientIdentifierGenerator;
         this.idGeneratorService = idGenerator;
         this.entityManager = entityManager;
@@ -43,7 +47,7 @@ public class BasicPatientCreator {
 
         input.getNames().stream()
             .map(name -> asName(context, identifier, asOf, name))
-            .forEach(person::add);
+            .forEach(name -> person.add(name, resolver));
 
         input.getRaces().stream()
             .map(race -> asRace(context, identifier, asOf, race))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/BasicPatientCreator.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/create/BasicPatientCreator.java
@@ -47,7 +47,7 @@ public class BasicPatientCreator {
 
         input.getNames().stream()
             .map(name -> asName(context, identifier, asOf, name))
-            .forEach(name -> person.add(name, resolver));
+            .forEach(name -> person.add(resolver, name));
 
         input.getRaces().stream()
             .map(race -> asRace(context, identifier, asOf, race))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
@@ -99,7 +99,7 @@ class PatientCreationService {
     newPatient.names()
         .stream()
         .map(demographic -> asAddName(identifier.id(), context, demographic))
-        .forEach(name -> patient.add(name, this.soudexResolver));
+        .forEach(name -> patient.add(this.soudexResolver, name));
 
     newPatient.maybeMortality()
         .map(demographic -> asUpdateMortality(identifier.id(), context, demographic))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.PatientIdentifierGenerator;
 import gov.cdc.nbs.patient.RequestContext;
 import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.patient.profile.ethnicity.EthnicityDemographic;
 import jakarta.persistence.EntityManager;
@@ -29,19 +30,23 @@ import static gov.cdc.nbs.patient.profile.mortality.MortalityDemographicPatientC
 @Component
 class PatientCreationService {
 
+  private final SoundexResolver soudexResolver;
   private final PatientIdentifierGenerator patientIdentifierGenerator;
   private final AddressIdentifierGenerator addressIdentifierGenerator;
-  private final PermissionScopeResolver resolver;
+  private final PermissionScopeResolver permissionScopeResolver;
   private final EntityManager entityManager;
 
   PatientCreationService(
+      final SoundexResolver soudexResolver,
       final PatientIdentifierGenerator patientIdentifierGenerator,
       final AddressIdentifierGenerator addressIdentifierGenerator,
-      final PermissionScopeResolver resolver,
-      final EntityManager entityManager) {
+      final PermissionScopeResolver permissionScopeResolver,
+      final EntityManager entityManager
+  ) {
+    this.soudexResolver = soudexResolver;
     this.patientIdentifierGenerator = patientIdentifierGenerator;
     this.addressIdentifierGenerator = addressIdentifierGenerator;
-    this.resolver = resolver;
+    this.permissionScopeResolver = permissionScopeResolver;
     this.entityManager = entityManager;
   }
 
@@ -89,12 +94,12 @@ class PatientCreationService {
 
     newPatient.maybeGeneralInformation()
         .flatMap(demographic -> maybeAsAssociateStateHIVCase(identifier.id(), context, demographic))
-        .ifPresent(association -> patient.associate(resolver, association));
+        .ifPresent(association -> patient.associate(permissionScopeResolver, association));
 
     newPatient.names()
         .stream()
         .map(demographic -> asAddName(identifier.id(), context, demographic))
-        .forEach(patient::add);
+        .forEach(name -> patient.add(name, this.soudexResolver));
 
     newPatient.maybeMortality()
         .map(demographic -> asUpdateMortality(identifier.id(), context, demographic))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/change/PatientNameChangeService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/change/PatientNameChangeService.java
@@ -26,6 +26,7 @@ class PatientNameChangeService {
     return service.with(
             request.patient(),
             found -> found.add(
+                this.resolver,
                 new PatientCommand.AddName(
                     request.patient(),
                     request.asOf(),
@@ -40,7 +41,7 @@ class PatientNameChangeService {
                     request.type(),
                     context.requestedBy(),
                     context.requestedAt()
-                ),this.resolver
+                )
             )
         )
         .map(added -> new PatientNameAdded(added.getId().getPersonUid(), added.getId().getPersonNameSeq()))
@@ -49,6 +50,7 @@ class PatientNameChangeService {
 
   void update(final RequestContext context, final UpdatePatientNameInput input) {
     this.service.using(input.patient(), found -> found.update(
+            resolver,
             new PatientCommand.UpdateNameInfo(
                 input.patient(),
                 input.sequence(),

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/change/PatientNameChangeService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/names/change/PatientNameChangeService.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.patient.profile.names.change;
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.PatientNotFoundException;
 import gov.cdc.nbs.patient.RequestContext;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.profile.PatientProfileService;
 import org.springframework.stereotype.Component;
 
@@ -11,9 +12,14 @@ import org.springframework.stereotype.Component;
 class PatientNameChangeService {
 
   private final PatientProfileService service;
+  private final SoundexResolver resolver;
 
-  PatientNameChangeService(PatientProfileService service) {
+  PatientNameChangeService(
+      final PatientProfileService service,
+      final SoundexResolver resolver
+  ) {
     this.service = service;
+    this.resolver = resolver;
   }
 
   PatientNameAdded add(final RequestContext context, final NewPatientNameInput request) {
@@ -34,7 +40,7 @@ class PatientNameChangeService {
                     request.type(),
                     context.requestedBy(),
                     context.requestedAt()
-                )
+                ),this.resolver
             )
         )
         .map(added -> new PatientNameAdded(added.getId().getPersonUid(), added.getId().getPersonNameSeq()))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/soundex/ApacheSoundexResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/soundex/ApacheSoundexResolver.java
@@ -1,0 +1,17 @@
+package gov.cdc.nbs.soundex;
+
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
+import org.apache.commons.codec.language.Soundex;
+import org.springframework.stereotype.Component;
+
+@Component
+class ApacheSoundexResolver implements SoundexResolver {
+
+  @Override
+  public String resolve(final String value) {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+    return Soundex.US_ENGLISH.encode(value);
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
@@ -35,41 +35,41 @@ public class PatientMother {
   private final SequentialIdentityGenerator idGenerator;
   private final PatientLocalIdentifierGenerator localIdentifierGenerator;
   private final AddressIdentifierGenerator addressIdentifierGenerator;
-  private final PatientShortIdentifierResolver resolver;
+  private final PatientShortIdentifierResolver shortIdentifierResolver;
   private final EntityManager entityManager;
   private final Available<PatientIdentifier> available;
   private final Active<PatientIdentifier> active;
   private final PatientCleaner cleaner;
   private final RevisionPatientCreator revisionCreator;
   private final JdbcClient jdbcClient;
-  private final SoundexResolver encoder;
+  private final SoundexResolver soundexResolver;
 
   PatientMother(
       final MotherSettings settings,
       final SequentialIdentityGenerator idGenerator,
       final PatientLocalIdentifierGenerator localIdentifierGenerator,
       final AddressIdentifierGenerator addressIdentifierGenerator,
-      final PatientShortIdentifierResolver resolver,
+      final PatientShortIdentifierResolver shortIdentifierResolver,
       final EntityManager entityManager,
       final Available<PatientIdentifier> available,
       final Active<PatientIdentifier> active,
       final PatientCleaner cleaner,
       final RevisionPatientCreator revisionCreator,
       final JdbcClient jdbcClient,
-      final SoundexResolver encoder
+      final SoundexResolver soundexResolver
   ) {
     this.settings = settings;
     this.idGenerator = idGenerator;
     this.localIdentifierGenerator = localIdentifierGenerator;
     this.addressIdentifierGenerator = addressIdentifierGenerator;
-    this.resolver = resolver;
+    this.shortIdentifierResolver = shortIdentifierResolver;
     this.entityManager = entityManager;
     this.available = available;
     this.active = active;
     this.cleaner = cleaner;
     this.revisionCreator = revisionCreator;
     this.jdbcClient = jdbcClient;
-    this.encoder = encoder;
+    this.soundexResolver = soundexResolver;
     this.faker = new Faker(Locale.of("en-us"));
   }
 
@@ -101,7 +101,7 @@ public class PatientMother {
 
     this.entityManager.persist(patient);
 
-    long shortId = this.resolver.resolve(local).orElse(0L);
+    long shortId = this.shortIdentifierResolver.resolve(local).orElse(0L);
 
     return new PatientIdentifier(patient.getId(), shortId, local);
   }
@@ -334,6 +334,7 @@ public class PatientMother {
     Person patient = managed(identifier);
 
     patient.add(
+        this.soundexResolver,
         new PatientCommand.AddName(
             identifier.id(),
             asOf,
@@ -348,7 +349,7 @@ public class PatientMother {
             type,
             this.settings.createdBy(),
             this.settings.createdOn()
-        ), this.encoder
+        )
     );
   }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/PatientMother.java
@@ -5,6 +5,7 @@ import gov.cdc.nbs.entity.odse.Person;
 import gov.cdc.nbs.identity.MotherSettings;
 import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.patient.identifier.PatientLocalIdentifierGenerator;
 import gov.cdc.nbs.patient.identifier.PatientShortIdentifierResolver;
@@ -41,6 +42,7 @@ public class PatientMother {
   private final PatientCleaner cleaner;
   private final RevisionPatientCreator revisionCreator;
   private final JdbcClient jdbcClient;
+  private final SoundexResolver encoder;
 
   PatientMother(
       final MotherSettings settings,
@@ -53,7 +55,8 @@ public class PatientMother {
       final Active<PatientIdentifier> active,
       final PatientCleaner cleaner,
       final RevisionPatientCreator revisionCreator,
-      final JdbcClient jdbcClient
+      final JdbcClient jdbcClient,
+      final SoundexResolver encoder
   ) {
     this.settings = settings;
     this.idGenerator = idGenerator;
@@ -66,6 +69,7 @@ public class PatientMother {
     this.cleaner = cleaner;
     this.revisionCreator = revisionCreator;
     this.jdbcClient = jdbcClient;
+    this.encoder = encoder;
     this.faker = new Faker(Locale.of("en-us"));
   }
 
@@ -344,7 +348,7 @@ public class PatientMother {
             type,
             this.settings.createdBy(),
             this.settings.createdOn()
-        )
+        ), this.encoder
     );
   }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/create/PatientCreatedEmitterTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/create/PatientCreatedEmitterTest.java
@@ -5,6 +5,7 @@ import gov.cdc.nbs.message.enums.Deceased;
 import gov.cdc.nbs.message.enums.Gender;
 import gov.cdc.nbs.message.patient.event.PatientEvent;
 import gov.cdc.nbs.patient.PatientCommand;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.event.PatientEventEmitter;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -18,412 +19,352 @@ import static org.mockito.Mockito.verify;
 
 class PatientCreatedEmitterTest {
 
-    @Test
-    void should_emit_person_as_created_event() {
+  @Test
+  void should_emit_person_as_created_event() {
 
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
 
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
 
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
+    Person patient = new Person(
+        new PatientCommand.AddPatient(
+            117L,
+            "patient-local-id",
+            LocalDate.parse("2000-09-03"),
+            Gender.M,
+            Gender.F,
+            Deceased.Y,
+            Instant.parse("2085-09-07T13:09:07Z"),
+            "Marital Status",
+            "EthCode",
+            Instant.parse("2019-03-03T10:15:30Z"),
+            "comments",
+            "HIV-Case",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+
+    createdEmitter.created(patient);
+
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+    verify(emitter).emit(captor.capture());
+
+    PatientEvent.Created actual = captor.getValue();
+
+    assertThat(actual)
+        .returns(117L, PatientEvent.Created::patient)
+        .returns("patient-local-id", PatientEvent.Created::localId)
+        .returns(LocalDate.parse("2000-09-03"), PatientEvent.Created::dateOfBirth)
+        .returns("M", PatientEvent.Created::birthGender)
+        .returns("F", PatientEvent.Created::currentGender)
+        .returns("Y", PatientEvent.Created::deceased)
+        .returns(Instant.parse("2085-09-07T13:09:07Z"), PatientEvent.Created::deceasedOn)
+        .returns("Marital Status", PatientEvent.Created::maritalStatus)
+        .returns("EthCode", PatientEvent.Created::ethnicGroup)
+        .returns(Instant.parse("2019-03-03T10:15:30Z"), PatientEvent.Created::asOf)
+        .returns("comments", PatientEvent.Created::comments)
+        .returns("HIV-Case", PatientEvent.Created::stateHIVCase)
+        .returns(131L, PatientEvent.Created::createdBy)
+        .returns(Instant.parse("2020-03-03T10:15:30.00Z"), PatientEvent.Created::createdOn)
+    ;
+
+    assertThat(actual.names()).isEmpty();
+    assertThat(actual.races()).isEmpty();
+    assertThat(actual.addresses()).isEmpty();
+    assertThat(actual.phoneNumbers()).isEmpty();
+    assertThat(actual.emails()).isEmpty();
+    assertThat(actual.identifications()).isEmpty();
+  }
+
+  @Test
+  void should_emit_person_as_created_event_with_names() {
+
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+    SoundexResolver encoder = mock(SoundexResolver.class);
+
+    Person patient = new Person(
+        new PatientCommand.CreatePatient(
+            117L,
+            "patient-local-id",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    patient.add(
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            "First",
+            "Middle",
+            "Last",
+            "JR",
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        ), encoder
+    );
+
+    createdEmitter.created(patient);
+
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+    verify(emitter).emit(captor.capture());
+
+    PatientEvent.Created created = captor.getValue();
+
+    assertThat(created.names())
+        .satisfiesExactly(
+            actual -> assertThat(actual)
+                .returns("L", PatientEvent.Created.Name::use)
+                .returns("First", PatientEvent.Created.Name::first)
+                .returns("Middle", PatientEvent.Created.Name::middle)
+                .returns("Last", PatientEvent.Created.Name::last)
+                .returns("JR", PatientEvent.Created.Name::suffix)
         );
+  }
 
+  @Test
+  void should_emit_person_as_created_event_with_races() {
 
-        createdEmitter.created(patient);
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
 
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
 
-        verify(emitter).emit(captor.capture());
+    Person patient = new Person(
+        new PatientCommand.CreatePatient(
+            117L,
+            "patient-local-id",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        PatientEvent.Created actual = captor.getValue();
+    patient.add(
+        new PatientCommand.AddRace(
+            117L,
+            Instant.parse("2022-05-12T11:15:17Z"),
+            "race-category-value",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        assertThat(actual)
-            .returns(117L, PatientEvent.Created::patient)
-            .returns("patient-local-id", PatientEvent.Created::localId)
-            .returns(LocalDate.parse("2000-09-03"), PatientEvent.Created::dateOfBirth)
-            .returns("M", PatientEvent.Created::birthGender)
-            .returns("F", PatientEvent.Created::currentGender)
-            .returns("Y", PatientEvent.Created::deceased)
-            .returns(Instant.parse("2085-09-07T13:09:07Z"), PatientEvent.Created::deceasedOn)
-            .returns("Marital Status", PatientEvent.Created::maritalStatus)
-            .returns("EthCode", PatientEvent.Created::ethnicGroup)
-            .returns(Instant.parse("2019-03-03T10:15:30Z"), PatientEvent.Created::asOf)
-            .returns("comments", PatientEvent.Created::comments)
-            .returns("HIV-Case", PatientEvent.Created::stateHIVCase)
-            .returns(131L, PatientEvent.Created::createdBy)
-            .returns(Instant.parse("2020-03-03T10:15:30.00Z"), PatientEvent.Created::createdOn)
-        ;
+    createdEmitter.created(patient);
 
-        assertThat(actual.names()).isEmpty();
-        assertThat(actual.races()).isEmpty();
-        assertThat(actual.addresses()).isEmpty();
-        assertThat(actual.phoneNumbers()).isEmpty();
-        assertThat(actual.emails()).isEmpty();
-        assertThat(actual.identifications()).isEmpty();
-    }
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
 
-    @Test
-    void should_emit_person_as_created_event_with_names() {
+    verify(emitter).emit(captor.capture());
 
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+    PatientEvent.Created created = captor.getValue();
 
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+    assertThat(created.races())
+        .contains("race-category-value");
+  }
 
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
+  @Test
+  void should_emit_person_as_created_event_with_addresses() {
+
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+    Person patient = new Person(
+        new PatientCommand.CreatePatient(
+            117L,
+            "patient-local-id",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    patient.add(
+        new PatientCommand.AddAddress(
+            117L,
+            4861L,
+            Instant.parse("2021-07-07T03:06:09Z"),
+            "SA1",
+            "SA2",
+            "city-description",
+            "State",
+            "Zip",
+            "county-code",
+            "country-code",
+            "Census Tract",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    createdEmitter.created(patient);
+
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+    verify(emitter).emit(captor.capture());
+
+    PatientEvent.Created created = captor.getValue();
+
+    assertThat(created.addresses())
+        .satisfiesExactly(
+            actual -> assertThat(actual)
+                .returns(4861L, PatientEvent.Created.Address::identifier)
+                .returns(Instant.parse("2021-07-07T03:06:09Z"), PatientEvent.Created.Address::asOf)
+                .returns("SA1", PatientEvent.Created.Address::streetAddress1)
+                .returns("SA2", PatientEvent.Created.Address::streetAddress2)
+                .returns("city-description", PatientEvent.Created.Address::city)
+                .returns("State", PatientEvent.Created.Address::state)
+                .returns("Zip", PatientEvent.Created.Address::zip)
+                .returns("county-code", PatientEvent.Created.Address::county)
+                .returns("country-code", PatientEvent.Created.Address::country)
+                .returns("Census Tract", PatientEvent.Created.Address::censusTract)
         );
+  }
 
-        patient.add(
-            new PatientCommand.AddName(
-                117L,
-                Instant.parse("2021-05-15T10:00:00Z"),
-                "First",
-                "Middle",
-                "Last",
-                "JR",
-                "L",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
+  @Test
+  void should_emit_person_as_created_event_with_phones() {
+
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+    Person patient = new Person(
+        new PatientCommand.CreatePatient(
+            117L,
+            "patient-local-id",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    patient.add(
+        new PatientCommand.AddPhoneNumber(
+            117L,
+            5347L,
+            Instant.parse("2017-05-16T11:13:19Z"),
+            "CP",
+            "MC",
+            "Phone Number",
+            "Extension",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    createdEmitter.created(patient);
+
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+    verify(emitter).emit(captor.capture());
+
+    PatientEvent.Created created = captor.getValue();
+
+    assertThat(created.phoneNumbers())
+        .satisfiesExactly(
+            actual -> assertThat(actual)
+                .returns(5347L, PatientEvent.Created.Phone::identifier)
+                .returns(Instant.parse("2017-05-16T11:13:19Z"), PatientEvent.Created.Phone::asOf)
+                .returns("CP", PatientEvent.Created.Phone::type)
+                .returns("MC", PatientEvent.Created.Phone::use)
+                .returns("Phone Number", PatientEvent.Created.Phone::number)
+                .returns("Extension", PatientEvent.Created.Phone::extension)
         );
+  }
 
-        createdEmitter.created(patient);
+  @Test
+  void should_emit_person_as_created_event_with_email() {
 
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
 
-        verify(emitter).emit(captor.capture());
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
 
-        PatientEvent.Created created = captor.getValue();
+    Person patient = new Person(
+        new PatientCommand.CreatePatient(
+            117L,
+            "patient-local-id",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        assertThat(created.names())
-            .satisfiesExactly(
-                actual -> assertThat(actual)
-                    .returns("L", PatientEvent.Created.Name::use)
-                    .returns("First", PatientEvent.Created.Name::first)
-                    .returns("Middle", PatientEvent.Created.Name::middle)
-                    .returns("Last", PatientEvent.Created.Name::last)
-                    .returns("JR", PatientEvent.Created.Name::suffix)
-            );
-    }
+    patient.add(
+        new PatientCommand.AddEmailAddress(
+            117L,
+            5333L,
+            Instant.parse("2017-05-16T11:13:19Z"),
+            "AnEmail@email.com",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-    @Test
-    void should_emit_person_as_created_event_with_races() {
+    createdEmitter.created(patient);
 
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
 
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+    verify(emitter).emit(captor.capture());
 
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
+    PatientEvent.Created created = captor.getValue();
+
+    assertThat(created.emails())
+        .satisfiesExactly(
+            actual -> assertThat(actual)
+                .returns(5333L, PatientEvent.Created.Email::identifier)
+                .returns(Instant.parse("2017-05-16T11:13:19Z"), PatientEvent.Created.Email::asOf)
+                .returns("NET", PatientEvent.Created.Email::type)
+                .returns("H", PatientEvent.Created.Email::use)
+                .returns("AnEmail@email.com", PatientEvent.Created.Email::address)
         );
+  }
 
-        patient.add(
-            new PatientCommand.AddRace(
-                117L,
-                Instant.parse("2022-05-12T11:15:17Z"),
-                "race-category-value",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
+  @Test
+  void should_emit_person_as_created_event_with_identifications() {
+
+    PatientEventEmitter emitter = mock(PatientEventEmitter.class);
+
+    PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
+
+    Person patient = new Person(
+        new PatientCommand.CreatePatient(
+            117L,
+            "patient-local-id",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    patient.add(
+        new PatientCommand.AddIdentification(
+            117L,
+            Instant.parse("2017-05-16T11:13:19Z"),
+            "identification-value",
+            "authority-value",
+            "identification-type",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    createdEmitter.created(patient);
+
+    ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
+
+    verify(emitter).emit(captor.capture());
+
+    PatientEvent.Created created = captor.getValue();
+
+    assertThat(created.identifications())
+        .satisfiesExactly(
+            actual -> assertThat(actual)
+                .returns(1, PatientEvent.Created.Identification::identifier)
+                .returns(Instant.parse("2017-05-16T11:13:19Z"), PatientEvent.Created.Identification::asOf)
+                .returns("identification-type", PatientEvent.Created.Identification::type)
+                .returns("authority-value", PatientEvent.Created.Identification::authority)
+                .returns("identification-value", PatientEvent.Created.Identification::value)
         );
-
-        createdEmitter.created(patient);
-
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
-
-        verify(emitter).emit(captor.capture());
-
-        PatientEvent.Created created = captor.getValue();
-
-        assertThat(created.races())
-            .contains("race-category-value");
-    }
-
-    @Test
-    void should_emit_person_as_created_event_with_addresses() {
-
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
-
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
-
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        patient.add(
-            new PatientCommand.AddAddress(
-                117L,
-                4861L,
-                Instant.parse("2021-07-07T03:06:09Z"),
-                "SA1",
-                "SA2",
-                "city-description",
-                "State",
-                "Zip",
-                "county-code",
-                "country-code",
-                "Census Tract",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        createdEmitter.created(patient);
-
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
-
-        verify(emitter).emit(captor.capture());
-
-        PatientEvent.Created created = captor.getValue();
-
-        assertThat(created.addresses())
-            .satisfiesExactly(
-                actual -> assertThat(actual)
-                    .returns(4861L, PatientEvent.Created.Address::identifier)
-                    .returns(Instant.parse("2021-07-07T03:06:09Z"),PatientEvent.Created.Address::asOf)
-                    .returns("SA1", PatientEvent.Created.Address::streetAddress1)
-                    .returns("SA2", PatientEvent.Created.Address::streetAddress2)
-                    .returns("city-description", PatientEvent.Created.Address::city)
-                    .returns("State", PatientEvent.Created.Address::state)
-                    .returns("Zip", PatientEvent.Created.Address::zip)
-                    .returns("county-code", PatientEvent.Created.Address::county)
-                    .returns("country-code", PatientEvent.Created.Address::country)
-                    .returns("Census Tract", PatientEvent.Created.Address::censusTract)
-            );
-    }
-
-    @Test
-    void should_emit_person_as_created_event_with_phones() {
-
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
-
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
-
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        patient.add(
-            new PatientCommand.AddPhoneNumber(
-                117L,
-                5347L,
-                Instant.parse("2017-05-16T11:13:19Z"),
-                "CP",
-                "MC",
-                "Phone Number",
-                "Extension",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        createdEmitter.created(patient);
-
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
-
-        verify(emitter).emit(captor.capture());
-
-        PatientEvent.Created created = captor.getValue();
-
-        assertThat(created.phoneNumbers())
-            .satisfiesExactly(
-                actual -> assertThat(actual)
-                    .returns(5347L, PatientEvent.Created.Phone::identifier)
-                    .returns(Instant.parse("2017-05-16T11:13:19Z"), PatientEvent.Created.Phone::asOf)
-                    .returns("CP", PatientEvent.Created.Phone::type)
-                    .returns("MC", PatientEvent.Created.Phone::use)
-                    .returns("Phone Number", PatientEvent.Created.Phone::number)
-                    .returns("Extension", PatientEvent.Created.Phone::extension)
-            );
-    }
-
-    @Test
-    void should_emit_person_as_created_event_with_email() {
-
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
-
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
-
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        patient.add(
-            new PatientCommand.AddEmailAddress(
-                117L,
-                5333L,
-                Instant.parse("2017-05-16T11:13:19Z"),
-                "AnEmail@email.com",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        createdEmitter.created(patient);
-
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
-
-        verify(emitter).emit(captor.capture());
-
-        PatientEvent.Created created = captor.getValue();
-
-        assertThat(created.emails())
-            .satisfiesExactly(
-                actual -> assertThat(actual)
-                    .returns(5333L, PatientEvent.Created.Email::identifier)
-                    .returns(Instant.parse("2017-05-16T11:13:19Z"),PatientEvent.Created.Email::asOf)
-                    .returns("NET", PatientEvent.Created.Email::type)
-                    .returns("H", PatientEvent.Created.Email::use)
-                    .returns("AnEmail@email.com", PatientEvent.Created.Email::address)
-            );
-    }
-
-    @Test
-    void should_emit_person_as_created_event_with_identifications() {
-
-        PatientEventEmitter emitter = mock(PatientEventEmitter.class);
-
-        PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
-
-        Person patient = new Person(
-            new PatientCommand.AddPatient(
-                117L,
-                "patient-local-id",
-                LocalDate.parse("2000-09-03"),
-                Gender.M,
-                Gender.F,
-                Deceased.Y,
-                Instant.parse("2085-09-07T13:09:07Z"),
-                "Marital Status",
-                "EthCode",
-                Instant.parse("2019-03-03T10:15:30Z"),
-                "comments",
-                "HIV-Case",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        patient.add(
-            new PatientCommand.AddIdentification(
-                117L,
-                Instant.parse("2017-05-16T11:13:19Z"),
-                "identification-value",
-                "authority-value",
-                "identification-type",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
-
-        createdEmitter.created(patient);
-
-        ArgumentCaptor<PatientEvent.Created> captor = ArgumentCaptor.forClass(PatientEvent.Created.class);
-
-        verify(emitter).emit(captor.capture());
-
-        PatientEvent.Created created = captor.getValue();
-
-        assertThat(created.identifications())
-            .satisfiesExactly(
-                actual -> assertThat(actual)
-                    .returns(1, PatientEvent.Created.Identification::identifier)
-                    .returns(Instant.parse("2017-05-16T11:13:19Z"), PatientEvent.Created.Identification::asOf)
-                    .returns("identification-type", PatientEvent.Created.Identification::type)
-                    .returns("authority-value", PatientEvent.Created.Identification::authority)
-                    .returns("identification-value", PatientEvent.Created.Identification::value)
-            );
-    }
+  }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/create/PatientCreatedEmitterTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/create/PatientCreatedEmitterTest.java
@@ -84,7 +84,7 @@ class PatientCreatedEmitterTest {
 
     PatientEventEmitter emitter = mock(PatientEventEmitter.class);
     PatientCreatedEmitter createdEmitter = new PatientCreatedEmitter(emitter);
-    SoundexResolver encoder = mock(SoundexResolver.class);
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     Person patient = new Person(
         new PatientCommand.CreatePatient(
@@ -96,6 +96,7 @@ class PatientCreatedEmitterTest {
     );
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -106,7 +107,7 @@ class PatientCreatedEmitterTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), encoder
+        )
     );
 
     createdEmitter.created(patient);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/change/PatientNameChangeServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/names/change/PatientNameChangeServiceTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.patient.profile.names.change;
 
 import gov.cdc.nbs.patient.PatientException;
 import gov.cdc.nbs.patient.RequestContext;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.profile.PatientProfileService;
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +25,10 @@ class PatientNameChangeServiceTest {
 
     when(profileService.with(anyLong(), any())).thenReturn(Optional.empty());
 
+    SoundexResolver encoder = mock(SoundexResolver.class);
+
     PatientNameChangeService service =
-        new PatientNameChangeService(profileService);
+        new PatientNameChangeService(profileService, encoder);
 
     NewPatientNameInput input = mock(NewPatientNameInput.class);
 

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
@@ -283,7 +283,7 @@ public class Person {
     this.birthTimeCalc = this.birthTime;
   }
 
-  public PersonName add(final PatientCommand.AddName added, final SoundexResolver resolver) {
+  public PersonName add(final SoundexResolver resolver, final PatientCommand.AddName added ) {
 
     Collection<PersonName> existing = ensureNames();
 
@@ -310,13 +310,13 @@ public class Person {
     return personName;
   }
 
-  public void update(final PatientCommand.UpdateNameInfo updated) {
+  public void update(final SoundexResolver resolver, final PatientCommand.UpdateNameInfo updated) {
     PersonNameId identifier = PersonNameId.from(updated.person(), updated.sequence());
 
     ensureNames().stream()
         .filter(name -> Objects.equals(name.getId(), identifier))
         .findFirst()
-        .ifPresent(name -> name.update(updated));
+        .ifPresent(name -> name.update(resolver, updated));
 
     changed(updated);
   }

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/Person.java
@@ -15,6 +15,7 @@ import gov.cdc.nbs.patient.demographic.GeneralInformation;
 import gov.cdc.nbs.patient.demographic.PatientEthnicity;
 import gov.cdc.nbs.patient.demographic.PatientRaceDemographic;
 import gov.cdc.nbs.patient.demographic.name.PatientLegalNameResolver;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -282,7 +283,7 @@ public class Person {
     this.birthTimeCalc = this.birthTime;
   }
 
-  public PersonName add(final PatientCommand.AddName added) {
+  public PersonName add(final PatientCommand.AddName added, final SoundexResolver resolver) {
 
     Collection<PersonName> existing = ensureNames();
 
@@ -299,7 +300,9 @@ public class Person {
     PersonName personName = new PersonName(
         identifier,
         this,
-        added);
+        resolver,
+        added
+    );
 
     existing.add(personName);
 

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PersonName.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PersonName.java
@@ -31,7 +31,7 @@ import java.util.function.Predicate;
 @Table(name = "Person_name")
 @SuppressWarnings(
     //  The PatientNameHistoryListener is an entity listener specifically for instances of this class
-    {"javaarchitecture:S7027","javaarchitecture:S7091"}
+    {"javaarchitecture:S7027", "javaarchitecture:S7091"}
 )
 @EntityListeners(PatientNameHistoryListener.class)
 public class PersonName {
@@ -41,7 +41,7 @@ public class PersonName {
   }
 
   public static Predicate<PersonName> havingType(final String use) {
-    return input -> Objects.equals(input.type(),use);
+    return input -> Objects.equals(input.type(), use);
   }
 
   @EmbeddedId
@@ -164,19 +164,21 @@ public class PersonName {
     return this.nmUseCd;
   }
 
-  public void update(final PatientCommand.UpdateNameInfo info) {
+  public PersonName update(final SoundexResolver resolver, final PatientCommand.UpdateNameInfo info) {
     this.asOfDate = info.asOf();
     this.nmPrefix = info.prefix();
-    this.firstNm = info.first();
+    applyFirstName(info.first(), resolver);
     this.middleNm = info.middle();
     this.middleNm2 = info.secondMiddle();
-    this.lastNm = info.last();
-    this.lastNm2 = info.secondLast();
+    applyLastName(info.last(), resolver);
+    applySecondLastName(info.secondLast(), resolver);
     this.nmSuffix = Suffix.resolve(info.suffix());
     this.nmDegree = info.degree();
     this.nmUseCd = info.type();
 
     this.audit.changed(info.requester(), info.requestedOn());
+
+    return this;
   }
 
   public void delete(final PatientCommand.DeleteNameInfo deleted) {

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PersonName.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/PersonName.java
@@ -6,6 +6,7 @@ import gov.cdc.nbs.entity.enums.converter.SuffixConverter;
 import gov.cdc.nbs.message.enums.Suffix;
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.PatientNameHistoryListener;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
@@ -54,11 +55,20 @@ public class PersonName {
   @Column(name = "first_nm", length = 50)
   private String firstNm;
 
+  @Column(name = "first_nm_sndx", length = 50)
+  private String firstNameSoundex;
+
   @Column(name = "last_nm", length = 50)
   private String lastNm;
 
+  @Column(name = "last_nm_sndx", length = 50)
+  private String lastNameSoundex;
+
   @Column(name = "last_nm2", length = 50)
   private String lastNm2;
+
+  @Column(name = "last_nm2_sndx", length = 50)
+  private String secondLastNameSoundex;
 
   @Column(name = "middle_nm", length = 50)
   private String middleNm;
@@ -104,7 +114,9 @@ public class PersonName {
   public PersonName(
       final PersonNameId identifier,
       final Person person,
-      final PatientCommand.AddName added) {
+      final SoundexResolver resolver,
+      final PatientCommand.AddName added
+  ) {
     this.asOfDate = added.asOf();
 
     this.statusCd = 'A';
@@ -117,16 +129,31 @@ public class PersonName {
     this.personUid = person;
 
     this.nmPrefix = added.prefix();
-    this.firstNm = added.first();
+    applyFirstName(added.first(), resolver);
     this.middleNm = added.middle();
     this.middleNm2 = added.secondMiddle();
-    this.lastNm = added.last();
-    this.lastNm2 = added.secondLast();
+    applyLastName(added.last(), resolver);
+    applySecondLastName(added.secondLast(), resolver);
     this.nmSuffix = Suffix.resolve(added.suffix());
     this.nmDegree = added.degree();
     this.nmUseCd = added.type();
 
     this.audit = new Audit(added.requester(), added.requestedOn());
+  }
+
+  private void applyFirstName(final String value, final SoundexResolver resolver) {
+    this.firstNm = value;
+    this.firstNameSoundex = resolver.resolve(value);
+  }
+
+  private void applyLastName(final String value, final SoundexResolver resolver) {
+    this.lastNm = value;
+    this.lastNameSoundex = resolver.resolve(value);
+  }
+
+  private void applySecondLastName(final String value, final SoundexResolver resolver) {
+    this.lastNm2 = value;
+    this.secondLastNameSoundex = resolver.resolve(value);
   }
 
   public LocalDate asOf() {

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/demographic/name/SoundexResolver.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/demographic/name/SoundexResolver.java
@@ -1,0 +1,7 @@
+package gov.cdc.nbs.patient.demographic.name;
+
+public interface SoundexResolver {
+
+  String resolve(final String value);
+
+}

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonNameTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonNameTest.java
@@ -12,150 +12,291 @@ import static org.mockito.Mockito.mock;
 
 class PersonNameTest {
 
-    @Test
-    void should_inactivate_existing_name() {
+  @Test
+  void should_inactivate_existing_name() {
 
-        Person patient = new Person(117L, "local-id-value");
-        SoundexResolver resolver = mock(SoundexResolver.class);
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
-        PersonNameId identifier = new PersonNameId(117L, (short)2);
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
 
-        PersonName name = new PersonName(
-            identifier,
-            patient,
-            resolver,
-            new PatientCommand.AddName(
-                117L,
-                Instant.parse("2021-05-15T10:00:00Z"),
-                "Other-First",
-                "Other-Middle",
-                "Other-Last",
-                null,
-                "L",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
+    PersonName name = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            "Other-First",
+            "Other-Middle",
+            "Other-Last",
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        name.delete(
-            new PatientCommand.DeleteNameInfo(
-                117L,
-                (short) 2,
-                171L,
-                Instant.parse("2021-03-03T10:15:30.00Z")
-            )
-        );
+    name.delete(
+        new PatientCommand.DeleteNameInfo(
+            117L,
+            (short) 2,
+            171L,
+            Instant.parse("2021-03-03T10:15:30.00Z")
+        )
+    );
 
-        assertThat(name)
-            .satisfies(
-                removed -> assertThat(removed.getAudit())
-                    .describedAs("expected name audit state")
-                    .satisfies(
-                        audit -> assertThat(audit.changed())
-                            .returns(171L, Changed::changedBy)
-                            .returns(Instant.parse("2021-03-03T10:15:30.00Z"), Changed::changedOn)
-                    )
-            )
-            .satisfies(
-                removed -> assertThat(removed)
-                    .describedAs("expected name is inactive")
-                    .returns("INACTIVE", PersonName::getRecordStatusCd)
-                    .returns(Instant.parse("2021-03-03T10:15:30.00Z"), PersonName::getRecordStatusTime)
-            )
-            .extracting(PersonName::getId)
-            .returns(117L, PersonNameId::getPersonUid)
-            .returns((short) 2, PersonNameId::getPersonNameSeq)
-            ;
-    }
+    assertThat(name)
+        .satisfies(
+            removed -> assertThat(removed.getAudit())
+                .describedAs("expected name audit state")
+                .satisfies(
+                    audit -> assertThat(audit.changed())
+                        .returns(171L, Changed::changedBy)
+                        .returns(Instant.parse("2021-03-03T10:15:30.00Z"), Changed::changedOn)
+                )
+        )
+        .satisfies(
+            removed -> assertThat(removed)
+                .describedAs("expected name is inactive")
+                .returns("INACTIVE", PersonName::getRecordStatusCd)
+                .returns(Instant.parse("2021-03-03T10:15:30.00Z"), PersonName::getRecordStatusTime)
+        )
+        .extracting(PersonName::getId)
+        .returns(117L, PersonNameId::getPersonUid)
+        .returns((short) 2, PersonNameId::getPersonNameSeq)
+    ;
+  }
 
-    @Test
-    void should_create_name_with_first_name_and_soundex() {
-        Person patient = new Person(117L, "local-id-value");
-        SoundexResolver resolver = value -> value + "_encoded";
+  @Test
+  void should_create_name_with_first_name_and_soundex() {
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = value -> value + "_encoded";
 
-        PersonNameId identifier = new PersonNameId(117L, (short)2);
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
 
-        PersonName actual = new PersonName(
-            identifier,
-            patient,
-            resolver,
-            new PatientCommand.AddName(
-                117L,
-                Instant.parse("2021-05-15T10:00:00Z"),
-                "First",
-                null,
-                null,
-                null,
-                "L",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
+    PersonName actual = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            "First",
+            null,
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        assertThat(actual)
-            .returns("First", PersonName::getFirstNm)
-            .returns("First_encoded", PersonName::getFirstNameSoundex);
-    }
+    assertThat(actual)
+        .returns("First", PersonName::getFirstNm)
+        .returns("First_encoded", PersonName::getFirstNameSoundex);
+  }
 
-    @Test
-    void should_create_name_with_last_name_and_soundex() {
-        Person patient = new Person(117L, "local-id-value");
-        SoundexResolver resolver = value -> value + "_encoded";
+  @Test
+  void should_create_name_with_last_name_and_soundex() {
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = value -> value + "_encoded";
 
-        PersonNameId identifier = new PersonNameId(117L, (short)2);
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
 
-        PersonName actual = new PersonName(
-            identifier,
-            patient,
-            resolver,
-            new PatientCommand.AddName(
-                117L,
-                Instant.parse("2021-05-15T10:00:00Z"),
-                null,
-                null,
-                "Last",
-                null,
-                "L",
-                131L,
-                Instant.parse("2020-03-03T10:15:30.00Z")
-            )
-        );
+    PersonName actual = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            null,
+            "Last",
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
 
-        assertThat(actual)
-            .returns("Last", PersonName::getLastNm)
-            .returns("Last_encoded", PersonName::getLastNameSoundex);
-    }
+    assertThat(actual)
+        .returns("Last", PersonName::getLastNm)
+        .returns("Last_encoded", PersonName::getLastNameSoundex);
+  }
 
-    @Test
-    void should_create_name_with_second_last_name_and_soundex() {
-        Person patient = new Person(117L, "local-id-value");
-        SoundexResolver resolver = value -> value + "_encoded";
+  @Test
+  void should_create_name_with_second_last_name_and_soundex() {
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = value -> value + "_encoded";
 
-        PersonNameId identifier = new PersonNameId(117L, (short)2);
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
 
-        PersonName actual = new PersonName(
-            identifier,
-            patient,
-            resolver,
-            new PatientCommand.AddName(
-                117L,
-                Instant.parse("2023-05-15T10:00:00Z"),
-                null,
-                null,
-                null,
-                null,
-                null,
-                "Second-Last",
-                null,
-                null,
-                "L",
-                131L,
-                Instant.parse("2020-03-03T10:15:30Z")
-            )
-        );
+    PersonName actual = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2023-05-15T10:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Second-Last",
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30Z")
+        )
+    );
 
-        assertThat(actual)
-            .returns("Second-Last", PersonName::getLastNm2)
-            .returns("Second-Last_encoded", PersonName::getSecondLastNameSoundex);
-    }
+    assertThat(actual)
+        .returns("Second-Last", PersonName::getLastNm2)
+        .returns("Second-Last_encoded", PersonName::getSecondLastNameSoundex);
+  }
+
+  @Test
+  void should_update_name_with_first_name_and_soundex() {
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = value -> value + "_encoded";
+
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
+
+    PersonName actual = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    ).update(
+        resolver,
+        new PatientCommand.UpdateNameInfo(
+            117L,
+            1,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            "update_first_name",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual)
+        .returns("update_first_name", PersonName::getFirstNm)
+        .returns("update_first_name_encoded", PersonName::getFirstNameSoundex);
+  }
+
+  @Test
+  void should_update_name_with_last_name_and_soundex() {
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = value -> value + "_encoded";
+
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
+
+    PersonName actual = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    ).update(
+        resolver,
+        new PatientCommand.UpdateNameInfo(
+            117L,
+            1,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            "update_last_name",
+            null,
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual)
+        .returns("update_last_name", PersonName::getLastNm)
+        .returns("update_last_name_encoded", PersonName::getLastNameSoundex);
+  }
+
+  @Test
+  void should_update_name_with_second_last_name_and_soundex() {
+    Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = value -> value + "_encoded";
+
+    PersonNameId identifier = new PersonNameId(117L, (short) 2);
+
+    PersonName actual = new PersonName(
+        identifier,
+        patient,
+        resolver,
+        new PatientCommand.AddName(
+            117L,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    ).update(
+        resolver,
+        new PatientCommand.UpdateNameInfo(
+            117L,
+            1,
+            Instant.parse("2021-05-15T10:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            "update_second_last_name",
+            null,
+            null,
+            "L",
+            131L,
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        )
+    );
+
+    assertThat(actual)
+        .returns("update_second_last_name", PersonName::getLastNm2)
+        .returns("update_second_last_name_encoded", PersonName::getSecondLastNameSoundex);
+  }
 }

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonNameTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonNameTest.java
@@ -2,11 +2,13 @@ package gov.cdc.nbs.entity.odse;
 
 import gov.cdc.nbs.audit.Changed;
 import gov.cdc.nbs.patient.PatientCommand;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class PersonNameTest {
 
@@ -14,12 +16,14 @@ class PersonNameTest {
     void should_inactivate_existing_name() {
 
         Person patient = new Person(117L, "local-id-value");
+        SoundexResolver resolver = mock(SoundexResolver.class);
 
         PersonNameId identifier = new PersonNameId(117L, (short)2);
 
         PersonName name = new PersonName(
             identifier,
             patient,
+            resolver,
             new PatientCommand.AddName(
                 117L,
                 Instant.parse("2021-05-15T10:00:00Z"),
@@ -62,5 +66,96 @@ class PersonNameTest {
             .returns(117L, PersonNameId::getPersonUid)
             .returns((short) 2, PersonNameId::getPersonNameSeq)
             ;
+    }
+
+    @Test
+    void should_create_name_with_first_name_and_soundex() {
+        Person patient = new Person(117L, "local-id-value");
+        SoundexResolver resolver = value -> value + "_encoded";
+
+        PersonNameId identifier = new PersonNameId(117L, (short)2);
+
+        PersonName actual = new PersonName(
+            identifier,
+            patient,
+            resolver,
+            new PatientCommand.AddName(
+                117L,
+                Instant.parse("2021-05-15T10:00:00Z"),
+                "First",
+                null,
+                null,
+                null,
+                "L",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        assertThat(actual)
+            .returns("First", PersonName::getFirstNm)
+            .returns("First_encoded", PersonName::getFirstNameSoundex);
+    }
+
+    @Test
+    void should_create_name_with_last_name_and_soundex() {
+        Person patient = new Person(117L, "local-id-value");
+        SoundexResolver resolver = value -> value + "_encoded";
+
+        PersonNameId identifier = new PersonNameId(117L, (short)2);
+
+        PersonName actual = new PersonName(
+            identifier,
+            patient,
+            resolver,
+            new PatientCommand.AddName(
+                117L,
+                Instant.parse("2021-05-15T10:00:00Z"),
+                null,
+                null,
+                "Last",
+                null,
+                "L",
+                131L,
+                Instant.parse("2020-03-03T10:15:30.00Z")
+            )
+        );
+
+        assertThat(actual)
+            .returns("Last", PersonName::getLastNm)
+            .returns("Last_encoded", PersonName::getLastNameSoundex);
+    }
+
+    @Test
+    void should_create_name_with_second_last_name_and_soundex() {
+        Person patient = new Person(117L, "local-id-value");
+        SoundexResolver resolver = value -> value + "_encoded";
+
+        PersonNameId identifier = new PersonNameId(117L, (short)2);
+
+        PersonName actual = new PersonName(
+            identifier,
+            patient,
+            resolver,
+            new PatientCommand.AddName(
+                117L,
+                Instant.parse("2023-05-15T10:00:00Z"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Second-Last",
+                null,
+                null,
+                "L",
+                131L,
+                Instant.parse("2020-03-03T10:15:30Z")
+            )
+        );
+
+        assertThat(actual)
+            .returns("Second-Last", PersonName::getLastNm2)
+            .returns("Second-Last_encoded", PersonName::getSecondLastNameSoundex);
     }
 }

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -13,6 +13,7 @@ import gov.cdc.nbs.patient.PatientHasAssociatedEventsException;
 import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
 import gov.cdc.nbs.patient.demographic.GeneralInformation;
 import gov.cdc.nbs.patient.demographic.PatientEthnicity;
+import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
@@ -99,6 +100,7 @@ class PersonTest {
   @Test
   void should_add_name() {
     Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
         new PatientCommand.AddName(
@@ -115,7 +117,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30Z")
-        )
+        ), resolver
     );
 
     assertThat(patient)
@@ -155,6 +157,7 @@ class PersonTest {
   @Test
   void should_add_another_name() {
     Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
         new PatientCommand.AddName(
@@ -167,7 +170,7 @@ class PersonTest {
             "L",
             171L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        )
+        ), resolver
     );
 
     patient.add(
@@ -185,7 +188,7 @@ class PersonTest {
             "A",
             131L,
             Instant.parse("2021-02-03T04:05:06Z")
-        )
+        ), resolver
     );
 
     assertThat(patient.getNames()).satisfiesExactly(
@@ -233,6 +236,7 @@ class PersonTest {
   @Test
   void should_update_existing_name() {
     Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
         new PatientCommand.AddName(
@@ -245,7 +249,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        )
+        ), resolver
     );
 
     patient.update(
@@ -302,6 +306,7 @@ class PersonTest {
   @Test
   void should_remove_existing_name() {
     Person patient = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
         new PatientCommand.AddName(
@@ -314,7 +319,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        )
+        ), resolver
     );
 
     patient.add(
@@ -328,7 +333,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        )
+        ), resolver
     );
 
     patient.delete(
@@ -356,6 +361,7 @@ class PersonTest {
   @Test
   void should_add_minimal_name_at_sequence_one() {
     Person actual = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     actual.add(
         new PatientCommand.AddName(
@@ -368,7 +374,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        )
+        ), resolver
     );
 
     assertThat(actual.getNames()).satisfiesExactly(
@@ -389,6 +395,7 @@ class PersonTest {
   void should_add_secondary_name() {
 
     Person actual = new Person(117L, "local-id-value");
+    SoundexResolver resolver = mock(SoundexResolver.class);
 
     actual.add(
         new PatientCommand.AddName(
@@ -400,7 +407,9 @@ class PersonTest {
             "JR",
             "L",
             131L,
-            Instant.parse("2020-03-03T10:15:30.00Z")));
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        ), resolver
+    );
 
     actual.add(
         new PatientCommand.AddName(
@@ -412,7 +421,9 @@ class PersonTest {
             "SR",
             "AL",
             131L,
-            Instant.parse("2020-03-03T10:15:30.00Z")));
+            Instant.parse("2020-03-03T10:15:30.00Z")
+        ), resolver
+    );
 
     assertThat(actual.getFirstNm()).isEqualTo("First");
     assertThat(actual.getMiddleNm()).isEqualTo("Middle");

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -103,6 +103,7 @@ class PersonTest {
     SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2023-05-15T10:00:00Z"),
@@ -117,7 +118,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30Z")
-        ), resolver
+        )
     );
 
     assertThat(patient)
@@ -160,6 +161,7 @@ class PersonTest {
     SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -170,10 +172,11 @@ class PersonTest {
             "L",
             171L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2023-05-15T10:00:00Z"),
@@ -188,7 +191,7 @@ class PersonTest {
             "A",
             131L,
             Instant.parse("2021-02-03T04:05:06Z")
-        ), resolver
+        )
     );
 
     assertThat(patient.getNames()).satisfiesExactly(
@@ -239,6 +242,7 @@ class PersonTest {
     SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -249,10 +253,11 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     patient.update(
+        resolver,
         new PatientCommand.UpdateNameInfo(
             117L,
             (short) 1,
@@ -309,6 +314,7 @@ class PersonTest {
     SoundexResolver resolver = mock(SoundexResolver.class);
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -319,10 +325,11 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     patient.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -333,7 +340,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     patient.delete(
@@ -364,6 +371,7 @@ class PersonTest {
     SoundexResolver resolver = mock(SoundexResolver.class);
 
     actual.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -374,7 +382,7 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     assertThat(actual.getNames()).satisfiesExactly(
@@ -398,6 +406,7 @@ class PersonTest {
     SoundexResolver resolver = mock(SoundexResolver.class);
 
     actual.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -408,10 +417,11 @@ class PersonTest {
             "L",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     actual.add(
+        resolver,
         new PatientCommand.AddName(
             117L,
             Instant.parse("2021-05-15T10:00:00Z"),
@@ -422,7 +432,7 @@ class PersonTest {
             "AL",
             131L,
             Instant.parse("2020-03-03T10:15:30.00Z")
-        ), resolver
+        )
     );
 
     assertThat(actual.getFirstNm()).isEqualTo("First");

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/demographic/name/PatientLegalNameResolverTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/demographic/name/PatientLegalNameResolverTest.java
@@ -29,12 +29,14 @@ class PatientLegalNameResolverTest {
   void should_resolve_empty_when_no_legal_name() {
 
     Person person = mock(Person.class);
+    SoundexResolver encoder = mock(SoundexResolver.class);
 
     Optional<PersonName> actual = PatientLegalNameResolver.resolve(
         List.of(
             new PersonName(
                 new PersonNameId(457L, (short) 2),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("1993-11-09T00:00:00Z"),
@@ -50,6 +52,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 3),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2003-06-04T00:00:00Z"),
@@ -73,12 +76,14 @@ class PatientLegalNameResolverTest {
   void should_resolve_most_recent_legal_name() {
 
     Person person = mock(Person.class);
+    SoundexResolver encoder = mock(SoundexResolver.class);
 
     Optional<PersonName> actual = PatientLegalNameResolver.resolve(
         List.of(
             new PersonName(
                 new PersonNameId(457L, (short) 2),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("1993-11-09T00:00:00Z"),
@@ -94,6 +99,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 3),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2003-06-04T00:00:00Z"),
@@ -109,6 +115,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 5),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2021-07-29T00:00:00Z"),
@@ -124,6 +131,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 7),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2024-03-19T00:00:00Z"),
@@ -150,12 +158,14 @@ class PatientLegalNameResolverTest {
   void should_resolve_most_effective_legal_name_including_that_day() {
 
     Person person = mock(Person.class);
+    SoundexResolver encoder = mock(SoundexResolver.class);
 
     Optional<PersonName> actual = PatientLegalNameResolver.resolve(
         List.of(
             new PersonName(
                 new PersonNameId(457L, (short) 2),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("1993-11-09T00:00:00Z"),
@@ -171,6 +181,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 3),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2003-06-04T00:00:00Z"),
@@ -186,6 +197,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 5),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2021-07-29T00:00:00Z"),
@@ -201,6 +213,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 7),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2024-03-19T00:00:00Z"),
@@ -227,12 +240,14 @@ class PatientLegalNameResolverTest {
   void should_resolve_most_recent_legal_name_using_sequence_when_as_of_matches() {
 
     Person person = mock(Person.class);
+    SoundexResolver encoder = mock(SoundexResolver.class);
 
     Optional<PersonName> actual = PatientLegalNameResolver.resolve(
         List.of(
             new PersonName(
                 new PersonNameId(457L, (short) 2),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("1993-11-09T00:00:00Z"),
@@ -248,6 +263,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 3),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2021-07-29T00:00:00Z"),
@@ -263,6 +279,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 5),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2021-07-29T00:00:00Z"),
@@ -278,6 +295,7 @@ class PatientLegalNameResolverTest {
             new PersonName(
                 new PersonNameId(457L, (short) 7),
                 person,
+                encoder,
                 new PatientCommand.AddName(
                     457L,
                     Instant.parse("2017-03-19T00:00:00Z"),


### PR DESCRIPTION
## Description

The corresponding soundex values are now populated when a Patient name is added or updated from the `modernization-api`.

- The `first_nm_sndx` column of the `Person_Name` table is populated with the encoded value of the "First name"
- The `last_nm_sndx` column of the `Person_Name` table is populated with the encoded value of the "Last name"
- The `last_nm2_sndx` column of the `Person_Name` table is populated with the encoded value of the "Second last name"

## Tickets

* [CNFT1-3682](https://cdc-nbs.atlassian.net/browse/CNFT1-3682)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3682]: https://cdc-nbs.atlassian.net/browse/CNFT1-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ