### PR TITLE
Add SubText to Card Component

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtendedForm.spec.tsx
@@ -166,34 +166,34 @@ describe('AddPatientExtendedForm', () => {
         const requiredTexts = getAllByText('Required');
 
         expect(headers[0]).toHaveTextContent('Administrative');
-        expect(headers[0].parentElement).toContainElement(requiredTexts[0]);
+        expect(headers[0].parentElement?.parentElement).toContainElement(requiredTexts[0]);
 
         expect(headers[1]).toHaveTextContent('Name');
-        expect(headers[1].parentElement).toContainElement(requiredTexts[1]);
+        expect(headers[1].parentElement?.parentElement).toContainElement(requiredTexts[1]);
 
         expect(headers[2]).toHaveTextContent('Address');
-        expect(headers[2].parentElement).toContainElement(requiredTexts[2]);
+        expect(headers[2].parentElement?.parentElement).toContainElement(requiredTexts[2]);
 
         expect(headers[3]).toHaveTextContent('Phone & email');
-        expect(headers[3].parentElement).toContainElement(requiredTexts[3]);
+        expect(headers[3].parentElement?.parentElement).toContainElement(requiredTexts[3]);
 
         expect(headers[4]).toHaveTextContent('Identification');
-        expect(headers[4].parentElement).toContainElement(requiredTexts[4]);
+        expect(headers[4].parentElement?.parentElement).toContainElement(requiredTexts[4]);
 
         expect(headers[5]).toHaveTextContent('Race');
-        expect(headers[5].parentElement).toContainElement(requiredTexts[5]);
+        expect(headers[5].parentElement?.parentElement).toContainElement(requiredTexts[5]);
 
         expect(headers[6]).toHaveTextContent('Ethnicity');
-        expect(headers[6].parentElement).toContainElement(requiredTexts[6]);
+        expect(headers[6].parentElement?.parentElement).toContainElement(requiredTexts[6]);
 
         expect(headers[7]).toHaveTextContent('Sex & birth');
-        expect(headers[7].parentElement).toContainElement(requiredTexts[7]);
+        expect(headers[7].parentElement?.parentElement).toContainElement(requiredTexts[7]);
 
         expect(headers[8]).toHaveTextContent('Mortality');
-        expect(headers[8].parentElement).toContainElement(requiredTexts[8]);
+        expect(headers[8].parentElement?.parentElement).toContainElement(requiredTexts[8]);
 
         expect(headers[9]).toHaveTextContent('General patient information');
-        expect(headers[9].parentElement).toContainElement(requiredTexts[9]);
+        expect(headers[9].parentElement?.parentElement).toContainElement(requiredTexts[9]);
     });
 
     it('should set default date for as of fields', async () => {

--- a/apps/modernization-ui/src/design-system/card/Card.spec.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Card } from './Card';
 
 describe('Card Component', () => {
@@ -20,5 +20,31 @@ describe('Card Component', () => {
             </Card>
         );
         expect(container.querySelector('section')).toHaveAttribute('id', 'test-id');
+    });
+
+    it('does not render subtext when subtext prop is not provided', () => {
+        // Render the Card without subtext
+        render(
+            <Card id="test-card" title="Test Title" children={<p>Test content</p>}>
+                {/* No subtext prop here */}
+            </Card>
+        );
+
+        // Check that subtext is not in the document
+        const subtextElement = screen.queryByText(/subtext/i);
+        expect(subtextElement).toBeNull();
+    });
+
+    it('renders subtext when subtext prop is provided', () => {
+        // Render the Card with subtext
+        render(
+            <Card id="test-card" title="Test Title" subtext="This is the subtext" children={<p>Test content</p>}>
+                {/* Subtext is passed */}
+            </Card>
+        );
+
+        // Check that subtext is in the document
+        const subtextElement = screen.getByText(/This is the subtext/i);
+        expect(subtextElement).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -14,10 +14,8 @@ export const Card = ({ id, title, info, subtext, children, level = 2 }: Props) =
     return (
         <section id={id} className={styles.card}>
             <header>
-                <div>
-                    <Heading level={level}>{title}</Heading>
-                    {subtext && <div className={styles.subtext}>{subtext}</div>}
-                </div>
+                <Heading level={level}>{title}</Heading>
+                {subtext && <div className={styles.subtext}>{subtext}</div>}
                 {info}
             </header>
             {children}

--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -11,14 +11,14 @@ type Props = {
     children: ReactNode;
 };
 export const Card = ({ id, title, info, subtext, children, level = 2 }: Props) => {
-    const cardClassName = subtext ? `${styles.card} ${styles.withSubtext}` : styles.card;
-
     return (
-        <section id={id} className={cardClassName}>
+        <section id={id} className={styles.card}>
             <header>
-                <Heading level={level}>{title}</Heading>
+                <div>
+                    <Heading level={level}>{title}</Heading>
+                    {subtext && <div className={styles.subtext}>{subtext}</div>}
+                </div>
                 {info}
-                {subtext && <div className={styles.subtext}>{subtext}</div>}
             </header>
             {children}
         </section>

--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -6,15 +6,19 @@ type Props = {
     id: string;
     title: ReactNode;
     info?: ReactNode;
+    subtext?: string;
     level?: HeadingLevel;
     children: ReactNode;
 };
-export const Card = ({ id, title, info, children, level = 2 }: Props) => {
+export const Card = ({ id, title, info, subtext, children, level = 2 }: Props) => {
+    const cardClassName = subtext ? `${styles.card} ${styles.withSubtext}` : styles.card;
+
     return (
-        <section id={id} className={styles.card}>
+        <section id={id} className={cardClassName}>
             <header>
                 <Heading level={level}>{title}</Heading>
                 {info}
+                {subtext && <div className={styles.subtext}>{subtext}</div>}
             </header>
             {children}
         </section>

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -19,5 +19,6 @@
     font-size: 14px;
     line-height: 21px;
     color: colors.$base-darker;
-    margin-top: 0.25rem;
+    align-items: flex-start;
+    flex-direction: column;
 }

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -4,6 +4,7 @@
 .card {
     @extend %thin;
     background-color: colors.$base-white;
+    @include borders.rounded();
 
     & > header {
         display: flex;
@@ -12,19 +13,6 @@
         align-items: center;
         @extend %thin-bottom;
     }
-
-    &.withSubtext {
-        border-radius: 5px;
-        align-items: flex-start;
-        flex-direction: column;
-    }
-}
-
-.subtext {
-    font-size: 14px;
-    line-height: 21px;
-    color: colors.$base-darker;
-    margin-top: 0.25rem;
 }
 
 .subtext {

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -9,7 +9,26 @@
         display: flex;
         padding: 1rem;
         justify-content: space-between;
-        align-items: center;
-        @extend %thin-bottom;
+        flex-direction: column;
+        align-items: flex-start;
+        @extend %thin-bottom
     }
+
+    &.withSubtext {
+        border-radius: 5px;
+    }
+}
+
+.subtext {
+    font-size: 14px;
+    line-height: 21px;
+    color: colors.$base-darker;
+    margin-top: 0.25rem;
+}
+
+.subtext {
+    font-size: 14px;
+    line-height: 21px;
+    color: colors.$base-darker;
+    margin-top: 0.25rem;
 }

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -16,8 +16,8 @@
 }
 
 .subtext {
-    font-size: 14px;
-    line-height: 21px;
+    font-size: 0.875rem;
+    line-height: 1.3125rem;
     color: colors.$base-darker;
     align-items: flex-start;
     flex-direction: column;

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -9,13 +9,14 @@
         display: flex;
         padding: 1rem;
         justify-content: space-between;
-        flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
         @extend %thin-bottom
     }
 
     &.withSubtext {
         border-radius: 5px;
+        align-items: flex-start;
+        flex-direction: column;
     }
 }
 

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -10,7 +10,7 @@
         padding: 1rem;
         justify-content: space-between;
         align-items: center;
-        @extend %thin-bottom
+        @extend %thin-bottom;
     }
 
     &.withSubtext {


### PR DESCRIPTION
## Description

This PR introduces an optional subtext prop to the Card component. When provided, the subtext will be rendered directly below the card's title. If no subtext is passed, the component will function as it did previously, without rendering the subtext section.

Additionally, there are some changes to the `border-radius` etc. but it is propagated only when subtext is included.

Use case for this change:
Mactching Criteria Pages like~
<img width="527" alt="use case 1" src="https://github.com/user-attachments/assets/7642dde7-0553-46f0-9357-0b38d2930c47" />

<img width="522" alt="use case 2" src="https://github.com/user-attachments/assets/3275c4c1-c1fb-4564-96e4-cb42d04b2ac5" />

Added unit tests to verify that:
    Subtext only renders when the subtext prop is provided.
    The component's existing behavior is not affected when the subtext prop is omitted.

## Tickets

* [Jira Ticket](url)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
