### PR TITLE
CNFT1-3899: RepeatingBlock Fix need to double click Clear button after validation blur

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -178,7 +178,8 @@ const RepeatingBlock = <V extends FieldValues>({
                             outline
                             sizing={sizing}
                             aria-details={`clear ${title.toLowerCase()}`}
-                            onClick={handleClear}>
+                            onClick={handleClear}
+                            onMouseDown={(e) => e.preventDefault() /* prevent need to double click after blur */}>
                             Clear
                         </Button>
                     </Shown>


### PR DESCRIPTION
## Description

In RepeatingBlock, fix the need to double click the Clear button after errors cleared/revalidation.

## Tickets

* [Jira Ticket](url)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
