### PR TITLE
CNFT1-3865: New patient button - add permissions

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
@@ -1,24 +1,53 @@
 import { ButtonActionMenu } from 'components/ButtonActionMenu/ButtonActionMenu';
 import { Button } from 'components/button';
 import { useAddPatientFromSearch } from './add/useAddPatientFromSearch';
+import { Permitted } from 'libs/permission';
+import { Icon } from 'design-system/icon';
+
+const ADD_PATIENT_PERMISSION = 'ADD-PATIENT';
+const ADD_LAB_REPORT_PERMISSION = 'ADD-OBSERVATIONLABREPORT';
+
 type Props = {
     disabled: boolean;
 };
 
 const PatientSearchActions = ({ disabled }: Props) => {
     const { add } = useAddPatientFromSearch();
+    const handleLabReport = () => (window.location.href = '/nbs/MyTaskList1.do?ContextAction=AddLabDataEntry');
 
     return (
-        <ButtonActionMenu label="Add new" disabled={disabled}>
-            <>
-                <Button type="button" onClick={add}>
+        <Permitted include={[ADD_PATIENT_PERMISSION, ADD_LAB_REPORT_PERMISSION]} mode="any">
+            <Permitted include={[ADD_PATIENT_PERMISSION, ADD_LAB_REPORT_PERMISSION]} mode="all">
+                <ButtonActionMenu label="Add new" disabled={disabled}>
+                    <>
+                        <Button type="button" onClick={add}>
+                            Add new patient
+                        </Button>
+                        <Button onClick={handleLabReport}>Add new lab report</Button>
+                    </>
+                </ButtonActionMenu>
+            </Permitted>
+            <Permitted include={[ADD_PATIENT_PERMISSION]} exclude={[ADD_LAB_REPORT_PERMISSION]}>
+                <Button
+                    type="button"
+                    onClick={add}
+                    disabled={disabled}
+                    icon={<Icon name="add_circle" />}
+                    labelPosition="right">
                     Add new patient
                 </Button>
-                <Button onClick={() => (window.location.href = '/nbs/MyTaskList1.do?ContextAction=AddLabDataEntry')}>
+            </Permitted>
+            <Permitted include={[ADD_LAB_REPORT_PERMISSION]} exclude={[ADD_PATIENT_PERMISSION]}>
+                <Button
+                    type="button"
+                    onClick={handleLabReport}
+                    disabled={disabled}
+                    icon={<Icon name="add_circle" />}
+                    labelPosition="right">
                     Add new lab report
                 </Button>
-            </>
-        </ButtonActionMenu>
+            </Permitted>
+        </Permitted>
     );
 };
 

--- a/apps/modernization-ui/src/libs/permission/Permitted.spec.tsx
+++ b/apps/modernization-ui/src/libs/permission/Permitted.spec.tsx
@@ -1,26 +1,112 @@
 import { render } from '@testing-library/react';
 import { Permitted } from './Permitted';
 
-const mockPermissions: string[] = [];
-const mockAllowed = jest.fn();
+const mockPermissions: string[] = ['permitted', 'other-permitted'];
+const mockAllows = (p: string) => mockPermissions.includes(p);
+const mockAllowFn = jest.fn(mockAllows);
 
 jest.mock('./usePermissions', () => ({
-    usePermissions: () => ({ permissions: mockPermissions, allows: mockAllowed })
+    usePermissions: () => ({ permissions: mockPermissions, allows: mockAllowFn })
 }));
 
 describe('Permitted', () => {
-    it('should not render children when not allowed', () => {
-        mockAllowed.mockReturnValue(false);
+    beforeEach(() => {
+        mockAllowFn.mockImplementation(mockAllows);
+    });
 
+    it('should not render children when not allowed using permission property', () => {
         const { queryByText } = render(<Permitted permission="not-permitted">Content</Permitted>);
 
         expect(queryByText('Content')).not.toBeInTheDocument();
     });
 
-    it('should  render children when allowed', () => {
-        mockAllowed.mockReturnValue(true);
+    it('should render children when allowed using permission property', () => {
         const { queryByText } = render(<Permitted permission="permitted">Content</Permitted>);
 
         expect(queryByText('Content')).toBeInTheDocument();
+    });
+
+    it('should not render children when not all permission is included', () => {
+        const { queryByText } = render(<Permitted include={['permitted', 'not-permitted']}>Content</Permitted>);
+
+        expect(queryByText('Content')).not.toBeInTheDocument();
+    });
+
+    it('should render children when any permission is included', () => {
+        const { queryByText } = render(
+            <Permitted include={['permitted', 'not-permitted']} mode="any">
+                Content
+            </Permitted>
+        );
+
+        expect(queryByText('Content')).toBeInTheDocument();
+    });
+
+    it('should not render children when permission is excluded', () => {
+        const { queryByText } = render(<Permitted exclude={['permitted']}>Content</Permitted>);
+
+        expect(queryByText('Content')).not.toBeInTheDocument();
+    });
+
+    it('should not render children when all permissions are excluded', () => {
+        const { queryByText } = render(<Permitted exclude={['permitted', 'other-permitted']}>Content</Permitted>);
+
+        expect(queryByText('Content')).not.toBeInTheDocument();
+    });
+
+    it('should not render children when any permissions are excluded', () => {
+        const { queryByText } = render(
+            <Permitted exclude={['permitted', 'some-permitted']} mode="any">
+                Content
+            </Permitted>
+        );
+
+        expect(queryByText('Content')).not.toBeInTheDocument();
+    });
+
+    it('should not render children when any of the permissions are excluded', () => {
+        const { queryByText } = render(
+            <Permitted exclude={['permitted', 'some-permitted']} mode="any">
+                Content
+            </Permitted>
+        );
+
+        expect(queryByText('Content')).not.toBeInTheDocument();
+    });
+
+    it('should render children when any of the permissions excluded are not in user permission list', () => {
+        const { queryByText } = render(<Permitted exclude={['not-permitted']}>Content</Permitted>);
+
+        expect(queryByText('Content')).toBeInTheDocument();
+    });
+
+    it('should render children when not all permissions are excluded', () => {
+        const { queryByText } = render(
+            <Permitted exclude={['some-permitted', 'other-permitted']} mode="all">
+                Content
+            </Permitted>
+        );
+
+        expect(queryByText('Content')).toBeInTheDocument();
+    });
+
+    it('should render children when included and excluded are set', () => {
+        const { queryByText } = render(
+            <Permitted include={['permitted']} exclude={['not-permitted']}>
+                Content
+            </Permitted>
+        );
+
+        expect(queryByText('Content')).toBeInTheDocument();
+    });
+
+    it('should not render children when included and excluded overlap', () => {
+        const { queryByText } = render(
+            <Permitted include={['permitted']} exclude={['permitted']}>
+                Content
+            </Permitted>
+        );
+
+        expect(queryByText('Content')).not.toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/libs/permission/Permitted.tsx
+++ b/apps/modernization-ui/src/libs/permission/Permitted.tsx
@@ -3,14 +3,25 @@ import { Shown } from 'conditional-render';
 import { usePermissions } from './usePermissions';
 
 type PermittedProps = {
-    permission: string;
+    /** @deprecated Use include or exclude properties */
+    permission?: string;
+    /** One or more permissions that MUST be present in the user's permission */
+    include?: string[];
+    /** One or more permissions that MUST NOT be present in the user's permissions */
+    exclude?: string[];
+    /** Whether all or any permissions are included or excluded */
+    mode?: 'all' | 'any';
+    /** The children to render if permissions are satisfied */
     children: ReactNode | ReactNode[];
 };
 
-const Permitted = ({ permission, children }: PermittedProps) => {
+const Permitted = ({ permission, include, exclude, mode, children }: PermittedProps) => {
     const { allows } = usePermissions();
-
-    const allowed = allows(permission);
+    const permissionList = permission ? [permission] : undefined;
+    include = include ?? permissionList;
+    const checkIncluded = !include || (mode === 'any' ? include.some(allows) : include.every(allows));
+    const checkExcluded = !exclude || (mode === 'any' ? !exclude.some(allows) : !exclude.every(allows));
+    const allowed = checkIncluded && checkExcluded;
 
     return <Shown when={allowed}>{children}</Shown>;
 };


### PR DESCRIPTION
## Description

Implement permissions around the "add new patient" and "add new lab report" menu. When either is not permitted, show the single button instead of menu button.

![image](https://github.com/user-attachments/assets/74654958-a3ba-4110-85a9-fb387376aec7)


Updated the `<Permitted>` component to expand its capabilities:
* Support multiple permissions
* Ability to include and exclude specific permissions

## Tickets

* [Jira Ticket](url)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
