### PR TITLE
Notification status api by investigation Uid

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/nbs/api/notifications")
+@RequestMapping("/nbs/api/investigations/{id}/notifications")
 @PreAuthorize("hasAuthority('VIEW-INVESTIGATION')")
 public class NotificationStatusController {
   private final NotificationStatusResolver resolver;
@@ -16,8 +16,8 @@ public class NotificationStatusController {
     this.resolver = resolver;
   }
 
-  @GetMapping("/{id}/transport/status")
-  public NotificationStatus findStatus(@PathVariable final String id) {
+  @GetMapping("/transport/status")
+  public NotificationStatus findLatestStatus(@PathVariable final String id) {
     return resolver.resolve(id);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusResolver.java
@@ -17,16 +17,21 @@ class NotificationStatusResolver {
 
   private static final String QUERY = """
       SELECT
-          processingStatus
+          TOP 1 t.processingStatus
       FROM
-          NBS_MSGOUTE.dbo.TransportQ_out
+          Act_relationship ar
+          JOIN Notification n ON n.notification_uid = ar.source_act_uid
+          JOIN NBS_MSGOUTE.dbo.TransportQ_out t ON t.messageId = n.local_id
       WHERE
-          messageId = :notificationId
-            """;
+          ar.target_act_uid = :investigationId
+          AND ar.type_cd = 'Notification'
+      ORDER BY
+          t.messageCreationTime DESC;
+                  """;
 
-  public NotificationStatus resolve(String notificationId) {
+  public NotificationStatus resolve(String investigationId) {
     SqlParameterSource params = new MapSqlParameterSource()
-        .addValue("notificationId", notificationId);
+        .addValue("investigationId", investigationId);
     try {
       return new NotificationStatus(template.queryForObject(QUERY, params, String.class));
     } catch (EmptyResultDataAccessException e) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
@@ -79,7 +79,7 @@ public class InvestigationNotificationSteps {
   @When("I query for a notifications transport status")
   public void i_query_for_a_notifications_transport_status() throws Exception {
     assertThat(activeNotification.active()).isNotNull();
-    response.active(requester.request(activeNotification.active().local()));
+    response.active(requester.request(activeInvestigation.active().identifier()));
   }
 
   @Then("I receive a notification transport status of {notificationTransportStatus}")

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/NotificationTransportStatusRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/NotificationTransportStatusRequester.java
@@ -21,10 +21,10 @@ class NotificationTransportStatusRequester {
     this.authenticated = authenticated;
   }
 
-  ResultActions request(final String notificationId) throws Exception {
+  ResultActions request(final Long investigationId) throws Exception {
     return mvc.perform(
         this.authenticated.withUser(
-            get("/nbs/api/notifications/{id}/transport/status", notificationId)))
+            get("/nbs/api/investigations/{id}/notifications/transport/status", investigationId)))
         .andDo(print());
   }
 }


### PR DESCRIPTION
## Description

Updates the notification transport status API to use the Investigation Uid instead of the Notification Local Id.

Updated API:
`/nbs/api/investigations/{id}/notifications`

Example:
`/nbs/api/investigations/10034124/notifications`

## Tickets

* [CNT-149](https://cdc-nbs.atlassian.net/browse/CNT-149)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNT-149]: https://cdc-nbs.atlassian.net/browse/CNT-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ