### PR TITLE
[CNFT1-3635]: saving default sort on load in useSortingPreferences

### DIFF
--- a/apps/modernization-ui/src/design-system/sorting/preferences/useSortingPreferences.tsx
+++ b/apps/modernization-ui/src/design-system/sorting/preferences/useSortingPreferences.tsx
@@ -77,6 +77,7 @@ const SortingPreferenceProvider = ({ id, children, available = [], defaultSort }
             dispatch({ type: 'load', active: value });
         } else if (defaultSort) {
             dispatch({ type: 'load', active: defaultSort });
+            save(defaultSort);
         }
     }, [value]);
 


### PR DESCRIPTION
## Description
Ensuring Patient Name column defaultSort is saved on load through `useSortingPreferences`
<img width="1498" alt="Screenshot 2025-01-27 at 9 16 25 AM" src="https://github.com/user-attachments/assets/4e1092dc-56f0-4cd8-8c21-4f0dc6d397f2" />

## Tickets

* [CNFT1-3635](https://cdc-nbs.atlassian.net/browse/CNFT1-3635)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
