### PR TITLE
[CNT-126] - E2E - Invalid future date in "information as of date"

### DIFF
--- a/testing/regression/cypress/e2e/features/nbs-classic/patient.feature
+++ b/testing/regression/cypress/e2e/features/nbs-classic/patient.feature
@@ -19,10 +19,15 @@ Feature: Classic NBS - Dedupe - User can view data in NBS Patient Search Page
     Then Form should be submitted successfully without errors
     And I should receive a confirmation message
 
-  Scenario: Scenario: Valid "Information as of Date"
+  Scenario: Valid "Information as of Date"
     Given I am on the New patient Extended form
     And I have filled out all Information as of Date field
     When I click the Save button
     Then Form should be submitted successfully without errors
     And I should receive a confirmation message
+
+  Scenario: Invalid "Information as of Date"
+    Given I am on the New patient Extended form
+    And I have filled out future date in Information as of Date field
+    Then Error message should appear right above Information as of Date field
 

--- a/testing/regression/cypress/e2e/pages/nbs-classic/patient.page.js
+++ b/testing/regression/cypress/e2e/pages/nbs-classic/patient.page.js
@@ -51,8 +51,32 @@ class ClassicPatientSearchPage {
     cy.contains("You have successfully added a new patient")
   }
 
-  fillInformationAsOfDateField() {
-    cy.get('input[id="administrative.asOf"]').type("01/20/2025")
+  fillInformationAsOfDateField(date) {
+    const field = cy.get('input[id="administrative.asOf"]')
+    field.invoke('val', date || "01/20/2024").trigger('change')
+    field.click()
+    cy.contains("Administrative").eq(0).click()
+  }
+
+  errorMessageInformationAsOfField() {
+    cy.contains("The Information as of date should occur before or within the current year")
+  }
+
+  fillCommentsField(type) {
+    let commentText;
+    if(type === 'empty') {
+      return commentText = ''
+    } if('invalid') {
+        commentText = 'A'.repeat(2001)
+    } else {
+        commentText = 'Comments about the new patient'
+    }
+    cy.get('textarea[id="administrative.comment"]').type(commentText)
+    cy.contains("Administrative").eq(0).click()
+  }
+
+  errorMessageCommentsField() {
+    cy.contains("The Comments only allows 2000 characters")
   }
 
 }

--- a/testing/regression/cypress/step_definitions/nbs-classic/patient.steps.js
+++ b/testing/regression/cypress/step_definitions/nbs-classic/patient.steps.js
@@ -44,3 +44,23 @@ Then("I should receive a confirmation message", () => {
 Then("I have filled out all Information as of Date field", () => {
     classicSearchPatientPage.fillInformationAsOfDateField()
 });
+
+Then("I have filled out future date in Information as of Date field", () => {
+    classicSearchPatientPage.fillInformationAsOfDateField("01/23/2055")
+});
+
+Then("Error message should appear right above Information as of Date field", () => {
+    classicSearchPatientPage.errorMessageInformationAsOfField()
+});
+
+Then("I have filled out invalid text in Comments field", () => {
+    classicSearchPatientPage.fillCommentsField('invalid')
+});
+
+Then("Error message should appear right above Comments field", () => {
+    classicSearchPatientPage.errorMessageCommentsField()
+});
+
+Then("I have filled out empty text in Comments field", () => {
+    classicSearchPatientPage.fillCommentsField("empty")
+});


### PR DESCRIPTION
## Description

Added end to end test for invalid future date in "information as of date" field.
<img width="1501" alt="Screenshot 2025-01-24 at 7 47 10 AM" src="https://github.com/user-attachments/assets/cb82d23b-d545-4434-9b49-c7f3cf53ced4" />

## Tickets

* [CNT-126](https://cdc-nbs.atlassian.net/browse/CNT-126)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNT-126]: https://cdc-nbs.atlassian.net/browse/CNT-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ