### PR TITLE
CNFT1-3905, 3907, 3910, 3908, 3914, 3915 Fix search api sort fixes-nulls last, case insensitive

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSortResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientSearchCriteriaSortResolver.java
@@ -16,6 +16,7 @@ import static gov.cdc.nbs.search.SearchSorting.asSortOrder;
 @Component
 class PatientSearchCriteriaSortResolver {
   private static final String ADDRESS = "address";
+  private static final String NAME = "name";
 
   List<SortOptions> resolve(final Pageable pageable) {
     return pageable.getSort()
@@ -30,23 +31,24 @@ class PatientSearchCriteriaSortResolver {
     return switch (sorting.getProperty().toLowerCase()) {
       case "patientid" -> Stream.of(asSortOption("local_id", order));
       case "patientname" -> Stream.of(
-          asSortOption("name", "name.lastNm.keyword", order),
-          asSortOption("name", "name.firstNm.keyword", order),
-          asSortOption("name", "name.middleNm.keyword", order),
-          asSortOption("name", "name.nmSuffix.keyword", order),
+          asSortOption(NAME, "name.lastNm.keyword", order),
+          asSortOption(NAME, "name.firstNm.keyword", order),
+          asSortOption(NAME, "name.middleNm.keyword", order),
+          asSortOption(NAME, "name.nmSuffix.keyword", order),
           asHandlingNullSortOption("birth_time", order),
           asHandlingNullSortOption("local_id", order));
-      case "lastnm" -> Stream.of(asSortOption("name", "name.lastNm.keyword", order));
-      case "firstnm" -> Stream.of(asSortOption("name", "name.firstNm.keyword", order));
-      case ADDRESS -> Stream.of(asSortOption("sort.address", order));
+      case "lastnm" -> Stream.of(asSortOption(NAME, "name.lastNm.keyword", order));
+      case "firstnm" -> Stream.of(asSortOption(NAME, "name.firstNm.keyword", order));
+      case ADDRESS -> Stream.of(asHandlingNullSortOption("sort.address", order));
       case "birthtime", "birthday" -> Stream.of(asSortOption("birth_time", order));
       case "city" -> Stream.of(asSortOption(ADDRESS, "address.city.keyword", order));
       case "county" -> Stream.of(asSortOption(ADDRESS, "address.cntyText.keyword", order));
       case "country" -> Stream.of(asSortOption(ADDRESS, "address.cntryText.keyword", order));
-      case "email" -> Stream.of(asSortOption("sort.email", order));
+      case "email" -> Stream.of(asHandlingNullSortOption("sort.email", order));
       case "id" -> Stream.of(asSortOption("patient", order));
-      case "identification" -> Stream.of(asSortOption("sort.identification", order));
-      case "phonenumber" -> Stream.of(asSortOption("sort.phone", order));
+      case "identification" -> Stream.of(asHandlingNullSortOption("sort.identification", order));
+      case NAME -> Stream.of(asHandlingNullSortOption("sort.name", order));
+      case "phonenumber" -> Stream.of(asHandlingNullSortOption("sort.phone", order));
       case "state" -> Stream.of(asSortOption(ADDRESS, "address.stateText.keyword", order));
       case "sex" -> Stream.of(asSortOption("curr_sex_cd", order));
       case "zip" -> Stream.of(asSortOption(ADDRESS, "address.zip.keyword", order));

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatient.java
@@ -109,7 +109,8 @@ public record SearchablePatient(
       @JsonProperty("lastNm") @JsonSerialize(using = WithoutHyphensJsonSerializer.class, as = String.class) String last,
       @JsonProperty("lastNmSndx") String lastSoundex,
       @JsonProperty("nmPrefix") String prefix,
-      @JsonProperty("nmSuffix") String suffix) {
+      @JsonProperty("nmSuffix") String suffix,
+      @JsonProperty("full") String full) {
   }
 
 
@@ -123,7 +124,8 @@ public record SearchablePatient(
       @JsonProperty("cntryCd") String country,
       @JsonProperty("cntyText") String countyText,
       @JsonProperty("stateText") String stateText,
-      @JsonProperty("cntryText") String countryText) {
+      @JsonProperty("cntryText") String countryText,
+      @JsonProperty("full") String full) {
   }
 
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatient.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/SearchablePatient.java
@@ -91,6 +91,7 @@ public record SearchablePatient(
   }
 
   public record Sort(
+      String name,
       String identification,
       String email,
       String phone,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Optional;
 
-@SuppressWarnings("java:S3776") // cog complexity on name sorting
 @Component
 class SearchablePatientResolver {
 
@@ -46,45 +45,40 @@ class SearchablePatientResolver {
 
     List<SearchablePatient.Name> names = this.nameFinder.find(patient.identifier());
     String name = names.stream()
-        .map(elem -> (elem.last() == null ? "" : elem.last()) + " "
-            + (elem.first() == null ? "" : elem.first()))
-        .findFirst()
-        .orElse("");
-    name = name != null ? name.toUpperCase() : null;
+        .map(SearchablePatient.Name::full)
+        .map(String::toUpperCase)
+        .findFirst().orElse(null);
 
     List<SearchablePatient.Address> addresses = this.addressFinder.find(patient.identifier());
     List<SearchablePatient.Race> races = this.raceFinder.find(patient.identifier());
     List<SearchablePatient.Identification> identifications = identificationFinder.find(patient.identifier());
     String identification = identifications.stream()
         .map(SearchablePatient.Identification::value)
+        .map(String::toUpperCase)
         .findFirst()
         .orElse(null);
-    identification = identification != null ? identification.toUpperCase() : null;
 
     SearchablePatientTelecom telecom = this.telecomFinder.find(patient.identifier());
 
     List<SearchablePatient.Phone> phones = telecom.phones();
     String phone = phones.stream()
         .map(SearchablePatient.Phone::number)
+        .map(String::toUpperCase)
         .findFirst()
         .orElse(null);
-    phone = phone != null ? phone.toUpperCase() : null;
 
     List<SearchablePatient.Email> emails = telecom.emails();
 
     String email = emails.stream()
         .map(SearchablePatient.Email::address)
+        .map(String::toUpperCase)
         .findFirst()
         .orElse(null);
-    email = email != null ? email.toUpperCase() : null;
 
     String address = addresses.stream()
-        .map(elem -> (elem.address1() == null ? "" : elem.address1()) + " "
-            + (elem.address2() == null ? "" : elem.address2()) + " " + (elem.city() == null ? "" : elem.city()) + " "
-            + (elem.state() == null ? "" : elem.state()) + " " + (elem.zip() == null ? "" : elem.zip()))
-        .findFirst()
-        .orElse("");
-    address = address != null ? address.toUpperCase() : null;
+        .map(SearchablePatient.Address::full)
+        .map(String::toUpperCase)
+        .findFirst().orElse(null);
 
     SearchablePatient.Sort sort = new SearchablePatient.Sort(name, identification, email, phone, address);
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
@@ -44,6 +44,13 @@ class SearchablePatientResolver {
   private SearchablePatient withDemographics(final SearchablePatient patient) {
 
     List<SearchablePatient.Name> names = this.nameFinder.find(patient.identifier());
+    String name = names.stream()
+        .map(elem -> (elem.last() == null ? "" : elem.last()) + " "
+            + (elem.first() == null ? "" : elem.first()))
+        .findFirst()
+        .orElse("");
+    name = name != null ? name.toUpperCase() : null;
+
     List<SearchablePatient.Address> addresses = this.addressFinder.find(patient.identifier());
     List<SearchablePatient.Race> races = this.raceFinder.find(patient.identifier());
     List<SearchablePatient.Identification> identifications = identificationFinder.find(patient.identifier());
@@ -71,14 +78,14 @@ class SearchablePatientResolver {
     email = email != null ? email.toUpperCase() : null;
 
     String address = addresses.stream()
-        .map(elem -> (elem.address1() == null ? "" : elem.address1())
-            + (elem.address2() == null ? "" : elem.address2()) + (elem.city() == null ? "" : elem.city())
-            + (elem.state() == null ? "" : elem.state()) + (elem.zip() == null ? "" : elem.zip()))
+        .map(elem -> (elem.address1() == null ? "" : elem.address1()) + " "
+            + (elem.address2() == null ? "" : elem.address2()) + " " + (elem.city() == null ? "" : elem.city()) + " "
+            + (elem.state() == null ? "" : elem.state()) + " " + (elem.zip() == null ? "" : elem.zip()))
         .findFirst()
         .orElse("");
     address = address != null ? address.toUpperCase() : null;
 
-    SearchablePatient.Sort sort = new SearchablePatient.Sort(identification, email, phone, address);
+    SearchablePatient.Sort sort = new SearchablePatient.Sort(name, identification, email, phone, address);
 
     return new SearchablePatient(
         patient.identifier(),

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
@@ -51,6 +51,7 @@ class SearchablePatientResolver {
         .map(SearchablePatient.Identification::value)
         .findFirst()
         .orElse(null);
+    identification = identification != null ? identification.toUpperCase() : null;
 
     SearchablePatientTelecom telecom = this.telecomFinder.find(patient.identifier());
 
@@ -59,6 +60,7 @@ class SearchablePatientResolver {
         .map(SearchablePatient.Phone::number)
         .findFirst()
         .orElse(null);
+    phone = phone != null ? phone.toUpperCase() : null;
 
     List<SearchablePatient.Email> emails = telecom.emails();
 
@@ -66,6 +68,7 @@ class SearchablePatientResolver {
         .map(SearchablePatient.Email::address)
         .findFirst()
         .orElse(null);
+    email = email != null ? email.toUpperCase() : null;
 
     String address = addresses.stream()
         .map(elem -> (elem.address1() == null ? "" : elem.address1())
@@ -73,6 +76,7 @@ class SearchablePatientResolver {
             + (elem.state() == null ? "" : elem.state()) + (elem.zip() == null ? "" : elem.zip()))
         .findFirst()
         .orElse("");
+    address = address != null ? address.toUpperCase() : null;
 
     SearchablePatient.Sort sort = new SearchablePatient.Sort(identification, email, phone, address);
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientResolver.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Optional;
 
+@SuppressWarnings("java:S3776") // cog complexity on name sorting
 @Component
 class SearchablePatientResolver {
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientRowMapper.java
@@ -19,8 +19,6 @@ class SearchablePatientRowMapper implements RowMapper<SearchablePatient> {
       int deceased,
       int gender,
       int ethnicity,
-      int name,
-      int address,
       int documentIds,
       int morbidityReportIds,
       int treatmentIds,
@@ -50,8 +48,6 @@ class SearchablePatientRowMapper implements RowMapper<SearchablePatient> {
     String deceased = resultSet.getString(columns.deceased());
     String gender = resultSet.getString(columns.gender());
     String ethnicity = resultSet.getString(columns.ethnicity());
-    String name = resultSet.getString(columns.name());
-    String address = resultSet.getString(columns.address());
     String documentIds = resultSet.getString(columns.documentIds());
     String morbidityReportIds = resultSet.getString(columns.morbidityReportIds());
     String treatmentIds = resultSet.getString(columns.treatmentIds());
@@ -75,8 +71,6 @@ class SearchablePatientRowMapper implements RowMapper<SearchablePatient> {
         deceased,
         gender,
         ethnicity,
-        name,
-        address,
         documentIds,
         morbidityReportIds,
         treatmentIds,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/SearchablePatientRowMapper.java
@@ -19,6 +19,8 @@ class SearchablePatientRowMapper implements RowMapper<SearchablePatient> {
       int deceased,
       int gender,
       int ethnicity,
+      int name,
+      int address,
       int documentIds,
       int morbidityReportIds,
       int treatmentIds,
@@ -48,6 +50,8 @@ class SearchablePatientRowMapper implements RowMapper<SearchablePatient> {
     String deceased = resultSet.getString(columns.deceased());
     String gender = resultSet.getString(columns.gender());
     String ethnicity = resultSet.getString(columns.ethnicity());
+    String name = resultSet.getString(columns.name());
+    String address = resultSet.getString(columns.address());
     String documentIds = resultSet.getString(columns.documentIds());
     String morbidityReportIds = resultSet.getString(columns.morbidityReportIds());
     String treatmentIds = resultSet.getString(columns.treatmentIds());
@@ -71,6 +75,8 @@ class SearchablePatientRowMapper implements RowMapper<SearchablePatient> {
         deceased,
         gender,
         ethnicity,
+        name,
+        address,
         documentIds,
         morbidityReportIds,
         treatmentIds,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
@@ -28,7 +28,7 @@ public class SearchablePatientAddressFinder {
                     isNull([address].street_addr1, '') + ' '
                   + isNull([address].street_addr2, '') + ' '
                   + isNull([address].city_desc_txt, '') + ' '
-                  + isNull([state].state_nm, '')  + ' '
+                  + isNull([srte_state].state_nm, '')  + ' '
                   + isNull([address].zip_cd, ''),
                   'json'
                   )

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressFinder.java
@@ -22,9 +22,18 @@ public class SearchablePatientAddressFinder {
               [address].cntry_cd              as [country],
               [srte_county].code_desc_txt     as [county_text],
               [srte_state].state_nm           as [state_text],
-              [srte_country].code_short_desc_txt as [country_text]
+              [srte_country].code_short_desc_txt as [country_text],
+              trim(
+                string_escape(
+                    isNull([address].street_addr1, '') + ' '
+                  + isNull([address].street_addr2, '') + ' '
+                  + isNull([address].city_desc_txt, '') + ' '
+                  + isNull([state].state_nm, '')  + ' '
+                  + isNull([address].zip_cd, ''),
+                  'json'
+                  )
+                ) as [full]
           from Entity_locator_participation [locators]
-
               join Postal_locator [address] on
                       [address].[postal_locator_uid] = [locators].[locator_uid]
               left join NBS_SRTE..State_county_code_value [srte_county] on [srte_county].code = [address].cnty_cd
@@ -48,6 +57,7 @@ public class SearchablePatientAddressFinder {
   private static final int COUNTY_TEXT_COLUMN = 8;
   private static final int STATE_TEXT_COLUMN = 9;
   private static final int COUNTRY_TEXT_COLUMN = 10;
+  private static final int FULL_COLUMN = 11;
 
   private final JdbcTemplate template;
   private final RowMapper<SearchablePatient.Address> mapper;
@@ -65,7 +75,8 @@ public class SearchablePatientAddressFinder {
             COUNTRY_COLUMN,
             COUNTY_TEXT_COLUMN,
             STATE_TEXT_COLUMN,
-            COUNTRY_TEXT_COLUMN));
+            COUNTRY_TEXT_COLUMN,
+            FULL_COLUMN));
   }
 
   public List<SearchablePatient.Address> find(final long patient) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientAddressRowMapper.java
@@ -18,7 +18,8 @@ class SearchablePatientAddressRowMapper implements RowMapper<SearchablePatient.A
       int country,
       int countyText,
       int stateText,
-      int countryText) {
+      int countryText,
+      int full) {
   }
 
 
@@ -40,6 +41,7 @@ class SearchablePatientAddressRowMapper implements RowMapper<SearchablePatient.A
     String countyText = resultSet.getString(this.columns.countyText());
     String stateText = resultSet.getString(this.columns.stateText());
     String countryText = resultSet.getString(this.columns.countryText());
+    String full = resultSet.getString(this.columns.full());
     return new SearchablePatient.Address(
         address1,
         address2,
@@ -50,6 +52,7 @@ class SearchablePatientAddressRowMapper implements RowMapper<SearchablePatient.A
         country,
         countyText,
         stateText,
-        countryText);
+        countryText,
+        full);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameFinder.java
@@ -29,7 +29,7 @@ public class SearchablePatientNameFinder {
                   ),
                 'json'
                 )
-              ) as [full],
+              ) as [full]
       from person_name [name]
       join NBS_SRTE..Code_value_general [use] on
                  [use].[code_set_nm] = 'P_NM_USE'

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameFinder.java
@@ -17,8 +17,26 @@ public class SearchablePatientNameFinder {
           [name].middle_nm,
           [name].last_nm,
           [name].nm_prefix,
-          [name].nm_suffix
+          [name].nm_suffix,
+          trim(
+                string_escape(
+                  replace(
+                    isNull([name].last_nm, '') + ' '
+                  + isNull([name].first_nm, '') + ' '
+                  + isNull([name].middle_nm, '') + ' '
+                  + isNull([suffix].code_short_desc_txt, ''),
+                    '-', ' '
+                  ),
+                'json'
+                )
+              ) as [full],
       from person_name [name]
+      join NBS_SRTE..Code_value_general [use] on
+                 [use].[code_set_nm] = 'P_NM_USE'
+             and [use].[code] = [name].nm_use_cd
+      left join NBS_SRTE..Code_value_general [suffix] on
+                  [suffix].[code_set_nm] = 'P_NM_SFX'
+              and [suffix].[code] = [name].nm_suffix
       where [name].person_uid = ?
       """;
   private static final int PATIENT_PARAMETER = 1;
@@ -28,6 +46,7 @@ public class SearchablePatientNameFinder {
   private static final int MIDDLE_COLUMN = 3;
   private static final int FIRST_COLUMN = 2;
   private static final int USE_COLUMN = 1;
+  private static final int FULL_COLUMN = 7;
 
   private final JdbcTemplate template;
   private final RowMapper<SearchablePatient.Name> mapper;
@@ -41,16 +60,14 @@ public class SearchablePatientNameFinder {
             MIDDLE_COLUMN,
             LAST_COLUMN,
             PREFIX_COLUMN,
-            SUFFIX_COLUMN
-        )
-    );
+            SUFFIX_COLUMN,
+            FULL_COLUMN));
   }
 
   public List<SearchablePatient.Name> find(final long patient) {
     return this.template.query(
         QUERY,
         statement -> statement.setLong(PATIENT_PARAMETER, patient),
-        this.mapper
-    );
+        this.mapper);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameRowMapper.java
@@ -15,8 +15,8 @@ class SearchablePatientNameRowMapper implements RowMapper<SearchablePatient.Name
       int middle,
       int last,
       int prefix,
-      int suffix
-  ) {
+      int suffix,
+      int full) {
   }
 
 
@@ -38,6 +38,7 @@ class SearchablePatientNameRowMapper implements RowMapper<SearchablePatient.Name
     String lastSoundex = encoded(last);
     String prefix = resultSet.getString(column.prefix());
     String suffix = resultSet.getString(column.suffix());
+    String full = resultSet.getString(column.full());
 
     return new SearchablePatient.Name(
         use,
@@ -47,8 +48,8 @@ class SearchablePatientNameRowMapper implements RowMapper<SearchablePatient.Name
         last,
         lastSoundex,
         prefix,
-        suffix
-    );
+        suffix,
+        full);
   }
 
   private String encoded(final String value) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientDocumentAddressRowMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/indexing/address/SearchablePatientDocumentAddressRowMapperTest.java
@@ -16,7 +16,7 @@ class SearchablePatientDocumentAddressRowMapperTest {
   void should_map_from_result_set() throws SQLException {
 
     SearchablePatientAddressRowMapper.Column columns =
-        new SearchablePatientAddressRowMapper.Column(2, 3, 5, 7, 11, 13, 17, 18, 19, 20);
+        new SearchablePatientAddressRowMapper.Column(2, 3, 5, 7, 11, 13, 17, 18, 19, 20, 21);
 
     ResultSet resultSet = mock(ResultSet.class);
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameRowMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/search/indexing/name/SearchablePatientNameRowMapperTest.java
@@ -15,8 +15,7 @@ class SearchablePatientNameRowMapperTest {
   @Test
   void should_map_from_result_set() throws SQLException {
 
-    SearchablePatientNameRowMapper.Column
-        columns = new SearchablePatientNameRowMapper.Column(2, 3, 5, 7, 11, 13);
+    SearchablePatientNameRowMapper.Column columns = new SearchablePatientNameRowMapper.Column(2, 3, 5, 7, 11, 13, 17);
 
     ResultSet resultSet = mock(ResultSet.class);
 


### PR DESCRIPTION
## Description

In nifi we make all sort fields upper case so that elastic does a case insensitive sort.  Update the incremental indexer by doing a `toUpperCase` on sort fields in java.

## Tickets

* [CNFT1-3905](https://cdc-nbs.atlassian.net/browse/CNFT1-3905)
* [CNFT1-3907](https://cdc-nbs.atlassian.net/browse/CNFT1-3907)
* [CNFT1-3910](https://cdc-nbs.atlassian.net/browse/CNFT1-3910)
* [CNFT1-3908](https://cdc-nbs.atlassian.net/browse/CNFT1-3908)
* [CNFT1-3914](https://cdc-nbs.atlassian.net/browse/CNFT1-3914)
* [CNFT1-3915](https://cdc-nbs.atlassian.net/browse/CNFT1-3915)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3905]: https://cdc-nbs.atlassian.net/browse/CNFT1-3905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNFT1-3910]: https://cdc-nbs.atlassian.net/browse/CNFT1-3910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNFT1-3907]: https://cdc-nbs.atlassian.net/browse/CNFT1-3907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNFT1-3908]: https://cdc-nbs.atlassian.net/browse/CNFT1-3908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-3914]: https://cdc-nbs.atlassian.net/browse/CNFT1-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-3915]: https://cdc-nbs.atlassian.net/browse/CNFT1-3915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ