### PR TITLE
[CNFT1-3805] non email type addresess in search results

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/email/PatientSearchResultEmailFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/email/PatientSearchResultEmailFinder.java
@@ -10,17 +10,17 @@ class PatientSearchResultEmailFinder {
 
   private static final String QUERY = """
       select distinct
-          IsNull([email_address].email_address, '') as [email]
+          [email_address].email_address as [email]
       from Entity_locator_participation [locator]
-
+      
           join Tele_locator [email_address] on
                   [email_address].[tele_locator_uid] = [locator].[locator_uid]
               and [email_address].record_status_cd = [locator].[record_status_cd]
-
-
+              and [email_address].email_address is not null
+      
+      
       where   [locator].entity_uid = ?
           and [locator].[class_cd] = 'TELE'
-          and [locator].cd = 'NET'
           and [locator].record_status_cd = 'ACTIVE'
       """;
   private static final int PATIENT_PARAMETER = 1;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultDetailedPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/phone/PatientSearchResultDetailedPhoneFinder.java
@@ -26,6 +26,7 @@ class PatientSearchResultDetailedPhoneFinder {
           join Tele_locator [phone_number] on
                   [phone_number].[tele_locator_uid] = [locators].[locator_uid]
               and [phone_number].record_status_cd   = [locators].[record_status_cd]
+              and [phone_number].phone_nbr_txt is not null
 
           left join  NBS_SRTE..Code_value_general [type] on
                   [type].code_set_nm = 'EL_TYPE_TELE_PAT'


### PR DESCRIPTION
## Description

Email addresses from Phone & Email entries that do not have a "Type" of "Email Address" are now included in patient search results.

![image](https://github.com/user-attachments/assets/b616653d-2c31-409f-97ac-788f6cd2fe79)

![image](https://github.com/user-attachments/assets/2cf5bdf2-522a-4796-a2c4-b6e7bb00ad61)


## Tickets

* [CNFT1-3805](https://cdc-nbs.atlassian.net/browse/CNFT1-3805)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3805]: https://cdc-nbs.atlassian.net/browse/CNFT1-3805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ