### PR TITLE
distinguishing between when filter for a id is applied or pending

### DIFF
--- a/apps/modernization-ui/src/design-system/filter/useFilter.tsx
+++ b/apps/modernization-ui/src/design-system/filter/useFilter.tsx
@@ -50,7 +50,14 @@ const FilterProvider = ({ children }: FilterProviderProps) => {
 
     const apply = () => setFilter(pendingFilter);
 
-    const clear = (id: string) => updateFilter(withoutProperty(id)(pendingFilter) as Filter | undefined);
+    const clear = (id: string) => {
+        const applied = filter?.[id] !== undefined;
+        if (applied) {
+            setFilter(withoutProperty(id)(filter) as Filter | undefined);
+        } else {
+            setPendingFilter(withoutProperty(id)(pendingFilter) as Filter | undefined);
+        }
+    };
 
     const clearAll = () => updateFilter(undefined);
     const reset = useCallback(() => {


### PR DESCRIPTION
## Description
The original implementation had a limitation: clicking on X or removing the text manually on any filter would call updateFilter(withoutProperty(id)(pendingFilter)), which would remove that property from pendingFilter, set filter to match the modified pendingFilter

with the changes this is solved by separating applied filters (filter state) and pending filters (pendingFilter state) and only applying the appropriate state based on where the filter exists because basically before the clear used updateFilter which would set both filter and pendingFilter to the same value. 


Attaching screen recording to show expected behavior given the scenario of having applied filter on one field and entering text in other fields but then removing the text(without having applied filter) will not apply filter on other fields where there is text in pending state
https://github.com/user-attachments/assets/76ced955-f367-483b-bb7f-4efd9ae65393


## Tickets

* [CNFT1-3951](https://cdc-nbs.atlassian.net/browse/CNFT1-3951)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3951]: https://cdc-nbs.atlassian.net/browse/CNFT1-3951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ