### PR TITLE
Adds notification transport status API

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatus.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatus.java
@@ -1,0 +1,5 @@
+package gov.cdc.nbs.patient.profile.investigation.notification;
+
+public record NotificationStatus(String status) {
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusController.java
@@ -2,12 +2,12 @@ package gov.cdc.nbs.patient.profile.investigation.notification;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/nbs/api/notification")
+@RequestMapping("/nbs/api/notifications")
 @PreAuthorize("hasAuthority('VIEW-INVESTIGATION')")
 public class NotificationStatusController {
   private final NotificationStatusResolver resolver;
@@ -16,8 +16,8 @@ public class NotificationStatusController {
     this.resolver = resolver;
   }
 
-  @GetMapping("/transport/status")
-  public NotificationStatus findStatus(@RequestParam final String notificationId) {
-    return resolver.resolve(notificationId);
+  @GetMapping("/{id}/transport/status")
+  public NotificationStatus findStatus(@PathVariable final String id) {
+    return resolver.resolve(id);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusController.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.patient.profile.investigation.notification;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/nbs/api/notification")
+@PreAuthorize("hasAuthority('VIEW-INVESTIGATION')")
+public class NotificationStatusController {
+  private final NotificationStatusResolver resolver;
+
+  public NotificationStatusController(final NotificationStatusResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @GetMapping("/transport/status")
+  public NotificationStatus findStatus(@RequestParam final String notificationId) {
+    return resolver.resolve(notificationId);
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusResolver.java
@@ -1,0 +1,37 @@
+package gov.cdc.nbs.patient.profile.investigation.notification;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Component;
+
+@Component
+class NotificationStatusResolver {
+
+  private final NamedParameterJdbcTemplate template;
+
+  NotificationStatusResolver(NamedParameterJdbcTemplate template) {
+    this.template = template;
+  }
+
+  private static final String QUERY = """
+      SELECT
+          processingStatus
+      FROM
+          NBS_MSGOUTE.dbo.TransportQ_out
+      WHERE
+          messageId = :notificationId
+            """;
+
+  public NotificationStatus resolve(String notificationId) {
+    SqlParameterSource params = new MapSqlParameterSource()
+        .addValue("notificationId", notificationId);
+    try {
+      return new NotificationStatus(template.queryForObject(QUERY, params, String.class));
+    } catch (EmptyResultDataAccessException e) {
+      return new NotificationStatus(null);
+    }
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
@@ -4,29 +4,48 @@ import gov.cdc.nbs.testing.support.Active;
 import gov.cdc.nbs.testing.support.concept.ConceptParameterResolver;
 import io.cucumber.java.ParameterType;
 import io.cucumber.java.en.Given;
-
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import java.time.Instant;
+import org.springframework.test.web.servlet.ResultActions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
 
 public class InvestigationNotificationSteps {
 
   private final Active<InvestigationIdentifier> activeInvestigation;
+  private final Active<NotificationIdentifier> activeNotification;
+  private final Active<ResultActions> response;
   private final InvestigationNotificationMother mother;
   private final ConceptParameterResolver resolver;
+  private final NotificationTransportStatusRequester requester;
 
   InvestigationNotificationSteps(
       final Active<InvestigationIdentifier> activeInvestigation,
+      final Active<NotificationIdentifier> activeNotification,
+      final Active<ResultActions> response,
       final InvestigationNotificationMother mother,
-      final ConceptParameterResolver resolver
-  ) {
+      final ConceptParameterResolver resolver,
+      final NotificationTransportStatusRequester requester) {
     this.activeInvestigation = activeInvestigation;
+    this.activeNotification = activeNotification;
+    this.response = response;
     this.mother = mother;
     this.resolver = resolver;
+    this.requester = requester;
   }
 
   @ParameterType(name = "notificationStatus", value = ".*")
   public String notificationStatus(final String value) {
     return resolver.resolve("REC_STAT_NOT_UI", value)
         .orElse(null);
+  }
+
+  @ParameterType(name = "notificationTransportStatus", value = ".*")
+  public String notificationTransportStatus(final String value) {
+    return "null".equals(value) ? null : value;
   }
 
   @Given("the investigation has a notification {notificationStatus} as of {date}")
@@ -36,9 +55,7 @@ public class InvestigationNotificationSteps {
           investigation -> mother.create(
               investigation,
               value,
-              on
-          )
-      );
+              on));
     }
   }
 
@@ -49,10 +66,27 @@ public class InvestigationNotificationSteps {
           investigation -> mother.create(
               investigation,
               value,
-              Instant.now()
-          )
-      );
+              Instant.now()));
     }
+  }
+
+  @Given("the notification exists in the TransportQ_out table with status of {notificationTransportStatus}")
+  public void the_notification_exists_in_the_transportq_out_table_with_status_of(final String status) {
+    this.activeInvestigation.maybeActive().ifPresent(
+        investigation -> mother.createTransportStatus(status));
+  }
+
+  @When("I query for a notifications transport status")
+  public void i_query_for_a_notifications_transport_status() throws Exception {
+    assertThat(activeNotification.active()).isNotNull();
+    response.active(requester.request(activeNotification.active().local()));
+  }
+
+  @Then("I receive a notification transport status of {notificationTransportStatus}")
+  public void i_receive_a_notification_transport_status(final String status) throws Exception {
+    response.active()
+        .andExpect(jsonPath("$.status").value(equalTo(status)));
+
   }
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/NotificationTransportStatusRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/NotificationTransportStatusRequester.java
@@ -24,8 +24,7 @@ class NotificationTransportStatusRequester {
   ResultActions request(final String notificationId) throws Exception {
     return mvc.perform(
         this.authenticated.withUser(
-            get("/nbs/api/notification/transport/status")
-                .queryParam("notificationId", notificationId)))
+            get("/nbs/api/notifications/{id}/transport/status", notificationId)))
         .andDo(print());
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/NotificationTransportStatusRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/NotificationTransportStatusRequester.java
@@ -1,0 +1,31 @@
+package gov.cdc.nbs.event.investigation;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import gov.cdc.nbs.testing.interaction.http.Authenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+
+
+@Component
+class NotificationTransportStatusRequester {
+  private final MockMvc mvc;
+  private final Authenticated authenticated;
+
+  NotificationTransportStatusRequester(
+      final MockMvc mvc,
+      final Authenticated authenticated) {
+    this.mvc = mvc;
+    this.authenticated = authenticated;
+  }
+
+  ResultActions request(final String notificationId) throws Exception {
+    return mvc.perform(
+        this.authenticated.withUser(
+            get("/nbs/api/notification/transport/status")
+                .queryParam("notificationId", notificationId)))
+        .andDo(print());
+  }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/profile/event/notification/PatientProfile.notification.status.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/event/notification/PatientProfile.notification.status.feature
@@ -1,0 +1,19 @@
+@notification_processing_status
+Feature: Notification status from TransportQ_out table
+
+  Background:
+    Given I am logged in
+    And I can "VIEW" any "INVESTIGATION"
+    And I have a patient
+    And the patient is a subject of an investigation
+    And the investigation has a notification status of APPROVED
+
+
+  Scenario: I can view a notification's status in the TransportQ_out table
+    Given the notification exists in the TransportQ_out table with status of queued
+    When I query for a notifications transport status
+    Then I receive a notification transport status of queued
+
+  Scenario: I can view a notification's status in the TransportQ_out table
+    When I query for a notifications transport status
+    Then I receive a notification transport status of null


### PR DESCRIPTION
## Description

Adds a notification status api that returns the status from the NBS_MSGOUTE.TransportQ_out table for the specified notification.

This is to support the request to have a true end-to-end automated test that:
1. Ingests ELR
2. Triggers pre-configured WDS rule to generate a notification
3. Verify Investigation and notification are created via UI
4. Verify Notification is picked up and moved into `TransportQ_out` table with status of `queued` to await pickup by PHINMS


## Tickets

* [CNT-149](https://cdc-nbs.atlassian.net/browse/CNT-149)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNT-149]: https://cdc-nbs.atlassian.net/browse/CNT-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ