### PR TITLE
[CNFT1-3882]: card padding change

### DIFF
--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -7,7 +7,7 @@
 
     & > header {
         display: flex;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-content: space-between;
         align-items: center;
         @extend %thin-bottom;


### PR DESCRIPTION
## Description

Update the padding of the Header Components from 24 to 16px 
<img width="1224" alt="Screenshot 2025-03-06 at 9 18 15 AM" src="https://github.com/user-attachments/assets/c644d361-bfbe-4823-bfdf-29903b6235b0" />

## Tickets

* [CNFT1-3882](https://cdc-nbs.atlassian.net/browse/CNFT1-3882)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3882]: https://cdc-nbs.atlassian.net/browse/CNFT1-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ