### PR TITLE
[CNFT1-3776]: removing margin on input near date-picker and correcting width for sizing on button width

### DIFF
--- a/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
+++ b/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
@@ -1,18 +1,23 @@
-@mixin sizedButtonIcon($height: 1rem, $width: 1rem) {
+@mixin sizedButtonIcon($height: 1rem, $width: 1rem, $buttonWidth: 1.5rem) {
     button {
         background-size: $height $width;
         background-position: left;
+        width: $buttonWidth;
+    }
+
+    input {
+        margin-right: 0 !important;
     }
 }
 
 .small {
-    @include sizedButtonIcon(1rem, 1rem);
+    @include sizedButtonIcon(1rem, 1rem, 1.125rem);
 }
 
 .medium {
-    @include sizedButtonIcon(1.125rem, 1.125rem);
+    @include sizedButtonIcon(1.125rem, 1.125rem, 1.25rem);
 }
 
 .large {
-    @include sizedButtonIcon(1.25rem, 1.25rem);
+    @include sizedButtonIcon(1.25rem, 1.25rem, 1.375rem);
 }


### PR DESCRIPTION
This pr is made to correct the spacing and sizes for the date picker icon and input field 

Here you can see the date picker along side the input with no margin 
<img width="312" alt="Screenshot 2025-02-17 at 4 22 12 PM" src="https://github.com/user-attachments/assets/9af70f98-e659-4659-81fc-0bf94a2d668b" />

This is the figma design
<img width="428" alt="Screenshot 2025-02-17 at 4 23 32 PM" src="https://github.com/user-attachments/assets/43371ad6-b17d-4345-a22b-b08f1f585db2" />

Here you can also see the calendar icon's bkg is highlighted grey, and the unselected input has a transparent calendar icon bkg. The width of the icon button is contains the datepicker icon in this case.
<img width="180" alt="Screenshot 2025-02-17 at 4 24 17 PM" src="https://github.com/user-attachments/assets/97024820-0589-4f84-84f3-656a90f722c3" />


Please reference https://www.figma.com/design/lU5zi29qGeVt3cGxoRIU3V/NBS-Design-System-2.0?node-id=11397-79323&m=dev
## Tickets

* [CNFT1-3776](https://cdc-nbs.atlassian.net/browse/CNFT1-3776)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3776]: https://cdc-nbs.atlassian.net/browse/CNFT1-3776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ