### PR TITLE
CND-234 fix deduplication url

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/api/useDataElements.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/api/useDataElements.tsx
@@ -32,7 +32,7 @@ export const useDataElements = () => {
     };
 
     const save = async (updatedDataElements: DataElements, successCallback?: () => void) => {
-        fetch(`${Config.deduplicationUrl}/api/configuration/data-elements`, {
+        fetch(`${Config.deduplicationUrl}/configuration/data-elements`, {
             method: 'POST',
             headers: {
                 Accept: 'application/json',

--- a/apps/modernization-ui/src/apps/deduplication/api/useDataElements.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/api/useDataElements.tsx
@@ -10,7 +10,7 @@ export const useDataElements = () => {
     const fetchDataElements = async () => {
         setLoading(true);
 
-        fetch(`${Config.deduplicationUrl}/api/configuration/data-elements`, {
+        fetch(`${Config.deduplicationUrl}/configuration/data-elements`, {
             method: 'GET',
             headers: {
                 Accept: 'application/json'

--- a/apps/modernization-ui/src/apps/deduplication/api/useMatchConfiguration.ts
+++ b/apps/modernization-ui/src/apps/deduplication/api/useMatchConfiguration.ts
@@ -32,7 +32,7 @@ export const useMatchConfiguration = (lazy = false) => {
     const fetchConfiguration = async () => {
         setLoading(true);
 
-        fetch(`${Config.deduplicationUrl}/api/configuration`, {
+        fetch(`${Config.deduplicationUrl}/configuration`, {
             method: 'GET',
             headers: {
                 Accept: 'application/json'
@@ -63,7 +63,7 @@ export const useMatchConfiguration = (lazy = false) => {
             setPasses(passes.filter((p) => p.id !== undefined));
             successCallback?.();
         } else {
-            fetch(`${Config.deduplicationUrl}/api/configuration/pass/${id}`, {
+            fetch(`${Config.deduplicationUrl}/configuration/pass/${id}`, {
                 method: 'DELETE',
                 headers: {
                     Accept: 'application/json'
@@ -120,7 +120,7 @@ export const useMatchConfiguration = (lazy = false) => {
     };
 
     const makeUpdateRequest = (pass: Pass, onResponse: (passes: Pass[]) => void) => {
-        fetch(`${Config.deduplicationUrl}/api/configuration/pass/${pass.id}`, {
+        fetch(`${Config.deduplicationUrl}/configuration/pass/${pass.id}`, {
             method: 'PUT',
             headers: {
                 Accept: 'application/json',
@@ -152,7 +152,7 @@ export const useMatchConfiguration = (lazy = false) => {
     };
 
     const makeCreateRequest = (pass: Pass, onResponse: (passes: Pass[]) => void) => {
-        fetch(`${Config.deduplicationUrl}/api/configuration/pass`, {
+        fetch(`${Config.deduplicationUrl}/configuration/pass`, {
             method: 'POST',
             headers: {
                 Accept: 'application/json',
@@ -175,7 +175,7 @@ export const useMatchConfiguration = (lazy = false) => {
     };
 
     const exportAlgorithm = () => {
-        fetch(`${Config.deduplicationUrl}/api/configuration/export`, {
+        fetch(`${Config.deduplicationUrl}/configuration/export`, {
             method: 'GET',
             headers: {
                 Accept: 'application/json'

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/DataElementConfig.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/DataElementConfig.tsx
@@ -1,4 +1,4 @@
-import { AlertProvider, useAlert } from 'alert';
+import { useAlert } from 'alert';
 import { Button } from 'components/button';
 import { Heading } from 'components/heading';
 import { useEffect } from 'react';
@@ -11,13 +11,6 @@ import styles from './data-elements.module.scss';
 import { Shown } from 'conditional-render';
 import { Loading } from 'components/Spinner';
 
-export const DataElementConfig = () => {
-    return (
-        <AlertProvider>
-            <DataElementConfigContent />
-        </AlertProvider>
-    );
-};
 const initial: DataElements = {
     firstName: { active: false, oddsRatio: undefined, logOdds: undefined, threshold: undefined },
     lastName: { active: false, oddsRatio: undefined, logOdds: undefined, threshold: undefined },
@@ -49,7 +42,7 @@ const initial: DataElements = {
     wicIdentifier: { active: false, oddsRatio: undefined, logOdds: undefined, threshold: undefined }
 };
 
-const DataElementConfigContent = () => {
+export const DataElementConfig = () => {
     const { showSuccess, showError } = useAlert();
     const { dataElements, save, error, loading } = useDataElements();
     const form = useForm<DataElements>({ mode: 'onBlur', defaultValues: initial });
@@ -93,7 +86,7 @@ const DataElementConfigContent = () => {
                 <main>
                     <Shown when={!loading} fallback={<Loading center />}>
                         <FormProvider {...form}>
-                            <DataElementsForm />
+                            <DataElementsForm dataElements={dataElements} />
                         </FormProvider>
                     </Shown>
                 </main>

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementRow/DataElementRow.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementRow/DataElementRow.spec.tsx
@@ -1,14 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { DataElementRow } from './DataElementRow';
-import { useDataElements } from 'apps/deduplication/api/useDataElements';
 import { DataElements } from 'apps/deduplication/data-elements/DataElement';
 import userEvent from '@testing-library/user-event';
-
-// Mock the useDataElements hook
-jest.mock('apps/deduplication/api/useDataElements', () => ({
-    useDataElements: jest.fn()
-}));
 
 // Test component that provides the form context
 const TestFormProvider = ({ fieldName, field }: { fieldName: string; field: string }) => {
@@ -16,22 +10,21 @@ const TestFormProvider = ({ fieldName, field }: { fieldName: string; field: stri
 
     return (
         <FormProvider {...methods}>
-            <DataElementRow fieldName={fieldName} field={field as keyof DataElements} />
+            <table>
+                <tbody>
+                    <DataElementRow
+                        dataElements={{ firstName: { oddsRatio: 1.5, threshold: 0.8 } }}
+                        fieldName={fieldName}
+                        field={field as keyof DataElements}
+                    />
+                </tbody>
+            </table>
         </FormProvider>
     );
 };
 
 describe('DataElementRow Component', () => {
     const field = 'firstName'; // Example field name
-
-    beforeEach(() => {
-        // Mocking configuration data for the test
-        (useDataElements as jest.Mock).mockReturnValue({
-            dataElements: {
-                firstName: { oddsRatio: 1.5, threshold: 0.8 }
-            }
-        });
-    });
 
     it('should render checkbox and numeric inputs', () => {
         render(<TestFormProvider fieldName="First Name" field={field} />);

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementRow/DataElementRow.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementRow/DataElementRow.tsx
@@ -3,16 +3,15 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DataElements } from '../../DataElement';
 import { TableNumericInput } from '../TableNumericInput/TableNumericInput';
 import styles from './DataElementRow.module.scss';
-import { useDataElements } from 'apps/deduplication/api/useDataElements';
 import { Checkbox } from 'design-system/checkbox';
 
 type Props = {
     fieldName: string;
+    dataElements?: DataElements;
     field: keyof DataElements;
 };
 
-export const DataElementRow = ({ fieldName, field }: Props) => {
-    const { dataElements } = useDataElements();
+export const DataElementRow = ({ fieldName, field, dataElements }: Props) => {
     const form = useFormContext<DataElements>();
     const watch = useWatch({ control: form.control });
 

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.tsx
@@ -39,7 +39,10 @@ const dataElementKeys: (keyof DataElements)[] = [
     'wicIdentifier'
 ];
 
-export const DataElementsForm = () => {
+type Props = {
+    dataElements?: DataElements;
+};
+export const DataElementsForm = ({ dataElements }: Props) => {
     const form = useFormContext<DataElements>();
     const watch = useWatch({ control: form.control });
 
@@ -129,31 +132,55 @@ export const DataElementsForm = () => {
                         </tr>
                     </thead>
                     <tbody>
-                        <DataElementRow fieldName="First name" field="firstName" />
-                        <DataElementRow fieldName="Last name" field="lastName" />
-                        <DataElementRow fieldName="Suffix" field="suffix" />
-                        <DataElementRow fieldName="Date of birth" field="dateOfBirth" />
-                        <DataElementRow fieldName="Current sex" field="sex" />
-                        <DataElementRow fieldName="Race" field="race" />
-                        <DataElementRow fieldName="SSN" field="socialSecurity" />
-                        <DataElementRow fieldName="Street address 1" field="address" />
-                        <DataElementRow fieldName="City" field="city" />
-                        <DataElementRow fieldName="State" field="state" />
-                        <DataElementRow fieldName="Zip" field="zip" />
-                        <DataElementRow fieldName="County" field="county" />
-                        <DataElementRow fieldName="Phone number" field="telephone" />
-                        <DataElementRow fieldName="Telecom" field="telecom" />
-                        <DataElementRow fieldName="Email" field="email" />
-                        <DataElementRow fieldName="Account number" field="accountNumber" />
-                        <DataElementRow fieldName="Drivers license number" field="driversLicenseNumber" />
-                        <DataElementRow fieldName="Medicaid number" field="medicaidNumber" />
-                        <DataElementRow fieldName="Medical record number" field="medicalRecordNumber" />
-                        <DataElementRow fieldName="National unique identifier" field="nationalUniqueIdentifier" />
-                        <DataElementRow fieldName="Patient external identifier" field="patientExternalIdentifier" />
-                        <DataElementRow fieldName="Patient internal identifier" field="patientInternalIdentifier" />
-                        <DataElementRow fieldName="Person number" field="personNumber" />
-                        <DataElementRow fieldName="Visa/Passport" field="visaPassport" />
-                        <DataElementRow fieldName="WIC Identifier" field="wicIdentifier" />
+                        <DataElementRow dataElements={dataElements} fieldName="First name" field="firstName" />
+                        <DataElementRow dataElements={dataElements} fieldName="Last name" field="lastName" />
+                        <DataElementRow dataElements={dataElements} fieldName="Suffix" field="suffix" />
+                        <DataElementRow dataElements={dataElements} fieldName="Date of birth" field="dateOfBirth" />
+                        <DataElementRow dataElements={dataElements} fieldName="Current sex" field="sex" />
+                        <DataElementRow dataElements={dataElements} fieldName="Race" field="race" />
+                        <DataElementRow dataElements={dataElements} fieldName="SSN" field="socialSecurity" />
+                        <DataElementRow dataElements={dataElements} fieldName="Street address 1" field="address" />
+                        <DataElementRow dataElements={dataElements} fieldName="City" field="city" />
+                        <DataElementRow dataElements={dataElements} fieldName="State" field="state" />
+                        <DataElementRow dataElements={dataElements} fieldName="Zip" field="zip" />
+                        <DataElementRow dataElements={dataElements} fieldName="County" field="county" />
+                        <DataElementRow dataElements={dataElements} fieldName="Phone number" field="telephone" />
+                        <DataElementRow dataElements={dataElements} fieldName="Telecom" field="telecom" />
+                        <DataElementRow dataElements={dataElements} fieldName="Email" field="email" />
+                        <DataElementRow dataElements={dataElements} fieldName="Account number" field="accountNumber" />
+                        <DataElementRow
+                            dataElements={dataElements}
+                            fieldName="Drivers license number"
+                            field="driversLicenseNumber"
+                        />
+                        <DataElementRow
+                            dataElements={dataElements}
+                            fieldName="Medicaid number"
+                            field="medicaidNumber"
+                        />
+                        <DataElementRow
+                            dataElements={dataElements}
+                            fieldName="Medical record number"
+                            field="medicalRecordNumber"
+                        />
+                        <DataElementRow
+                            dataElements={dataElements}
+                            fieldName="National unique identifier"
+                            field="nationalUniqueIdentifier"
+                        />
+                        <DataElementRow
+                            dataElements={dataElements}
+                            fieldName="Patient external identifier"
+                            field="patientExternalIdentifier"
+                        />
+                        <DataElementRow
+                            dataElements={dataElements}
+                            fieldName="Patient internal identifier"
+                            field="patientInternalIdentifier"
+                        />
+                        <DataElementRow dataElements={dataElements} fieldName="Person number" field="personNumber" />
+                        <DataElementRow dataElements={dataElements} fieldName="Visa/Passport" field="visaPassport" />
+                        <DataElementRow dataElements={dataElements} fieldName="WIC Identifier" field="wicIdentifier" />
                     </tbody>
                 </table>
             </div>

--- a/apps/modernization-ui/src/config.js
+++ b/apps/modernization-ui/src/config.js
@@ -1,14 +1,14 @@
 const prod = {
     modernizationUrl: `${window.location.protocol}//${window.location.host}`,
     pageBuilderUrl: `${window.location.protocol}//${window.location.host}/nbs/page-builder`,
-    deduplicationUrl: `${window.location.protocol}//${window.location.host}/nbs/deduplication`,
+    deduplicationUrl: `${window.location.protocol}//${window.location.host}/nbs/api/deduplication`,
     enableLogin: false
 };
 
 const dev = {
     modernizationUrl: `${window.location.protocol}//${window.location.host}`,
     pageBuilderUrl: `${window.location.protocol}//${window.location.host}/nbs/page-builder`,
-    deduplicationUrl: `${window.location.protocol}//${window.location.host}/nbs/deduplication`,
+    deduplicationUrl: `${window.location.protocol}//${window.location.host}/nbs/api/deduplication`,
     enableLogin: true,
     features: {
         address: {

--- a/apps/modernization-ui/src/config.js
+++ b/apps/modernization-ui/src/config.js
@@ -6,9 +6,7 @@ const prod = {
 };
 
 const dev = {
-    modernizationUrl: `${window.location.protocol}//${window.location.host}`,
-    pageBuilderUrl: `${window.location.protocol}//${window.location.host}/nbs/page-builder`,
-    deduplicationUrl: `${window.location.protocol}//${window.location.host}/nbs/api/deduplication`,
+    ...prod,
     enableLogin: true,
     features: {
         address: {

--- a/apps/modernization-ui/src/setupProxy.js
+++ b/apps/modernization-ui/src/setupProxy.js
@@ -10,7 +10,7 @@ const NBS_API = '/nbs/api';
 const GRAPHQL = '/graphql';
 const ENCRYPTION = '/encryption';
 const PAGEBUILDER_API = '/nbs/page-builder/api';
-const DEDUPLICATION_API = '/nbs/deduplication/api';
+const DEDUPLICATION_API = '/nbs/api/deduplication';
 
 // only forward POST methods so the login page can load
 const LOGIN = function (pathname, req) {
@@ -18,7 +18,7 @@ const LOGIN = function (pathname, req) {
 };
 
 module.exports = function (app) {
-    app.use(createProxyMiddleware([NBS_API, GRAPHQL, ENCRYPTION, PAGEBUILDER_API], { target }));
     app.use(createProxyMiddleware([DEDUPLICATION_API], { target: deduplication }));
+    app.use(createProxyMiddleware([NBS_API, GRAPHQL, ENCRYPTION, PAGEBUILDER_API], { target }));
     app.use(createProxyMiddleware(LOGIN, { target }));
 };


### PR DESCRIPTION
## Description

1. Updates the deduplication api calls to use the new url (`/nbs/api/deduplication`)
3. Removes extra `AlertProvider` from data element configuration page
4. Remove extra API call from `DataElementRow` component

## Tickets

* [CND-234](https://cdc-nbs.atlassian.net/browse/CND-234)

## Local Demo
![apiLocal](https://github.com/user-attachments/assets/8e6a1b32-897a-4bd7-a3b6-39454cdbdf81)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-234]: https://cdc-nbs.atlassian.net/browse/CND-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ