### PR TITLE
[CNFT1-3889] using correct error dark on asterisk

### DIFF
--- a/apps/modernization-ui/src/styles/_colors.scss
+++ b/apps/modernization-ui/src/styles/_colors.scss
@@ -68,8 +68,8 @@ $disabled-darkest: #454545;
 
 $border: #dfe1e2;
 
-$mandatory: #d83933;
-$requried: $mandatory;
+$mandatory: $error-dark;
+
 
 $visited-link: #562b97;
 $background: #f1f6f9;

--- a/apps/modernization-ui/src/styles/global.scss
+++ b/apps/modernization-ui/src/styles/global.scss
@@ -46,7 +46,7 @@ td span {
 .required-before {
     &::before {
         content: '* ';
-        color: colors.$mandatory;
+        color: colors.$error-dark;
     }
 }
 

--- a/apps/modernization-ui/src/styles/global.scss
+++ b/apps/modernization-ui/src/styles/global.scss
@@ -46,7 +46,7 @@ td span {
 .required-before {
     &::before {
         content: '* ';
-        color: colors.$error-dark;
+        color: colors.$mandatory;
     }
 }
 


### PR DESCRIPTION
## Description

 asterisk is using the wrong color: Should be using error/dark which is #B51D09

## Tickets

* [CNFT1-3889](https://cdc-nbs.atlassian.net/browse/CNFT1-3889)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3889]: https://cdc-nbs.atlassian.net/browse/CNFT1-3889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ