### PR TITLE
change work phone extension to 1 to 8 digits

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/phoneEmail/BasicPhoneEmailFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/phoneEmail/BasicPhoneEmailFields.tsx
@@ -62,15 +62,15 @@ export const BasicPhoneEmailFields = ({
                 rules={{
                     pattern: {
                         value: /^\+?\d{1,20}$/,
-                        message: 'An Extension should be 1 to 20 digits'
+                        message: 'An Extension should be 1 to 8 digits'
                     }
                 }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
                     <MaskedTextInputField
                         id={name}
                         label="Work phone extension"
-                        mask="____________________"
-                        pattern="^\+?\d{1,20}$"
+                        mask="________"
+                        pattern="^\+?\d{1,8}$"
                         value={value}
                         onBlur={onBlur}
                         onChange={onChange}


### PR DESCRIPTION
## Description

UI: New patient: Phone & email: Work phone extension: character limit has to be 8.
Add character limit (8) to the Extension field. After character 8, user should not be allowed to enter any data.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3672)
