### PR TITLE
CNFT1-3879: Move error message below input fields

### DIFF
--- a/apps/modernization-ui/src/design-system/field/HorizontalField.tsx
+++ b/apps/modernization-ui/src/design-system/field/HorizontalField.tsx
@@ -37,11 +37,11 @@ const HorizontalField = ({
             {helperText && <HelperText id={`${htmlFor}-hint`}>{helperText}</HelperText>}
         </div>
         <div className={styles.right}>
+            <div className={styles.children}>{children}</div>
             <div className={styles.message}>
                 {warning && <InlineWarningMessage id={`${htmlFor}-warning`}>{warning}</InlineWarningMessage>}
                 {error && <InlineErrorMessage id={`${htmlFor}-error`}>{error}</InlineErrorMessage>}
             </div>
-            <div className={styles.children}>{children}</div>
         </div>
     </div>
 );

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -54,13 +54,11 @@
         flex-grow: 1;
 
         .children {
-            order: 1;
             width: 20rem;
         }
 
         .message {
             margin-left: 0.25rem;
-            order: 2;
         }
     }
 
@@ -71,13 +69,8 @@
             align-items: flex-start;
             gap: 0.25rem;
 
-            .children {
-                order: 2;
-            }
-
             .message {
                 margin-left: 0;
-                order: 1;
             }
         }
     }


### PR DESCRIPTION
## Description

Moves the warning and error message below the input and select fields when screen size < 1280px

![image](https://github.com/user-attachments/assets/fdd4bfa9-7748-4ead-9ef4-27526c9dc820)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3879)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
