### PR TITLE
[CNFT1-3877] Left / right long error message stlyes

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/add-patient-basic-form.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/basic/add-patient-basic-form.module.scss
@@ -13,12 +13,5 @@
         flex-direction: column;
         gap: 1rem;
         padding-bottom: 12rem;
-
-        input {
-            width: 100% !important;
-        }
-        select {
-            width: 100% !important;
-        }
     }
 }

--- a/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended-form.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/extended/add-patient-extended-form.module.scss
@@ -19,13 +19,6 @@
         flex-direction: column;
         gap: 1rem;
         padding-bottom: 12rem;
-
-        input {
-            width: 100% !important;
-        }
-        select {
-            width: 100% !important;
-        }
     }
 
     .errorList {

--- a/apps/modernization-ui/src/design-system/field/field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/field.module.scss
@@ -7,6 +7,7 @@
     input,
     select,
     textarea {
+        width: 100%;
         outline: none;
         padding-top: 0.25rem;
         padding-bottom: 0.25rem;
@@ -34,6 +35,7 @@
     input,
     select,
     textarea {
+        width: 100%;
         box-sizing: border-box;
         margin: 0;
     }
@@ -59,8 +61,10 @@
             @extend %small-textarea;
         }
 
-        &.error, &.warn {
-            select, input {
+        &.error,
+        &.warn {
+            select,
+            input {
                 min-height: 1.75rem;
             }
         }

--- a/apps/modernization-ui/src/design-system/field/field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/field.module.scss
@@ -1,7 +1,9 @@
 @use 'styles/colors';
 @use 'styles/components';
 
-@mixin highlight($color) {
+$error-border-width: 4px;
+
+@mixin highlight($color, $border-width: $error-border-width) {
     border-left-color: $color;
 
     input,
@@ -9,10 +11,8 @@
     textarea {
         width: 100%;
         outline: none;
-        padding-top: 0.25rem;
-        padding-bottom: 0.25rem;
 
-        border-width: 4px;
+        border-width: $border-width;
         border-style: solid;
         border-color: $color;
     }
@@ -27,9 +27,12 @@
     border-left-style: solid;
     border-left-color: colors.$clear;
 
+    line-height: normal;
+
     label {
         margin: 0;
         color: colors.$base-darkest;
+        font-size: var(--component-font-size);
     }
 
     input,
@@ -38,49 +41,28 @@
         width: 100%;
         box-sizing: border-box;
         margin: 0;
+        font-size: var(--component-font-size);
+        height: var(--component-height);
     }
 
     &.small {
         @extend %small;
 
-        label {
-            @extend %small;
-        }
-
         select {
-            @extend %small-input;
             padding: 0.1875rem 0.5rem;
         }
 
         input {
-            @extend %small-input;
             padding: 0.25rem 0.5rem;
         }
 
         textarea {
             @extend %small-textarea;
         }
-
-        &.error,
-        &.warn {
-            select,
-            input {
-                min-height: 1.75rem;
-            }
-        }
     }
 
     &.medium {
         @extend %medium;
-
-        label {
-            @extend %medium;
-        }
-
-        input,
-        select {
-            @extend %medium-input;
-        }
 
         textarea {
             @extend %medium-textarea;
@@ -90,17 +72,17 @@
     &.large {
         @extend %large;
 
-        label {
-            @extend %large;
-        }
-
-        input,
-        select {
-            @extend %large-input;
-        }
-
         textarea {
             @extend %large-textarea;
+        }
+    }
+
+    &.error,
+    &.warn {
+        input,
+        select {
+            //  Adjusts the sizing of select and input components to account for a thicker border.
+            min-height: calc(var(--component-height) + ($error-border-width * 2));
         }
     }
 

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -34,7 +34,7 @@
         flex-direction: row;
         flex-wrap: wrap;
         align-items: flex-start;
-        gap: 0.25rem;
+        gap: 0.5rem;
 
         .children {
             width: 20rem;
@@ -52,6 +52,8 @@
         .left {
             --label-area-width: 12rem;
             --label-area-font-size: #{components.$small-font-size};
+
+            padding-top: 0.25rem;
         }
 
         padding-left: 1rem;

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -7,7 +7,6 @@
     padding: 0.5rem 1.5rem;
     align-items: flex-start;
     gap: 2rem;
-    min-height: 3rem;
 
     @extend %thin-bottom;
 

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -1,78 +1,71 @@
 @use 'styles/borders';
+@use 'styles/components';
 
 .horizontalInput {
     display: flex;
     flex-direction: row;
     padding: 0.5rem 1.5rem;
-    align-items: center;
+    align-items: flex-start;
     gap: 2rem;
     min-height: 3rem;
+
     @extend %thin-bottom;
+
+    .left {
+        --label-area-width: 13rem;
+        --label-area-font-size: inherit;
+
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding-top: 0.5rem;
+        min-width: var(--label-area-width);
+        width: var(--label-area-width);
+
+        label {
+            font-weight: 700;
+            font-size: var(--label-area-font-size);
+        }
+    }
+
+    .right {
+        width: 100%;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        gap: 0.25rem;
+
+        .children {
+            width: 20rem;
+            flex-shrink: 0;
+        }
+
+        .message {
+            width: 9rem;
+            flex-shrink: 1;
+            flex-grow: 1;
+        }
+    }
 
     &.small {
         .left {
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-            min-width: 12rem;
-            width: 12rem;
+            --label-area-width: 12rem;
+            --label-area-font-size: #{components.$small-font-size};
         }
 
-        padding: 0.5rem 1.5rem;
+        padding-left: 1rem;
     }
 
     &.medium {
         .left {
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-            min-width: 13rem;
-            width: 13rem;
+            --label-area-font-size: #{components.$medium-font-size};
         }
     }
 
     &.large {
         .left {
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-            min-width: 13rem;
-            width: 13rem;
+            --label-area-font-size: #{components.$large-font-size};
         }
     }
-
-
-    label {
-        font-size: 0.875rem;
-        font-weight: 700;
-    }
-
-    .right {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        flex-grow: 1;
-
-        .children {
-            width: 20rem;
-        }
-
-        .message {
-            margin-left: 0.25rem;
-        }
-    }
-
-    @media (max-width: 1279px) {
-        .right {
-            flex-direction: column;
-            flex-grow: 0;
-            align-items: flex-start;
-            gap: 0.25rem;
-
-            .message {
-                margin-left: 0;
-            }
-        }
-    }
-
 }

--- a/apps/modernization-ui/src/design-system/field/inline-message.module.scss
+++ b/apps/modernization-ui/src/design-system/field/inline-message.module.scss
@@ -6,9 +6,3 @@
     display: block;
     font-weight: 700;
 }
-
-@media (min-width: 1280px) {
-    .message {
-        margin-left: 0.25rem;
-    }
-}

--- a/apps/modernization-ui/src/design-system/field/vertical-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/vertical-field.module.scss
@@ -1,5 +1,3 @@
-@use 'styles/components';
-
 .entry {
     flex-direction: column;
     gap: 0.5rem;

--- a/apps/modernization-ui/src/styles/_components.scss
+++ b/apps/modernization-ui/src/styles/_components.scss
@@ -1,70 +1,50 @@
 @use 'styles/colors';
 
-$medium-font-size: 0.875rem;
-$medium-height: 2rem;
-$medium-textarea-height: 7.5rem;
-
-%medium {
-    line-height: normal;
-    font-size: $medium-font-size;
-}
-
-%medium-input {
-    height: $medium-height;
-
-    @extend %medium;
-}
-
-%medium-textarea {
-    height: $medium-textarea-height;
-
-    @extend %medium;
-}
-
 $small-font-size: 0.75rem;
 $small-height: 1.375rem;
-$small-textarea-height: 6.25rem;
+$small-textarea-height: 5.0625rem;
 
 %small {
-    line-height: normal;
-    font-size: $small-font-size;
-}
+    --component-font-size: #{$small-font-size};
+    --component-height: #{$small-height};
 
-%small-label {
-    line-height: normal;
-    font-size: $small-font-size;
-}
-
-%small-input {
-    height: $small-height;
-    padding: 0.25rem 0.5rem;
-
-    @extend %small;
+    font-size: var(--component-font-size);
 }
 
 %small-textarea {
-    height: $small-textarea-height;
-
-    @extend %small;
+    --component-height: #{$small-textarea-height};
 }
+
+//
+
+$medium-font-size: 0.875rem;
+$medium-height: 2rem;
+$medium-textarea-height: 6rem;
+
+%medium {
+    --component-font-size: #{$medium-font-size};
+    --component-height: #{$medium-height};
+
+    font-size: var(--component-font-size);
+}
+
+%medium-textarea {
+    --component-height: #{$medium-textarea-height};
+}
+
+//
 
 $large-font-size: 1rem;
 $large-height: 2.2rem;
-$large-textarea-height: 6.5rem;
+$large-textarea-height: 10rem;
 
 %large {
-    line-height: normal;
-    font-size: $large-font-size;
-}
+    --component-font-size: #{$large-font-size};
+    --component-height: #{$large-height};
 
-%large-input {
-    height: $large-height;
-
-    @extend %large;
+    font-size: var(--component-font-size);
 }
 
 %large-textarea {
-    height: $large-textarea-height;
-
-    @extend %large;
+    --component-height: #{$large-textarea-height};
 }

--- a/apps/modernization-ui/src/styles/_components.scss
+++ b/apps/modernization-ui/src/styles/_components.scss
@@ -11,14 +11,12 @@ $medium-textarea-height: 7.5rem;
 
 %medium-input {
     height: $medium-height;
-    width: unset;
 
     @extend %medium;
 }
 
 %medium-textarea {
     height: $medium-textarea-height;
-    width: unset;
 
     @extend %medium;
 }
@@ -39,7 +37,6 @@ $small-textarea-height: 6.25rem;
 
 %small-input {
     height: $small-height;
-    width: unset;
     padding: 0.25rem 0.5rem;
 
     @extend %small;
@@ -47,7 +44,6 @@ $small-textarea-height: 6.25rem;
 
 %small-textarea {
     height: $small-textarea-height;
-    width: unset;
 
     @extend %small;
 }
@@ -63,14 +59,12 @@ $large-textarea-height: 6.5rem;
 
 %large-input {
     height: $large-height;
-    width: unset;
 
     @extend %large;
 }
 
 %large-textarea {
     height: $large-textarea-height;
-    width: unset;
 
     @extend %large;
 }


### PR DESCRIPTION
## Description

Adjust the styles for left / right fields so that longer error messages do not cause inputs to shrink.  The field component styles were consolidated to allow the label, component, and messages to be aligned.

![cnft1-3877](https://github.com/user-attachments/assets/76c3545f-57e5-4e64-953b-53e55a6ef5a4)


## Tickets

* [CNFT1-3877](https://cdc-nbs.atlassian.net/browse/CNFT1-3877)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3877]: https://cdc-nbs.atlassian.net/browse/CNFT1-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ