### PR TITLE
Deduplication configuration - design review

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/notification-cards/notification-card.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/notification-cards/notification-card.module.scss
@@ -4,7 +4,6 @@
 
 .notificationCard {
     flex-grow: 1;
-    width: 100%;
     padding: 1rem;
 
     .card {

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/attribute/BlockingCriteriaAttribute.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/attribute/BlockingCriteriaAttribute.tsx
@@ -26,8 +26,8 @@ export const BlockingCriteriaAttribute = ({ label, description, attribute, onRem
     }, [blockingCriteria]);
     return (
         <Shown when={visible}>
-            <div className={styles.blockingAttribute}>
-                <div>
+            <div className={styles.blockingAttributeRow}>
+                <div className={styles.blockingAttributeInfo}>
                     <div className={styles.label}>{label}</div>
                     <div className={styles.description}>{description}</div>
                 </div>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/attribute/blocking-criteria-attribute.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/blocking-criteria/attribute/blocking-criteria-attribute.module.scss
@@ -1,7 +1,7 @@
 @use 'styles/colors';
 @use 'styles/borders';
 
-.blockingAttribute {
+.blockingAttributeRow {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -9,19 +9,25 @@
     gap: 1rem;
     @extend %thin-bottom;
 
-    .label {
-        color: colors.$base-darkest;
-        font-size: 1rem;
-        font-style: normal;
-        font-weight: 700;
-        line-height: 1.25rem;
-    }
+    .blockingAttributeInfo {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
 
-    .description {
-        color: colors.$base-darkest;
-        font-size: 0.875rem;
-        font-style: normal;
-        font-weight: 400;
-        line-height: 1.09375rem;
+        .label {
+            color: colors.$base-darkest;
+            font-size: 1rem;
+            font-style: normal;
+            font-weight: 700;
+            line-height: 1.25rem;
+        }
+
+        .description {
+            color: colors.$base-darkest;
+            font-size: 0.875rem;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 1.09375rem;
+        }
     }
 }

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/attribute/MatchingCriteriaAttribute.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/attribute/MatchingCriteriaAttribute.tsx
@@ -30,9 +30,9 @@ export const MatchingCriteriaAttribute = ({ label, attribute, logOdds, onRemove 
 
     return (
         <Shown when={visible}>
-            <div className={styles.matchingAttribute}>
-                <div className={styles.info}>
-                    <div>
+            <div className={styles.matchingAttributeRow}>
+                <div className={styles.attributeInfoWrapper}>
+                    <div className={styles.attributeInfo}>
                         <div className={styles.label}>{label}</div>
                         <div className={styles.logOdds}>
                             <span>Log odds:</span>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/attribute/matching-criteria-attribute.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-criteria/attribute/matching-criteria-attribute.module.scss
@@ -1,7 +1,7 @@
 @use 'styles/colors';
 @use 'styles/borders';
 
-.matchingAttribute {
+.matchingAttributeRow {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -9,29 +9,36 @@
     gap: 1rem;
     @extend %thin-bottom;
 
-    .info {
+    .attributeInfoWrapper {
         display: flex;
         gap: 2rem;
         align-items: center;
 
-        .label {
-            color: colors.$base-darkest;
-            font-size: 1rem;
-            font-style: normal;
-            font-weight: 700;
-            line-height: 1.25rem;
-            width: 17.5rem;
+        .attributeInfo {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+
+            .label {
+                color: colors.$base-darkest;
+                font-size: 1rem;
+                font-style: normal;
+                font-weight: 700;
+                line-height: 1.25rem;
+                width: 17.5rem;
+            }
+
+            .logOdds {
+                display: flex;
+                gap: 0.5rem;
+                color: colors.$base-darkest;
+                font-size: 0.875rem;
+                font-style: normal;
+                font-weight: 400;
+                line-height: 1.09375rem;
+            }
         }
 
-        .logOdds {
-            display: flex;
-            gap: 0.5rem;
-            color: colors.$base-darkest;
-            font-size: 0.875rem;
-            font-style: normal;
-            font-weight: 400;
-            line-height: 1.09375rem;
-        }
         & > span {
             width: 19.8125rem;
             gap: 0;

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/save-modal/SavePassModal.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/save-modal/SavePassModal.tsx
@@ -5,6 +5,7 @@ import { Button } from 'design-system/button';
 import { Modal } from 'design-system/modal';
 import { Controller, useFormContext, useFormState } from 'react-hook-form';
 import styles from './save-pass-modal.module.scss';
+import { useEffect } from 'react';
 
 type Props = {
     visible: boolean;
@@ -14,6 +15,22 @@ type Props = {
 export const SavePassModal = ({ visible, onCancel, onAccept }: Props) => {
     const form = useFormContext<Pass>();
     const { isValid } = useFormState({ control: form.control });
+
+    useEffect(() => {
+        if (visible) {
+            const isNewPass = form.getValues('id') === undefined;
+            const blockingCriteria = form.getValues('blockingCriteria');
+            if (isNewPass && blockingCriteria.length > 0) {
+                const newName = blockingCriteria
+                    .map((b) => {
+                        const name = b.toString().replaceAll('_', '');
+                        return name[0].toUpperCase() + name.substring(1).toLowerCase();
+                    })
+                    .join('_');
+                form.setValue('name', newName);
+            }
+        }
+    }, [visible]);
 
     const footer = () => (
         <>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/PassList.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/PassList.tsx
@@ -59,7 +59,7 @@ export const PassList = ({ passes, selectedPass, onSetSelectedPass, onAddPass, o
                     labelPosition="right"
                     unstyled
                     onClick={onAddPass}
-                    disabled={selectedPass?.id === undefined}
+                    disabled={selectedPass !== undefined && selectedPass?.id === undefined}
                     className={styles.addPassButton}>
                     Add pass configuration
                 </Button>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/PassList.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/PassList.tsx
@@ -59,6 +59,7 @@ export const PassList = ({ passes, selectedPass, onSetSelectedPass, onAddPass, o
                     labelPosition="right"
                     unstyled
                     onClick={onAddPass}
+                    disabled={selectedPass?.id === undefined}
                     className={styles.addPassButton}>
                     Add pass configuration
                 </Button>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/pass-entry/pass-entry.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/pass-entry/pass-entry.module.scss
@@ -8,11 +8,17 @@
     gap: 0.75rem;
     width: 100%;
     @extend %thin-bottom;
+    word-break: break-all;
 
     &.selected {
         background: colors.$primary-lightest;
         .border {
             border-left: 0.25rem solid colors.$primary;
+        }
+
+        .content .passNameRow .nameLink {
+            color: colors.$primary;
+            font-weight: 700;
         }
     }
 
@@ -34,10 +40,9 @@
             align-items: center;
 
             .nameLink {
-                color: colors.$primary;
                 font-size: 1rem;
                 font-style: normal;
-                font-weight: 700;
+                font-weight: 400;
                 line-height: normal;
                 cursor: pointer;
                 text-align: left;

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/pass-list.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-list/pass-list.module.scss
@@ -21,6 +21,16 @@
     .addPassButton {
         margin-top: 0.5rem !important;
         text-decoration: none;
+
+        &:disabled {
+            color: colors.$disabled-darker !important;
+            background: none !important;
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
     }
 
     .noPassesText {

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementRow/DataElementRow.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementRow/DataElementRow.tsx
@@ -117,7 +117,6 @@ export const DataElementRow = ({ fieldName, field, dataElements }: Props) => {
                     )}
                 />
             </td>
-            <td></td>
         </tr>
     );
 };

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.module.scss
@@ -80,6 +80,7 @@
             padding-left: 1.125rem;
             align-items: center;
             justify-content: center;
+
             label::before {
                 margin-top: -0.85rem;
                 width: 1rem;
@@ -113,8 +114,6 @@
 }
 
 .infoIcon svg {
-    height: 1.25rem !important;
-    width: 1rem !important;
     vertical-align: middle;
     display: inline-block;
     gap: 0.125rem;

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.module.scss
@@ -34,7 +34,7 @@
             margin: 0 !important;
             box-sizing: border-box;
 
-            tr th{
+            tr th {
                 max-height: 1.5625rem !important;
                 line-height: 1.5625rem;
                 padding-left: 0.375rem;
@@ -68,8 +68,7 @@
         tr th,
         td {
             height: 1.5625rem;
-            width: 13.5rem;
-            padding: 0.2rem 0.4rem;
+            padding: 0.25rem 0.5rem;
             text-align: left !important;
             vertical-align: middle;
         }
@@ -88,13 +87,12 @@
             }
         }
 
-        tbody tr:nth-child(odd) td{
+        tbody tr:nth-child(odd) td {
             background-color: colors.$base-lightest;
             width: 100%;
             display: table-cell;
         }
     }
-
 }
 
 .headerWithIcon {
@@ -104,8 +102,7 @@
     max-height: 1rem;
 }
 
-
-.infoIcon use{
+.infoIcon use {
     fill: colors.$primary !important;
     align-items: center;
     display: inline-flex;
@@ -120,7 +117,7 @@
     width: 1rem !important;
     vertical-align: middle;
     display: inline-block;
-    gap:0.125rem;
+    gap: 0.125rem;
 }
 
 .cardInfo {

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.tsx
@@ -114,7 +114,7 @@ export const DataElementsForm = ({ dataElements }: Props) => {
                                 <span className={styles.headerWithIcon}>
                                     Threshold{' '}
                                     <span ref={thresholdRef} className={styles.infoIcon}>
-                                        <RichTooltip anchorRef={thresholdRef} marginTop={38}>
+                                        <RichTooltip anchorRef={thresholdRef} marginLeft={-300} marginTop={38}>
                                             <span>Threshold - </span>
                                             <span style={{ fontWeight: 'normal' }}>
                                                 Values above which two strings are said to be “similar enough” that

--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.tsx
@@ -63,7 +63,7 @@ export const DataElementsForm = ({ dataElements }: Props) => {
         <Card
             id="dataElementsCard"
             title="Data elements"
-            subtext="This table contains all the possible data elements that are available for use as person matching criteria">
+            subtext="This table contains all the possible data elements that are available for use as person matching criteria.">
             <div className={styles.dataElementsForm}>
                 <table>
                     <thead>
@@ -128,7 +128,7 @@ export const DataElementsForm = ({ dataElements }: Props) => {
                             </th>
                         </tr>
                         <tr className={styles.border}>
-                            <th colSpan={6} />
+                            <th colSpan={5} />
                         </tr>
                     </thead>
                     <tbody>

--- a/apps/modernization-ui/src/design-system/richTooltip/useRichTooltip.ts
+++ b/apps/modernization-ui/src/design-system/richTooltip/useRichTooltip.ts
@@ -31,7 +31,7 @@ export function useTooltip({ anchorRef, richTooltipRef, marginTop, marginLeft }:
 
         if (isVisible) {
             const { top, left, width } = anchorRef.current.getBoundingClientRect();
-            setPosition({ ...calcBottomLeftPosition(marginTop || top, marginLeft || left, width) });
+            setPosition({ ...calcBottomLeftPosition(marginTop ?? top, marginLeft ? marginLeft + left : left, width) });
         }
 
         if (!isVisible) {

--- a/apps/modernization-ui/src/design-system/richTooltip/useRichTooltip.ts
+++ b/apps/modernization-ui/src/design-system/richTooltip/useRichTooltip.ts
@@ -13,7 +13,7 @@ type Position = {
     width?: number;
 };
 
-export function useTooltip({ anchorRef, richTooltipRef, marginTop, marginLeft }: UseTooltipProps) {
+export function useTooltip({ anchorRef, richTooltipRef, marginTop, marginLeft = 0 }: UseTooltipProps) {
     const [isVisible, setIsVisible] = useState<boolean>(false);
     const [position, setPosition] = useState<Position>({});
 
@@ -31,7 +31,7 @@ export function useTooltip({ anchorRef, richTooltipRef, marginTop, marginLeft }:
 
         if (isVisible) {
             const { top, left, width } = anchorRef.current.getBoundingClientRect();
-            setPosition({ ...calcBottomLeftPosition(marginTop ?? top, marginLeft ? marginLeft + left : left, width) });
+            setPosition({ ...calcBottomLeftPosition(marginTop ?? top, marginLeft + left, width) });
         }
 
         if (!isVisible) {


### PR DESCRIPTION
## Description

Addresses findings from design review

Findings addressed
1. Data elements form should extend to end of table (width)
2. Add `.` to end of data elements info 
3. Fix padding on data element table cell
4. Fix sizing of info Icons on data elements configuration page
5. Fix width of Pass selection panel
6. Pass names should only be blue when selected
7. Add pass button should have disabled styling when adding a new pass
8. Provide a default name for new pass based on selected blocking attributes
9. Fix gap between attribute and info for blocking and matching criteria display
10. Fix Lower bound / Upper bound info icon alignment

## Tickets

* [CND-262](https://cdc-nbs.atlassian.net/browse/CND-262)

## Demo

### Data elements form should extend to end of table (width)
![image](https://github.com/user-attachments/assets/522cccbc-0cee-4f31-ad8f-cf0b0006e519)

### Add `.` to end of data elements info 
![image](https://github.com/user-attachments/assets/a0110d11-bd5c-4b2c-9317-6efbb0961ec9)

### Fix padding on data element table cell
![image](https://github.com/user-attachments/assets/b3de579e-c0fe-4724-a480-a801e60870de)


### Fix sizing of info Icons on data elements configuration page
![image](https://github.com/user-attachments/assets/4e73ded1-0931-445a-831e-7e68a115030c)

### Fix width of Pass selection panel
![image](https://github.com/user-attachments/assets/a17af8c0-ef06-469a-bb59-799132890fdd)

### Pass names should only be blue when selected
![image](https://github.com/user-attachments/assets/89921391-184c-4371-b78d-e99ce5215a4e)
![image](https://github.com/user-attachments/assets/2e4e78a2-eaf8-45c1-9bb5-c8f5a1bcff28)

### Add pass button should have disabled styling when adding a new pass
![image](https://github.com/user-attachments/assets/8aeced3c-ca7b-4190-bd19-43a20f865239)

### Provide a default name for new pass based on selected blocking attributes
![image](https://github.com/user-attachments/assets/cc7aa3e6-062c-405f-8ec8-8da9a95c1ee3)

### Fix gap between attribute and info for blocking and matching criteria display
![image](https://github.com/user-attachments/assets/729fe009-25cc-4882-9bfd-9e435775bb8d)
![image](https://github.com/user-attachments/assets/070aca52-35da-402b-a4a8-d809f1dc1463)

### Fix Lower bound / Upper bound info icon alignment
![image](https://github.com/user-attachments/assets/b71c8016-9863-4630-a4e1-087a86b27102)




## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-262]: https://cdc-nbs.atlassian.net/browse/CND-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ