### PR TITLE
[CNFT1-3931-required-text-alignment]: adding 1 rem padding for repeating block headers

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -8,7 +8,7 @@
     background-color: colors.$base-white;
     header {
         display: flex;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-content: space-between;
         align-items: center;
         background-color: colors.$base-white;


### PR DESCRIPTION
## Description

adding 1 rem padding for repeating block headers to match the padding on cards and figma
**This is the Implementation** 
<img width="835" alt="Screenshot 2025-03-17 at 2 43 53 PM" src="https://github.com/user-attachments/assets/b2ab4161-68e6-4f23-bd8f-72f420104282" />
**This is the Figma Reference**
<img width="797" alt="Screenshot 2025-03-17 at 2 48 19 PM" src="https://github.com/user-attachments/assets/b7c5a796-a78a-4db6-a1e3-d3377530f5c0" />
<img width="753" alt="Screenshot 2025-03-17 at 2 48 05 PM" src="https://github.com/user-attachments/assets/252001e5-f036-420d-8be2-7e1b968d675b" />


## Tickets

* [CNFT1-3931](https://cdc-nbs.atlassian.net/browse/CNFT1-3931)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3931]: https://cdc-nbs.atlassian.net/browse/CNFT1-3931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ