### PR TITLE
Remove padding bottom from repeating block

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -27,7 +27,6 @@
     }
 
     .dataTable {
-        padding-bottom: 1rem;
         .iconContainer {
             display: flex;
             gap: 0.5rem;


### PR DESCRIPTION
## Description

Remove the padding at the end of the Table.
AC: User should not be seeing any space after the table in the repeating block.


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3680)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
