### PR TITLE
CNFT1-3950-multiple-filters using pendingFilter instead of filter on clear

### DIFF
--- a/apps/modernization-ui/src/design-system/filter/useFilter.tsx
+++ b/apps/modernization-ui/src/design-system/filter/useFilter.tsx
@@ -50,7 +50,7 @@ const FilterProvider = ({ children }: FilterProviderProps) => {
 
     const apply = () => setFilter(pendingFilter);
 
-    const clear = (id: string) => updateFilter(withoutProperty(id)(filter) as Filter | undefined);
+    const clear = (id: string) => updateFilter(withoutProperty(id)(pendingFilter) as Filter | undefined);
 
     const clearAll = () => updateFilter(undefined);
     const reset = useCallback(() => {


### PR DESCRIPTION
## Description

Using pendingFilter instead of just filter on clear when updating filter, because this will allow for the user to be in a state of continues filters being set before actually applying the filter. 

## Tickets

* [CNFT1-3950](https://cdc-nbs.atlassian.net/browse/CNFT1-3950)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3950]: https://cdc-nbs.atlassian.net/browse/CNFT1-3950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ