### PR TITLE
[CNFT1-3798]: adding padding right to filter class for header filter field

### DIFF
--- a/apps/modernization-ui/src/design-system/table/header/filter/header-filter-field.module.scss
+++ b/apps/modernization-ui/src/design-system/table/header/filter/header-filter-field.module.scss
@@ -3,4 +3,5 @@
 .filter {
     font-size: components.$medium-font-size;
     height: components.$medium-height !important;
+    padding-right: 1.75rem !important;
 }


### PR DESCRIPTION
## Description

Adding padding right to fix issue with text overlapping over the x icon on the filter field
Issue
<img width="425" alt="Screenshot 2025-02-14 at 9 46 45 AM" src="https://github.com/user-attachments/assets/ad0355f9-c29d-4fe6-a268-9979b49e6ba1" />

Issue resolved 
<img width="552" alt="Screenshot 2025-02-14 at 9 47 06 AM" src="https://github.com/user-attachments/assets/91ce68b8-ce7f-4790-abb8-9f51bdc548a1" />

## Tickets

* [CNFT1-3798](https://cdc-nbs.atlassian.net/browse/CNFT1-3798)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3798]: https://cdc-nbs.atlassian.net/browse/CNFT1-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ