### PR TITLE
[FIX/ CNFT1-3866] HeaderFilterField uses TextInput

### DIFF
--- a/apps/modernization-ui/src/design-system/field/Field.tsx
+++ b/apps/modernization-ui/src/design-system/field/Field.tsx
@@ -9,9 +9,9 @@ type Orientation = 'horizontal' | 'vertical';
 type Sizing = 'small' | 'medium' | 'large';
 
 type FieldProps = {
+    label: string;
     orientation?: Orientation;
     sizing?: Sizing;
-    label?: string;
     helperText?: string;
     error?: string;
     required?: boolean;

--- a/apps/modernization-ui/src/design-system/field/HorizontalField.tsx
+++ b/apps/modernization-ui/src/design-system/field/HorizontalField.tsx
@@ -10,7 +10,7 @@ type Props = {
     className?: string;
     sizing: Sizing;
     htmlFor: string;
-    label?: string;
+    label: string;
     helperText?: string;
     error?: string;
     required?: boolean;
@@ -29,13 +29,17 @@ const HorizontalField = ({
     warning,
     children
 }: Props) => (
-    <div className={classNames(styles.horizontalInput, styles[sizing], className)}>
+    <div
+        className={classNames(styles.horizontalInput, className, {
+            [styles.small]: sizing === 'small',
+            [styles.medium]: sizing === 'medium',
+            [styles.large]: sizing === 'large'
+        })}>
         <div className={styles.left}>
-            {label && (
-                <label className={classNames({ required })} htmlFor={htmlFor}>
-                    {label}
-                </label>
-            )}
+            <label className={classNames({ required })} htmlFor={htmlFor}>
+                {label}
+            </label>
+
             {helperText && <HelperText id={`${htmlFor}-hint`}>{helperText}</HelperText>}
         </div>
         <div className={styles.right}>

--- a/apps/modernization-ui/src/design-system/field/VerticalField.tsx
+++ b/apps/modernization-ui/src/design-system/field/VerticalField.tsx
@@ -9,7 +9,7 @@ import styles from './vertical-field.module.scss';
 type Props = {
     className?: string;
     htmlFor: string;
-    label?: string;
+    label: string;
     helperText?: string;
     error?: string;
     required?: boolean;
@@ -19,11 +19,10 @@ type Props = {
 
 const VerticalField = ({ className, htmlFor, label, helperText, required, error, warning, children }: Props) => (
     <span className={classNames(styles.entry, className, { [styles.alert]: warning || error })}>
-        {label && (
-            <label className={classNames({ required })} htmlFor={htmlFor}>
-                {label}
-            </label>
-        )}
+        <label className={classNames({ required })} htmlFor={htmlFor}>
+            {label}
+        </label>
+
         {helperText && <HelperText id={`${htmlFor}-hint`}>{helperText}</HelperText>}
         {warning && <InlineWarningMessage id={`${htmlFor}-warning`}>{warning}</InlineWarningMessage>}
         {error && <InlineErrorMessage id={`${htmlFor}-error`}>{error}</InlineErrorMessage>}

--- a/apps/modernization-ui/src/design-system/field/field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/field.module.scss
@@ -33,10 +33,6 @@ $error-border-width: 4px;
         margin: 0;
         color: colors.$base-darkest;
         font-size: var(--component-font-size);
-        :empty {
-            margin: 0;
-            padding: 0;
-        }
     }
 
     input,

--- a/apps/modernization-ui/src/design-system/input/text/TextInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInput.tsx
@@ -15,7 +15,6 @@ type TextInputProps = {
     onBlur?: () => void;
     onClear?: () => void;
     clearable?: boolean;
-    sorted?: boolean;
 } & Omit<
     JSX.IntrinsicElements['input'],
     'defaultValue' | 'onChange' | 'onBlur' | 'value' | 'type' | 'inputMode' | 'autoComplete'
@@ -31,7 +30,6 @@ const TextInput = ({
     onBlur,
     className,
     clearable = false,
-    sorted = false,
     onClear,
     ...props
 }: TextInputProps) => {
@@ -59,7 +57,7 @@ const TextInput = ({
                 name={props.name ?? id}
                 type={type}
                 inputMode={inputMode}
-                className={classNames({ [styles.sorted]: sorted }, 'usa-input', className)}
+                className={classNames('usa-input', className)}
                 onChange={handleChange}
                 onBlur={onBlur}
                 placeholder={placeholder}

--- a/apps/modernization-ui/src/design-system/input/text/TextInputField.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInputField.tsx
@@ -11,7 +11,6 @@ const TextInputField = ({
     error,
     warning,
     required,
-    sorted,
     ...remaining
 }: TextInputFieldProps) => {
     return (
@@ -23,7 +22,7 @@ const TextInputField = ({
             required={required}
             error={error}
             warning={warning}>
-            <TextInput id={id} sorted={sorted} {...remaining} />
+            <TextInput id={id} {...remaining} />
         </Field>
     );
 };

--- a/apps/modernization-ui/src/design-system/input/text/text-input.module.scss
+++ b/apps/modernization-ui/src/design-system/input/text/text-input.module.scss
@@ -1,5 +1,3 @@
-@use 'styles/colors';
-
 .grouped {
     align-items: center;
     display: flex;
@@ -21,8 +19,4 @@
         right: 0;
         line-height: 0;
     }
-}
-
-.sorted {
-    border-color: colors.$base-darkest !important;
 }

--- a/apps/modernization-ui/src/design-system/table/Header.tsx
+++ b/apps/modernization-ui/src/design-system/table/Header.tsx
@@ -74,7 +74,6 @@ const SortableHeader = <V,>({ className, sorting, children, filtering, sizing }:
                         descriptor={children.filter}
                         filtering={filtering}
                         sizing={sizing}
-                        sorted={direction !== Direction.None}
                     />
                 )}
             </div>

--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
@@ -1,20 +1,20 @@
 import { KeyboardEvent as ReactKeyboardEvent, useEffect, useState } from 'react';
-import { TextInputField } from 'design-system/input/text';
+import { TextInput } from 'design-system/input/text';
 import { Shown } from 'conditional-render';
 import { FilterDescriptor, FilterInteraction } from 'design-system/filter';
 
 import styles from './header-filter-field.module.scss';
 import { Sizing } from 'design-system/field';
+import classNames from 'classnames';
 
 type HeaderFilterFieldProps = {
     descriptor: FilterDescriptor;
     sizing: Sizing | undefined;
     label: string;
     filtering: FilterInteraction;
-    sorted?: boolean;
 };
 
-const HeaderFilterField = ({ descriptor, label, filtering, sizing, sorted }: HeaderFilterFieldProps) => {
+const HeaderFilterField = ({ descriptor, label, filtering, sizing }: HeaderFilterFieldProps) => {
     const { valueOf, apply, clear } = filtering;
 
     const initialValue = valueOf(descriptor.id);
@@ -42,9 +42,13 @@ const HeaderFilterField = ({ descriptor, label, filtering, sizing, sorted }: Hea
 
     return (
         <Shown when={descriptor.type === 'text'}>
-            <TextInputField
+            <TextInput
                 clearable={Boolean(initialValue)}
-                className={styles.filter}
+                className={classNames(styles.filter, {
+                    [styles.small]: sizing === 'small',
+                    [styles.medium]: sizing === 'medium',
+                    [styles.large]: sizing === 'large'
+                })}
                 id={`text-filter-${descriptor.id}`}
                 name={label}
                 aria-label={`filter by ${label}`}
@@ -52,8 +56,6 @@ const HeaderFilterField = ({ descriptor, label, filtering, sizing, sorted }: Hea
                 onChange={handleChange}
                 onClear={handleClear}
                 onKeyDown={handleKey}
-                sizing={sizing}
-                sorted={sorted}
             />
         </Shown>
     );

--- a/apps/modernization-ui/src/design-system/table/header/filter/header-filter-field.module.scss
+++ b/apps/modernization-ui/src/design-system/table/header/filter/header-filter-field.module.scss
@@ -1,6 +1,21 @@
+@use 'styles/colors';
 @use 'styles/components';
 
 .filter {
-    font-size: components.$medium-font-size;
-    height: components.$medium-height;
+    border-color: colors.$base-darkest !important;
+
+    font-size: var(--component-font-size);
+    height: var(--component-height) !important;
+
+    &.small {
+        @extend %small;
+    }
+
+    &.medium {
+        @extend %medium;
+    }
+
+    &.large {
+        @extend %large;
+    }
 }


### PR DESCRIPTION
## Description

Removes the extra padding on filter inputs by removing the `TextInputField` from the header that was adding padding from the label.

Before

![image](https://github.com/user-attachments/assets/70c8f7a2-3369-43df-9882-6bce31ecc6a1)


After

![image](https://github.com/user-attachments/assets/67bb188d-3a22-43a3-a830-617d76b72b9e)

The `label` property should be _required_ on the `Field`, `HorizontalField`, and `VerticalField` components.  Since this is a specialized component it needs to apply the sizing to the `TextInput` component. 

## Tickets

* [CNFT1-3866](https://cdc-nbs.atlassian.net/browse/CNFT1-3866)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3866]: https://cdc-nbs.atlassian.net/browse/CNFT1-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ