### PR TITLE
Change to CN_Transportq_out table

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatusResolver.java
@@ -17,17 +17,15 @@ class NotificationStatusResolver {
 
   private static final String QUERY = """
       SELECT
-          TOP 1 t.processingStatus
+          top 1 t.record_status_cd
       FROM
           Act_relationship ar
-          JOIN Notification n ON n.notification_uid = ar.source_act_uid
-          JOIN NBS_MSGOUTE.dbo.TransportQ_out t ON t.messageId = n.local_id
+          JOIN Public_health_case phc on ar.target_act_uid = phc.public_health_case_uid
+          JOIN CN_transportq_out t on t.notification_uid = ar.source_act_uid
       WHERE
-          ar.target_act_uid = :investigationId
-          AND ar.type_cd = 'Notification'
-      ORDER BY
-          t.messageCreationTime DESC;
-                  """;
+          target_act_uid = :investigationId
+          AND type_cd = 'Notification';
+      """;
 
   public NotificationStatus resolve(String investigationId) {
     SqlParameterSource params = new MapSqlParameterSource()

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationMother.java
@@ -64,28 +64,18 @@ class InvestigationNotificationMother {
       """;
 
   private static final String DELETE = """
+      delete from CN_transportq_out where notification_uid in (:identifiers);
       delete from Notification where notification_uid in (:identifiers);
       delete from Act_relationship where source_act_uid in (:identifiers);
       delete from Act where act_uid in (:identifiers);
-      delete from NBS_MSGOUTE.[dbo].TransportQ_out where messageId in (:localIds);
       """;
 
   private static final String CREATE_TRANSPORT_NOTIFICATION = """
-      insert into NBS_MSGOUTE.[dbo].TransportQ_out (
-      		routeInfo,
-      		SERVICE,
-      		ACTION,
-      		encryption,
-      		SIGNATURE,
-      		messageId,
-      		processingStatus
+      insert into CN_transportq_out (
+      		notification_uid,
+      		record_status_cd
       	) values (
-          'CDC',
-          'NNDM_1.1.3',
-          'send',
-          'yes',
-          'no',
-          :messageId,
+          :notificationId,
           :processingStatus);
         """;
 
@@ -112,14 +102,10 @@ class InvestigationNotificationMother {
         .map(NotificationIdentifier::identifier)
         .toList();
 
-    List<String> localIds = this.available.all()
-        .map(NotificationIdentifier::local)
-        .toList();
     if (!created.isEmpty()) {
 
       SqlParameterSource params = new MapSqlParameterSource()
-          .addValue("identifiers", created)
-          .addValue("localIds", localIds);
+          .addValue("identifiers", created);
 
       template.execute(
           DELETE,
@@ -156,7 +142,7 @@ class InvestigationNotificationMother {
 
   void createTransportStatus(final String status) {
     SqlParameterSource parameters = new MapSqlParameterSource()
-        .addValue("messageId", active.active().local())
+        .addValue("notificationId", active.active().identifier())
         .addValue("processingStatus", status);
     template.execute(
         CREATE_TRANSPORT_NOTIFICATION,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
@@ -70,7 +70,7 @@ public class InvestigationNotificationSteps {
     }
   }
 
-  @Given("the notification exists in the TransportQ_out table with status of {notificationTransportStatus}")
+  @Given("the notification exists in the CN_TransportQ_out table with status of {notificationTransportStatus}")
   public void the_notification_exists_in_the_transportq_out_table_with_status_of(final String status) {
     this.activeInvestigation.maybeActive().ifPresent(
         investigation -> mother.createTransportStatus(status));

--- a/apps/modernization-api/src/test/resources/features/patient/profile/event/notification/PatientProfile.notification.status.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/event/notification/PatientProfile.notification.status.feature
@@ -10,7 +10,7 @@ Feature: Notification status from TransportQ_out table
 
 
   Scenario: I can view a notification's status in the TransportQ_out table
-    Given the notification exists in the TransportQ_out table with status of queued
+    Given the notification exists in the CN_TransportQ_out table with status of queued
     When I query for a notifications transport status
     Then I receive a notification transport status of queued
 


### PR DESCRIPTION
## Description

Transport status change to pull from `CN_Transportq_out` instead of `Transportq_out`. 
Still uses investigation uid.

## Tickets

* [CNT-149](https://cdc-nbs.atlassian.net/browse/CNT-149)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNT-149]: https://cdc-nbs.atlassian.net/browse/CNT-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ