### PR TITLE
[CNFT1-3804] Reset clears inactive filters

### DIFF
--- a/apps/modernization-ui/src/design-system/filter/useFilter.spec.tsx
+++ b/apps/modernization-ui/src/design-system/filter/useFilter.spec.tsx
@@ -72,6 +72,18 @@ describe('FilterProvider', () => {
         expect(result.current.filter).toEqual(expect.objectContaining({ filtered: 'filtered-value' }));
     });
 
+    it('should return applied filter value for the id', () => {
+        const { result } = renderHook(() => useFilter(), { wrapper });
+
+        act(() => {
+            result.current.apply('filtered', 'filtered-value');
+        });
+
+        const actual = result.current.valueOf('filtered');
+
+        expect(actual).toEqual('filtered-value');
+    });
+
     it('should clear the filter value for the id', () => {
         const { result } = renderHook(() => useFilter(), { wrapper });
 

--- a/apps/modernization-ui/src/design-system/filter/useFilter.tsx
+++ b/apps/modernization-ui/src/design-system/filter/useFilter.tsx
@@ -8,6 +8,7 @@ type FilterInteraction = {
     show: () => void;
     hide: () => void;
     toggle: () => void;
+    valueOf: (id: string) => string | undefined;
     apply: (id: string, value: string) => void;
     clear: (id: string) => void;
     clearAll: () => void;
@@ -22,6 +23,7 @@ const FilterProvider = ({ children }: FilterProviderProps) => {
     const [active, setActive] = useState(false);
     const [filter, setFilter] = useState<Filter>();
 
+    const valueOf = useCallback((id: string) => (filter ? filter[id] : undefined), [filter]);
     const show = useCallback(() => setActive(true), [setActive]);
     const hide = useCallback(() => setActive(false), [setActive]);
     const toggle = useCallback(() => setActive((prev) => !prev), [setActive]);
@@ -37,7 +39,8 @@ const FilterProvider = ({ children }: FilterProviderProps) => {
     }, [setActive, setFilter]);
 
     return (
-        <FilterableContext.Provider value={{ active, filter, show, hide, toggle, apply, clear, clearAll, reset }}>
+        <FilterableContext.Provider
+            value={{ active, filter, show, hide, toggle, valueOf, apply, clear, clearAll, reset }}>
             {children}
         </FilterableContext.Provider>
     );

--- a/apps/modernization-ui/src/design-system/input/text/TextInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInput.tsx
@@ -64,9 +64,9 @@ const TextInput = ({
                 value={current}
                 {...props}
             />
-            {clearable && (
+            {clearable && current && (
                 <span className={styles.suffix}>
-                    {current && <Icon role="button" name="close" size="small" onClick={handleClear} />}
+                    <Icon role="button" name="close" size="small" onClick={handleClear} />
                 </span>
             )}
         </span>

--- a/apps/modernization-ui/src/design-system/input/text/text-input.module.scss
+++ b/apps/modernization-ui/src/design-system/input/text/text-input.module.scss
@@ -4,6 +4,7 @@
     align-items: center;
     display: flex;
     padding: 0;
+    margin-top: 0.5rem;
     position: relative;
 
     border-width: 1px;
@@ -16,6 +17,8 @@
         border: 0;
         margin-top: 0;
         min-width: 0;
+
+        padding-right: 1.5rem;
     }
 
     .suffix {

--- a/apps/modernization-ui/src/design-system/table/Header.tsx
+++ b/apps/modernization-ui/src/design-system/table/Header.tsx
@@ -40,7 +40,7 @@ const StandardHeader = <V,>({ className, children, filtering, sizing }: Standard
         })}>
         <div className={classNames(styles.content)}>
             {children.name}
-            {filtering && filtering.active && children.filter != undefined && (
+            {filtering?.active && children?.filter?.id && (
                 <HeaderFilterField label={children.name} descriptor={children.filter} filtering={filtering} />
             )}
         </div>
@@ -72,7 +72,7 @@ const SortableHeader = <V,>({ className, sorting, children, filtering, sizing }:
                         onClick={() => sorting.toggle(children.id)}
                     />
                 </div>
-                {filtering && filtering.active && children.filter != undefined && (
+                {filtering?.active && children?.filter?.id && (
                     <HeaderFilterField label={children.name} descriptor={children.filter} filtering={filtering} />
                 )}
             </div>

--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.spec.tsx
@@ -1,8 +1,9 @@
 import { render, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FilterInteraction, FilterProvider, FilterType } from 'design-system/filter';
+import { FilterInteraction, FilterType } from 'design-system/filter';
 import { HeaderFilterField } from './HeaderFilterField';
 
+const mockValueOf = jest.fn();
 const mockApply = jest.fn();
 const mockClear = jest.fn();
 
@@ -12,6 +13,7 @@ const mockInteraction: FilterInteraction = {
     show: jest.fn(),
     hide: jest.fn(),
     toggle: jest.fn(),
+    valueOf: mockValueOf,
     apply: mockApply,
     clear: mockClear,
     clearAll: jest.fn(),
@@ -33,6 +35,14 @@ describe('when filtering table data from the header', () => {
         const { getByRole } = render(<Fixture id="test-id" />);
         const input = getByRole('textbox');
         expect(input).toHaveValue('');
+    });
+
+    it('should contain the applied filter value', () => {
+        mockValueOf.mockReturnValue('applied-value');
+
+        const { getByRole } = render(<Fixture id="test-id" />);
+        const input = getByRole('textbox');
+        expect(input).toHaveValue('applied-value');
     });
 
     it('should apply the filter when enter is pressed', () => {

--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
@@ -8,20 +8,21 @@ import styles from './header-filter-field.module.scss';
 type HeaderFilterFieldProps = { descriptor: FilterDescriptor; label: string; filtering: FilterInteraction };
 
 const HeaderFilterField = ({ descriptor, label, filtering }: HeaderFilterFieldProps) => {
-    const { apply, clear, filter } = filtering;
+    const { valueOf, apply, clear } = filtering;
 
-    const initialValue = filter ? filter[descriptor.id] : undefined;
+    const initialValue = valueOf(descriptor.id);
     const [value, setValue] = useState<string | undefined>(initialValue);
 
     useEffect(() => {
-        setValue(initialValue);
-    }, [initialValue]);
+        setValue(valueOf(descriptor.id));
+    }, [valueOf]);
 
     const handleKey = (event: ReactKeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'Enter') {
             event.stopPropagation();
-            if (value) {
-                apply(descriptor.id, value);
+            const next = (event.target as HTMLInputElement).value;
+            if (next) {
+                apply(descriptor.id, next);
             } else {
                 clear(descriptor.id);
             }
@@ -35,7 +36,7 @@ const HeaderFilterField = ({ descriptor, label, filtering }: HeaderFilterFieldPr
     return (
         <Shown when={descriptor.type === 'text'}>
             <TextInput
-                clearable
+                clearable={Boolean(initialValue)}
                 className={styles.filter}
                 id={`text-filter-${descriptor.id}`}
                 name={label}


### PR DESCRIPTION
## Description

Ensures that filter values that have not been applied are cleared when "Reset sort/filters" is clicked.

![CNFT1-3804](https://github.com/user-attachments/assets/35d4092e-5429-4835-ba2a-2561683c1c82)


## Tickets

* [CNFT1-3804](https://cdc-nbs.atlassian.net/browse/CNFT1-3804)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3804]: https://cdc-nbs.atlassian.net/browse/CNFT1-3804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-3804]: https://cdc-nbs.atlassian.net/browse/CNFT1-3804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ