### PR TITLE
Prevent focus loss on input

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/notification-cards/AlgorithmNotConfigured.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/notification-cards/AlgorithmNotConfigured.tsx
@@ -1,7 +1,7 @@
-import { Icon } from '@trussworks/react-uswds';
 import { Button } from 'design-system/button';
 import { useNavigate } from 'react-router';
 import { NotificationCard } from './NotificationCard';
+import { Icon } from 'design-system/icon';
 
 type Props = {
     onImportClick: () => void;
@@ -20,13 +20,14 @@ export const AlgorithmNotConfigured = ({ onImportClick }: Props) => {
             }
             buttons={
                 <>
-                    <Button sizing="medium" onClick={() => nav('/deduplication/data_elements')}>
-                        <Icon.Settings size={3} />
+                    <Button
+                        icon={<Icon name="settings" />}
+                        labelPosition="right"
+                        onClick={() => nav('/deduplication/data_elements')}>
                         Configure data elements
                     </Button>
 
-                    <Button sizing="medium" onClick={onImportClick}>
-                        <Icon.UploadFile size={3} />
+                    <Button icon={<Icon name="file_upload" />} labelPosition="right" onClick={onImportClick}>
                         Import configuration file
                     </Button>
                 </>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/PassForm.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/PassForm.tsx
@@ -1,19 +1,19 @@
+import { DataElements } from 'apps/deduplication/api/model/DataElement';
 import { BlockingAttribute, MatchingAttribute, MatchMethod, Pass } from 'apps/deduplication/api/model/Pass';
 import { Shown } from 'conditional-render';
 import { Button } from 'design-system/button';
 import { useEffect, useState } from 'react';
 import { useFormContext, useFormState, useWatch } from 'react-hook-form';
+import { exists } from 'utils';
+import { ActivateToggle } from './activate-toggle/ActivateToggle';
 import { BlockingCriteria } from './blocking-criteria/BlockingCriteria';
 import { BlockingCriteriaSidePanel } from './blocking-criteria/panel/BlockingCriteriaSidePanel';
 import { DeletePassConfirmation } from './confirmation/DeletePassConfirmation';
 import { UnsavedChangesConfirmation } from './confirmation/UnsavedChangesConfirmation';
-import { MatchingCriteria } from './matching-criteria/MatchingCriteria';
 import { MatchingBounds } from './matching-bounds/MatchingBounds';
-import { ActivateToggle } from './activate-toggle/ActivateToggle';
+import { MatchingCriteria } from './matching-criteria/MatchingCriteria';
 import { MatchingCriteriaSidePanel } from './matching-criteria/panel/MatchingCriteriaSidePanel';
-import { DataElements } from 'apps/deduplication/api/model/DataElement';
 import styles from './pass-form.module.scss';
-import { exists } from 'utils';
 
 type Props = {
     passCount: number;

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/BlockingCriteria.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/BlockingCriteria.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@trussworks/react-uswds';
 import { BlockingAttribute } from 'apps/deduplication/api/model/Pass';
 import { Shown } from 'conditional-render';
 import { Button } from 'design-system/button';
@@ -6,6 +5,7 @@ import { Card } from 'design-system/card';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { BlockingCriteriaAttribute } from './attribute/BlockingCriteriaAttribute';
 import styles from './blocking-criteria.module.scss';
+import { Icon } from 'design-system/icon';
 
 type Props = {
     onAddAttributes: () => void;
@@ -88,7 +88,7 @@ export const BlockingCriteria = ({ onAddAttributes: onShowAttributes }: Props) =
                 </Shown>
                 <div className={styles.buttonContainer}>
                     <Button
-                        icon={<Icon.Add size={3} />}
+                        icon={<Icon name="add" />}
                         labelPosition="right"
                         outline
                         onClick={onShowAttributes}

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/BlockingCriteriaAttribute.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/BlockingCriteriaAttribute.tsx
@@ -23,7 +23,7 @@ export const BlockingCriteriaAttribute = ({ label, description, attribute, onRem
         } else {
             setVisible(false);
         }
-    }, [blockingCriteria]);
+    }, [JSON.stringify(blockingCriteria)]);
     return (
         <Shown when={visible}>
             <div className={styles.attribute}>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/attribute/BlockingCriteriaAttribute.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/attribute/BlockingCriteriaAttribute.tsx
@@ -23,7 +23,7 @@ export const BlockingCriteriaAttribute = ({ label, description, attribute, onRem
         } else {
             setVisible(false);
         }
-    }, [blockingCriteria]);
+    }, [JSON.stringify(blockingCriteria)]);
     return (
         <Shown when={visible}>
             <div className={styles.blockingAttribute}>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/panel/BlockingCriteriaSidePanel.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/panel/BlockingCriteriaSidePanel.tsx
@@ -19,7 +19,7 @@ export const BlockingCriteriaSidePanel = ({ visible, onAccept, onCancel }: Props
 
     useEffect(() => {
         setSelectedAttributes(blockingCriteria ?? []);
-    }, [blockingCriteria, visible]);
+    }, [JSON.stringify(blockingCriteria), visible]);
 
     const handleOnChange = (attribute: BlockingAttribute) => {
         if (selectedAttributes.includes(attribute)) {

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
@@ -13,7 +13,8 @@ type Props = {
 };
 export const MatchingBounds = ({ dataElements }: Props) => {
     const form = useFormContext<Pass>();
-    const { matchingCriteria, blockingCriteria } = useWatch<Pass>(form);
+    const { blockingCriteria } = useWatch<Pass>(form);
+    const { matchingCriteria } = useWatch<Pass>(form);
     const [disabled, setDisabled] = useState<boolean>(true);
     const [totalLogOdds, setTotalLogOdds] = useState<number | undefined>();
 
@@ -24,7 +25,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                 matchingCriteria === undefined ||
                 matchingCriteria.length === 0
         );
-    }, [blockingCriteria, matchingCriteria]);
+    }, [JSON.stringify(blockingCriteria), JSON.stringify(matchingCriteria)]);
 
     useEffect(() => {
         if (disabled) {

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/MatchingCriteria.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/MatchingCriteria.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@trussworks/react-uswds';
 import { MatchingAttribute, Pass } from 'apps/deduplication/api/model/Pass';
 import { DataElements } from 'apps/deduplication/api/model/DataElement';
 import { Shown } from 'conditional-render';
@@ -9,6 +8,7 @@ import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { MatchingCriteriaAttribute } from './attribute/MatchingCriteriaAttribute';
 import { getLogOdds } from './getLogOdds';
 import styles from './matching-criteria.module.scss';
+import { Icon } from 'design-system/icon';
 
 type Props = {
     dataElements: DataElements;
@@ -22,7 +22,7 @@ export const MatchingCriteria = ({ dataElements, onAddAttributes }: Props) => {
 
     useEffect(() => {
         setDisabled(blockingCriteria === undefined || blockingCriteria.length === 0);
-    }, [blockingCriteria]);
+    }, [JSON.stringify(blockingCriteria)]);
 
     const handleRemoveAttribute = (index: number) => {
         remove(index);
@@ -84,7 +84,7 @@ export const MatchingCriteria = ({ dataElements, onAddAttributes }: Props) => {
                     </Shown>
                     <div className={styles.buttonContainer}>
                         <Button
-                            icon={<Icon.Add size={3} />}
+                            icon={<Icon name="add" />}
                             labelPosition="right"
                             outline
                             onClick={onAddAttributes}

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/attribute/MatchingCriteriaAttribute.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/attribute/MatchingCriteriaAttribute.tsx
@@ -26,7 +26,7 @@ export const MatchingCriteriaAttribute = ({ label, attribute, logOdds, onRemove 
         } else {
             setVisible(false);
         }
-    }, [matchingCriteria]);
+    }, [JSON.stringify(matchingCriteria)]);
 
     return (
         <Shown when={visible}>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/panel/MatchingCriteriaSidePanel.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/panel/MatchingCriteriaSidePanel.tsx
@@ -27,7 +27,7 @@ export const MatchingCriteriaSidePanel = ({ visible, dataElements, onAccept, onC
 
     useEffect(() => {
         setSelectedAttributes(matchingCriteria?.map((a) => a.attribute).filter((a) => a !== undefined) ?? []);
-    }, [matchingCriteria, visible]);
+    }, [JSON.stringify(matchingCriteria), visible]);
 
     useEffect(() => {
         setAttributeList([

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/side-panel/SidePanel.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/side-panel/SidePanel.tsx
@@ -1,8 +1,8 @@
-import { Icon } from '@trussworks/react-uswds';
 import { Heading } from 'components/heading';
 import { Shown } from 'conditional-render';
 import styles from './side-panel.module.scss';
 import { ReactNode, useEffect, useRef, useState } from 'react';
+import { Icon } from 'design-system/icon';
 
 type Props = {
     heading: string;
@@ -49,7 +49,7 @@ export const SidePanel = ({ heading, children, footer, visible, onClose }: Props
                     <div className={styles.heading}>
                         <Heading level={2}>{heading}</Heading>
                         <button onClick={onClose} aria-label={`Close ${heading}`}>
-                            <Icon.Close size={4} />
+                            <Icon name="close" />
                         </button>
                     </div>
                     <div className={styles.panelContent}>{children}</div>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/PassList.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/PassList.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@trussworks/react-uswds';
 import { useAlert } from 'alert';
 import { Pass } from 'apps/deduplication/api/model/Pass';
 import { Heading } from 'components/heading';
@@ -8,6 +7,7 @@ import { useState } from 'react';
 import { UpdatePassNameModal } from '../pass-form/save-modal/UpdatePassNameModal';
 import { PassEntry } from './pass-entry/PassEntry';
 import styles from './pass-list.module.scss';
+import { Icon } from 'design-system/icon';
 
 type Props = {
     passes: Pass[];
@@ -55,7 +55,7 @@ export const PassList = ({ passes, selectedPass, onSetSelectedPass, onAddPass, o
                     ))}
                 </Shown>
                 <Button
-                    icon={<Icon.Add size={3} />}
+                    icon={<Icon name="add" />}
                     labelPosition="right"
                     unstyled
                     onClick={onAddPass}

--- a/apps/modernization-ui/src/design-system/modal/Modal.tsx
+++ b/apps/modernization-ui/src/design-system/modal/Modal.tsx
@@ -39,7 +39,7 @@ const Modal = ({
         if (element.current) {
             element.current.focus();
         }
-    }, [element.current]);
+    }, []);
 
     const handleKeyDown = (event: ReactKeyboardEvent) => {
         if (event.key === 'Escape') {


### PR DESCRIPTION
## Description

1. Prevents loss of input focus by updating `Modal` useEffect to only trigger on mount
3. Fixes some Icon usage (use design system instead of Trussworks)
4. Prevent some unnecessary re-renders by invoking `JSON.stringify` on arrays in useEffect


## Tickets

* [CND-261](https://cdc-nbs.atlassian.net/browse/CND-261)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
