### PR TITLE
[CNT-136] -E2E - Valid Address Input

### DIFF
--- a/testing/regression/cypress/e2e/features/patient-extended-form/patient.feature
+++ b/testing/regression/cypress/e2e/features/patient-extended-form/patient.feature
@@ -57,4 +57,11 @@ Scenario: Required Name Fields
     Given I am on the New patient Extended form
     When I leave the Type field empty
     Then the system should display an error message indicating that the field is required
-    
+
+  Scenario: Valid Address Input
+    Given I am on the New patient Extended form
+    And I have filled out Address input fields
+    When I click the Save button
+    Then Form should be submitted successfully without errors
+    And I should receive a confirmation message
+

--- a/testing/regression/cypress/e2e/pages/patient-extended-form/patient.page.js
+++ b/testing/regression/cypress/e2e/pages/patient-extended-form/patient.page.js
@@ -87,6 +87,21 @@ class ClassicPatientSearchPage {
     cy.get('textarea[id="administrative.comment"]').clear().blur()
   }
 
+  fillExtendedAddressFormDetails(type) {
+    if(type === 'invalid') {
+        cy.contains('button', 'Add address').click()
+        return
+    }
+
+    cy.get('#address-type').select('H')
+    cy.get('#address-use').select('BDL')
+    cy.contains('button', 'Add address').click()
+  }
+
+  errorMessageAddressField() {
+    cy.contains('The Type is required')
+    cy.contains('The Use is required')
+  }
 }
 
 export default new ClassicPatientSearchPage();

--- a/testing/regression/cypress/step_definitions/patient-extended-form/patient.steps.js
+++ b/testing/regression/cypress/step_definitions/patient-extended-form/patient.steps.js
@@ -86,3 +86,14 @@ Then("the system should display an error message indicating that the field is re
 When("I leave the Type field empty", () => {
   });
 
+Then("I have filled out Address input fields", () => {
+    classicSearchPatientPage.fillExtendedAddressFormDetails()
+});
+
+Then("I have not filled out all Address input fields", () => {
+    classicSearchPatientPage.fillExtendedAddressFormDetails('invalid')
+});
+
+Then("Error message should appear right above Address fields", () => {
+    classicSearchPatientPage.errorMessageAddressField()
+});


### PR DESCRIPTION
## Description

Added end to end test for valid address  on patient extended form.
<img width="1507" alt="Screenshot 2025-01-30 at 6 07 22 AM" src="https://github.com/user-attachments/assets/0d818ede-7584-47ca-9ab5-18b18368bcdd" />

## Tickets

* [CNT-136](https://cdc-nbs.atlassian.net/browse/CNT-136)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNT-136]: https://cdc-nbs.atlassian.net/browse/CNT-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ