### PR TITLE
CNFT1-3818: ButtonActionMenu: make left side label the default (see image)

### DIFF
--- a/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.spec.tsx
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.spec.tsx
@@ -21,4 +21,26 @@ describe('When ButtonActionMenu renders', () => {
         expect(queryByText('Test this')).not.toBeInTheDocument();
         expect(queryByText('Test that')).not.toBeInTheDocument();
     });
+
+    it('should display label on the left by default', () => {
+        const { getByText } = render(
+            <ButtonActionMenu label="Add new">
+                <></>
+            </ButtonActionMenu>
+        );
+
+        expect(getByText('Add new')).toBeInTheDocument();
+        expect(getByText('Add new').previousElementSibling).toBeNull();
+    });
+
+    it('should display label on the right when specified', () => {
+        const { getByText } = render(
+            <ButtonActionMenu label="Add new" labelPosition="right">
+                <></>
+            </ButtonActionMenu>
+        );
+
+        expect(getByText('Add new')).toBeInTheDocument();
+        expect(getByText('Add new').nextElementSibling).toBeNull();
+    });
 });

--- a/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.tsx
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/ButtonActionMenu.tsx
@@ -22,8 +22,7 @@ export const ButtonActionMenu = ({
     icon,
     outline,
     className,
-    labelPosition = 'right',
-
+    labelPosition = 'left',
     children
 }: Props) => {
     const wrapperRef = useRef(null);

--- a/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
@@ -51,7 +51,10 @@
     .actionMenuButton {
         padding: 0.375rem 1.25rem;
         line-height: 0;
-        span {
+        span:first-child {
+            margin-left: 1rem;
+        }
+        span:last-child {
             margin-right: 1rem;
         }
     }


### PR DESCRIPTION
## Description

Change ButtonActionMenu default label position to left side.
Fix `<span>` element margin spacing so it looks correct for both sides.

![image](https://github.com/user-attachments/assets/4dbb81db-bf37-468d-99f2-5561e9b959c5)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3818)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
