### PR TITLE
[CNFT1-3969] Small sizing for search criteria

### DIFF
--- a/apps/modernization-ui/src/apps/search/criteria/SearchCriteria.tsx
+++ b/apps/modernization-ui/src/apps/search/criteria/SearchCriteria.tsx
@@ -1,11 +1,16 @@
 import { ReactNode } from 'react';
 
 import styles from './search-criteria.module.scss';
+import { Sizing } from 'design-system/field';
+import classNames from 'classnames';
 
 type Props = {
     children: ReactNode;
+    sizing?: Sizing;
 };
 
-const SearchCriteria = ({ children }: Props) => <div className={styles.criteria}>{children}</div>;
+const SearchCriteria = ({ children, sizing }: Props) => (
+    <div className={classNames(styles.criteria, { [styles.small]: sizing === 'small' })}>{children}</div>
+);
 
 export { SearchCriteria };

--- a/apps/modernization-ui/src/apps/search/criteria/search-criteria.module.scss
+++ b/apps/modernization-ui/src/apps/search/criteria/search-criteria.module.scss
@@ -5,4 +5,8 @@
     gap: 1rem;
 
     padding: 1rem;
+
+    &.small {
+        gap: 0.5rem;
+    }
 }

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/Address.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/Address.tsx
@@ -11,7 +11,7 @@ export const Address = ({ sizing, orientation }: EntryFieldsProps) => {
     const { control } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
     return (
         <SearchCriteriaProvider>
-            <SearchCriteria>
+            <SearchCriteria sizing={sizing}>
                 <Controller
                     control={control}
                     name="location.street"

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -15,7 +15,7 @@ export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
     const { control } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
 
     return (
-        <SearchCriteria>
+        <SearchCriteria sizing={sizing}>
             <Controller
                 control={control}
                 name="name.last"

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/Contact.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/Contact.tsx
@@ -8,7 +8,7 @@ import { EntryFieldsProps } from 'design-system/entry';
 export const Contact = ({ sizing, orientation }: EntryFieldsProps) => {
     const { control } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
     return (
-        <SearchCriteria>
+        <SearchCriteria sizing={sizing}>
             <Controller
                 control={control}
                 name="phoneNumber"

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/Id.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/Id.tsx
@@ -11,7 +11,7 @@ export const Id = ({ sizing, orientation }: EntryFieldsProps) => {
     const identificationType = useWatch({ control: control, name: 'identificationType' });
 
     return (
-        <SearchCriteria>
+        <SearchCriteria sizing={sizing}>
             <Controller
                 control={control}
                 name="identificationType"

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/RaceEthnicity.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/RaceEthnicity.tsx
@@ -12,7 +12,7 @@ export const RaceEthnicity = ({ sizing, orientation }: EntryFieldsProps) => {
     const categories = useRaceCategoryOptions();
 
     return (
-        <SearchCriteria>
+        <SearchCriteria sizing={sizing}>
             <Controller
                 control={control}
                 name="ethnicity"


### PR DESCRIPTION
## Description

Add small sizing support to the `SearchCriteria` component.

When `small` the gap between fields is `0.5rem`

![image](https://github.com/user-attachments/assets/cfc84952-d421-4739-be4e-f9efd880ef96)

When `medium` or `large` the gap between fields in `1rem`

![image](https://github.com/user-attachments/assets/b477361b-75d3-4a63-ad9c-d174417c50c9)


## Tickets

* [CNFT1-3969](https://cdc-nbs.atlassian.net/browse/CNFT1-3969)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3969]: https://cdc-nbs.atlassian.net/browse/CNFT1-3969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ