### PR TITLE
Return notification local id with status

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatus.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatus.java
@@ -1,5 +1,7 @@
 package gov.cdc.nbs.patient.profile.investigation.notification;
 
-public record NotificationStatus(String status) {
+public record NotificationStatus(
+    String status,
+    String notificationLocalId) {
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatus.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/notification/NotificationStatus.java
@@ -2,6 +2,6 @@ package gov.cdc.nbs.patient.profile.investigation.notification;
 
 public record NotificationStatus(
     String status,
-    String notificationLocalId) {
+    String localId) {
 
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationMother.java
@@ -73,9 +73,11 @@ class InvestigationNotificationMother {
   private static final String CREATE_TRANSPORT_NOTIFICATION = """
       insert into CN_transportq_out (
       		notification_uid,
+          notification_local_id,
       		record_status_cd
       	) values (
           :notificationId,
+          :notificationLocalId,
           :processingStatus);
         """;
 
@@ -143,6 +145,7 @@ class InvestigationNotificationMother {
   void createTransportStatus(final String status) {
     SqlParameterSource parameters = new MapSqlParameterSource()
         .addValue("notificationId", active.active().identifier())
+        .addValue("notificationLocalId", active.active().local())
         .addValue("processingStatus", status);
     template.execute(
         CREATE_TRANSPORT_NOTIFICATION,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
@@ -89,4 +89,10 @@ public class InvestigationNotificationSteps {
 
   }
 
+  @Then("the notification transport status includes the notification local Id")
+  public void notification_transport_status_includes_notification_local_id() throws Exception {
+    response.active()
+        .andExpect(jsonPath("$.notificationLocalId").value(equalTo(activeNotification.active().local())));
+  }
+
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationNotificationSteps.java
@@ -92,7 +92,7 @@ public class InvestigationNotificationSteps {
   @Then("the notification transport status includes the notification local Id")
   public void notification_transport_status_includes_notification_local_id() throws Exception {
     response.active()
-        .andExpect(jsonPath("$.notificationLocalId").value(equalTo(activeNotification.active().local())));
+        .andExpect(jsonPath("$.localId").value(equalTo(activeNotification.active().local())));
   }
 
 }

--- a/apps/modernization-api/src/test/resources/features/patient/profile/event/notification/PatientProfile.notification.status.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/event/notification/PatientProfile.notification.status.feature
@@ -13,6 +13,7 @@ Feature: Notification status from TransportQ_out table
     Given the notification exists in the CN_TransportQ_out table with status of queued
     When I query for a notifications transport status
     Then I receive a notification transport status of queued
+    And the notification transport status includes the notification local Id
 
   Scenario: I can view a notification's status in the TransportQ_out table
     When I query for a notifications transport status


### PR DESCRIPTION
## Description

Adds the notification local id to the transport status response to allow verification of `NETSS_TransportQ_out` status in simulated "on prem" database.

Unfortunately, when data is copied over to the database, only the Transport tables are copied. This removes the ability to query using the public_health_case_uid, so the notification local id is needed.


https://cdc-nbs.atlassian.net/wiki/spaces/NM/pages/1247051777/Data+Sync+Service+for+NNDSS+data+-+Montana



## Tickets

NA

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
