### PR TITLE
[CNFT1-3974]: Added aria label to the operator select or select component

### DIFF
--- a/apps/modernization-ui/src/design-system/input/text/criteria/TextCriteriaField.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/criteria/TextCriteriaField.tsx
@@ -93,6 +93,7 @@ export const TextCriteriaField = ({
                     value={asSelectableOperator(effectiveOperator)}
                     mode={operationMode}
                     onChange={onSelectionChange}
+                    ariaLabel={`${label} search criteria operator`}
                 />
                 <TextInput onChange={onInputChange} type="text" name={id} value={operatorValue.value ?? ''} id={id} />
             </div>

--- a/apps/modernization-ui/src/design-system/input/text/criteria/operator/OperatorSelect.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/criteria/operator/OperatorSelect.tsx
@@ -7,9 +7,10 @@ export type OperatorSelectProps = {
     value?: Selectable | null;
     mode?: 'alpha' | 'all';
     onChange: (value?: Selectable) => void;
+    ariaLabel?: string;
 };
 
-export const OperatorSelect = ({ id, value, mode, onChange }: OperatorSelectProps) => {
+export const OperatorSelect = ({ id, value, mode, onChange, ariaLabel }: OperatorSelectProps) => {
     return (
         <Select
             value={value || defaultTextOperator}
@@ -18,6 +19,7 @@ export const OperatorSelect = ({ id, value, mode, onChange }: OperatorSelectProp
             id={id}
             options={mode === 'alpha' ? textAlphaOperators : textOperators}
             placeholder=""
+            aria-label={ariaLabel}
         />
     );
 };


### PR DESCRIPTION
## Description

An aria-label can be added to the select component using the label to construct a meaningful message.  For example, “{label} search operator“

Fixed scanned Axe Dev tool on Patient Search
<img width="1506" alt="Screenshot 2025-04-09 at 10 27 28 AM" src="https://github.com/user-attachments/assets/2631920e-f3c5-4f4d-81aa-10d4ac9aaa7a" />

Previous Scan before fix
<img width="1488" alt="Screenshot 2025-04-09 at 10 28 18 AM" src="https://github.com/user-attachments/assets/e8c0d2e4-bda4-4598-bdf4-2f4602c274e6" />

## Tickets

* [CNFT1-3974](https://cdc-nbs.atlassian.net/browse/CNFT1-3974)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3974]: https://cdc-nbs.atlassian.net/browse/CNFT1-3974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ