### PR TITLE
CNFT1-3678: New patient extended - Race repeating block blank value to dashes

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/DetailedRaceDisplay.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/DetailedRaceDisplay.tsx
@@ -1,8 +1,0 @@
-import { RaceEntry } from 'apps/patient/data/race';
-import { NoData } from 'components/NoData';
-
-type Props = {
-    entry: RaceEntry;
-};
-export const DetailedRaceDisplay = ({ entry }: Props) =>
-    entry.detailed?.map((v) => v.name).join(', ') || <NoData display="dashes" />;

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/DetailedRaceDisplay.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/DetailedRaceDisplay.tsx
@@ -1,6 +1,8 @@
 import { RaceEntry } from 'apps/patient/data/race';
+import { NoData } from 'components/NoData';
 
 type Props = {
     entry: RaceEntry;
 };
-export const DetailedRaceDisplay = ({ entry }: Props) => entry.detailed?.map((v) => v.name).join(', ');
+export const DetailedRaceDisplay = ({ entry }: Props) =>
+    entry.detailed?.map((v) => v.name).join(', ') || <NoData display="dashes" />;

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/race/RaceRepeatingBlock.tsx
@@ -3,7 +3,6 @@ import { Column } from 'design-system/table';
 import { RepeatingBlock } from 'design-system/entry/multi-value';
 import { useRaceCategoryOptions } from 'options/race';
 import { RaceEntryFields, RaceEntry, initial } from 'apps/patient/data/race';
-import { DetailedRaceDisplay } from './DetailedRaceDisplay';
 import { RaceEntryView } from './RaceEntryView';
 import { categoryValidator } from './categoryValidator';
 
@@ -13,7 +12,7 @@ const columns: Column<RaceEntry>[] = [
     {
         id: 'race-detailed',
         name: 'Detailed race',
-        render: (v) => <DetailedRaceDisplay entry={v} />
+        render: (v) => v.detailed?.map((v) => v.name).join(', ')
     }
 ];
 


### PR DESCRIPTION
## Description

Convert Race repeating block table blank value to use dashes.

![image](https://github.com/user-attachments/assets/62aba930-b88e-48f9-8350-817e1a309f94)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3678)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
