### PR TITLE
CNFT1-3799 Fix search api email filter that contains '@'

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -328,7 +328,7 @@ class PatientDemographicQueryResolver {
       return Optional.empty();
     }
 
-    return Optional.of(new TextCriteria(null, null, null, criteria.getFilter().email(), null))
+    return Optional.of(new TextCriteria(null, null, null, criteria.getFilter().email().replace("@", " "), null))
         .flatMap(TextCriteria::maybeContains)
         .map(value -> contains(EMAILS, EMAIL_ADDRESS, value));
   }

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.feature
@@ -347,6 +347,16 @@ Feature: Patient Search
     When I search for patients
     Then the search results have a patient with an "email address" equal to "emailaddress@mail.com"
 
+  Scenario: I can search for a Patient using an email address and an exact match email filter
+    Given the patient has an "email address" of "emailaddress@mail.com"
+    And I have another patient
+    And the patient has an "email address" of "other@mail.com"
+    And patients are available for search
+    And I add the patient criteria for an "email address" equal to "emailaddress@mail.com"
+    And I would like to filter search results with email "emailaddress@mail.com"
+    When I search for patients
+    Then the search results have a patient with an "email address" equal to "emailaddress@mail.com"
+
   Scenario: I can search for a Patient using an email address and a non-matching email filter
     Given the patient has an "email address" of "emailaddress@mail.com"
     And I have another patient


### PR DESCRIPTION
## Description

Convert '@' to space so the string is tokenized properly during query string search

## Tickets

* [CNFT1-3799](https://cdc-nbs.atlassian.net/browse/CNFT1-3799)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3799]: https://cdc-nbs.atlassian.net/browse/CNFT1-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ