### PR TITLE
CNFT1-3467 Search API: Add filters for sex

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -41,17 +41,21 @@ public class PatientFilter {
     private String identificationType;
   }
 
-  public record Filter(String id, String name, String ageOrDateOfBirth) {
+  public record Filter(String id, String name, String ageOrDateOfBirth, String sex) {
     Filter withId(final String id) {
-      return new Filter(id, name(), ageOrDateOfBirth());
+      return new Filter(id, name(), ageOrDateOfBirth(), sex());
     }
 
     Filter withName(final String name) {
-      return new Filter(id(), name, ageOrDateOfBirth());
+      return new Filter(id(), name, ageOrDateOfBirth(), sex());
     }
 
     Filter withAgeOrDateOfBirth(final String ageOrDateOfBirth) {
-      return new Filter(id(), name(), ageOrDateOfBirth);
+      return new Filter(id(), name(), ageOrDateOfBirth, sex());
+    }
+
+    Filter withSex(final String sex) {
+      return new Filter(id(), name(), ageOrDateOfBirth(), sex);
     }
   }
 
@@ -157,7 +161,7 @@ public class PatientFilter {
 
   public Filter getFilter() {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, null);
+      this.filter = new Filter(null, null, null, null);
     }
     return filter;
   }
@@ -183,7 +187,7 @@ public class PatientFilter {
 
   public PatientFilter withIdFilter(final String idFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(idFilter, null, null);
+      this.filter = new Filter(idFilter, null, null, null);
     } else {
       this.filter = this.filter.withId(idFilter);
     }
@@ -192,7 +196,7 @@ public class PatientFilter {
 
   public PatientFilter withNameFilter(final String nameFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, nameFilter, null);
+      this.filter = new Filter(null, nameFilter, null, null);
     } else {
       this.filter = this.filter.withName(nameFilter);
     }
@@ -202,9 +206,19 @@ public class PatientFilter {
 
   public PatientFilter withAgeOrDateOfBirthFilter(final String ageOrDateOfBirthFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, ageOrDateOfBirthFilter);
+      this.filter = new Filter(null, null, ageOrDateOfBirthFilter, null);
     } else {
       this.filter = this.filter.withAgeOrDateOfBirth(ageOrDateOfBirthFilter);
+    }
+    return this;
+
+  }
+
+  public PatientFilter withSexFilter(final String sexFilter) {
+    if (this.filter == null) {
+      this.filter = new Filter(null, null, null, sexFilter);
+    } else {
+      this.filter = this.filter.withSex(sexFilter);
     }
     return this;
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaFilterResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaFilterResolver.java
@@ -76,8 +76,6 @@ class PatientSearchCriteriaFilterResolver {
   }
 
   private String getImpliedGenderFromSexFilter(String sexFilter) {
-    if (sexFilter == null)
-      return null;
     String lowerSexFilter = sexFilter.toLowerCase();
     if (lowerSexFilter.equals(Gender.F.display().toLowerCase())
         || lowerSexFilter.equals(Gender.F.value().toLowerCase())) {

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -42,6 +42,7 @@ input Filter {
   id: String
   name: String
   ageOrDateOfBirth: String
+  sex: String
 }
 
 input PersonFilter {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -61,6 +61,11 @@ public class PatientSearchCriteriaSteps {
     this.activeCriteria.maybeActive().ifPresent(found -> found.withGender(Gender.resolve(value).value()));
   }
 
+  @Given("I add the patient criteria for sex filter of {string}")
+  public void i_add_the_patient_criteria_for_sex_filter(final String value) {
+    this.activeCriteria.maybeActive().ifPresent(found -> found.withSexFilter(value));
+  }
+
   @Given("I would like patients that are {string}")
   public void i_add_the_partial_patient_criteria_record_status_of(final String status) {
     RecordStatus recordStatus = PatientStatusCriteriaResolver.resolve(status);

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -481,7 +481,7 @@ Feature: Patient Search
     And I add the patient criteria for sex filter of "u"
     When I search for patients
     Then the search results have a patient with a "gender" equal to "Unknown"
-    And there is only one patient search result    
+    Then there is only one patient search result    
 
   Scenario: I can search for a Patient when sex filter does not match gender
     Given the patient has the gender Male
@@ -494,7 +494,26 @@ Feature: Patient Search
     And I add the patient criteria for a gender of Unknown
     And I add the patient criteria for sex filter of "F"
     When I search for patients
-    And there are 0 patient search results
+    Then there are 0 patient search results
+
+  Scenario: I can search for a patient with a sex filter and name filter
+    Given the patient has the gender Male
+    And the patient has a "first name" of "Eva"
+    And patients are available for search
+    And I add the patient criteria for an "first name" equal to "Eva"
+    And I would like to filter search results with name "eva"
+    And I add the patient criteria for sex filter of "M"
+    When I search for patients
+    And there are 1 patient search results
+
+  Scenario: I can search for a patient with a sex filter that does not exist
+    Given the patient has the gender Male
+    And the patient has a "first name" of "Eva"
+    And patients are available for search
+    And I add the patient criteria for an "first name" equal to "Eva"
+    And I add the patient criteria for sex filter of "Q"
+    When I search for patients
+    Then there are 0 patient search results
 
   Scenario: BUG: CNFT1-1560 Patients with only a country code are searchable
     Given the patient has a "country code" of "+32"

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -409,9 +409,92 @@ Feature: Patient Search
     And I add the patient criteria for a gender of Unknown
     When I search for patients
     Then the search results have a patient with a "gender" equal to "Unknown"
-    And the search results have a patient without a "gender" equal to "Female"
-    And the search results have a patient without a "gender" equal to "Male"
     And there is only one patient search result
+
+  Scenario: I can find the Patient with a short sex filter
+    Given the patient has the gender <gender>
+    And the patient has a "first name" of "Eva"
+    And patients are available for search
+    And I add the patient criteria for an "first name" equal to "Eva"
+    And I add the patient criteria for sex filter of "<code>"
+    When I search for patients
+    Then there is only one patient search result    
+
+    Examples:
+      | gender  | code |
+      | Male    | M    |
+      | Female  | F    |
+      | Unknown | U    |
+
+  Scenario: I can find the Patient with a long sex filter
+    Given the patient has the gender <gender>
+    And the patient has a "first name" of "Eva"
+    And patients are available for search
+    And I add the patient criteria for an "first name" equal to "Eva"
+    And I add the patient criteria for sex filter of "<gender>"
+    When I search for patients
+    Then there is only one patient search result    
+
+    Examples:
+      | gender  |
+      | Male    |
+      | Female  |
+      | Unknown |   
+
+  Scenario: I can search for a Patient when expanded sex filter matches gender
+    Given the patient has the gender <gender>
+    And patients are available for search
+    And I add the patient criteria for a gender of <gender>
+    And I add the patient criteria for sex filter of "<gender>"
+    When I search for patients
+    Then there is only one patient search result      
+
+    Examples:
+      | gender  |
+      | Male    |
+      | Female  |
+      | Unknown |
+
+  Scenario: I can search for a Patient when short sex filter matches gender
+    Given the patient has the gender <gender>
+    And patients are available for search
+    And I add the patient criteria for a gender of <gender>
+    And I add the patient criteria for sex filter of "<code>"
+    When I search for patients
+    Then there is only one patient search result      
+
+    Examples:
+      | gender  | code |
+      | Male    | M    |
+      | Female  | F    |
+      | Unknown | U    |
+
+  Scenario: I can search for a Patient when sex filter matches gender
+    Given the patient has the gender Male
+    And I have another patient
+    And the patient has the gender Female
+    And I have another patient
+    And the patient has the gender Unknown
+    And I have another patient
+    And patients are available for search
+    And I add the patient criteria for a gender of Unknown
+    And I add the patient criteria for sex filter of "u"
+    When I search for patients
+    Then the search results have a patient with a "gender" equal to "Unknown"
+    And there is only one patient search result    
+
+  Scenario: I can search for a Patient when sex filter does not match gender
+    Given the patient has the gender Male
+    And I have another patient
+    And the patient has the gender Female
+    And I have another patient
+    And the patient has the gender Unknown
+    And I have another patient
+    And patients are available for search
+    And I add the patient criteria for a gender of Unknown
+    And I add the patient criteria for sex filter of "F"
+    When I search for patients
+    And there are 0 patient search results
 
   Scenario: BUG: CNFT1-1560 Patients with only a country code are searchable
     Given the patient has a "country code" of "+32"

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -207,6 +207,7 @@ export type Filter = {
   ageOrDateOfBirth?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  sex?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum Gender {

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1136,6 +1136,7 @@ input Filter {
   id: String
   name: String
   ageOrDateOfBirth: String
+  sex: String
 }
 
 input PersonFilter {


### PR DESCRIPTION
## Description

Combine the existing term query for gender with sex filter.  Derive the implied sex by parsing the text (ie m is Male).
1) if the filter matches the old term query nothing to be done
2) if the filter does not match the old term query add a non-existent term query to return no results found. We could also bubble this up to the top to return no results but not worth the effort to optimize a rare condition.
3) if there is no old term query just use the implied sex as the term query

## Tickets

* [CNFT1-3467](https://cdc-nbs.atlassian.net/browse/CNFT1-3467)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3467]: https://cdc-nbs.atlassian.net/browse/CNFT1-3467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ