### PR TITLE
Add support for '.' when inputMode is decimal

### DIFF
--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.spec.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.spec.tsx
@@ -3,10 +3,10 @@ import userEvent from '@testing-library/user-event';
 
 import { Numeric, NumericProps } from './Numeric';
 
-const Fixture = ({ id = 'testing-numeric', ...remaining }: Partial<NumericProps>) => (
+const Fixture = ({ id = 'testing-numeric', inputMode = 'numeric', ...remaining }: Partial<NumericProps>) => (
     <div>
         <label htmlFor={id}>Numeric input test</label>
-        <Numeric id={id} {...remaining} />
+        <Numeric inputMode={inputMode} id={id} {...remaining} />
     </div>
 );
 
@@ -123,6 +123,18 @@ describe('when entering numeric values', () => {
             await user.tab();
 
             expect(input).not.toHaveValue();
+        });
+
+        it('should allow entry of decimals if set to decimal inputMode', async () => {
+            const user = userEvent.setup();
+            const { getByRole } = render(<Fixture inputMode="decimal" />);
+
+            const input = getByRole('spinbutton', { name: 'Numeric input test' });
+
+            await user.type(input, '0.1');
+            await user.tab();
+
+            expect(input).toHaveValue(0.1);
         });
     });
 });

--- a/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/Numeric.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent as ReactChangeEvent, useEffect } from 'react';
 import classNames from 'classnames';
-import { onlyNumericKeys } from './onlyNumericKeys';
+import { onlyNumericKeys, onlyNumericOrDecimal } from './onlyNumericKeys';
 import { useNumeric } from './useNumeric';
 
 type NumericOnChange = (value?: number) => void;
@@ -60,7 +60,7 @@ const Numeric = ({
             placeholder={placeholder}
             value={current ?? ''}
             pattern="[0-9]*"
-            onKeyDown={onlyNumericKeys}
+            onKeyDown={inputMode === 'numeric' ? onlyNumericKeys : onlyNumericOrDecimal}
             {...props}
         />
     );

--- a/apps/modernization-ui/src/design-system/input/numeric/onlyNumericKeys.ts
+++ b/apps/modernization-ui/src/design-system/input/numeric/onlyNumericKeys.ts
@@ -1,7 +1,7 @@
 import { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 const isNumericKey = (key: string) => {
-    return key.length == 1 ? /[0-9]/.test(key) : true;
+    return key.length == 1 ? /\d/.test(key) : true;
 };
 
 const onlyNumericKeys = (event: KeyboardEvent | ReactKeyboardEvent) => {
@@ -11,4 +11,10 @@ const onlyNumericKeys = (event: KeyboardEvent | ReactKeyboardEvent) => {
     }
 };
 
-export { onlyNumericKeys };
+const onlyNumericOrDecimal = (event: KeyboardEvent | ReactKeyboardEvent) => {
+    if (event.key !== '.' && !isNumericKey(event.key)) {
+        event.preventDefault();
+    }
+};
+
+export { onlyNumericKeys, onlyNumericOrDecimal };


### PR DESCRIPTION
## Description

Adds support for decimal in Numeric inputs when inputMode is set to `decimal`

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
