### PR TITLE
cnft1 3952 border bug

### DIFF
--- a/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
+++ b/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
@@ -23,7 +23,7 @@
 .small {
     @include sizedDatePicker(1rem, 17.75rem, 15rem);
 
-    --calendar-date-margin: 4px;
+    --calendar-date-margin: 2px;
     --calendar-navigation-padding: 18px;
     --calendar-day-of-week-padding: 4px;
     --calendar-date-padding: 8px;

--- a/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
+++ b/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
@@ -23,6 +23,7 @@
 .small {
     @include sizedDatePicker(1rem, 17.75rem, 15rem);
 
+    --calendar-date-margin: 4px;
     --calendar-navigation-padding: 18px;
     --calendar-day-of-week-padding: 4px;
     --calendar-date-padding: 8px;

--- a/apps/modernization-ui/src/styles/_uswds.scss
+++ b/apps/modernization-ui/src/styles/_uswds.scss
@@ -189,3 +189,7 @@ input.usa-input--error:focus {
 .usa-date-picker__calendar__date {
     padding: var(--calendar-date-padding, 10px) 0;
 }
+
+.usa-date-picker__calendar {
+    margin-top: var(--calendar-date-margin, 0.1rem);
+}


### PR DESCRIPTION
## Description

Bottom part of the blue highlight border was not showing earlier, so added a margin-top to the calendar itself so when opened and the input is highlighted there where will slight space for the border to show
![Screenshot 2025-04-02 at 10 16 08 AM](https://github.com/user-attachments/assets/bea9d6cc-a8ca-4b0a-9ca7-6123c143fda5)


## Tickets

* [CNFT1-3952](https://cdc-nbs.atlassian.net/browse/CNFT1-3952)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3952]: https://cdc-nbs.atlassian.net/browse/CNFT1-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ