### PR TITLE
CNFT1-3852: Fix padding around Add New button

### DIFF
--- a/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
+++ b/apps/modernization-ui/src/components/ButtonActionMenu/buttonActionMenu.module.scss
@@ -57,6 +57,12 @@
         span:last-child {
             margin-right: 1rem;
         }
+        svg:first-child {
+            margin-left: 0.5rem;
+        }
+        svg:last-child {
+            margin-right: 0.5rem;
+        }
     }
     .menu {
         position: absolute;


### PR DESCRIPTION
## Description

Fix the margin/padding around button so that both text and icon have equivalent 20px spacing for both left and right modes.

![image](https://github.com/user-attachments/assets/3879a14a-7519-416b-aadb-adec7196a6df)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3852)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
