### PR TITLE
[CNFT1-3789] Language & Occupation lists

### DIFF
--- a/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
+++ b/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
@@ -3721,6 +3721,63 @@
 					]
 				},
 				{
+					"name": "Occupations",
+					"item": [
+						{
+							"name": "All Occupations",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base}}/nbs/api/options/occupations",
+									"host": [
+										"{{base}}"
+									],
+									"path": [
+										"nbs",
+										"api",
+										"options",
+										"occupations"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Specific Occupations",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base}}/nbs/api/options/occupations/search?criteria=w",
+									"host": [
+										"{{base}}"
+									],
+									"path": [
+										"nbs",
+										"api",
+										"options",
+										"occupations",
+										"search"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "",
+											"disabled": true
+										},
+										{
+											"key": "criteria",
+											"value": "w"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
 					"name": "Resulted Test",
 					"request": {
 						"method": "GET",

--- a/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
+++ b/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
@@ -311,8 +311,8 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query search($filter: PersonFilter!, $page: SortablePage, $share: String) {\n  findPatientsByFilter(filter: $filter, page: $page, share: $share) {\n    content {\n      patient\n      shortId\n      legalName {\n        first\n        middle\n        last\n        suffix\n      }\n      addresses {\n        type\n        use\n        address\n        city\n        county\n        zipcode\n        state\n      }\n    }\n    total\n    page\n    size\n  }\n}\n",
-								"variables": "{\n    \"filter\" :{\n        \"recordStatus\": [\"ACTIVE\"]\n    },\n    \"page\": {\n        \"pageNumber\": 0,\n        \"pageSize\": 5\n\t}\n}"
+								"query": "      query patients($filter: PersonFilter!, $page: SortablePage) {\n        findPatientsByFilter(filter: $filter, page: $page) {\n          content {\n            patient\n            shortId\n            status\n            birthday\n            age\n            gender\n            legalName {\n              first\n              middle\n              last\n              suffix\n            }\n            names {\n              type\n              first\n              middle\n              last\n              suffix\n            }\n            identification {\n              type\n              value\n            }\n            emails\n            phones\n            addresses {\n                type\n                use\n                address\n                address2\n                city\n                county\n                state\n                zipcode\n            }\n            detailedPhones {\n                type\n                use\n                number\n            }\n          }\n          total\n        }\n      }",
+								"variables": "{\n    \"filter\" :{\n        \"recordStatus\": [\"ACTIVE\"],\n        \"id\":\"114097\"\n        }        \n    },\n    \"page\": {\n        \"pageNumber\": 0,\n        \"pageSize\": 25\n\t}\n}"
 							}
 						},
 						"url": {
@@ -3653,6 +3653,65 @@
 										{
 											"key": "limit",
 											"value": "4"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Languages",
+					"item": [
+						{
+							"name": "All Primary languages",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base}}/nbs/api/options/languages/primary",
+									"host": [
+										"{{base}}"
+									],
+									"path": [
+										"nbs",
+										"api",
+										"options",
+										"languages",
+										"primary"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Specific Primary languages",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base}}/nbs/api/options/languages/primary/search?criteria=w",
+									"host": [
+										"{{base}}"
+									],
+									"path": [
+										"nbs",
+										"api",
+										"options",
+										"languages",
+										"primary",
+										"search"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "",
+											"disabled": true
+										},
+										{
+											"key": "criteria",
+											"value": "w"
 										}
 									]
 								}

--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -36,6 +36,7 @@ export { EncryptionControllerService } from './services/EncryptionControllerServ
 export { FacilityOptionsService } from './services/FacilityOptionsService';
 export { JurisdictionOptionsService } from './services/JurisdictionOptionsService';
 export { LoginService } from './services/LoginService';
+export { OccupationOptionsService } from './services/OccupationOptionsService';
 export { PatientProfileService } from './services/PatientProfileService';
 export { PatientRaceService } from './services/PatientRaceService';
 export { PrimaryLanguageOptionsService } from './services/PrimaryLanguageOptionsService';

--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -38,6 +38,7 @@ export { JurisdictionOptionsService } from './services/JurisdictionOptionsServic
 export { LoginService } from './services/LoginService';
 export { PatientProfileService } from './services/PatientProfileService';
 export { PatientRaceService } from './services/PatientRaceService';
+export { PrimaryLanguageOptionsService } from './services/PrimaryLanguageOptionsService';
 export { ProgramAreaOptionsService } from './services/ProgramAreaOptionsService';
 export { ProviderOptionsService } from './services/ProviderOptionsService';
 export { RaceOptionsService } from './services/RaceOptionsService';

--- a/apps/modernization-ui/src/generated/services/OccupationOptionsService.ts
+++ b/apps/modernization-ui/src/generated/services/OccupationOptionsService.ts
@@ -1,0 +1,44 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Option } from '../models/Option';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class OccupationOptionsService {
+    /**
+     * Occupation Option
+     * Provides all Occupations options.
+     * @returns Option OK
+     * @throws ApiError
+     */
+    public static occupations(): CancelablePromise<Array<Option>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/options/occupations',
+        });
+    }
+    /**
+     * Occupation Option Autocomplete
+     * Provides options from Occupation that have a name matching a criteria.
+     * @returns Option OK
+     * @throws ApiError
+     */
+    public static occupationComplete({
+        criteria,
+        limit = 15,
+    }: {
+        criteria: string,
+        limit?: number,
+    }): CancelablePromise<Array<Option>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/options/occupations/search',
+            query: {
+                'criteria': criteria,
+                'limit': limit,
+            },
+        });
+    }
+}

--- a/apps/modernization-ui/src/generated/services/PrimaryLanguageOptionsService.ts
+++ b/apps/modernization-ui/src/generated/services/PrimaryLanguageOptionsService.ts
@@ -1,0 +1,44 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Option } from '../models/Option';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class PrimaryLanguageOptionsService {
+    /**
+     * Primary language Option
+     * Provides all Primary language options.
+     * @returns Option OK
+     * @throws ApiError
+     */
+    public static primaryLanguages(): CancelablePromise<Array<Option>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/options/languages/primary',
+        });
+    }
+    /**
+     * Primary language Option Autocomplete
+     * Provides options from Primary languages that have a name matching a criteria.
+     * @returns Option OK
+     * @throws ApiError
+     */
+    public static primaryLanguageComplete({
+        criteria,
+        limit = 15,
+    }: {
+        criteria: string,
+        limit?: number,
+    }): CancelablePromise<Array<Option>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/options/languages/primary/search',
+            query: {
+                'criteria': criteria,
+                'limit': limit,
+            },
+        });
+    }
+}

--- a/apps/modernization-ui/src/options/language/index.ts
+++ b/apps/modernization-ui/src/options/language/index.ts
@@ -1,0 +1,2 @@
+export { usePrimaryLanguageOptions } from './usePrimaryLanguageOptions';
+export { usePrimaryLanguageOptionsAutocomplete } from './usePrimaryLanguageOptionsAutocomplete';

--- a/apps/modernization-ui/src/options/language/usePrimaryLanguageOptions.ts
+++ b/apps/modernization-ui/src/options/language/usePrimaryLanguageOptions.ts
@@ -1,0 +1,8 @@
+import { PrimaryLanguageOptionsService } from 'generated';
+import { useSelectableOptions } from 'options/useSelectableOptions';
+
+const resolver = () => PrimaryLanguageOptionsService.primaryLanguages();
+
+const usePrimaryLanguageOptions = (settings = { lazy: false }) => useSelectableOptions({ ...settings, resolver });
+
+export { usePrimaryLanguageOptions };

--- a/apps/modernization-ui/src/options/language/usePrimaryLanguageOptionsAutocomplete.ts
+++ b/apps/modernization-ui/src/options/language/usePrimaryLanguageOptionsAutocomplete.ts
@@ -1,0 +1,34 @@
+import { PrimaryLanguageOptionsService } from 'generated';
+
+import { AutocompleteOptionsResolver, SelectableAutocompletion, useSelectableAutocomplete } from 'options/autocompete';
+
+type Settings = {
+    initialCriteria?: string;
+    limit?: number;
+};
+
+const usePrimaryLanguageOptionsAutocomplete = (
+    settings: Settings = { initialCriteria: '' }
+): SelectableAutocompletion => {
+    const resolver: AutocompleteOptionsResolver = (criteria: string, limit?: number) =>
+        PrimaryLanguageOptionsService.primaryLanguageComplete({
+            criteria,
+            limit
+        });
+
+    const { criteria, options, suggest, complete, reset } = useSelectableAutocomplete({
+        resolver,
+        criteria: settings.initialCriteria,
+        limit: settings.limit
+    });
+
+    return {
+        criteria,
+        options,
+        suggest,
+        complete,
+        reset
+    };
+};
+
+export { usePrimaryLanguageOptionsAutocomplete };

--- a/apps/modernization-ui/src/options/occupations/index.ts
+++ b/apps/modernization-ui/src/options/occupations/index.ts
@@ -1,0 +1,2 @@
+export { useOccupationOptions } from './useOccupationOptions';
+export { useOccupationOptionsAutocomplete } from './useOccupationOptionsAutocomplete';

--- a/apps/modernization-ui/src/options/occupations/useOccupationOptions.ts
+++ b/apps/modernization-ui/src/options/occupations/useOccupationOptions.ts
@@ -1,0 +1,8 @@
+import { OccupationOptionsService } from 'generated';
+import { useSelectableOptions } from 'options/useSelectableOptions';
+
+const resolver = () => OccupationOptionsService.occupations();
+
+const useOccupationOptions = (settings = { lazy: false }) => useSelectableOptions({ ...settings, resolver });
+
+export { useOccupationOptions };

--- a/apps/modernization-ui/src/options/occupations/useOccupationOptionsAutocomplete.ts
+++ b/apps/modernization-ui/src/options/occupations/useOccupationOptionsAutocomplete.ts
@@ -1,0 +1,32 @@
+import { OccupationOptionsService } from 'generated';
+
+import { AutocompleteOptionsResolver, SelectableAutocompletion, useSelectableAutocomplete } from 'options/autocompete';
+
+type Settings = {
+    initialCriteria?: string;
+    limit?: number;
+};
+
+const useOccupationOptionsAutocomplete = (settings: Settings = { initialCriteria: '' }): SelectableAutocompletion => {
+    const resolver: AutocompleteOptionsResolver = (criteria: string, limit?: number) =>
+        OccupationOptionsService.occupationComplete({
+            criteria,
+            limit
+        });
+
+    const { criteria, options, suggest, complete, reset } = useSelectableAutocomplete({
+        resolver,
+        criteria: settings.initialCriteria,
+        limit: settings.limit
+    });
+
+    return {
+        criteria,
+        options,
+        suggest,
+        complete,
+        reset
+    };
+};
+
+export { useOccupationOptionsAutocomplete };

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionFinder.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionFinder.java
@@ -1,0 +1,27 @@
+package gov.cdc.nbs.option.language.primary;
+
+import gov.cdc.nbs.option.jdbc.SQLBasedOptionFinder;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class PrimaryLanguageOptionFinder extends SQLBasedOptionFinder {
+
+  private static final String QUERY = """
+      select
+          code                                as [value],
+          code_desc_txt                       as [name],
+          row_number() over (order by [code]) as [order]
+      from NBS_SRTE..Language_code
+      where status_cd = 'A'
+      order by
+        code_desc_txt
+      """;
+
+
+  PrimaryLanguageOptionFinder(final JdbcTemplate template) {
+    super(QUERY, template);
+  }
+
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionsController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionsController.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.option.language.primary;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+class PrimaryLanguageOptionsController {
+
+  private final PrimaryLanguageOptionFinder finder;
+
+  PrimaryLanguageOptionsController(final PrimaryLanguageOptionFinder finder) {
+    this.finder = finder;
+  }
+
+  @Operation(
+      operationId = "primaryLanguages",
+      summary = "Primary language Option",
+      description = "Provides all Primary language options.",
+      tags = "PrimaryLanguageOptions"
+  )
+  @GetMapping("nbs/api/options/languages/primary")
+  Collection<Option> all() {
+    return this.finder.find();
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageOptionAutocompleteController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageOptionAutocompleteController.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.option.language.primary.autocomplete;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+class PrimaryLanguageOptionAutocompleteController {
+
+  private final PrimaryLanguageOptionResolver resolver;
+
+  PrimaryLanguageOptionAutocompleteController(final PrimaryLanguageOptionResolver finder) {
+    this.resolver = finder;
+  }
+
+  @Operation(
+      operationId = "primaryLanguageComplete",
+      summary = "Primary language Option Autocomplete",
+      description = "Provides options from Primary languages that have a name matching a criteria.",
+      tags = "PrimaryLanguageOptions"
+  )
+  @GetMapping("nbs/api/options/languages/primary/search")
+  Collection<Option> complete(
+      @RequestParam final String criteria,
+      @RequestParam(defaultValue = "15") final int limit
+  ) {
+    return this.resolver.resolve(criteria, limit);
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageOptionResolver.java
@@ -1,0 +1,27 @@
+package gov.cdc.nbs.option.language.primary.autocomplete;
+
+import gov.cdc.nbs.option.jdbc.autocomplete.SQLBasedOptionResolver;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class PrimaryLanguageOptionResolver extends SQLBasedOptionResolver {
+
+  private static final String QUERY = """
+      select
+          code                                as [value],
+          code_desc_txt                       as [name],
+          row_number() over (order by [code]) as [order]
+      from NBS_SRTE..Language_code
+      where   status_cd = 'A'
+          and code_desc_txt like :criteria
+      order by
+          code_desc_txt
+      offset 0 rows
+      fetch next :limit rows only
+      """;
+
+  PrimaryLanguageOptionResolver(final NamedParameterJdbcTemplate template) {
+    super(QUERY, template);
+  }
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/OccupationOptionFinder.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/OccupationOptionFinder.java
@@ -1,0 +1,28 @@
+package gov.cdc.nbs.option.occupations;
+
+import gov.cdc.nbs.option.jdbc.SQLBasedOptionFinder;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class OccupationOptionFinder extends SQLBasedOptionFinder {
+
+  private static final String QUERY = """
+      select
+          code                                as [value],
+          code_short_desc_txt                 as [name],
+          row_number() over (order by [code]) as [order]
+      from NBS_SRTE..NAICS_Industry_code
+      where status_cd = 'A'
+        and parent_is_cd = 'root'
+      order by
+        code_short_desc_txt
+      """;
+
+
+  OccupationOptionFinder(final JdbcTemplate template) {
+    super(QUERY, template);
+  }
+
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/OccupationOptionsController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/OccupationOptionsController.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.option.occupations;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+class OccupationOptionsController {
+
+  private final OccupationOptionFinder finder;
+
+  OccupationOptionsController(final OccupationOptionFinder finder) {
+    this.finder = finder;
+  }
+
+  @Operation(
+      operationId = "occupations",
+      summary = "Occupation Option",
+      description = "Provides all Occupations options.",
+      tags = "OccupationOptions"
+  )
+  @GetMapping("nbs/api/options/occupations")
+  Collection<Option> all() {
+    return this.finder.find();
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationOptionAutocompleteController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationOptionAutocompleteController.java
@@ -1,0 +1,34 @@
+package gov.cdc.nbs.option.occupations.autocomplete;
+
+import gov.cdc.nbs.option.Option;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+@RestController
+class OccupationOptionAutocompleteController {
+
+  private final OccupationOptionResolver resolver;
+
+  OccupationOptionAutocompleteController(final OccupationOptionResolver finder) {
+    this.resolver = finder;
+  }
+
+  @Operation(
+      operationId = "occupationComplete",
+      summary = "Occupation Option Autocomplete",
+      description = "Provides options from Occupation that have a name matching a criteria.",
+      tags = "OccupationOptions"
+  )
+  @GetMapping("nbs/api/options/occupations/search")
+  Collection<Option> complete(
+      @RequestParam final String criteria,
+      @RequestParam(defaultValue = "15") final int limit
+  ) {
+    return this.resolver.resolve(criteria, limit);
+  }
+
+}

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationOptionResolver.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationOptionResolver.java
@@ -1,0 +1,28 @@
+package gov.cdc.nbs.option.occupations.autocomplete;
+
+import gov.cdc.nbs.option.jdbc.autocomplete.SQLBasedOptionResolver;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class OccupationOptionResolver extends SQLBasedOptionResolver {
+
+  private static final String QUERY = """
+      select
+          code                                as [value],
+          code_short_desc_txt                 as [name],
+          row_number() over (order by [code]) as [order]
+      from NBS_SRTE..NAICS_Industry_code
+      where   status_cd = 'A'
+          and parent_is_cd = 'root'
+          and code_short_desc_txt like :criteria
+      order by
+          code_short_desc_txt
+      offset 0 rows
+      fetch next :limit rows only
+      """;
+
+  OccupationOptionResolver(final NamedParameterJdbcTemplate template) {
+    super(QUERY, template);
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageMother.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageMother.java
@@ -1,0 +1,93 @@
+package gov.cdc.nbs.option.language.primary;
+
+import gov.cdc.nbs.option.Option;
+import gov.cdc.nbs.testing.support.Available;
+import io.cucumber.spring.ScenarioScope;
+import jakarta.annotation.PreDestroy;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@ScenarioScope
+class PrimaryLanguageMother {
+
+  private static final String DELETE_IN = """
+      delete
+      from NBS_SRTE.[dbo].language_code
+      where code in (:codes)
+      """;
+
+  private static final String CREATE = """
+      insert into NBS_SRTE.[dbo].language_code(
+        code,
+        code_desc_txt,
+        indent_level_nbr, 
+        status_cd
+      )
+      values (:identifier, :name, :order, 'A')
+      """;
+
+  private final NamedParameterJdbcTemplate template;
+  private final Available<Option> availalbe;
+
+  PrimaryLanguageMother(final JdbcTemplate template) {
+    this.template = new NamedParameterJdbcTemplate(template);
+    this.availalbe = new Available<>();
+  }
+
+  @PreDestroy
+  void reset() {
+
+    List<String> codes = this.availalbe.all()
+        .map(Option::value)
+        .toList();
+
+    if (!codes.isEmpty()) {
+
+      Map<String, List<String>> parameters = Map.of("codes", codes);
+
+      template.execute(
+          DELETE_IN,
+          new MapSqlParameterSource(parameters),
+          PreparedStatement::executeUpdate);
+
+      this.availalbe.reset();
+    }
+  }
+
+  void create(final String name) {
+
+    String code = UUID.randomUUID().toString()
+        .replace("-", "")
+        .substring(0, 20);
+
+    int order = this.availalbe.all()
+        .map(Option::order)
+        .max(Comparator.naturalOrder())
+        .orElse(1) + 1;
+
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "identifier", code,
+        "name", name,
+        "order", order);
+
+    template.execute(
+        CREATE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate
+    );
+
+    this.availalbe.available(new Option(code, name, name, order));
+
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionRequester.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.option.language.primary;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@Component
+class PrimaryLanguageOptionRequester {
+
+  private final MockMvc mvc;
+
+  PrimaryLanguageOptionRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions request() throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/languages/primary")
+    );
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionsSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageOptionsSteps.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.option.language.primary;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+public class PrimaryLanguageOptionsSteps {
+
+
+  private final PrimaryLanguageOptionRequester requester;
+  private final Active<ResultActions> response;
+
+  PrimaryLanguageOptionsSteps(
+
+      final PrimaryLanguageOptionRequester requester,
+      final Active<ResultActions> response
+  ) {
+
+    this.requester = requester;
+    this.response = response;
+  }
+
+  @When("I request all primary languages")
+  public void i_request_all() throws Exception {
+    response.active(requester.request().andDo(print()));
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/PrimaryLanguageSteps.java
@@ -1,0 +1,21 @@
+package gov.cdc.nbs.option.language.primary;
+
+import io.cucumber.java.en.Given;
+
+public class PrimaryLanguageSteps {
+
+  private final PrimaryLanguageMother mother;
+
+
+  PrimaryLanguageSteps(final PrimaryLanguageMother mother) {
+    this.mother = mother;
+  }
+
+  @Given("there is a {string} primary language")
+  public void the_language_exists_in_the_value_set(final String name) {
+    mother.create(name);
+  }
+
+
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageAutocompleteSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageAutocompleteSteps.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.language.primary.autocomplete;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class PrimaryLanguageAutocompleteSteps {
+
+  private final PrimaryLanguageOptionAutocompleteRequester request;
+  private final Active<ResultActions> response;
+
+  PrimaryLanguageAutocompleteSteps(
+      final PrimaryLanguageOptionAutocompleteRequester request,
+      final Active<ResultActions> response
+  ) {
+    this.request = request;
+    this.response = response;
+  }
+
+  @When("I am trying to find primary languages that start with {string}")
+  public void i_am_trying_to_find_options_that_start_with(final String criteria) throws Exception {
+    response.active(request.complete(criteria));
+  }
+
+  @When("I am trying to find at most {int} primary language(s) that start with {string}")
+  public void i_am_trying_to_find_n_options_that_start_with(
+      final int limit,
+      final String criteria
+  ) throws Exception {
+    response.active(request.complete(criteria, limit));
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageOptionAutocompleteRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/language/primary/autocomplete/PrimaryLanguageOptionAutocompleteRequester.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.language.primary.autocomplete;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+class PrimaryLanguageOptionAutocompleteRequester {
+
+  private final MockMvc mvc;
+
+  PrimaryLanguageOptionAutocompleteRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions complete(final String criteria) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/languages/primary/search")
+            .param("criteria", criteria)
+    ).andDo(print());
+  }
+
+  ResultActions complete(final String criteria, final int limit) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/languages/primary/search")
+            .param("criteria", criteria)
+            .param("limit", String.valueOf(limit))
+    ).andDo(print());
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationMother.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationMother.java
@@ -1,0 +1,94 @@
+package gov.cdc.nbs.option.occupations;
+
+import gov.cdc.nbs.option.Option;
+import gov.cdc.nbs.testing.support.Available;
+import io.cucumber.spring.ScenarioScope;
+import jakarta.annotation.PreDestroy;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@ScenarioScope
+class OccupationMother {
+
+  private static final String DELETE_IN = """
+      delete
+      from NBS_SRTE.[dbo].NAICS_Industry_code
+      where code in (:codes)
+      """;
+
+  private static final String CREATE = """
+      insert into NBS_SRTE.[dbo].NAICS_Industry_code(
+        code,
+        code_short_desc_txt,
+        indent_level_nbr, 
+        status_cd,
+        parent_is_cd
+      )
+      values (:identifier, :name, :order, 'A', 'root')
+      """;
+
+  private final NamedParameterJdbcTemplate template;
+  private final Available<Option> availalbe;
+
+  OccupationMother(final JdbcTemplate template) {
+    this.template = new NamedParameterJdbcTemplate(template);
+    this.availalbe = new Available<>();
+  }
+
+  @PreDestroy
+  void reset() {
+
+    List<String> codes = this.availalbe.all()
+        .map(Option::value)
+        .toList();
+
+    if (!codes.isEmpty()) {
+
+      Map<String, List<String>> parameters = Map.of("codes", codes);
+
+      template.execute(
+          DELETE_IN,
+          new MapSqlParameterSource(parameters),
+          PreparedStatement::executeUpdate);
+
+      this.availalbe.reset();
+    }
+  }
+
+  void create(final String name) {
+
+    String code = UUID.randomUUID().toString()
+        .replace("-", "")
+        .substring(0, 20);
+
+    int order = this.availalbe.all()
+        .map(Option::order)
+        .max(Comparator.naturalOrder())
+        .orElse(1) + 1;
+
+    Map<String, ? extends Serializable> parameters = Map.of(
+        "identifier", code,
+        "name", name,
+        "order", order);
+
+    template.execute(
+        CREATE,
+        new MapSqlParameterSource(parameters),
+        PreparedStatement::executeUpdate
+    );
+
+    this.availalbe.available(new Option(code, name, name, order));
+
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationOptionRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationOptionRequester.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.option.occupations;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@Component
+class OccupationOptionRequester {
+
+  private final MockMvc mvc;
+
+  OccupationOptionRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions request() throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/occupations")
+    );
+  }
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationOptionsSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationOptionsSteps.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.option.occupations;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+public class OccupationOptionsSteps {
+
+
+  private final OccupationOptionRequester requester;
+  private final Active<ResultActions> response;
+
+  OccupationOptionsSteps(
+
+      final OccupationOptionRequester requester,
+      final Active<ResultActions> response
+  ) {
+
+    this.requester = requester;
+    this.response = response;
+  }
+
+  @When("I request all occupations")
+  public void i_request_all() throws Exception {
+    response.active(requester.request().andDo(print()));
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/OccupationSteps.java
@@ -1,0 +1,21 @@
+package gov.cdc.nbs.option.occupations;
+
+import io.cucumber.java.en.Given;
+
+public class OccupationSteps {
+
+  private final OccupationMother mother;
+
+
+  OccupationSteps(final OccupationMother mother) {
+    this.mother = mother;
+  }
+
+  @Given("there is a {string} occupation")
+  public void the_occupation_exists(final String name) {
+    mother.create(name);
+  }
+
+
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationAutocompleteSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationAutocompleteSteps.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.occupations.autocomplete;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class OccupationAutocompleteSteps {
+
+  private final OccupationOptionAutocompleteRequester request;
+  private final Active<ResultActions> response;
+
+  OccupationAutocompleteSteps(
+      final OccupationOptionAutocompleteRequester request,
+      final Active<ResultActions> response
+  ) {
+    this.request = request;
+    this.response = response;
+  }
+
+  @When("I am trying to find occupations that start with {string}")
+  public void i_am_trying_to_find_options_that_start_with(final String criteria) throws Exception {
+    response.active(request.complete(criteria));
+  }
+
+  @When("I am trying to find at most {int} occupation(s) that start with {string}")
+  public void i_am_trying_to_find_n_options_that_start_with(
+      final int limit,
+      final String criteria
+  ) throws Exception {
+    response.active(request.complete(criteria, limit));
+  }
+
+}

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationOptionAutocompleteRequester.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/occupations/autocomplete/OccupationOptionAutocompleteRequester.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.option.occupations.autocomplete;
+
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+class OccupationOptionAutocompleteRequester {
+
+  private final MockMvc mvc;
+
+  OccupationOptionAutocompleteRequester(final MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  ResultActions complete(final String criteria) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/occupations/search")
+            .param("criteria", criteria)
+    ).andDo(print());
+  }
+
+  ResultActions complete(final String criteria, final int limit) throws Exception {
+    return mvc.perform(
+        get("/nbs/api/options/occupations/search")
+            .param("criteria", criteria)
+            .param("limit", String.valueOf(limit))
+    ).andDo(print());
+  }
+}

--- a/libs/options-api/src/test/resources/features/language/primary/PrimaryLanguages.feature
+++ b/libs/options-api/src/test/resources/features/language/primary/PrimaryLanguages.feature
@@ -1,0 +1,41 @@
+@language @options
+Feature: Primary Language Options REST API
+
+  Background:
+    Given there is a "rubaboo" primary language
+    And there is a "recense" primary language
+    And there is a "philter" primary language
+    And there is a "regrate" primary language
+    And there is a "silesia" primary language
+    And there is a "regulus" primary language
+    And there is a "exergue" primary language
+    And there is a "regreet" primary language
+    And there is a "rhombos" primary language
+    And there is a "wive" primary language
+    And there is a "waveson" primary language
+    And there is a "withe" primary language
+    And there is a "wasm" primary language
+    And there is a "wanion" primary language
+    And there is a "washery" primary language
+    And there is a "waterman" primary language
+    And there is a "waulk" primary language
+    And there is a "wheelhouse" primary language
+
+  Scenario: I can find all primary languages
+    When I request all primary languages
+    Then there are options available
+
+  Scenario: I can find specific primary languages
+    When I am trying to find primary languages that start with "reg"
+    Then there are options available
+    And the option named "regrate" is included
+    And the option named "regulus" is included
+    And the option named "regreet" is not included
+
+  Scenario: I can find a specific number of primary languages
+    When I am trying to find at most 4 primary languages that start with "w"
+    Then there are 4 options included
+
+  Scenario: I cannot find specific concepts that do not exist
+    When I am trying to find primary languages that start with "zzzzzzzzz"
+    Then there aren't any options available

--- a/libs/options-api/src/test/resources/features/occupations/Occupations.feature
+++ b/libs/options-api/src/test/resources/features/occupations/Occupations.feature
@@ -1,0 +1,41 @@
+@occupations @options
+Feature: Occupation Options REST API
+
+  Background:
+    Given there is a "rubaboo" occupation
+    And there is a "recense" occupation
+    And there is a "philter" occupation
+    And there is a "regrate" occupation
+    And there is a "silesia" occupation
+    And there is a "regulus" occupation
+    And there is a "exergue" occupation
+    And there is a "regreet" occupation
+    And there is a "rhombos" occupation
+    And there is a "wive" occupation
+    And there is a "waveson" occupation
+    And there is a "withe" occupation
+    And there is a "wasm" occupation
+    And there is a "wanion" occupation
+    And there is a "washery" occupation
+    And there is a "waterman" occupation
+    And there is a "waulk" occupation
+    And there is a "wheelhouse" occupation
+
+  Scenario: I can find all occupations
+    When I request all occupations
+    Then there are options available
+
+  Scenario: I can find specific occupations
+    When I am trying to find occupations that start with "reg"
+    Then there are options available
+    And the option named "regrate" is included
+    And the option named "regulus" is included
+    And the option named "regreet" is not included
+
+  Scenario: I can find a specific number of occupations
+    When I am trying to find at most 4 occupations that start with "w"
+    Then there are 4 options included
+
+  Scenario: I cannot find specific concepts that do not exist
+    When I am trying to find occupations that start with "zzzzzzzzz"
+    Then there aren't any options available


### PR DESCRIPTION
## Description

Adds endpoints to support full list retrieval and autocompletion of Primary language and Occupations.

Adds `usePrimaryLanguageOptions` that uses the `/nbs/api/options/languages/primary` endpoint to return all Primary Languages

Adds `useOccupationOptions` that uses the `/nbs/api/options/occupations` endpoint to return all Occupations

## Tickets

* [CNFT1-3789](https://cdc-nbs.atlassian.net/browse/CNFT1-3789)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3789]: https://cdc-nbs.atlassian.net/browse/CNFT1-3789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ