### PR TITLE
CNFT1-3880 adding dob numeric sort icon instead of generic

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -50,7 +50,7 @@ const columns: Column<PatientSearchResult>[] = [
         className: styles['col-dob'],
         render: (result) => result.birthday && displayPatientAge(result, 'multiline'),
         filter: { id: 'ageOrDateOfBirth', type: 'text' },
-        sortIconType: 'default'
+        sortIconType: 'numeric'
     },
     {
         ...SEX,


### PR DESCRIPTION
## Description

Let’s use the numeric sort icons for DOB as tt’s conflicting with the first requirement that says to use numeric for number and date fields.

## Tickets

* [CNFT1-3880](https://cdc-nbs.atlassian.net/browse/CNFT1-3880)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3880]: https://cdc-nbs.atlassian.net/browse/CNFT1-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ