### PR TITLE
[CNFT1-3882]: fixing padding on repeating blocks

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -6,15 +6,6 @@
 .input {
     @extend %thin;
     background-color: colors.$base-white;
-    header {
-        display: flex;
-        padding: 1.5rem;
-        justify-content: space-between;
-        align-items: center;
-        background-color: colors.$base-white;
-
-        @extend %thin-bottom;
-    }
 
     .errorList {
         list-style: inside;
@@ -39,7 +30,7 @@
 
             .active {
                 border-radius: 0.25rem;
-                padding:  0.0625rem;
+                padding: 0.0625rem;
                 color: colors.$base-white;
                 background-color: colors.$primary-darker;
             }


### PR DESCRIPTION
## Description

Removing repeating styles already on card component to fix padding on cards to be 1 rem
## Tickets

* [CNFT1-3882](https://cdc-nbs.atlassian.net/browse/CNFT1-3882)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3882]: https://cdc-nbs.atlassian.net/browse/CNFT1-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ