### PR TITLE
CNFT1-3990: RepeatingBlock buttons fix aria descriptions

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -65,3 +65,9 @@
         }
     }
 }
+
+.iconColumn {
+    div {
+        visibility: hidden !important;
+    }   
+}

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -332,7 +332,7 @@ describe('RepeatingBlock', () => {
     });
 
     it('should render view when view icon clicked', async () => {
-        const { getByLabelText, getByText } = render(
+        const { getByLabelText, getByText, getAllByRole } = render(
             <Fixture
                 values={[
                     {
@@ -351,6 +351,39 @@ describe('RepeatingBlock', () => {
 
         expect(getByText('Render view first value: first-value')).toBeInTheDocument();
         expect(getByText('Render view second value: second-value')).toBeInTheDocument();
+
+        const buttons = getAllByRole('button');
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0]).toHaveTextContent('Add test title');
+        expect(buttons[0].innerHTML).toContain('svg');
+    });
+
+    it('should render edit when edit icon clicked', async () => {
+        const { getByLabelText, getAllByRole } = render(
+            <Fixture
+                values={[
+                    {
+                        firstInput: 'first-value',
+                        secondInput: 'second-value',
+                        others: []
+                    }
+                ]}
+            />
+        );
+
+        const editIcon = getByLabelText('Edit');
+        const user = userEvent.setup();
+
+        await user.click(editIcon);
+
+        expect(getByLabelText('First Input')).toBeInTheDocument();
+        expect(getByLabelText('Second Input')).toBeInTheDocument();
+
+        const buttons = getAllByRole('button');
+        expect(buttons).toHaveLength(2);
+        expect(buttons[0]).toHaveTextContent('Update test title');
+        expect(buttons[0].innerHTML).not.toContain('svg');
+        expect(buttons[1]).toHaveTextContent('Cancel');
     });
 
     it('should delete row when delete icon clicked', async () => {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Input } from 'components/FormInputs/Input';
 import { RepeatingBlock, RepeatingBlockProps } from './RepeatingBlock';
+import { axe } from 'jest-axe';
 
 type TestType = {
     firstInput: string;
@@ -139,6 +140,7 @@ describe('RepeatingBlock', () => {
 
         const button = getByRole('button', { name: 'Add test title' });
         expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute('aria-description');
     });
 
     it('should display add button with correct size', () => {
@@ -200,7 +202,10 @@ describe('RepeatingBlock', () => {
 
         await user.type(input1, '-change');
 
-        expect(getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+        const button = getByRole('button', { name: 'Clear' });
+
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute('aria-description');
     });
 
     it('should reset values to default state when Clear is clicked.', async () => {
@@ -356,6 +361,7 @@ describe('RepeatingBlock', () => {
         expect(buttons).toHaveLength(1);
         expect(buttons[0]).toHaveTextContent('Add test title');
         expect(buttons[0].innerHTML).toContain('svg');
+        expect(buttons[0]).toHaveAttribute('aria-description');
     });
 
     it('should render edit when edit icon clicked', async () => {
@@ -382,8 +388,10 @@ describe('RepeatingBlock', () => {
         const buttons = getAllByRole('button');
         expect(buttons).toHaveLength(2);
         expect(buttons[0]).toHaveTextContent('Update test title');
+        expect(buttons[0]).toHaveAttribute('aria-description');
         expect(buttons[0].innerHTML).not.toContain('svg');
         expect(buttons[1]).toHaveTextContent('Cancel');
+        expect(buttons[1]).toHaveAttribute('aria-description');
     });
 
     it('should delete row when delete icon clicked', async () => {
@@ -550,5 +558,11 @@ describe('RepeatingBlock', () => {
 
         expect(getByText('First input is required.')).toBeInTheDocument();
         expect(isValid).toHaveBeenCalledWith(false);
+    });
+
+    it('should render with no accessibility violations', async () => {
+        const { container } = render(<Fixture />);
+
+        expect(await axe(container)).toHaveNoViolations();
     });
 });

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -100,7 +100,8 @@ const RepeatingBlock = <V extends FieldValues>({
 
     const iconColumn: Column<V> = {
         id: 'actions',
-        name: '',
+        name: 'Actions',
+        className: styles.iconColumn,
         render: (value: V) => (
             <div className={classNames(styles.actions, sizing && styles[sizing])}>
                 <div data-tooltip-position="top" aria-label="View" onClick={() => view(value)}>
@@ -207,7 +208,11 @@ const RepeatingBlock = <V extends FieldValues>({
                     </Button>
                 </Shown>
                 <Shown when={status === 'viewing'}>
-                    <Button outline sizing={sizing} onClick={handleReset}>
+                    <Button
+                        outline
+                        sizing={sizing}
+                        aria-description={`add ${title.toLowerCase()}`}
+                        onClick={handleReset}>
                         <Icon name="add" sizing={sizing} />
                         {`Add ${title.toLowerCase()}`}
                     </Button>

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -171,7 +171,11 @@ const RepeatingBlock = <V extends FieldValues>({
             </Shown>
             <footer>
                 <Shown when={status === 'adding'}>
-                    <Button outline sizing={sizing} onClick={form.handleSubmit(handleAdd)}>
+                    <Button
+                        outline
+                        sizing={sizing}
+                        aria-description={`add ${title.toLowerCase()}`}
+                        onClick={form.handleSubmit(handleAdd)}>
                         <Icon name="add" sizing={sizing} />
                         {`Add ${title.toLowerCase()}`}
                     </Button>
@@ -179,7 +183,7 @@ const RepeatingBlock = <V extends FieldValues>({
                         <Button
                             outline
                             sizing={sizing}
-                            aria-details={`clear ${title.toLowerCase()}`}
+                            aria-description={`clear ${title.toLowerCase()}`}
                             onClick={handleClear}
                             onMouseDown={(e) => e.preventDefault() /* prevent need to double click after blur */}>
                             Clear
@@ -187,14 +191,17 @@ const RepeatingBlock = <V extends FieldValues>({
                     </Shown>
                 </Shown>
                 <Shown when={status === 'editing'}>
-                    <Button outline sizing={sizing} onClick={form.handleSubmit(handleUpdate)}>
-                        <Icon name="add" sizing={sizing} />
+                    <Button
+                        outline
+                        sizing={sizing}
+                        aria-description={`update ${title.toLowerCase()}`}
+                        onClick={form.handleSubmit(handleUpdate)}>
                         {`Update ${title.toLowerCase()}`}
                     </Button>
                     <Button
                         outline
                         sizing={sizing}
-                        aria-details={`cancel editing current ${title.toLowerCase()}`}
+                        aria-description={`cancel editing current ${title.toLowerCase()}`}
                         onClick={handleReset}>
                         Cancel
                     </Button>


### PR DESCRIPTION
## Description

- Fix all buttons to have aria-description attribute with reasonable description.
- Add Axe unit test to test for accessibility issues.
- Fix empty header accessibility issue.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3990)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
