### PR TITLE
[CNFT1-3897] "No value" available as a search option

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.spec.ts
@@ -1,37 +1,263 @@
 import { asBasicNewPatientEntry } from './asBasicNewPatientEntry';
 
+const defaults = { administrative: { asOf: '04/04/2004' } };
+
 describe('when adding a new patient from a patient search', () => {
+    it('should default the administrative as of date from the provided defaults', () => {
+        const actual = asBasicNewPatientEntry({ administrative: { asOf: '03/10/1997' } })({});
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                administrative: expect.objectContaining({ asOf: '03/10/1997' })
+            })
+        );
+    });
+
+    it('should populate the first name from the First name text criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            name: { first: { equals: 'first-name-value' } }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                name: expect.objectContaining({ first: 'first-name-value' })
+            })
+        );
+    });
+
+    it('should populate the last name from the Last name text criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            name: { last: { equals: 'last-name-value' } }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                name: expect.objectContaining({ last: 'last-name-value' })
+            })
+        );
+    });
+
     it('should populate the date of birth from the date equals criteria with a full date', () => {
         const criteria = { bornOn: { equals: { month: 6, day: 5, year: 2025 } } };
 
-        const actual = asBasicNewPatientEntry(criteria);
+        const actual = asBasicNewPatientEntry(defaults)(criteria);
 
         expect(actual).toEqual(
             expect.objectContaining({ personalDetails: expect.objectContaining({ bornOn: '06/05/2025' }) })
         );
     });
 
-    it('should populate the date of birth from the date equals criteria with only a month', () => {
+    it('should not populate the date of birth from the date equals criteria with only a month', () => {
         const criteria = { bornOn: { equals: { month: 6 } } };
 
-        const actual = asBasicNewPatientEntry(criteria);
+        const actual = asBasicNewPatientEntry(defaults)(criteria);
 
         expect(actual.personalDetails?.bornOn).toBeUndefined();
     });
 
-    it('should populate the date of birth from the date equals criteria with only a day', () => {
+    it('should not populate the date of birth from the date equals criteria with only a day', () => {
         const criteria = { bornOn: { equals: { day: 5 } } };
 
-        const actual = asBasicNewPatientEntry(criteria);
+        const actual = asBasicNewPatientEntry(defaults)(criteria);
 
         expect(actual.personalDetails?.bornOn).toBeUndefined();
     });
 
-    it('should populate the date of birth from the date equals criteria with only a year', () => {
+    it('should not populate the date of birth from the date equals criteria with only a year', () => {
         const criteria = { bornOn: { equals: { year: 2025 } } };
 
-        const actual = asBasicNewPatientEntry(criteria);
+        const actual = asBasicNewPatientEntry(defaults)(criteria);
 
         expect(actual.personalDetails?.bornOn).toBeUndefined();
+    });
+
+    it('should populate the current sex from the gender criteria when the value is not "No value"', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            gender: { name: 'Value', value: 'value' }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                personalDetails: expect.objectContaining({
+                    currentSex: { name: 'Value', value: 'value' }
+                })
+            })
+        );
+    });
+
+    it('should not populate the current sex from the Gender criteria when the value is "No value"', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            gender: { name: 'No value', value: 'NO_VALUE' }
+        });
+
+        expect(actual.personalDetails?.currentSex).toBeUndefined();
+    });
+
+    it('should populate the address street from the Address text criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            location: { street: { equals: 'street-value' } }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                address: expect.objectContaining({ address1: 'street-value' })
+            })
+        );
+    });
+
+    it('should populate the address city from the City text criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            location: { city: { equals: 'city-value' } }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                address: expect.objectContaining({ city: 'city-value' })
+            })
+        );
+    });
+
+    it('should populate the address state from the State criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            state: { name: 'State', value: 'state-value' }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                address: expect.objectContaining({
+                    state: expect.objectContaining({ name: 'State', value: 'state-value' })
+                })
+            })
+        );
+    });
+
+    it('should populate the address zip code from the Zip criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            zip: 449
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                address: expect.objectContaining({
+                    zipcode: '449'
+                })
+            })
+        );
+    });
+
+    it('should default the address country from the provided defaults', () => {
+        const actual = asBasicNewPatientEntry({
+            administrative: { asOf: '03/10/1997' },
+            address: { country: { name: 'Default country', value: 'default-country' } }
+        })({});
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                address: expect.objectContaining({
+                    country: expect.objectContaining({ name: 'Default country', value: 'default-country' })
+                })
+            })
+        );
+    });
+
+    it('should populate the Phone & email home from the Phone number criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            phoneNumber: 'phone-number-value'
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                phoneEmail: expect.objectContaining({
+                    home: 'phone-number-value'
+                })
+            })
+        );
+    });
+
+    it('should populate the Phone & email email address from the Email address criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            email: 'email-value'
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                phoneEmail: expect.objectContaining({
+                    email: 'email-value'
+                })
+            })
+        );
+    });
+
+    it('should populate the ethnicity from the Ethnicity criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            ethnicity: { name: 'Ethnicity', value: 'ethnicity-value' }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                ethnicityRace: expect.objectContaining({
+                    ethnicity: expect.objectContaining({ name: 'Ethnicity', value: 'ethnicity-value' })
+                })
+            })
+        );
+    });
+
+    it('should populate races from the Race criteria', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            race: { name: 'Race', value: 'race-value' }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                ethnicityRace: expect.objectContaining({
+                    races: expect.arrayContaining([expect.objectContaining({ name: 'Race', value: 'race-value' })])
+                })
+            })
+        );
+    });
+
+    it('should populate identifications from the ID type and ID number', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            identificationType: { name: 'Identification type', value: 'identification-type-value' },
+            identification: 'identification-value'
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                identifications: expect.arrayContaining([
+                    expect.objectContaining({
+                        id: 'identification-value',
+                        type: expect.objectContaining({
+                            name: 'Identification type',
+                            value: 'identification-type-value'
+                        })
+                    })
+                ])
+            })
+        );
+    });
+
+    it('should not populate identifications without an ID number', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            identificationType: { name: 'Identification type', value: 'identification-type-value' }
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                identifications: []
+            })
+        );
+    });
+
+    it('should not populate identifications without an ID type', () => {
+        const actual = asBasicNewPatientEntry(defaults)({
+            identification: 'identification-value'
+        });
+
+        expect(actual).toEqual(
+            expect.objectContaining({
+                identifications: []
+            })
+        );
     });
 });

--- a/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/asBasicNewPatientEntry.ts
@@ -1,4 +1,3 @@
-import { internalizeDate } from 'date';
 import {
     BasicAddressEntry,
     BasicNewPatientEntry,
@@ -6,8 +5,7 @@ import {
     NameInformationEntry,
     BasicPhoneEmail,
     BasicEthnicityRace,
-    BasicIdentificationEntry,
-    initial
+    BasicIdentificationEntry
 } from './entry';
 import { asTextCriteriaValue, TextCriteria } from 'options/operator';
 import { resolveDate } from 'design-system/date/criteria';
@@ -17,17 +15,19 @@ import { Selectable } from 'options';
 const resolveCriteria = (textCriteria?: TextCriteria): string | undefined =>
     asTextCriteriaValue(textCriteria) ?? undefined;
 
-const asBasicNewPatientEntry = (criteria: Partial<PatientCriteriaEntry>): BasicNewPatientEntry => {
-    return {
-        administrative: { asOf: internalizeDate(new Date()) },
-        name: nameBasic(criteria),
-        personalDetails: personalDetailsBasic(criteria),
-        address: addressBasic(criteria, initial().address),
-        phoneEmail: phoneEmailBasic(criteria),
-        ethnicityRace: ethnicityRaceBasic(criteria),
-        identifications: identificationBasic(criteria)
+const asBasicNewPatientEntry =
+    (defaults: BasicNewPatientEntry) =>
+    (criteria: Partial<PatientCriteriaEntry>): BasicNewPatientEntry => {
+        return {
+            ...defaults,
+            name: nameBasic(criteria),
+            personalDetails: personalDetailsBasic(criteria),
+            address: addressBasic(criteria, defaults?.address),
+            phoneEmail: phoneEmailBasic(criteria),
+            ethnicityRace: ethnicityRaceBasic(criteria),
+            identifications: identificationBasic(criteria)
+        };
     };
-};
 
 const nameBasic = (initial: Partial<PatientCriteriaEntry>): NameInformationEntry => ({
     first: resolveCriteria(initial.name?.first),
@@ -47,11 +47,11 @@ const personalDetailsBasic = (initial: Partial<PatientCriteriaEntry>): BasicPers
 };
 
 const addressBasic = (initial: Partial<PatientCriteriaEntry>, defaults?: BasicAddressEntry): BasicAddressEntry => ({
+    ...defaults,
     address1: resolveCriteria(initial.location?.street),
     city: resolveCriteria(initial.location?.city),
     state: initial.state,
-    zipcode: initial.zip?.toString(),
-    country: defaults?.country
+    zipcode: initial.zip?.toString()
 });
 
 const phoneEmailBasic = (initial: Partial<PatientCriteriaEntry>): BasicPhoneEmail => ({

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -6,10 +6,10 @@ import { SingleSelect } from 'design-system/select';
 import { EntryFieldsProps } from 'design-system/entry';
 import { Input } from 'components/FormInputs/Input';
 import { validNameRule } from 'validation/entry';
-import { genders } from 'options/gender';
 import { SearchCriteria } from 'apps/search/criteria';
 import { PatientCriteriaEntry, statusOptions } from 'apps/search/patient/criteria';
 import { Permitted } from 'libs/permission';
+import { searchableGenders } from './searchableGenders';
 
 export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
     const { control } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
@@ -75,7 +75,7 @@ export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
                         name={name}
                         label="Current sex"
                         id={name}
-                        options={genders}
+                        options={searchableGenders}
                         sizing={sizing}
                         orientation={orientation}
                     />

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/searchableGenders.ts
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/searchableGenders.ts
@@ -1,0 +1,8 @@
+import { asSelectable } from 'options';
+import { genders } from 'options/gender';
+
+const NO_VALUE = asSelectable('NO_VALUE', 'No value');
+
+const searchableGenders = [...genders, NO_VALUE];
+
+export { searchableGenders, NO_VALUE };

--- a/apps/modernization-ui/src/apps/search/patient/add/useAddPatientFromSearch.ts
+++ b/apps/modernization-ui/src/apps/search/patient/add/useAddPatientFromSearch.ts
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router';
 import { PatientCriteriaEntry } from '../criteria';
 import { useSearchCriteriaEncrypted } from 'apps/search/useSearchCriteriaEncrypted';
 import { useFormContext } from 'react-hook-form';
+import { initial } from 'apps/patient/add/basic/entry';
 import { asBasicNewPatientEntry } from 'apps/patient/add/basic/asBasicNewPatientEntry';
 import { useConfiguration } from 'configuration';
 import { asNewPatientEntry } from './asNewPatientEntry';
@@ -18,7 +19,7 @@ const useAddPatientFromSearch = (): Interaction => {
     const { features } = useConfiguration();
 
     const addBasic = (criteria: Partial<PatientCriteriaEntry>) => {
-        const defaults = asBasicNewPatientEntry(criteria);
+        const defaults = asBasicNewPatientEntry(initial())(criteria);
         navigate('/patient/add', { state: { defaults, criteria: found } });
     };
 


### PR DESCRIPTION
## Description

Adds "No value" as an option for searching gender values.

- Added more unit tests for `asBasicNewPatientEntry`

![image](https://github.com/user-attachments/assets/208a6c7a-1c05-4d76-870d-20c04e8a3088)

![image](https://github.com/user-attachments/assets/ff3e0921-9c7e-4097-89c2-512b10704178)



## Tickets

* [CNFT1-3897](https://cdc-nbs.atlassian.net/browse/CNFT1-3897)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-3897]: https://cdc-nbs.atlassian.net/browse/CNFT1-3897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ