### PR TITLE
defaultValues on AddPatientBasic form initialization set to include the US as the default country.

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
@@ -21,7 +21,15 @@ export const AddPatientBasic = () => {
     const interaction = useAddBasicPatient();
     const { features } = useConfiguration();
     const form = useForm<BasicNewPatientEntry>({
-        defaultValues: initialize(),
+        defaultValues: {
+            ...initialize(),
+            address: {
+                country: {
+                    value: '840',
+                    name: 'United States'
+                }
+            }
+        },
         mode: 'onBlur'
     });
 


### PR DESCRIPTION
## Description

The default short add patient form was not correctly displaying the default country code. The short add patient form now auto populates with US as default country. 



## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3718)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
