### PR TITLE
Error checking for required name fields

### DIFF
--- a/testing/regression/cypress/e2e/features/patient-extended-form/patient.feature
+++ b/testing/regression/cypress/e2e/features/patient-extended-form/patient.feature
@@ -53,3 +53,8 @@ Feature: Classic NBS - Dedupe - User can view data in NBS Patient Search Page
     Then Form should be submitted successfully without errors
     And I should receive a confirmation message
 
+Scenario: Required Name Fields
+    Given I am on the New patient Extended form
+    When I leave the Type field empty
+    Then the system should display an error message indicating that the field is required
+    

--- a/testing/regression/cypress/e2e/pages/patient-extended-form/patient-extended.page.js
+++ b/testing/regression/cypress/e2e/pages/patient-extended-form/patient-extended.page.js
@@ -19,6 +19,17 @@ class NameEntryPage {
     // Click the "Add name" button
     cy.contains("button", "Add name").click();
   }
+
+  verifyRequiredFieldError() {
+    // Click the "Add name" button
+    cy.contains("button", "Add name").click({ force: true });
+
+    // Verify that the error message is displayed
+    cy.get(".alert-message_title__UqoEz")
+      .should("be.visible")
+      .and("contain.text", "Please fix the following errors:");
+  }
+
 }
 
 export default new NameEntryPage();

--- a/testing/regression/cypress/step_definitions/patient-extended-form/patient.steps.js
+++ b/testing/regression/cypress/step_definitions/patient-extended-form/patient.steps.js
@@ -78,3 +78,11 @@ Then("I clear Comments sections field", () => {
 When("I enter a valid name in the First and Last name fields", () => {
     NameEntryPage.enterValidFirstAndLastName();
   });
+
+Then("the system should display an error message indicating that the field is required", () => {
+    NameEntryPage.verifyRequiredFieldError();
+  });
+
+When("I leave the Type field empty", () => {
+  });
+


### PR DESCRIPTION
Check that error message is displayed when required field is empty in the Name section.

## Description

Check that error message is displayed when required field is empty in the Name section. 
<img width="1512" alt="CNT-135" src="https://github.com/user-attachments/assets/e95f984c-7bba-4ea1-b654-3224d4fdd237" />


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNT-135)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
