### PR TITLE
[CNFT1-3892]: Changing input type to text to allow maxLength to work

### DIFF
--- a/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
@@ -80,7 +80,10 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
             <Controller
                 control={control}
                 name="general.adultsInResidence"
-                rules={{ min: { value: 0, message: 'Must be greater than 0' } }}
+                rules={{
+                    min: { value: 0, message: 'Must be greater than 0' },
+                    max: { value: 99999, message: 'Must be 99999 or less' }
+                }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <NumericInput
                         label="Number of adults in residence"
@@ -94,14 +97,17 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         min="0"
                         error={error?.message}
                         sizing={sizing}
-                        maxLength={5}
+                        max={99999}
                     />
                 )}
             />
             <Controller
                 control={control}
                 name="general.childrenInResidence"
-                rules={{ min: { value: 0, message: 'Must be greater than 0' } }}
+                rules={{
+                    min: { value: 0, message: 'Must be greater than 0' },
+                    max: { value: 99999, message: 'Must be 99999 or less' }
+                }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <NumericInput
                         label="Number of children in residence"
@@ -115,7 +121,7 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         min="0"
                         error={error?.message}
                         sizing={sizing}
-                        maxLength={5}
+                        max={99999}
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
@@ -94,6 +94,7 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         min="0"
                         error={error?.message}
                         sizing={sizing}
+                        maxLength={5}
                     />
                 )}
             />
@@ -114,6 +115,7 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         min="0"
                         error={error?.message}
                         sizing={sizing}
+                        maxLength={5}
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
@@ -97,7 +97,6 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         min="0"
                         error={error?.message}
                         sizing={sizing}
-                        max={99999}
                     />
                 )}
             />
@@ -121,7 +120,6 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         min="0"
                         error={error?.message}
                         sizing={sizing}
-                        max={99999}
                     />
                 )}
             />

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -57,7 +57,7 @@ const Numeric = ({
             id={id}
             name={props.name ?? id}
             className={classNames('usa-input', className)}
-            type="text" // Adding type='text' to allow maxLength to work as expected as with number type the attribute does not work as expected, this is a known limitaiton of number inputs in HTML.
+            type="text" // Adding type='text' to allow maxLength to work as expected as with number type the attribute does not work as expected, this is a known limitation of number inputs in HTML.
             inputMode={inputMode}
             onChange={handleChange}
             onBlur={onBlur}

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -40,6 +40,8 @@ const Numeric = ({
             clear();
         } else if (Number.isNaN(next)) {
             event.preventDefault();
+        } else if (props.maxLength && next.length > props.maxLength) {
+            event.preventDefault();
         } else {
             const adjusted = Number(next);
             if (!Number.isNaN(adjusted)) {

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent as ReactChangeEvent, useEffect, useMemo } from 'react';
+import { ChangeEvent as ReactChangeEvent, useEffect } from 'react';
 import classNames from 'classnames';
 import { onlyNumericKeys } from './onlyNumericKeys';
 import { useNumeric } from './useNumeric';

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -40,7 +40,7 @@ const Numeric = ({
             clear();
         } else if (Number.isNaN(next)) {
             event.preventDefault();
-        } else if (props.maxLength && next.length > props.maxLength) {
+        } else if (props.max && next > props.max) {
             event.preventDefault();
         } else {
             const adjusted = Number(next);

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -59,7 +59,7 @@ const Numeric = ({
             id={id}
             name={props.name ?? id}
             className={classNames('usa-input', className)}
-            type="text" // Adding type='text' to allow maxLength to work as expected as with number type the attribute does not work as expected, this is a known limitation of number inputs in HTML.
+            type="number"
             inputMode={inputMode}
             onChange={handleChange}
             onBlur={onBlur}

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -57,7 +57,7 @@ const Numeric = ({
             id={id}
             name={props.name ?? id}
             className={classNames('usa-input', className)}
-            type="number"
+            type="text" // Adding type='text' to allow maxLength to work as expected as with number type the attribute does not work as expected, this is a known limitaiton of number inputs in HTML.
             inputMode={inputMode}
             onChange={handleChange}
             onBlur={onBlur}

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -3,8 +3,6 @@ import classNames from 'classnames';
 import { onlyNumericKeys } from './onlyNumericKeys';
 import { useNumeric } from './useNumeric';
 
-const asDisplay = (value?: string | number | null) => (value === undefined ? '' : `${value}`);
-
 type NumericOnChange = (value?: number) => void;
 
 type NumericProps = {
@@ -31,16 +29,12 @@ const Numeric = ({
         onChange?.(current);
     }, [current]);
 
-    const display = useMemo(() => asDisplay(current), [current]);
-
     const handleChange = (event: ReactChangeEvent<HTMLInputElement>) => {
         const next = event.target.value;
 
         if (next === '') {
             clear();
         } else if (Number.isNaN(next)) {
-            event.preventDefault();
-        } else if (props.max && next > props.max) {
             event.preventDefault();
         } else {
             const adjusted = Number(next);
@@ -64,7 +58,7 @@ const Numeric = ({
             onChange={handleChange}
             onBlur={onBlur}
             placeholder={placeholder}
-            value={display}
+            value={current ?? ''}
             pattern="[0-9]*"
             onKeyDown={onlyNumericKeys}
             {...props}


### PR DESCRIPTION
## Description
 **Number of adults in residence** and **Number of children in residence**
adding conditional check that prevents users from entering more digits than allowed by the max prop. If the input's text length would exceed the specified maximum which is 99999

also added max validation to handle when a value greater than 99999 is entered. We should only be preventing typing when a value has a format. as per https://github.com/CDCgov/NEDSS-Modernization/pull/2380#pullrequestreview-2699943338

## Tickets

* [CNFT1-3892](https://cdc-nbs.atlassian.net/browse/CNFT1-3892)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3892]: https://cdc-nbs.atlassian.net/browse/CNFT1-3892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ