### PR TITLE
CNFT1-3795: New patient extended: responsive error message display

### DIFF
--- a/apps/modernization-ui/src/design-system/field/HorizontalField.tsx
+++ b/apps/modernization-ui/src/design-system/field/HorizontalField.tsx
@@ -26,9 +26,11 @@ const HorizontalField = ({ className, htmlFor, label, helperText, required, erro
             {helperText && <HelperText id={`${htmlFor}-hint`}>{helperText}</HelperText>}
         </div>
         <div className={styles.right}>
-            {warning && <InlineWarningMessage id={`${htmlFor}-warning`}>{warning}</InlineWarningMessage>}
-            {error && <InlineErrorMessage id={`${htmlFor}-error`}>{error}</InlineErrorMessage>}
-            {children}
+            <div className={styles.message}>
+                {warning && <InlineWarningMessage id={`${htmlFor}-warning`}>{warning}</InlineWarningMessage>}
+                {error && <InlineErrorMessage id={`${htmlFor}-error`}>{error}</InlineErrorMessage>}
+            </div>
+            <div className={styles.children}>{children}</div>
         </div>
     </div>
 );

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -2,6 +2,7 @@
 
 .horizontalInput {
     display: flex;
+    flex-direction: row;
     padding: 0.5rem 1.5rem;
     align-items: center;
     gap: 2rem;
@@ -12,6 +13,7 @@
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+        min-width: 13rem;
         width: 13rem;
     }
 
@@ -21,6 +23,39 @@
     }
 
     .right {
-        width: 20rem;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        flex-grow: 1;
+        
+        .children {
+            order: 1;
+            width: 20rem;
+        }
+
+        .message {
+            margin-left: 0.25rem;
+            order: 2;
+        }
     }
+
+    @media (max-width: 1279px) {
+        .right {
+            flex-direction: column;
+            flex-grow: 0;
+            align-items: flex-start;
+            gap: 0.25rem;
+
+            .children {
+                order: 2;
+            }
+    
+            .message {
+                margin-left: 0;
+                order: 1;
+            }
+        }
+    }
+
 }
+

--- a/apps/modernization-ui/src/design-system/field/inline-message.module.scss
+++ b/apps/modernization-ui/src/design-system/field/inline-message.module.scss
@@ -6,3 +6,9 @@
     display: block;
     font-weight: 700;
 }
+
+@media (min-width: 1280px) {
+    .message {
+        margin-left: 0.25rem;
+    }
+}

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.tsx
@@ -30,6 +30,7 @@ type Props = {
     sizing?: Sizing;
     error?: string;
     required?: boolean;
+    warning?: string;
 } & Omit<JSX.IntrinsicElements['select'], 'defaultValue' | 'onChange' | 'value'>;
 
 const SingleSelect = ({
@@ -44,6 +45,7 @@ const SingleSelect = ({
     sizing,
     error,
     required,
+    warning,
     placeholder = '- Select -',
     ...inputProps
 }: Props) => {
@@ -64,7 +66,8 @@ const SingleSelect = ({
             helperText={helperText}
             htmlFor={id}
             required={required}
-            error={error}>
+            error={error}
+            warning={warning}>
             <select
                 key={value?.value ?? ''}
                 id={id}


### PR DESCRIPTION
## Description

Updated the CSS to make error message display more responsive according to the images below.
Add more support for warning (also see images).

### 1 - Greater than 1280px
Error messages float on the right side

![image](https://github.com/user-attachments/assets/d52946ad-47a8-408c-a7ac-3da756ddaeca)


### 2 - Less than 1280px
Error message display above the field

![image](https://github.com/user-attachments/assets/848dde57-188d-41fb-8bb5-68a10bee1714)



## Tickets

* [Jira Ticket](url)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
