### PR TITLE
[CNFT1-3712] Repeating block clear and cancel

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/identification/BasicIdentificationRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/identification/BasicIdentificationRepeatingBlock.spec.tsx
@@ -1,6 +1,9 @@
 import { render } from '@testing-library/react';
 import { PatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
-import { BasicIdentificationRepeatingBlock } from './BasicIdentificationRepeatingBlock';
+import {
+    BasicIdentificationRepeatingBlock,
+    BasicIdentificationRepeatingBlockProps
+} from './BasicIdentificationRepeatingBlock';
 
 const mockPatientIdentificationCodedValues: PatientIdentificationCodedValues = {
     types: [{ name: 'Account number', value: 'AN' }],
@@ -11,29 +14,26 @@ jest.mock('apps/patient/profile/identification/usePatientIdentificationCodedValu
     usePatientIdentificationCodedValues: () => mockPatientIdentificationCodedValues
 }));
 
-const mockEntry = {
-    state: {
-        data: [
-            {
-                type: 'AN',
-                idValue: '12341241'
-            }
-        ]
-    }
-};
-
-jest.mock('design-system/entry/multi-value/useMultiValueEntryState', () => ({
-    useMultiValueEntryState: () => mockEntry
-}));
-
-const onChange = jest.fn();
-const isDirty = jest.fn();
-
-const Fixture = () => <BasicIdentificationRepeatingBlock id="identifications" onChange={onChange} isDirty={isDirty} />;
+const Fixture = ({
+    values,
+    onChange = jest.fn(),
+    isDirty = jest.fn()
+}: Partial<BasicIdentificationRepeatingBlockProps>) => (
+    <BasicIdentificationRepeatingBlock id="identifications" values={values} onChange={onChange} isDirty={isDirty} />
+);
 
 describe('BasicIdentificationRepeatingBlock', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<Fixture />);
+        const { getAllByRole } = render(
+            <Fixture
+                values={[
+                    {
+                        type: { value: 'type-value', name: 'type-name' },
+                        id: '12341241'
+                    }
+                ]}
+            />
+        );
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('Type');

--- a/apps/modernization-ui/src/apps/patient/add/basic/identification/BasicIdentificationRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/identification/BasicIdentificationRepeatingBlock.tsx
@@ -52,3 +52,5 @@ export const BasicIdentificationRepeatingBlock = ({
         />
     );
 };
+
+export type { BasicIdentificationRepeatingBlockProps };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/address/AddressRepeatingBlock.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { internalizeDate } from 'date';
 import { AddressRepeatingBlock } from './AddressRepeatingBlock';
+import { AddressEntry } from 'apps/patient/data';
 
 const mockPatientAddressCodedValues = {
     types: [{ name: 'House', value: 'H' }],
@@ -9,22 +10,6 @@ const mockPatientAddressCodedValues = {
 
 jest.mock('apps/patient/profile/addresses/usePatientAddressCodedValues', () => ({
     usePatientAddressCodedValues: () => mockPatientAddressCodedValues
-}));
-
-const mockEntry = {
-    state: {
-        data: [
-            {
-                asOf: internalizeDate(new Date()),
-                type: 'H',
-                use: 'HM'
-            }
-        ]
-    }
-};
-
-jest.mock('design-system/entry/multi-value/useMultiValueEntryState', () => ({
-    useMultiValueEntryState: () => mockEntry
 }));
 
 const mockLocationCodedValues = {
@@ -44,11 +29,27 @@ jest.mock('location/useLocationCodedValues', () => ({
 const onChange = jest.fn();
 const isDirty = jest.fn();
 
-const Fixture = () => <AddressRepeatingBlock id="races" onChange={onChange} isDirty={isDirty} />;
+type FixtureProps = {
+    values?: AddressEntry[];
+};
 
-describe('RaceMultiEntry', () => {
+const Fixture = ({ values }: FixtureProps) => (
+    <AddressRepeatingBlock id="races" values={values} onChange={onChange} isDirty={isDirty} />
+);
+
+describe('when entering multiple address demographics', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<Fixture />);
+        const { getAllByRole } = render(
+            <Fixture
+                values={[
+                    {
+                        asOf: '07/11/1997',
+                        type: { name: 'type-name', value: 'type-value' },
+                        use: { name: 'use-name', value: 'use-value' }
+                    }
+                ]}
+            />
+        );
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { internalizeDate } from 'date';
-import { IdentificationRepeatingBlock } from './IdentificationRepeatingBlock';
+import { IdentificationRepeatingBlock, IdentificationRepeatingBlockProps } from './IdentificationRepeatingBlock';
 import { PatientIdentificationCodedValues } from 'apps/patient/profile/identification/usePatientIdentificationCodedValues';
 
 const mockPatientIdentificationCodedValues: PatientIdentificationCodedValues = {
@@ -12,30 +12,17 @@ jest.mock('apps/patient/profile/identification/usePatientIdentificationCodedValu
     usePatientIdentificationCodedValues: () => mockPatientIdentificationCodedValues
 }));
 
-const mockEntry = {
-    state: {
-        data: [
-            {
-                asOf: internalizeDate(new Date()),
-                type: 'AN',
-                idValue: '12341241'
-            }
-        ]
-    }
-};
-
-jest.mock('design-system/entry/multi-value/useMultiValueEntryState', () => ({
-    useMultiValueEntryState: () => mockEntry
-}));
-
-const onChange = jest.fn();
-const isDirty = jest.fn();
-
-const Fixture = () => <IdentificationRepeatingBlock id="identifications" onChange={onChange} isDirty={isDirty} />;
+const Fixture = ({ values, onChange = jest.fn(), isDirty = jest.fn() }: Partial<IdentificationRepeatingBlockProps>) => (
+    <IdentificationRepeatingBlock id="identifications" values={values} onChange={onChange} isDirty={isDirty} />
+);
 
 describe('IdentificationMultiEntry', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<Fixture />);
+        const { getAllByRole } = render(
+            <Fixture
+                values={[{ asOf: '02/19/2023', type: { value: 'type-value', name: 'type-name' }, id: '12341241' }]}
+            />
+        );
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/identification/IdentificationRepeatingBlock.tsx
@@ -6,14 +6,20 @@ import { IdentificationView } from './IdentificationView';
 
 const defaultValue: Partial<IdentificationEntry> = initial();
 
-type Props = {
+type IdentificationRepeatingBlockProps = {
     id: string;
     values?: IdentificationEntry[];
     onChange: (data: IdentificationEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
     errors?: ReactNode[];
 };
-export const IdentificationRepeatingBlock = ({ id, errors, values, onChange, isDirty }: Props) => {
+export const IdentificationRepeatingBlock = ({
+    id,
+    errors,
+    values,
+    onChange,
+    isDirty
+}: IdentificationRepeatingBlockProps) => {
     const renderForm = () => <IdentificationEntryFields />;
     const renderView = (entry: IdentificationEntry) => <IdentificationView entry={entry} />;
 
@@ -38,3 +44,5 @@ export const IdentificationRepeatingBlock = ({ id, errors, values, onChange, isD
         />
     );
 };
+
+export type { IdentificationRepeatingBlockProps };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.spec.tsx
@@ -1,9 +1,6 @@
 import { render } from '@testing-library/react';
 import { internalizeDate } from 'date';
-import { NameRepeatingBlock } from './NameRepeatingBlock';
-
-const onChange = jest.fn();
-const isDirty = jest.fn();
+import { NameRepeatingBlock, NameRepeatingBlockProps } from './NameRepeatingBlock';
 
 const mockPatientNameCodedValues = {
     types: [{ name: 'Adopted name', value: 'AN' }],
@@ -12,31 +9,26 @@ const mockPatientNameCodedValues = {
     degrees: [{ name: 'BA', value: 'BA' }]
 };
 
-const mockEntry = {
-    state: {
-        data: [
-            {
-                asOf: internalizeDate(new Date()),
-                type: 'AN',
-                first: 'test'
-            }
-        ]
-    }
-};
-
-jest.mock('design-system/entry/multi-value/useMultiValueEntryState', () => ({
-    useMultiValueEntryState: () => mockEntry
-}));
-
 jest.mock('apps/patient/profile/names/usePatientNameCodedValues', () => ({
     usePatientNameCodedValues: () => mockPatientNameCodedValues
 }));
 
-const Fixture = () => <NameRepeatingBlock id="names" onChange={onChange} isDirty={isDirty} />;
+const Fixture = ({ values, onChange = jest.fn(), isDirty = jest.fn() }: Partial<NameRepeatingBlockProps>) => (
+    <NameRepeatingBlock id="names" values={values} onChange={onChange} isDirty={isDirty} />
+);
 
 describe('NameRepeatingBlock', () => {
     it('should display correct table headers', async () => {
-        const { getAllByRole } = render(<Fixture />);
+        const { getAllByRole } = render(
+            <Fixture
+                values={[
+                    {
+                        asOf: '07/11/1997',
+                        type: { name: 'type-name', value: 'type-value' }
+                    }
+                ]}
+            />
+        );
 
         const headers = getAllByRole('columnheader');
         expect(headers[0]).toHaveTextContent('As of');

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/name/NameRepeatingBlock.tsx
@@ -15,7 +15,7 @@ const columns: Column<NameEntry>[] = [
     { id: 'nameSuffix', name: 'Suffix', render: (v) => v.suffix?.name }
 ];
 
-type Props = {
+type NameRepeatingBlockProps = {
     id: string;
     values?: NameEntry[];
     onChange: (data: NameEntry[]) => void;
@@ -23,7 +23,7 @@ type Props = {
     errors?: ReactNode[];
 };
 
-export const NameRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Props) => {
+export const NameRepeatingBlock = ({ id, values, errors, onChange, isDirty }: NameRepeatingBlockProps) => {
     const renderForm = () => <NameEntryFields />;
     const renderView = (entry: NameEntry) => <NameEntryView entry={entry} />;
 
@@ -42,3 +42,5 @@ export const NameRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Pr
         />
     );
 };
+
+export type { NameRepeatingBlockProps };

--- a/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/inputs/phone/PhoneAndEmailRepeatingBlock.tsx
@@ -6,14 +6,20 @@ import { PhoneEntryView } from './PhoneEntryView';
 
 const defaultValue: Partial<PhoneEmailEntry> = initial();
 
-type Props = {
+type PhoneAndEmailRepeatingBlockProps = {
     id: string;
     values?: PhoneEmailEntry[];
     onChange: (data: PhoneEmailEntry[]) => void;
     isDirty: (isDirty: boolean) => void;
     errors?: ReactNode[];
 };
-export const PhoneAndEmailRepeatingBlock = ({ id, values, errors, onChange, isDirty }: Props) => {
+export const PhoneAndEmailRepeatingBlock = ({
+    id,
+    values,
+    errors,
+    onChange,
+    isDirty
+}: PhoneAndEmailRepeatingBlockProps) => {
     const renderForm = () => <PhoneEmailEntryFields />;
     const renderView = (entry: PhoneEmailEntry) => <PhoneEntryView entry={entry} />;
 
@@ -40,3 +46,5 @@ export const PhoneAndEmailRepeatingBlock = ({ id, values, errors, onChange, isDi
         />
     );
 };
+
+export type { PhoneAndEmailRepeatingBlockProps };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -27,7 +27,7 @@
     }
 
     .dataTable {
-        .iconContainer {
+        .actions {
             display: flex;
             gap: 0.5rem;
             justify-content: flex-end;
@@ -36,6 +36,12 @@
                 color: colors.$primary;
                 cursor: pointer;
                 font-size: icons.$size-standard;
+            }
+
+            .active {
+                border-radius: 0.25rem;
+                color: colors.$base-white;
+                background-color: colors.$primary-darker;
             }
         }
     }

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -56,6 +56,7 @@
 
     footer {
         display: flex;
+        gap: 0.5rem;
         padding: 0.5rem 1.5rem 0.5rem 16.5rem;
 
         svg {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -183,7 +183,6 @@ describe('RepeatingBlock', () => {
         userEvent.click(button);
 
         await waitFor(() => {
-            expect(onChange).toBeCalledTimes(2);
             expect(onChange).toHaveBeenNthCalledWith(1, []);
             expect(onChange).toHaveBeenNthCalledWith(2, [
                 { firstInput: 'first input value', secondInput: 'second input value' }
@@ -200,7 +199,6 @@ describe('RepeatingBlock', () => {
         userEvent.click(button);
 
         await waitFor(() => {
-            expect(onChange).toBeCalledTimes(2);
             expect(onChange).toHaveBeenNthCalledWith(1, []);
             expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
         });
@@ -230,7 +228,6 @@ describe('RepeatingBlock', () => {
 
         // expect value to be added
         await waitFor(() => {
-            expect(onChange).toBeCalledTimes(2);
             expect(onChange).toHaveBeenNthCalledWith(1, []);
             expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'typed value', secondInput: 'second value' }]);
         });
@@ -258,7 +255,6 @@ describe('RepeatingBlock', () => {
         userEvent.click(button);
 
         await waitFor(() => {
-            expect(onChange).toBeCalledTimes(2);
             expect(onChange).toHaveBeenNthCalledWith(1, []);
             expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
         });
@@ -288,7 +284,6 @@ describe('RepeatingBlock', () => {
         userEvent.click(button);
 
         await waitFor(() => {
-            expect(onChange).toBeCalledTimes(2);
             expect(onChange).toHaveBeenNthCalledWith(1, []);
             expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
         });
@@ -304,50 +299,62 @@ describe('RepeatingBlock', () => {
     });
 
     it('should delete row when delete icon clicked', async () => {
-        const { getByRole, getAllByRole } = render(<Fixture />);
+        const { getByLabelText } = render(
+            <Fixture
+                values={[
+                    {
+                        firstInput: 'first-value',
+                        secondInput: 'second-value',
+                        others: []
+                    }
+                ]}
+            />
+        );
 
         await awaitRender();
 
-        const button = getByRole('button');
-        userEvent.click(button);
+        const remove = getByLabelText('Delete');
+        userEvent.click(remove);
 
         await waitFor(() => {
-            expect(onChange).toBeCalledTimes(2);
-            expect(onChange).toHaveBeenNthCalledWith(1, []);
-            expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
-        });
-
-        const iconContainer = getAllByRole('cell')[2].children[0].children[0];
-
-        await waitFor(() => {
-            userEvent.click(iconContainer.children[2].children[0]);
-            expect(onChange).toBeCalledTimes(3);
-            expect(onChange).toHaveBeenNthCalledWith(3, []);
+            expect(onChange).toHaveBeenCalledWith([]);
         });
     });
 
     it('should allow edit of row', async () => {
-        const { getByRole, getAllByRole, getByLabelText } = render(<Fixture />);
+        const { getByRole, getAllByRole, getByLabelText, debug } = render(
+            <Fixture
+                values={[
+                    {
+                        firstInput: 'first-value',
+                        secondInput: 'second-value',
+                        others: []
+                    }
+                ]}
+            />
+        );
 
         await awaitRender();
 
-        const button = getByRole('button');
-        const input1 = getByLabelText('First Input');
-        const input2 = getByLabelText('Second Input');
+        const edit = getByLabelText('Edit');
 
-        userEvent.clear(input1);
-        userEvent.type(input1, 'first changed');
-        userEvent.clear(input2);
-        userEvent.type(input2, 'second changed');
+        userEvent.click(edit);
+
+        const button = getByRole('button', { name: 'Update test title' });
+        const input1 = getByLabelText('First Input');
+
+        userEvent.type(input1, '-changed');
+        userEvent.tab();
+
         userEvent.click(button);
 
         await waitFor(() => {
             // change event fires, form resets to default
-            expect(onChange).toBeCalledTimes(2);
-            expect(onChange).toHaveBeenNthCalledWith(1, []);
-            expect(onChange).toHaveBeenNthCalledWith(2, [
-                { firstInput: 'first changed', secondInput: 'second changed' }
-            ]);
+            expect(onChange).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({ firstInput: 'first-value-changed', secondInput: 'second-value' })
+                ])
+            );
             expect(getByLabelText('First Input')).toHaveValue('first value');
             expect(getByLabelText('Second Input')).toHaveValue('second value');
         });
@@ -357,35 +364,15 @@ describe('RepeatingBlock', () => {
         await waitFor(() => {
             // view clicked, input values set to entry value
             userEvent.click(iconContainer.children[1].children[0]);
-            expect(getByLabelText('First Input')).toHaveValue('first changed');
-            expect(getByLabelText('Second Input')).toHaveValue('second changed');
-        });
-
-        userEvent.clear(input1);
-        userEvent.type(input1, 'first changed again');
-        userEvent.clear(input2);
-        userEvent.type(input2, 'second changed again');
-        userEvent.click(button);
-
-        await waitFor(() => {
-            // change event fires, form resets to default
-            expect(onChange).toBeCalledTimes(3);
-            expect(onChange).toHaveBeenNthCalledWith(1, []);
-            expect(onChange).toHaveBeenNthCalledWith(2, [
-                { firstInput: 'first changed', secondInput: 'second changed' }
-            ]);
-            expect(onChange).toHaveBeenNthCalledWith(3, [
-                { firstInput: 'first changed again', secondInput: 'second changed again' }
-            ]);
-            expect(getByLabelText('First Input')).toHaveValue('first value');
-            expect(getByLabelText('Second Input')).toHaveValue('second value');
+            expect(getByLabelText('First Input')).toHaveValue('first-value-changed');
+            expect(getByLabelText('Second Input')).toHaveValue('second-value');
         });
 
         // table display updated
         const columns = getAllByRole('cell');
         expect(columns).toHaveLength(3);
-        expect(columns[0]).toHaveTextContent('first changed again');
-        expect(columns[1]).toHaveTextContent('second changed again');
+        expect(columns[0]).toHaveTextContent('first-value-changed');
+        expect(columns[1]).toHaveTextContent('second-value');
         expect(columns[2]).toHaveTextContent('');
     });
 

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -2,22 +2,13 @@ import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Input } from 'components/FormInputs/Input';
-import { RepeatingBlock } from './RepeatingBlock';
-import { ReactNode } from 'react';
+import { RepeatingBlock, RepeatingBlockProps } from './RepeatingBlock';
 
 type TestType = {
     firstInput: string;
     secondInput: string;
     thirdInput?: number;
     others: [];
-};
-
-const onChange = jest.fn();
-const isDirty = jest.fn();
-
-const defaultValues: Partial<TestType> = {
-    firstInput: 'first value',
-    secondInput: 'second value'
 };
 
 const UnderTestForm = () => {
@@ -84,17 +75,17 @@ const columns = [
     }
 ];
 
-type Props = {
-    values?: TestType[];
-    errors?: ReactNode[];
-    defaults?: Partial<TestType>;
-};
-
-const Fixture = ({ values = [], errors, defaults }: Props) => (
+const Fixture = ({
+    values = [],
+    errors,
+    defaultValues,
+    onChange = jest.fn(),
+    isDirty = jest.fn()
+}: Partial<RepeatingBlockProps<TestType>>) => (
     <RepeatingBlock<TestType>
         id="testing"
         title={'Test title'}
-        defaultValues={{ ...defaultValues, ...defaults }}
+        defaultValues={defaultValues}
         columns={columns}
         values={values}
         onChange={onChange}
@@ -128,7 +119,14 @@ describe('RepeatingBlock', () => {
     });
 
     it('should display default values', async () => {
-        const { getByLabelText } = render(<Fixture />);
+        const { getByLabelText } = render(
+            <Fixture
+                defaultValues={{
+                    firstInput: 'first value',
+                    secondInput: 'second value'
+                }}
+            />
+        );
         await awaitRender();
 
         const firstInput = getByLabelText('First Input');
@@ -144,9 +142,8 @@ describe('RepeatingBlock', () => {
         const { getByRole } = render(<Fixture />);
         await awaitRender();
 
-        const button = getByRole('button');
+        const button = getByRole('button', { name: 'Add test title' });
         expect(button).toBeInTheDocument();
-        expect(button).toHaveTextContent('Add test');
     });
 
     it('should display specified columns', async () => {
@@ -163,12 +160,14 @@ describe('RepeatingBlock', () => {
     });
 
     it('should trigger on change when data is submitted', async () => {
-        const { getByRole, getByLabelText } = render(<Fixture />);
+        const onChange = jest.fn();
+
+        const { getByRole, getByLabelText } = render(<Fixture onChange={onChange} />);
 
         await awaitRender();
 
-        const button = getByRole('button');
-        expect(button).toBeInTheDocument();
+        const add = getByRole('button', { name: 'Add test title' });
+
         const input1 = getByLabelText('First Input');
         expect(input1).toBeInTheDocument();
         const input2 = getByLabelText('Second Input');
@@ -180,7 +179,7 @@ describe('RepeatingBlock', () => {
         userEvent.clear(input2);
         userEvent.type(input2, 'second input value');
         expect(input2).toHaveValue('second input value');
-        userEvent.click(button);
+        userEvent.click(add);
 
         await waitFor(() => {
             expect(onChange).toHaveBeenNthCalledWith(1, []);
@@ -190,16 +189,57 @@ describe('RepeatingBlock', () => {
         });
     });
 
-    it('should display submitted data in table', async () => {
-        const { getByRole, getAllByRole } = render(<Fixture />);
+    it('should not display clear button when adding and no changes have been made.', async () => {
+        const { queryByRole } = render(<Fixture />);
 
         await awaitRender();
 
-        const button = getByRole('button');
-        userEvent.click(button);
+        expect(queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    });
+
+    it('should display clear button when adding and changes have been made.', async () => {
+        const { getByRole, getByLabelText } = render(<Fixture />);
+
+        await awaitRender();
+
+        const input1 = getByLabelText('First Input');
+
+        userEvent.type(input1, '-change');
+
+        expect(getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+    });
+
+    it('should reset values to default state when Clear is clicked.', async () => {
+        const { getByRole, getByLabelText } = render(<Fixture />);
+
+        await awaitRender();
+
+        const input1 = getByLabelText('First Input');
+
+        userEvent.type(input1, '-change');
+
+        const clear = getByRole('button', { name: 'Clear' });
+
+        userEvent.click(clear);
+
+        userEvent.type(input1, 'first input value');
+    });
+
+    it('should display submitted data in table', async () => {
+        const onChange = jest.fn();
+
+        const { getByRole, getAllByRole, getByLabelText } = render(<Fixture onChange={onChange} />);
+
+        await awaitRender();
+
+        userEvent.type(getByLabelText('First Input'), 'first value');
+        userEvent.type(getByLabelText('Second Input'), 'second value');
+        userEvent.tab();
+
+        const add = getByRole('button', { name: 'Add test title' });
+        userEvent.click(add);
 
         await waitFor(() => {
-            expect(onChange).toHaveBeenNthCalledWith(1, []);
             expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
         });
 
@@ -211,11 +251,16 @@ describe('RepeatingBlock', () => {
     });
 
     it('should reset after adding data', async () => {
-        const { getByRole, getByLabelText, queryByText } = render(<Fixture defaults={{ firstInput: undefined }} />);
+        const onChange = jest.fn();
+
+        const { getByRole, getByLabelText, queryByText } = render(<Fixture onChange={onChange} />);
 
         await awaitRender();
+
+        const add = getByRole('button', { name: 'Add test title' });
+
         // try to add with empty required field
-        userEvent.click(getByRole('button'));
+        userEvent.click(add);
 
         // ensure validation message appears
         await waitFor(() => {
@@ -224,12 +269,12 @@ describe('RepeatingBlock', () => {
 
         // enter data and submit
         userEvent.type(getByLabelText('First Input'), 'typed value');
-        userEvent.click(getByRole('button'));
+        userEvent.click(add);
 
         // expect value to be added
         await waitFor(() => {
             expect(onChange).toHaveBeenNthCalledWith(1, []);
-            expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'typed value', secondInput: 'second value' }]);
+            expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'typed value', secondInput: undefined }]);
         });
 
         // verify validation message is no longer visible
@@ -238,7 +283,7 @@ describe('RepeatingBlock', () => {
         });
 
         // immediately click add button again
-        userEvent.click(getByRole('button'));
+        userEvent.click(add);
 
         // verify validation text is shown
         await waitFor(() => {
@@ -247,17 +292,19 @@ describe('RepeatingBlock', () => {
     });
 
     it('should display icons in last column of table', async () => {
-        const { getByRole, getAllByRole } = render(<Fixture />);
+        const { getByRole, getAllByRole } = render(
+            <Fixture
+                values={[
+                    {
+                        firstInput: 'first-value',
+                        secondInput: 'second-value',
+                        others: []
+                    }
+                ]}
+            />
+        );
 
         await awaitRender();
-
-        const button = getByRole('button');
-        userEvent.click(button);
-
-        await waitFor(() => {
-            expect(onChange).toHaveBeenNthCalledWith(1, []);
-            expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
-        });
 
         const iconContainer = getAllByRole('cell')[2].children[0].children[0];
         expect(iconContainer.children).toHaveLength(3);
@@ -276,31 +323,32 @@ describe('RepeatingBlock', () => {
     });
 
     it('should render view when view icon clicked', async () => {
-        const { getByRole, getAllByRole, getByText } = render(<Fixture />);
+        const { getByLabelText, getByText } = render(
+            <Fixture
+                values={[
+                    {
+                        firstInput: 'first-value',
+                        secondInput: 'second-value',
+                        others: []
+                    }
+                ]}
+            />
+        );
 
         await awaitRender();
 
-        const button = getByRole('button');
-        userEvent.click(button);
+        const view = getByLabelText('View');
+        userEvent.click(view);
 
-        await waitFor(() => {
-            expect(onChange).toHaveBeenNthCalledWith(1, []);
-            expect(onChange).toHaveBeenNthCalledWith(2, [{ firstInput: 'first value', secondInput: 'second value' }]);
-        });
-
-        const iconContainer = getAllByRole('cell')[2].children[0].children[0];
-        expect(iconContainer.children).toHaveLength(3);
-
-        // View icon
-        userEvent.click(iconContainer.children[0].children[0]);
-
-        expect(getByText('Render view first value: first value')).toBeInTheDocument();
-        expect(getByText('Render view second value: second value')).toBeInTheDocument();
+        expect(getByText('Render view first value: first-value')).toBeInTheDocument();
+        expect(getByText('Render view second value: second-value')).toBeInTheDocument();
     });
 
     it('should delete row when delete icon clicked', async () => {
+        const onChange = jest.fn();
         const { getByLabelText } = render(
             <Fixture
+                onChange={onChange}
                 values={[
                     {
                         firstInput: 'first-value',
@@ -322,8 +370,11 @@ describe('RepeatingBlock', () => {
     });
 
     it('should allow edit of row', async () => {
-        const { getByRole, getAllByRole, getByLabelText, debug } = render(
+        const onChange = jest.fn();
+
+        const { getByRole, getAllByRole, getByLabelText } = render(
             <Fixture
+                onChange={onChange}
                 values={[
                     {
                         firstInput: 'first-value',
@@ -340,13 +391,13 @@ describe('RepeatingBlock', () => {
 
         userEvent.click(edit);
 
-        const button = getByRole('button', { name: 'Update test title' });
+        const update = getByRole('button', { name: 'Update test title' });
         const input1 = getByLabelText('First Input');
 
         userEvent.type(input1, '-changed');
         userEvent.tab();
 
-        userEvent.click(button);
+        userEvent.click(update);
 
         await waitFor(() => {
             // change event fires, form resets to default
@@ -355,17 +406,6 @@ describe('RepeatingBlock', () => {
                     expect.objectContaining({ firstInput: 'first-value-changed', secondInput: 'second-value' })
                 ])
             );
-            expect(getByLabelText('First Input')).toHaveValue('first value');
-            expect(getByLabelText('Second Input')).toHaveValue('second value');
-        });
-
-        const iconContainer = getAllByRole('cell')[2].children[0].children[0];
-
-        await waitFor(() => {
-            // view clicked, input values set to entry value
-            userEvent.click(iconContainer.children[1].children[0]);
-            expect(getByLabelText('First Input')).toHaveValue('first-value-changed');
-            expect(getByLabelText('Second Input')).toHaveValue('second-value');
         });
 
         // table display updated
@@ -376,7 +416,53 @@ describe('RepeatingBlock', () => {
         expect(columns[2]).toHaveTextContent('');
     });
 
-    it('should display errors passed to component', async () => {
+    it('should allow cancelling update of row being edited', async () => {
+        const onChange = jest.fn();
+
+        const { getByRole, getAllByRole, getByLabelText } = render(
+            <Fixture
+                onChange={onChange}
+                values={[
+                    {
+                        firstInput: 'first-value',
+                        secondInput: 'second-value',
+                        others: []
+                    }
+                ]}
+            />
+        );
+
+        await awaitRender();
+
+        const edit = getByLabelText('Edit');
+
+        userEvent.click(edit);
+
+        const input1 = getByLabelText('First Input');
+
+        userEvent.type(input1, '-changed');
+        userEvent.tab();
+
+        const cancel = getByRole('button', { name: 'Cancel' });
+        userEvent.click(cancel);
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({ firstInput: 'first-value', secondInput: 'second-value' })
+                ])
+            );
+        });
+
+        // table display updated
+        const columns = getAllByRole('cell');
+        expect(columns).toHaveLength(3);
+        expect(columns[0]).toHaveTextContent('first-value');
+        expect(columns[1]).toHaveTextContent('second-value');
+        expect(columns[2]).toHaveTextContent('');
+    });
+
+    it('should display errors passed to component ', async () => {
         const { getByText } = render(<Fixture errors={['First error', 'Second error']} />);
         await awaitRender();
 

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -11,7 +11,7 @@ import { useMultiValueEntryState } from './useMultiValueEntryState';
 
 import styles from './RepeatingBlock.module.scss';
 
-type Props<V extends FieldValues> = {
+type RepeatingBlockProps<V extends FieldValues> = {
     id: string;
     title: string;
     columns: Column<V>[];
@@ -35,7 +35,7 @@ const RepeatingBlock = <V extends FieldValues>({
     isDirty,
     formRenderer,
     viewRenderer
-}: Props<V>) => {
+}: RepeatingBlockProps<V>) => {
     const form = useForm<V>({ mode: 'onSubmit', reValidateMode: 'onBlur', defaultValues });
     const { status, entries, selected, add, edit, update, remove, view, reset } = useMultiValueEntryState<V>({
         values
@@ -67,6 +67,10 @@ const RepeatingBlock = <V extends FieldValues>({
         reset();
     };
 
+    const handleClear = () => {
+        form.reset(defaultValues);
+    };
+
     const handleAdd = (value: V) => {
         // form reset must be triggered prior to `add` call,
         // otherwise internal form state retains some values and fails to properly reset
@@ -92,10 +96,16 @@ const RepeatingBlock = <V extends FieldValues>({
         render: (value: V) => (
             <div className={styles.actions}>
                 <div data-tooltip-position="top" aria-label="View" onClick={() => view(value)}>
-                    <Icon name="visibility" className={classNames({ [styles.active]: status === 'viewing' })} />
+                    <Icon
+                        name="visibility"
+                        className={classNames({ [styles.active]: status === 'viewing' && value === selected })}
+                    />
                 </div>
                 <div data-tooltip-position="top" aria-label="Edit" onClick={() => edit(value)}>
-                    <Icon name="edit" className={classNames({ [styles.active]: status === 'editing' })} />
+                    <Icon
+                        name="edit"
+                        className={classNames({ [styles.active]: status === 'editing' && value === selected })}
+                    />
                 </div>
                 <div data-tooltip-position="top" aria-label="Delete" onClick={() => handleRemove(value)}>
                     <Icon name="delete" />
@@ -152,11 +162,22 @@ const RepeatingBlock = <V extends FieldValues>({
                         <Icon name="add" />
                         {`Add ${title.toLowerCase()}`}
                     </Button>
+                    <Shown when={form.formState.isDirty}>
+                        <Button outline aria-details={`clear ${title.toLowerCase()}`} onClick={handleClear}>
+                            Clear
+                        </Button>
+                    </Shown>
                 </Shown>
                 <Shown when={status === 'editing'}>
                     <Button outline onClick={form.handleSubmit(handleUpdate)}>
                         <Icon name="add" />
                         {`Update ${title.toLowerCase()}`}
+                    </Button>
+                    <Button
+                        outline
+                        aria-details={`cancel editing current ${title.toLowerCase()}`}
+                        onClick={handleReset}>
+                        Cancel
                     </Button>
                 </Shown>
                 <Shown when={status === 'viewing'}>
@@ -171,3 +192,4 @@ const RepeatingBlock = <V extends FieldValues>({
 };
 
 export { RepeatingBlock };
+export type { RepeatingBlockProps };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/useMultiValueEntryState.ts
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/useMultiValueEntryState.ts
@@ -2,68 +2,83 @@ import { useReducer } from 'react';
 
 type State<V> =
     | { status: 'adding'; data: V[] }
-    | { status: 'viewing'; data: V[]; index: number; selected: V }
-    | { status: 'editing'; data: V[]; index: number; selected: V };
+    | { status: 'viewing'; data: V[]; selected: V }
+    | { status: 'editing'; data: V[]; selected: V };
 
 type Action<V> =
     | { type: 'add'; item: V }
-    | { type: 'edit'; index: number }
-    | { type: 'update'; index: number; item: V }
-    | { type: 'delete'; index: number }
-    | { type: 'view'; index: number }
+    | { type: 'edit'; item: V }
+    | { type: 'update'; item: V }
+    | { type: 'delete'; item: V }
+    | { type: 'view'; item: V }
     | { type: 'reset' };
 
 const reducer = <V>(current: State<V>, action: Action<V>): State<V> => {
     switch (action.type) {
-        case 'add':
-            return { status: 'adding', data: [...current.data, action.item] };
-        case 'view':
-            return { ...current, status: 'viewing', index: action.index, selected: current.data[action.index] };
-        case 'edit':
-            return { ...current, status: 'editing', index: action.index, selected: current.data[action.index] };
-        case 'update': {
-            const data = [...current.data];
-
-            data[action.index] = action.item;
+        case 'reset':
+            return { status: 'adding', data: current.data };
+        case 'view': {
+            const i = current.data.indexOf(action.item);
+            if (i >= 0) {
+                return { ...current, status: 'viewing', selected: action.item };
+            }
+            break;
+        }
+        case 'edit': {
+            const i = current.data.indexOf(action.item);
+            if (i >= 0) {
+                return { ...current, status: 'editing', selected: action.item };
+            }
+            break;
+        }
+        case 'add': {
+            const data = [...current.data, action.item];
             return { status: 'adding', data };
         }
+        case 'update': {
+            if (current.status === 'editing') {
+                const i = current.data.indexOf(current.selected);
+                const data = [...current.data];
+
+                data[i] = action.item;
+                return { status: 'adding', data };
+            }
+            break;
+        }
         case 'delete': {
+            const i = current.data.indexOf(action.item);
             const data = [...current.data];
-            data.splice(action.index, 1);
-            if (current.status === 'adding') {
-                return { ...current, data };
-            } else {
-                if (current.index === action.index) {
+            data.splice(i, 1);
+
+            if (current.status !== 'adding') {
+                if (current.selected === action.item) {
                     // currently editing or viewing the deleted entry
                     return { status: 'adding', data };
-                } else if (current.index > action.index) {
+                } else {
                     // editing or viewing an entry with index > than deleted index. updated index - 1
                     return {
                         status: current.status,
                         data,
-                        index: current.index - 1,
-                        selected: data[current.index - 1]
+                        selected: current.selected
                     };
-                } else {
-                    // editing or viewing an entry with index < than deleted index. keep current index
-                    return { ...current, data };
                 }
             }
+
+            return { ...current, data };
         }
-        case 'reset':
-            return { status: 'adding', data: current.data };
     }
+    return current;
 };
 
 type Interaction<V> = {
-    state: State<V>;
     status: 'adding' | 'viewing' | 'editing';
+    entries: V[];
     selected?: V;
     add: (item: V) => void;
-    edit: (index: number) => void;
-    update: (index: number, item: V) => void;
-    remove: (index: number) => void;
-    view: (index: number) => void;
+    edit: (item: V) => void;
+    update: (item: V) => void;
+    remove: (item: V) => void;
+    view: (item: V) => void;
     reset: () => void;
 };
 
@@ -77,14 +92,14 @@ const useMultiValueEntryState = <V>({ values = [] }: Settings<V>): Interaction<V
     const selected = state.status === 'editing' || state.status === 'viewing' ? state.selected : undefined;
 
     return {
-        state,
         status: state.status,
+        entries: state.data,
         selected,
         add: (item: V) => dispatch({ type: 'add', item }),
-        edit: (index: number) => dispatch({ type: 'edit', index }),
-        update: (index: number, item: V) => dispatch({ type: 'update', index, item }),
-        remove: (index: number) => dispatch({ type: 'delete', index }),
-        view: (index: number) => dispatch({ type: 'view', index }),
+        edit: (item: V) => dispatch({ type: 'edit', item }),
+        update: (item: V) => dispatch({ type: 'update', item }),
+        remove: (item: V) => dispatch({ type: 'delete', item }),
+        view: (item: V) => dispatch({ type: 'view', item }),
         reset: () => dispatch({ type: 'reset' })
     };
 };


### PR DESCRIPTION
## Description

Adds a "Clear" button to repeating blocks when adding a new value.

![image](https://github.com/user-attachments/assets/6e7b6f02-c76b-48f7-ad07-68bfcfeaae0b)

Adds a "Cancel" button to repeating blocks when editing an existing value.

![image](https://github.com/user-attachments/assets/cee57c91-c10d-4a24-b7d1-e8798cf3c3e7)


Existing unit tests for repeating block components were updated to accommodate the presence of multiple buttons.

## Tickets

* [CNFT1-3712](https://cdc-nbs.atlassian.net/browse/CNFT1-3712)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3712]: https://cdc-nbs.atlassian.net/browse/CNFT1-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ