### PR TITLE
CNFT1-3470 Search API: Add filters for Identification

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -51,6 +51,8 @@ class PatientDemographicQueryResolver {
   private static final String CITY = "address.city";
   private static final String STATE = "address.stateText";
   private static final String ZIP_CODE = "address.zip";
+  private static final String IDENTIFICATION = "entity_id.rootExtensionTxt";
+
   private final PatientSearchSettings settings;
   private final PatientLocalIdentifierResolver resolver;
   private final PatientNameDemographicQueryResolver nameQueryResolver;
@@ -88,6 +90,7 @@ class PatientDemographicQueryResolver {
         applyEmailCriteria(criteria),
         applyEmailFilter(criteria),
         applyIdentificationCriteria(criteria),
+        applyIdentificationFilter(criteria),
         applyDateOfBirthCriteria(criteria),
         applyPatientAgeOrDateOfBirthFilterCriteria(criteria),
         applyStreetAddressCriteria(criteria),
@@ -329,6 +332,17 @@ class PatientDemographicQueryResolver {
         .map(value -> contains(EMAILS, EMAIL_ADDRESS, value));
   }
 
+  private Optional<QueryVariant> applyIdentificationFilter(final PatientFilter criteria) {
+
+    if (criteria.getFilter().identification() == null) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(new TextCriteria(null, null, null, criteria.getFilter().identification(), null))
+        .flatMap(TextCriteria::maybeContains)
+        .map(value -> contains(IDENTIFICATIONS, IDENTIFICATION, value));
+  }
+
   private Optional<QueryVariant> applyEmailCriteria(final PatientFilter criteria) {
 
     String email = criteria.getEmail();
@@ -368,7 +382,7 @@ class PatientDemographicQueryResolver {
                                       .value(type)))
                               .must(
                                   must -> must.wildcard(
-                                      match -> match.field("entity_id.rootExtensionTxt").caseInsensitive(true)
+                                      match -> match.field(IDENTIFICATION).caseInsensitive(true)
                                           .value(WildCards.contains(value))))))));
     }
     return Optional.empty();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -338,7 +338,9 @@ class PatientDemographicQueryResolver {
       return Optional.empty();
     }
 
-    return Optional.ofNullable(new TextCriteria(null, null, null, criteria.getFilter().identification(), null))
+    return Optional
+        .ofNullable(new TextCriteria(null, null, null,
+            AdjustStrings.withoutSpecialCharacters(criteria.getFilter().identification()), null))
         .flatMap(TextCriteria::maybeContains)
         .map(value -> contains(IDENTIFICATIONS, IDENTIFICATION, value));
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientFilter.java
@@ -42,33 +42,37 @@ public class PatientFilter {
   }
 
   public record Filter(String id, String name, String ageOrDateOfBirth, String sex, String address, String email,
-      String phone) {
+      String phone, String identification) {
     Filter withId(final String id) {
-      return new Filter(id, name(), ageOrDateOfBirth(), sex(), address(), email(), null);
+      return new Filter(id, name(), ageOrDateOfBirth(), sex(), address(), email(), null, null);
     }
 
     Filter withName(final String name) {
-      return new Filter(id(), name, ageOrDateOfBirth(), sex(), address(), email(), null);
+      return new Filter(id(), name, ageOrDateOfBirth(), sex(), address(), email(), null, null);
     }
 
     Filter withAgeOrDateOfBirth(final String ageOrDateOfBirth) {
-      return new Filter(id(), name(), ageOrDateOfBirth, sex(), address(), email(), null);
+      return new Filter(id(), name(), ageOrDateOfBirth, sex(), address(), email(), null, null);
     }
 
     Filter withSex(final String sex) {
-      return new Filter(id(), name(), ageOrDateOfBirth(), sex, address(), email(), null);
+      return new Filter(id(), name(), ageOrDateOfBirth(), sex, address(), email(), null, null);
     }
 
     Filter withAddress(final String address) {
-      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address, email(), null);
+      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address, email(), null, null);
     }
 
     Filter withEmail(final String email) {
-      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address(), email, null);
+      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address(), email, null, null);
     }
 
     Filter withPhone(final String phone) {
-      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address(), email(), phone);
+      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address(), email(), phone, null);
+    }
+
+    Filter withIdentification(final String identification) {
+      return new Filter(id(), name(), ageOrDateOfBirth(), sex(), address(), email(), phone(), identification);
     }
 
   }
@@ -175,7 +179,7 @@ public class PatientFilter {
 
   public Filter getFilter() {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, null, null, null, null, null);
+      this.filter = new Filter(null, null, null, null, null, null, null, null);
     }
     return filter;
   }
@@ -201,7 +205,7 @@ public class PatientFilter {
 
   public PatientFilter withIdFilter(final String idFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(idFilter, null, null, null, null, null, null);
+      this.filter = new Filter(idFilter, null, null, null, null, null, null, null);
     } else {
       this.filter = this.filter.withId(idFilter);
     }
@@ -210,7 +214,7 @@ public class PatientFilter {
 
   public PatientFilter withNameFilter(final String nameFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, nameFilter, null, null, null, null, null);
+      this.filter = new Filter(null, nameFilter, null, null, null, null, null, null);
     } else {
       this.filter = this.filter.withName(nameFilter);
     }
@@ -220,7 +224,7 @@ public class PatientFilter {
 
   public PatientFilter withAddressFilter(final String addressFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, null, null, addressFilter, null, null);
+      this.filter = new Filter(null, null, null, null, addressFilter, null, null, null);
     } else {
       this.filter = this.filter.withAddress(addressFilter);
     }
@@ -230,7 +234,7 @@ public class PatientFilter {
 
   public PatientFilter withEmailFilter(final String emailFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, null, null, null, emailFilter, null);
+      this.filter = new Filter(null, null, null, null, null, emailFilter, null, null);
     } else {
       this.filter = this.filter.withEmail(emailFilter);
     }
@@ -240,7 +244,7 @@ public class PatientFilter {
 
   public PatientFilter withPhoneFilter(final String phoneFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, null, null, null, null, phoneFilter);
+      this.filter = new Filter(null, null, null, null, null, null, phoneFilter, null);
     } else {
       this.filter = this.filter.withPhone(phoneFilter);
     }
@@ -250,7 +254,7 @@ public class PatientFilter {
 
   public PatientFilter withAgeOrDateOfBirthFilter(final String ageOrDateOfBirthFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, ageOrDateOfBirthFilter, null, null, null, null);
+      this.filter = new Filter(null, null, ageOrDateOfBirthFilter, null, null, null, null, null);
     } else {
       this.filter = this.filter.withAgeOrDateOfBirth(ageOrDateOfBirthFilter);
     }
@@ -260,9 +264,19 @@ public class PatientFilter {
 
   public PatientFilter withSexFilter(final String sexFilter) {
     if (this.filter == null) {
-      this.filter = new Filter(null, null, null, sexFilter, null, null, null);
+      this.filter = new Filter(null, null, null, sexFilter, null, null, null, null);
     } else {
       this.filter = this.filter.withSex(sexFilter);
+    }
+    return this;
+
+  }
+
+  public PatientFilter withIdentificationFilter(final String identificationFilter) {
+    if (this.filter == null) {
+      this.filter = new Filter(null, null, null, null, null, null, null, identificationFilter);
+    } else {
+      this.filter = this.filter.withIdentification(identificationFilter);
     }
     return this;
 

--- a/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
+++ b/apps/modernization-api/src/main/resources/graphql/patient-search.graphqls
@@ -46,6 +46,7 @@ input Filter {
   sex: String
   email: String
   phone: String
+  identification: String
 }
 
 input PersonFilter {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSteps.java
@@ -152,6 +152,13 @@ public class PatientSearchCriteriaSteps {
             .active(criteria -> criteria.withPhoneFilter(phone)));
   }
 
+  @Given("I would like to filter search results with identification {string}")
+  public void i_would_like_to_filter_search_results_with_identification(String identification) {
+    this.patient.maybeActive().ifPresent(
+        found -> this.activeCriteria
+            .active(criteria -> criteria.withIdentificationFilter(identification)));
+  }
+
   @Given("I would like to filter search results with age or dob {string}")
   public void i_would_like_to_filter_search_results_with_age_or_dob(String ageOrDateOfBirth) {
     this.patient.maybeActive().ifPresent(

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -443,6 +443,35 @@ Feature: Patient Search
     When I search for patients
     Then the patient is in the search results
 
+  Scenario: I can search for a Patient using a specific Identification and filter
+    Given the patient can be identified with a "MC" of "5507"
+    And the patient can be identified with a "DL" of "4099"
+    And patients are available for search
+    And I add the patient criteria for an "identification value" equal to "4099"
+    And I would like to filter search results with identification "09"
+    When I search for patients
+    Then there are 1 patient search results
+
+  Scenario: I can search for a Patient using a specific Identification and non matching filter
+    Given the patient can be identified with a "MC" of "5507"
+    And the patient can be identified with a "DL" of "4099"
+    And patients are available for search
+    And I add the patient criteria for an "identification value" equal to "4099"
+    And I would like to filter search results with identification "111"
+    When I search for patients
+    Then there are 0 patient search results
+
+  Scenario: I can search for a Patient using a specific Identification and two filters
+    Given the patient can be identified with a "MC" of "5507"
+    And the patient can be identified with a "DL" of "4099"
+    And the patient has the gender Female
+    And patients are available for search
+    And I add the patient criteria for an "identification value" equal to "4099"
+    And I add the patient criteria for sex filter of "F"
+    And I would like to filter search results with identification "09"
+    When I search for patients
+    Then there are 1 patient search results
+
   Scenario Outline: I can search for a Patient with a specified Gender
     Given the patient has the gender Male
     And I have another patient

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -452,6 +452,15 @@ Feature: Patient Search
     When I search for patients
     Then there are 1 patient search results
 
+  Scenario: I can search for a Patient using a specific Identification and filter with dashes
+    Given the patient can be identified with a "MC" of "5507"
+    And the patient can be identified with a "DL" of "4099"
+    And patients are available for search
+    And I add the patient criteria for an "identification value" equal to "4099"
+    And I would like to filter search results with identification "40-99"
+    When I search for patients
+    Then there are 1 patient search results
+
   Scenario: I can search for a Patient using a specific Identification and non matching filter
     Given the patient can be identified with a "MC" of "5507"
     And the patient can be identified with a "DL" of "4099"

--- a/apps/modernization-ui/src/generated/graphql/schema.ts
+++ b/apps/modernization-ui/src/generated/graphql/schema.ts
@@ -208,6 +208,7 @@ export type Filter = {
   ageOrDateOfBirth?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
+  identification?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
   sex?: InputMaybe<Scalars['String']['input']>;

--- a/apps/modernization-ui/src/generated/schema.graphqls
+++ b/apps/modernization-ui/src/generated/schema.graphqls
@@ -1140,6 +1140,7 @@ input Filter {
   sex: String
   email: String
   phone: String
+  identification: String
 }
 
 input PersonFilter {


### PR DESCRIPTION
## Description

Leverage contains code in the TextCriteria for an elasticsearch filter query on `entity_id.rootExtensionTxt`. Strip special characters.

## Tickets

* [CNFT1-3470](https://cdc-nbs.atlassian.net/browse/CNFT1-3470)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3470]: https://cdc-nbs.atlassian.net/browse/CNFT1-3470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ