### PR TITLE
[CNFT1-3985] corrected urls

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/PatientCreatedPanel.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/PatientCreatedPanel.tsx
@@ -23,12 +23,12 @@ const PatientCreatedPanel = ({ created }: Props) => (
         footer={() => (
             <>
                 <Permitted include={[ADD_LAB_REPORT_PERMISSION]}>
-                    <ClassicButton outline url={`nbs/api/profile/${created.id}/report/lab`}>
+                    <ClassicButton outline url={`/nbs/api/profile/${created.id}/report/lab`}>
                         Add lab report
                     </ClassicButton>
                 </Permitted>
                 <Permitted include={[ADD_INVESTIGATION_PERMISSION]}>
-                    <ClassicButton outline url={`nbs/api/profile/${created.id}/investigation`}>
+                    <ClassicButton outline url={`/nbs/api/profile/${created.id}/investigation`}>
                         Add investigation
                     </ClassicButton>
                 </Permitted>

--- a/apps/modernization-ui/src/classic/ClassicButton.tsx
+++ b/apps/modernization-ui/src/classic/ClassicButton.tsx
@@ -6,9 +6,22 @@ type Props = {
     url: string;
     className?: string;
     outline?: boolean;
+    /**
+     * The destination for the resolved location
+     */
     destination?: Destination;
 } & JSX.IntrinsicElements['button'];
 
+/**
+ * A USWDS styled button that interacts with specialized API endpoints which prepare the NBS6 session and then provides
+ *  a url to redirect to within the {@code Location} header of the response.  This interaction pattern has since been
+ * replaced by a standard redirect issued from the response.
+ *
+ * This component exists to maintain compatibility with API's that provide this type of interaction and should only be
+ * used with those API endpoints.
+ *
+ * @param {Props} props
+ */
 export const ClassicButton = ({
     url,
     className,


### PR DESCRIPTION
## Description

The URLs for the "Add lab report" and "Add investigation" buttons were changed to page-relative URLs when they should be root-relative URLs.  The buttons were attempting to navigate to non-existing paths `patient/nbs/api/profile/{id}/report/lab` and `patient/nbs/api/profile/{id}/investigation`.

## Tickets

* [CNFT1-3985](https://cdc-nbs.atlassian.net/browse/CNFT1-3985)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
