### PR TITLE
Add support for secondary and secondary destructive

### DIFF
--- a/apps/modernization-ui/src/design-system/button/Button.spec.tsx
+++ b/apps/modernization-ui/src/design-system/button/Button.spec.tsx
@@ -75,8 +75,8 @@ describe('Button component tests', () => {
                 Destructive
             </Button>
         );
-        expect(screen.getByRole('button')).not.toHaveClass('destructive');
-        expect(screen.getByRole('button')).toHaveClass('secondaryDestructive');
+        expect(screen.getByRole('button')).toHaveClass('destructive');
+        expect(screen.getByRole('button')).toHaveClass('secondary');
     });
 
     it('renders the unpadded className when set', () => {

--- a/apps/modernization-ui/src/design-system/button/Button.spec.tsx
+++ b/apps/modernization-ui/src/design-system/button/Button.spec.tsx
@@ -69,14 +69,19 @@ describe('Button component tests', () => {
         expect(screen.getByRole('button')).toHaveClass('destructive');
     });
 
-    it('renders the secondaryDestructive className when set', () => {
+    it('renders the secondary className when set', () => {
+        render(<Button secondary>Destructive</Button>);
+        expect(screen.getByRole('button')).toHaveClass('secondary');
+    });
+
+    it('renders the secondary and destructive classNames when set', () => {
         render(
             <Button destructive secondary>
                 Destructive
             </Button>
         );
-        expect(screen.getByRole('button')).toHaveClass('destructive');
         expect(screen.getByRole('button')).toHaveClass('secondary');
+        expect(screen.getByRole('button')).toHaveClass('destructive');
     });
 
     it('renders the unpadded className when set', () => {

--- a/apps/modernization-ui/src/design-system/button/Button.spec.tsx
+++ b/apps/modernization-ui/src/design-system/button/Button.spec.tsx
@@ -69,6 +69,16 @@ describe('Button component tests', () => {
         expect(screen.getByRole('button')).toHaveClass('destructive');
     });
 
+    it('renders the secondaryDestructive className when set', () => {
+        render(
+            <Button destructive secondary>
+                Destructive
+            </Button>
+        );
+        expect(screen.getByRole('button')).not.toHaveClass('destructive');
+        expect(screen.getByRole('button')).toHaveClass('secondaryDestructive');
+    });
+
     it('renders the unpadded className when set', () => {
         render(<Button unpadded>Unpadded</Button>);
         expect(screen.getByRole('button')).toHaveClass('unpadded');

--- a/apps/modernization-ui/src/design-system/button/Button.tsx
+++ b/apps/modernization-ui/src/design-system/button/Button.tsx
@@ -8,7 +8,8 @@ type Props = {
     className?: string;
     icon?: ReactNode;
     children?: ReactNode;
-    outline?: boolean;
+    outline?: boolean; // Deprecated - replaced by secondary
+    secondary?: boolean;
     destructive?: boolean;
     disabled?: boolean;
     type?: 'button' | 'submit' | 'reset';
@@ -26,6 +27,7 @@ const Button = ({
     unpadded,
     children,
     outline = false,
+    secondary = false,
     destructive = false,
     unstyled = false,
     labelPosition = 'left',
@@ -33,8 +35,10 @@ const Button = ({
     ...defaultProps
 }: Props) => {
     const isIconOnly = icon && !children;
+    const isSecondary = secondary || outline;
     const classesArray = classNames(className, sizing && styles[sizing], {
-        [styles.destructive]: destructive,
+        [styles.destructive]: destructive && !isSecondary,
+        [styles.secondaryDestructive]: destructive && isSecondary,
         [styles.icon]: isIconOnly,
         [styles.unpadded]: unpadded
     });
@@ -46,7 +50,7 @@ const Button = ({
             type={type}
             unstyled={unstyled}
             size={isIconOnly ? 'big' : undefined}
-            outline={outline}>
+            outline={isSecondary}>
             {labelPosition === 'left' && children && icon ? (
                 <>
                     <span>{children}</span>

--- a/apps/modernization-ui/src/design-system/button/Button.tsx
+++ b/apps/modernization-ui/src/design-system/button/Button.tsx
@@ -37,8 +37,8 @@ const Button = ({
     const isIconOnly = icon && !children;
     const isSecondary = secondary || outline;
     const classesArray = classNames(className, sizing && styles[sizing], {
-        [styles.destructive]: destructive && !isSecondary,
-        [styles.secondaryDestructive]: destructive && isSecondary,
+        [styles.destructive]: destructive,
+        [styles.secondary]: isSecondary,
         [styles.icon]: isIconOnly,
         [styles.unpadded]: unpadded
     });
@@ -49,8 +49,7 @@ const Button = ({
             {...defaultProps}
             type={type}
             unstyled={unstyled}
-            size={isIconOnly ? 'big' : undefined}
-            outline={isSecondary}>
+            size={isIconOnly ? 'big' : undefined}>
             {labelPosition === 'left' && children && icon ? (
                 <>
                     <span>{children}</span>

--- a/apps/modernization-ui/src/styles/_buttons.scss
+++ b/apps/modernization-ui/src/styles/_buttons.scss
@@ -23,26 +23,26 @@ $icon-padding-medium: 0.5rem;
 }
 
 .destructive {
-    background-color: colors.$destructive !important;
+    background-color: colors.$destructive;
     &:hover {
-        background-color: colors.$secondary-dark !important;
+        background-color: colors.$secondary-dark;
     }
     &:active {
-        background-color: colors.$secondary-darker !important;
+        background-color: colors.$secondary-darker;
     }
 }
 
 .destructive.secondary {
-    background-color: colors.$base-white !important;
-    color: colors.$error !important;
-    box-shadow: inset 0 0 0 2px colors.$disabled !important;
+    background-color: colors.$base-white;
+    color: colors.$error;
+    box-shadow: inset 0 0 0 2px colors.$disabled;
     border-radius: 0.25rem;
 
     &:hover {
-        color: colors.$secondary-dark !important;
+        color: colors.$secondary-dark;
     }
     &:active {
-        color: colors.$error-darker !important;
+        color: colors.$error-darker;
     }
 }
 

--- a/apps/modernization-ui/src/styles/_buttons.scss
+++ b/apps/modernization-ui/src/styles/_buttons.scss
@@ -26,6 +26,20 @@ $icon-padding-medium: 0.5rem;
     }
 }
 
+.secondaryDestructive {
+    background-color: colors.$base-white;
+    color: colors.$error !important;
+    box-shadow: inset 0 0 0 2px colors.$disabled !important;
+    border-radius: 0.25rem;
+
+    &:hover {
+        color: colors.$secondary-dark !important;
+    }
+    &:active {
+        color: colors.$error-darker !important;
+    }
+}
+
 %button-small {
     padding: $button-padding-small;
     font-size: 0.875rem;

--- a/apps/modernization-ui/src/styles/_buttons.scss
+++ b/apps/modernization-ui/src/styles/_buttons.scss
@@ -20,6 +20,15 @@ $icon-padding-medium: 0.5rem;
     background-color: rgba(0, 0, 0, 0);
     box-shadow: inset 0 0 0 2px colors.$primary;
     color: colors.$primary;
+
+    &:hover {
+        box-shadow: inset 0 0 0 2px colors.$primary-dark;
+        color: colors.$primary-dark;
+    }
+    &:active {
+        box-shadow: inset 0 0 0 2px colors.$primary-darker;
+        color: colors.$primary-darker;
+    }
 }
 
 .destructive {

--- a/apps/modernization-ui/src/styles/_buttons.scss
+++ b/apps/modernization-ui/src/styles/_buttons.scss
@@ -16,6 +16,12 @@ $icon-padding-medium: 0.5rem;
     }
 }
 
+.secondary {
+    background-color: rgba(0, 0, 0, 0);
+    box-shadow: inset 0 0 0 2px colors.$primary;
+    color: colors.$primary;
+}
+
 .destructive {
     background-color: colors.$destructive !important;
     &:hover {
@@ -26,8 +32,8 @@ $icon-padding-medium: 0.5rem;
     }
 }
 
-.secondaryDestructive {
-    background-color: colors.$base-white;
+.destructive.secondary {
+    background-color: colors.$base-white !important;
     color: colors.$error !important;
     box-shadow: inset 0 0 0 2px colors.$disabled !important;
     border-radius: 0.25rem;
@@ -80,5 +86,4 @@ $icon-padding-medium: 0.5rem;
     &.medium {
         @extend %icon-button;
     }
-    
 }


### PR DESCRIPTION
## Description

1. Adds `secondary` prop to design system's `Button` component. This prop will be replacing `outline` in the future.
2. Adds styling for when both `secondary` and `destructive` is specified.

Standard
<img width="170" alt="image" src="https://github.com/user-attachments/assets/aebaa9d0-4831-494e-95bb-7cb9f156ee81" />

Outline
<img width="169" alt="image" src="https://github.com/user-attachments/assets/eed2f654-3696-4969-9fdb-f8e463a4e009" />

Secondary
<img width="172" alt="image" src="https://github.com/user-attachments/assets/ad6c33cd-8809-44aa-918f-f5e7bb868649" />

Destructive
<img width="158" alt="image" src="https://github.com/user-attachments/assets/e0cceb62-2297-4791-9bb4-b6c6aeeca12c" />

Outline Destructive
<img width="158" alt="image" src="https://github.com/user-attachments/assets/9c1e3e9e-ed6a-472e-89a7-515c43b6a947" />

Secondary Destructive
<img width="167" alt="image" src="https://github.com/user-attachments/assets/7c543b49-5096-4595-80d0-36f23a87bb30" />
