### PR TITLE
[CNFT1-3864] adding conditional render within span for no results found message ba…

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/none/NoPatientResults.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/none/NoPatientResults.tsx
@@ -18,14 +18,12 @@ const NoPatientResults = ({ sizing }: Props) => {
                     <div className={styles.noResultsContent}>
                         <span className={styles.noResultsHeader}> No result found</span>
                         <span className={styles.noResultsSubHeading}>
-                            Try refining your search
-                            <Permitted include={[ADD_PATIENT_PERMISSION]}>
-                                , or{' '}
+                            <Permitted include={[ADD_PATIENT_PERMISSION]} fallback="Try refining your search.">
+                                Try refining your search, or{' '}
                                 <a className={styles.link} onClick={add}>
                                     add a new patient.
                                 </a>
                             </Permitted>
-                            <Permitted exclude={[ADD_PATIENT_PERMISSION]}>.</Permitted>
                         </span>
                     </div>
                 </AlertBanner>

--- a/apps/modernization-ui/src/apps/search/patient/result/none/NoPatientResults.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/none/NoPatientResults.tsx
@@ -25,6 +25,7 @@ const NoPatientResults = ({ sizing }: Props) => {
                                     add a new patient.
                                 </a>
                             </Permitted>
+                            <Permitted exclude={[ADD_PATIENT_PERMISSION]}>.</Permitted>
                         </span>
                     </div>
                 </AlertBanner>

--- a/apps/modernization-ui/src/libs/permission/Permitted.tsx
+++ b/apps/modernization-ui/src/libs/permission/Permitted.tsx
@@ -13,9 +13,11 @@ type PermittedProps = {
     mode?: 'all' | 'any';
     /** The children to render if permissions are satisfied */
     children: ReactNode | ReactNode[];
+    /** The fallback to render if permissions are satisfied */
+    fallback?: ReactNode | String;
 };
 
-const Permitted = ({ permission, include, exclude, mode, children }: PermittedProps) => {
+const Permitted = ({ permission, include, exclude, mode, children, fallback }: PermittedProps) => {
     const { allows } = usePermissions();
     const permissionList = permission ? [permission] : undefined;
     include = include ?? permissionList;
@@ -23,7 +25,11 @@ const Permitted = ({ permission, include, exclude, mode, children }: PermittedPr
     const checkExcluded = !exclude || (mode === 'any' ? !exclude.some(allows) : !exclude.every(allows));
     const allowed = checkIncluded && checkExcluded;
 
-    return <Shown when={allowed}>{children}</Shown>;
+    return (
+        <Shown fallback={fallback} when={allowed}>
+            {children}
+        </Shown>
+    );
 };
 
 export { Permitted };

--- a/apps/modernization-ui/src/libs/permission/Permitted.tsx
+++ b/apps/modernization-ui/src/libs/permission/Permitted.tsx
@@ -13,8 +13,8 @@ type PermittedProps = {
     mode?: 'all' | 'any';
     /** The children to render if permissions are satisfied */
     children: ReactNode | ReactNode[];
-    /** The fallback to render if permissions are satisfied */
-    fallback?: ReactNode | String;
+    /** The fallback to render if permissions are not satisfied */
+    fallback?: ReactNode | ReactNode[];
 };
 
 const Permitted = ({ permission, include, exclude, mode, children, fallback }: PermittedProps) => {


### PR DESCRIPTION
## Description

- If the user has ADD_PATIENT_PERMISSION, show ", or add a new patient."
- If the user does not have ADD_PATIENT_PERMISSION, show a period (.) instead of a comma
<img width="434" alt="Screenshot 2025-03-12 at 1 20 08 PM" src="https://github.com/user-attachments/assets/6ae3f94d-9532-4a85-926e-42be2365b34f" />
<img width="357" alt="Screenshot 2025-03-12 at 1 20 53 PM" src="https://github.com/user-attachments/assets/a3c7b4ec-ef07-4785-8b21-4be52b0bf436" />


## Tickets

* [CNFT1-3864](https://cdc-nbs.atlassian.net/browse/CNFT1-3864)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3864]: https://cdc-nbs.atlassian.net/browse/CNFT1-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ