### PR TITLE
CNFT1-3924 Update padding around radio button from 1.5rem to 1.75rem

### DIFF
--- a/apps/modernization-ui/src/design-system/radio/radio.module.scss
+++ b/apps/modernization-ui/src/design-system/radio/radio.module.scss
@@ -5,7 +5,7 @@ $radio-small: 1rem;
 $radio-medium: 1.125rem;
 $radio-large: 1.25rem;
 
-@mixin sizedRadio($height: $radio-small, $width: $radio-small, $padding: 1.5rem, $extend: '%small') {
+@mixin sizedRadio($height: $radio-small, $width: $radio-small, $padding: 1.75rem, $extend: '%small') {
     height: $height;
     min-height: $height;
 
@@ -27,7 +27,7 @@ $radio-large: 1.25rem;
     }
 
     &.small {
-        @include sizedRadio($radio-small, $radio-small, 1.5rem, '%small');
+        @include sizedRadio($radio-small, $radio-small, 1.75rem, '%small');
     }
 
     &.medium {


### PR DESCRIPTION
## Description

Update padding around radio button from 1.5rem to 1.75rem on small size and default. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3924)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
