### PR TITLE
[CNFT1-3994] top / down (vertical) styles

### DIFF
--- a/apps/modernization-ui/.storybook/main.ts
+++ b/apps/modernization-ui/.storybook/main.ts
@@ -1,23 +1,18 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
-  ],
-  "addons": [
-    "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app",
-    "@storybook/addon-onboarding",
-    "@chromatic-com/storybook",
-    "@storybook/addon-interactions"
-  ],
-  "framework": {
-    "name": "@storybook/react-webpack5",
-    "options": {}
-  },
-  "staticDirs": [
-    "../public"
-  ]
+    stories: ['../src/**/*.mdx', '../src/**/*.stories.@(tsx)'],
+    addons: [
+        '@storybook/addon-essentials',
+        '@storybook/preset-create-react-app',
+        '@storybook/addon-onboarding',
+        '@chromatic-com/storybook',
+        '@storybook/addon-interactions'
+    ],
+    framework: {
+        name: '@storybook/react-webpack5',
+        options: {}
+    },
+    staticDirs: ['../public']
 };
 export default config;

--- a/apps/modernization-ui/.storybook/preview.ts
+++ b/apps/modernization-ui/.storybook/preview.ts
@@ -1,13 +1,6 @@
 import type { Preview } from '@storybook/react';
 import 'styles/global.scss';
 
-// v7-style sort
-function storySort(a, b) {
-    return a.title === b.title
-      ? 0
-      : a.id.localeCompare(b.id, undefined, { numeric: true });
-}
-
 const preview: Preview = {
     parameters: {
         controls: {
@@ -17,9 +10,10 @@ const preview: Preview = {
             }
         },
         options: {
-            storySort: (a, b) => a.title === b.title ? 0 : a.id.localeCompare(b.id, undefined, { numeric: true })
+            storySort: (a, b) => (a.title === b.title ? 0 : a.id.localeCompare(b.id, undefined, { numeric: true }))
         }
-    }
+    },
+    tags: ['autodocs']
 };
 
 export default preview;

--- a/apps/modernization-ui/src/apps/search/criteria/search-criteria.module.scss
+++ b/apps/modernization-ui/src/apps/search/criteria/search-criteria.module.scss
@@ -4,7 +4,7 @@
 
     gap: 1rem;
 
-    padding: 1rem;
+    padding: 1rem 0;
 
     &.small {
         gap: 0.5rem;

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -4,12 +4,12 @@ import { DateCriteriaField, validateDateCriteria } from 'design-system/date/crit
 import { TextCriteriaField } from 'design-system/input/text/criteria';
 import { SingleSelect } from 'design-system/select';
 import { EntryFieldsProps } from 'design-system/entry';
-import { Input } from 'components/FormInputs/Input';
 import { validNameRule } from 'validation/entry';
 import { SearchCriteria } from 'apps/search/criteria';
 import { PatientCriteriaEntry, statusOptions } from 'apps/search/patient/criteria';
 import { Permitted } from 'libs/permission';
 import { searchableGenders } from './searchableGenders';
+import { TextInputField } from 'design-system/input';
 
 export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
     const { control } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
@@ -91,15 +91,14 @@ export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
                     }
                 }}
                 render={({ field: { onChange, onBlur, value, name }, fieldState: { error } }) => (
-                    <Input
+                    <TextInputField
                         onBlur={onBlur}
                         onChange={onChange}
-                        defaultValue={value}
+                        value={value}
                         type="text"
                         label="Patient ID(s)"
                         helperText="Separate IDs by commas, semicolons, or spaces"
                         name={name}
-                        htmlFor={name}
                         id={name}
                         sizing={sizing}
                         orientation={orientation}

--- a/apps/modernization-ui/src/design-system/field/Field.stories.tsx
+++ b/apps/modernization-ui/src/design-system/field/Field.stories.tsx
@@ -21,17 +21,6 @@ export const Default: Story = {
     }
 };
 
-export const Vertical: Story = {
-    args: {
-        label: 'Name',
-        helperText: 'This is a helper text',
-        children: <span>Field</span>,
-        sizing: 'medium',
-        orientation: 'vertical',
-        htmlFor: 'name'
-    }
-};
-
 export const ErrorWarning: Story = {
     args: {
         label: 'Name',

--- a/apps/modernization-ui/src/design-system/field/Field.tsx
+++ b/apps/modernization-ui/src/design-system/field/Field.tsx
@@ -28,7 +28,6 @@ const Field = ({ sizing = 'large', orientation = 'vertical', className, children
     const resolvedClasses = classNames(
         styles.entry,
         className,
-        styles.vertical,
         sizing && styles[sizing],
         { [styles.warn]: remaining.warning && !remaining.error },
         { [styles.error]: remaining.error }

--- a/apps/modernization-ui/src/design-system/field/HorizontalField.stories.tsx
+++ b/apps/modernization-ui/src/design-system/field/HorizontalField.stories.tsx
@@ -1,0 +1,51 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Field } from './Field';
+
+const meta = {
+    title: 'Design System/Field/Left Right',
+    component: Field,
+    argTypes: {
+        label: { required: true }
+    }
+} satisfies Meta<typeof Field>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        label: 'Label',
+        children: <span>Field</span>,
+        orientation: 'horizontal',
+        htmlFor: 'story-horizontal-field'
+    }
+};
+
+export const Required: Story = {
+    args: {
+        ...Default.args,
+        required: true
+    }
+};
+
+export const HelperText: Story = {
+    args: {
+        ...Default.args,
+        helperText: 'Helper text'
+    }
+};
+
+export const Error: Story = {
+    args: {
+        ...Default.args,
+        error: 'Helpful error message'
+    }
+};
+
+export const Warning: Story = {
+    args: {
+        ...Default.args,
+        warning: 'Helpful warning message'
+    }
+};

--- a/apps/modernization-ui/src/design-system/field/VerticalField.stories.tsx
+++ b/apps/modernization-ui/src/design-system/field/VerticalField.stories.tsx
@@ -1,0 +1,48 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Field } from './Field';
+
+const meta = {
+    title: 'Design System/Field/Top down',
+    component: Field
+} satisfies Meta<typeof Field>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        label: 'Label',
+        children: <span>Field</span>,
+        orientation: 'vertical',
+        htmlFor: 'story-vertical-field'
+    }
+};
+
+export const Required: Story = {
+    args: {
+        ...Default.args,
+        required: true
+    }
+};
+
+export const HelperText: Story = {
+    args: {
+        ...Default.args,
+        helperText: 'Helper text'
+    }
+};
+
+export const Error: Story = {
+    args: {
+        ...Default.args,
+        error: 'Helpful error message'
+    }
+};
+
+export const Warning: Story = {
+    args: {
+        ...Default.args,
+        warning: 'Helpful warning message'
+    }
+};

--- a/apps/modernization-ui/src/design-system/field/VerticalField.tsx
+++ b/apps/modernization-ui/src/design-system/field/VerticalField.tsx
@@ -18,9 +18,9 @@ type Props = {
 };
 
 const VerticalField = ({ className, htmlFor, label, helperText, required, error, warning, children }: Props) => (
-    <span className={classNames(styles.entry, className, { [styles.alert]: warning || error })}>
-        <span className={styles.textContainer}>
-            <label className={classNames({ required })} htmlFor={htmlFor}>
+    <span className={classNames(styles.entry, className)}>
+        <span className={styles.labels}>
+            <label className={classNames({ [styles.required]: required })} htmlFor={htmlFor}>
                 {label}
             </label>
             {helperText && <HelperText id={`${htmlFor}-hint`}>{helperText}</HelperText>}

--- a/apps/modernization-ui/src/design-system/field/vertical-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/vertical-field.module.scss
@@ -1,14 +1,19 @@
+@use 'styles/components';
+
 .entry {
     flex-direction: column;
     gap: 0.25rem;
+    padding: 0 0.75rem;
 
-    &.alert {
-        padding-left: 1.25rem;
-    }
-
-    .textContainer {
+    .labels {
         display: flex;
         flex-direction: column;
         gap: 0.125rem;
+
+        label {
+            &.required {
+                @include components.required();
+            }
+        }
     }
 }

--- a/apps/modernization-ui/src/design-system/input/text/TextInputField.stories.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInputField.stories.tsx
@@ -14,26 +14,62 @@ export const Default: Story = {
     args: {
         id: 'text-input',
         label: 'Text Input',
-        placeholder: 'No Data',
-        value: 'some text',
-        onChange: (value) => {
-            console.log('Value changed:', value);
-        }
+        onChange: () => {}
     }
 };
 
 export const Horizontal: Story = {
     args: {
         ...Default.args,
-        id: 'text-input-horizontal',
         orientation: 'horizontal'
+    }
+};
+
+export const HorizontalHelperText: Story = {
+    args: {
+        ...Horizontal.args,
+        helperText: 'Helper text'
+    }
+};
+
+export const HorizontalError: Story = {
+    args: {
+        ...Horizontal.args,
+        error: 'Helpful error message'
+    }
+};
+
+export const HorizontalWarning: Story = {
+    args: {
+        ...Horizontal.args,
+        error: 'Helpful warning message'
     }
 };
 
 export const Vertical: Story = {
     args: {
         ...Default.args,
-        id: 'text-input-vertical',
         orientation: 'vertical'
+    }
+};
+
+export const VerticalHelperText: Story = {
+    args: {
+        ...Vertical.args,
+        helperText: 'Helper text'
+    }
+};
+
+export const VerticalError: Story = {
+    args: {
+        ...Vertical.args,
+        error: 'Helpful error message'
+    }
+};
+
+export const VerticalWarning: Story = {
+    args: {
+        ...Vertical.args,
+        warning: 'Helpful warning message'
     }
 };

--- a/apps/modernization-ui/src/design-system/input/text/TextInputField.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextInputField.tsx
@@ -8,6 +8,7 @@ const TextInputField = ({
     label,
     orientation,
     sizing,
+    helperText,
     error,
     warning,
     required,
@@ -19,6 +20,7 @@ const TextInputField = ({
             sizing={sizing}
             label={label}
             htmlFor={id}
+            helperText={helperText}
             required={required}
             error={error}
             warning={warning}>

--- a/apps/modernization-ui/src/styles/_components.scss
+++ b/apps/modernization-ui/src/styles/_components.scss
@@ -1,5 +1,13 @@
 @use 'styles/colors';
 
+@mixin required() {
+    &::after {
+        content: '*';
+        padding-left: 0.25rem;
+        color: colors.$mandatory;
+    }
+}
+
 $small-font-size: 0.75rem;
 $small-height: 1.5rem;
 $small-textarea-height: 5.0625rem;

--- a/apps/modernization-ui/src/styles/global.scss
+++ b/apps/modernization-ui/src/styles/global.scss
@@ -1,9 +1,11 @@
-@forward 'styles/headers';
 @use 'styles/colors';
-@import 'styles/uswds';
-@import 'styles/typography';
-@import 'styles/modal';
-@import 'styles/tooltip';
+@use 'styles/components';
+
+@forward 'styles/headers';
+@forward 'styles/uswds';
+@forward 'styles/typography';
+@forward 'styles/modal';
+@forward 'styles/tooltip';
 
 body {
     height: 100vh;
@@ -16,7 +18,8 @@ body {
 }
 
 .select-indicator {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTEyIDUuODNMMTUuMTcgOWwxLjQxLTEuNDFMMTIgMyA3LjQxIDcuNTkgOC44MyA5IDEyIDUuODN6bTAgMTIuMzRMOC44MyAxNWwtMS40MSAxLjQxTDEyIDIxbDQuNTktNC41OUwxNS4xNyAxNSAxMiAxOC4xN3oiLz48L3N2Zz4=),
+    background-image:
+        url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTEyIDUuODNMMTUuMTcgOWwxLjQxLTEuNDFMMTIgMyA3LjQxIDcuNTkgOC44MyA5IDEyIDUuODN6bTAgMTIuMzRMOC44MyAxNWwtMS40MSAxLjQxTDEyIDIxbDQuNTktNC41OUwxNS4xNyAxNSAxMiAxOC4xN3oiLz48L3N2Zz4=),
         linear-gradient(transparent, transparent);
 }
 
@@ -38,10 +41,7 @@ td span {
 }
 
 .required {
-    &::after {
-        content: ' *';
-        color: colors.$mandatory;
-    }
+    @include components.required();
 }
 .required-before {
     &::before {


### PR DESCRIPTION
## Description

Moved the left and right padding of the search criteria from the container to the `Field` component to prevent fields from shifting right when in an error state.

![image](https://github.com/user-attachments/assets/40158257-99e5-48f5-a46a-00f3f5e86984)

![image](https://github.com/user-attachments/assets/9a5d4bb9-bb61-45e3-ab62-20ee6371ebc9)

- Replaces use of `Input` on Basic Information search criteria with `TextInputField`
- Adds stories for Left Right and Top Down fields
- Adds stories for TextInputField

## Tickets

* [CNFT1-3994](https://cdc-nbs.atlassian.net/browse/CNFT1-3994)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
