### PR TITLE
[CNFT1-3854] Configurable session values

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-springBoot = '3.4.2'
-spring-security = '6.4.2'
+springBoot = '3.4.3'
+spring-security = '6.4.3'
 jackson = '2.18.2'
 queryDSL = '5.1.0'
 spring-kafka = '3.3.1'

--- a/libs/configuration-api/README.md
+++ b/libs/configuration-api/README.md
@@ -13,13 +13,19 @@ Boot.
 Provides the values Settings returned with in the `settings` property of
 the response of the `/nbs/api/configuration` endpoint.
 
-| Name                             | Default                  | Description                                                                                             |
-|----------------------------------|--------------------------|---------------------------------------------------------------------------------------------------------|
-| nbs.ui.settings.smarty.key       |                          | The embedded API key, when blank the Smarty API will not be invoked.                                    |
-| nbs.ui.settings.analytics.host   | https://us.i.posthog.com | The host name of the PostHog server to send analytics to.                                               |
-| nbs.ui.settings.analytics.key    |                          | The PostHog project key to associate frontend analytics with, when blank analytics will not be enabled. |
-| nbs.ui.settings.defaults.sizing  | medium                   | The default sizing of components on the modernized user interface.                                      |
-| nbs.ui.settings.defaults.country | 840 (United States)      | The default country for addresses.                                                                      |
+| Name                               | Default                  | Description                                                                                                                                                                                                                                                                                     |
+|------------------------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| nbs.ui.settings.smarty.key         |                          | The embedded API key, when blank the Smarty API will not be invoked.                                                                                                                                                                                                                            |
+| nbs.ui.settings.analytics.host     | https://us.i.posthog.com | The host name of the PostHog server to send analytics to.                                                                                                                                                                                                                                       |
+| nbs.ui.settings.analytics.key      |                          | The PostHog project key to associate frontend analytics with, when blank analytics will not be enabled.                                                                                                                                                                                         |
+| nbs.ui.settings.defaults.sizing    | medium                   | The default sizing of components on the modernized user interface.                                                                                                                                                                                                                              |
+| nbs.ui.settings.defaults.country   | 840 (United States)      | The default country for addresses.                                                                                                                                                                                                                                                              |
+| nbs.ui.settings.session.warning    | 28m                      | A [Duration](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties.conversion.durations) that defines the amount of time to wait while the user is idle before warning of session timeout                       |
+| nbs.ui.settings.session.expiration | 30m                      | A [Duration](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties.conversion.durations) that defines the amount of time to wait while the user is idle before navigating the user to the expired session page. |
+
+_Note:  The `session` configuration settings are meant for a user interface to be able to alert a user that a session is
+going to expire and do not actually control the session timeout. The `warning`, and `expiration` settings should
+correspond to the session expiration configuration on the OIDC provider.
 
 ## Features
 

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/Settings.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/Settings.java
@@ -2,7 +2,8 @@ package gov.cdc.nbs.configuration.settings;
 
 import gov.cdc.nbs.configuration.settings.analytics.Analytics;
 import gov.cdc.nbs.configuration.settings.defautls.Defaults;
+import gov.cdc.nbs.configuration.settings.session.Session;
 import gov.cdc.nbs.configuration.settings.smarty.Smarty;
 
-public record Settings(Smarty smarty, Analytics analytics, Defaults defaults) {
+public record Settings(Smarty smarty, Analytics analytics, Defaults defaults, Session session) {
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/SettingsConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/SettingsConfiguration.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.configuration.settings;
 
 import gov.cdc.nbs.configuration.settings.analytics.Analytics;
 import gov.cdc.nbs.configuration.settings.defautls.Defaults;
+import gov.cdc.nbs.configuration.settings.session.Session;
 import gov.cdc.nbs.configuration.settings.smarty.Smarty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,8 +16,9 @@ class SettingsConfiguration {
   SettingsResolver settingsResolver(
       final Smarty smarty,
       final Analytics analytics,
-      final Defaults defaults
+      final Defaults defaults,
+      final Session session
   ) {
-    return () -> new Settings(smarty, analytics, defaults);
+    return () -> new Settings(smarty, analytics, defaults, session);
   }
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/session/Session.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/session/Session.java
@@ -1,0 +1,4 @@
+package gov.cdc.nbs.configuration.settings.session;
+
+public record Session(long warning, long expiration) {
+}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/session/SessionConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/settings/session/SessionConfiguration.java
@@ -1,0 +1,26 @@
+package gov.cdc.nbs.configuration.settings.session;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import java.time.Duration;
+
+@Configuration
+class SessionConfiguration {
+
+  @Bean
+  @Scope("prototype")
+  Session session(
+      @Value("${nbs.ui.settings.session.warning:28m}") final Duration warning,
+      @Value("${nbs.ui.settings.session.expiration:30m}") final Duration expiration
+  ) {
+    return new Session(
+        warning.toMillis(),
+        expiration.toMillis()
+    );
+
+  }
+
+}

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/ConfigurationSteps.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/ConfigurationSteps.java
@@ -18,10 +18,10 @@ public class ConfigurationSteps {
     this.response = response;
   }
 
-  @Before
-  public void reset() {
-    response.reset();
-  }
+//  @Before
+//  public void reset() {
+//    response.reset();
+//  }
 
   @When("I request the frontend configuration")
   public void i_request_the_frontend_configuration() throws Exception {

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/settings/SettingEntrySteps.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/settings/SettingEntrySteps.java
@@ -1,0 +1,47 @@
+package gov.cdc.nbs.configuration.settings;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.spring.ScenarioScope;
+import jakarta.annotation.PostConstruct;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+
+@ScenarioScope
+public class SettingEntrySteps {
+  private static final String SETTINGS_PROPERTY_SOURCE = "settings-test-properties";
+
+  private final ConfigurableEnvironment environment;
+
+  SettingEntrySteps(final ConfigurableEnvironment environment) {
+    this.environment = environment;
+  }
+
+  @Given("I set the {setting} setting to {string}")
+  public void i_set_the_setting(final String setting, String value) {
+    properties().put("nbs.ui." + setting, value);
+  }
+
+  private Map<String, Object> properties() {
+    MutablePropertySources sources = environment.getPropertySources();
+
+    if (sources.get(SETTINGS_PROPERTY_SOURCE) instanceof MapPropertySource source) {
+      return source.getSource();
+    } else {
+      MapPropertySource properties = new MapPropertySource(SETTINGS_PROPERTY_SOURCE, new HashMap<>());
+      sources.addFirst(properties);
+      return properties.getSource();
+    }
+  }
+
+  @PostConstruct
+  void reset() {
+    Logger.getAnonymousLogger().info(">>>>>>>>>Resetting settings");
+    environment.getPropertySources().remove(SETTINGS_PROPERTY_SOURCE);
+  }
+}

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/settings/SettingsSteps.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/settings/SettingsSteps.java
@@ -2,30 +2,20 @@ package gov.cdc.nbs.configuration.settings;
 
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.ParameterType;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.MutablePropertySources;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 public class SettingsSteps {
 
-  private static final String SETTINGS_PROPERTY_SOURCE = "settings-test-properties";
 
-  private final ConfigurableEnvironment environment;
+
   private final Active<ResultActions> response;
 
-  public SettingsSteps(
-      final ConfigurableEnvironment environment,
+  SettingsSteps(
       final Active<ResultActions> response
   ) {
-    this.environment = environment;
     this.response = response;
   }
 
@@ -37,25 +27,10 @@ public class SettingsSteps {
       case "analytics host" -> "settings.analytics.host";
       case "default sizing" -> "settings.defaults.sizing";
       case "default country" -> "settings.defaults.country";
+      case "session warning" -> "settings.session.warning";
+      case "session expiration" -> "settings.session.expiration";
       default -> value;
     };
-  }
-
-  @Given("I set the {setting} setting to {string}")
-  public void i_set_the_setting(final String setting, String value) {
-    properties().put("nbs.ui." + setting, value);
-  }
-
-  private Map<String, Object> properties() {
-    MutablePropertySources sources = environment.getPropertySources();
-
-    if (sources.get(SETTINGS_PROPERTY_SOURCE) instanceof MapPropertySource source) {
-      return source.getSource();
-    } else {
-      MapPropertySource properties = new MapPropertySource(SETTINGS_PROPERTY_SOURCE, new HashMap<>());
-      sources.addFirst(properties);
-      return properties.getSource();
-    }
   }
 
   @Then("the settings include a(n) {setting} of {string}")

--- a/libs/configuration-api/src/test/resources/features/Settings.feature
+++ b/libs/configuration-api/src/test/resources/features/Settings.feature
@@ -1,14 +1,30 @@
 Feature: Frontend Settings Configuration
 
+  Scenario Outline: Default values are defined for Settings
+    When I request the frontend configuration
+    Then the settings include a <setting> of "<value>"
+
+    Examples:
+      | setting            | value                    |
+      | analytics host     | https://us.i.posthog.com |
+      | default sizing     | medium                   |
+      | default country    | 840                      |
+      | session warning    | 1680000                  |
+      | session expiration | 1800000                  |
+
+
   Scenario Outline: Property based Configuration values are available through the API
     Given I set the <setting> setting to "<value>"
     When I request the frontend configuration
     Then the settings include a <setting> of "<value>"
 
     Examples:
-      | setting         | value           |
-      | Smarty key      | smarty-key      |
-      | analytics host  | analytics-host  |
-      | analytics key   | analytics-key   |
-      | default sizing  | default-sizing  |
-      | default country | default-country |
+      | setting            | value           |
+      | Smarty key         | smarty-key      |
+      | analytics host     | analytics-host  |
+      | analytics key      | analytics-key   |
+      | default sizing     | default-sizing  |
+      | default country    | default-country |
+      | session warning    | 1063            |
+      | session expiration | 1049            |
+


### PR DESCRIPTION
## Description

Adds a configuration value for `nbs.ui.settings.session.warning` and `nbs.ui.settings.session.expiration`to allow the Idle timer on the `modernization-ui` to be changed to match whichever IDP is used in the deployed environment.

## Tickets

* [CNFT1-3854](https://cdc-nbs.atlassian.net/browse/CNFT1-3854)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
