### PR TITLE
Cnft1 3615 UI new patient extended all repeating blocks horizontal scroll bar

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -27,7 +27,6 @@
     }
 
     .dataTable {
-        overflow: hidden;
         padding-bottom: 1rem;
         .iconContainer {
             display: flex;

--- a/apps/modernization-ui/src/design-system/table/data-table.module.scss
+++ b/apps/modernization-ui/src/design-system/table/data-table.module.scss
@@ -5,7 +5,8 @@
     overflow: auto;
     height: 100%;
     width: 100%;
-
+    padding-right: 6px;
+    
     table {
         table-layout: auto !important;
         border-collapse: separate;


### PR DESCRIPTION
## Description

Removed the flag to always hide scrollbar, and instead added padding to the right of the data table to prevent the scrollbar from appearing when not needed. 

Padding right by 6px is needed to keep the table from trying to expand into the entirety of the container element, and then the margins of the table contents (buttons + text) **plus** border styling then pushing the table to be slightly larger than the width of the container element (making the scrollbar appear even when the table contents are not overflowing). 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3615)


