### PR TITLE
[CNFT1-3855]: Adding dashes to id when no data

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/patientSearchResult.tsx
@@ -4,6 +4,7 @@ import { displayAddress } from 'address/display';
 
 import { ItemGroup } from 'design-system/item';
 import { internalizeDate, displayAgeAsOfToday } from 'date';
+import { NoData } from 'components/NoData';
 
 // Displays Other names, that are not the legal name
 const displayOtherNames = (result: PatientSearchResult, order: 'normal' | 'reverse' = 'normal'): JSX.Element | null => {
@@ -68,6 +69,7 @@ const displayIdentifications = (result: PatientSearchResult): JSX.Element => (
                 </ItemGroup>
             </div>
         ))}
+        {result.identification.length === 0 && <NoData display="dashes" />}
     </div>
 );
 


### PR DESCRIPTION
## Description

When a patient does not have any data for ID, then in patient search results, ID column has to have "---".

## Tickets

* [CNFT1-3855](https://cdc-nbs.atlassian.net/browse/CNFT1-3855)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
