### PR TITLE
CNFT1-3936 When the user removes the address filter condition by removing inputted text, the filter has to be removed.

### DIFF
--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
@@ -31,7 +31,14 @@ const HeaderFilterField = ({ descriptor, label, filtering, sizing }: HeaderFilte
 
     const handleClear = () => clear(descriptor.id);
 
-    const handleChange = (next?: string) => add(descriptor.id, next);
+    const handleChange = (next?: string) => {
+        if (next) {
+            add(descriptor.id, next);
+        } else {
+            add(descriptor.id, next);
+            clear(descriptor.id);
+        }
+    };
 
     return (
         <Shown when={descriptor.type === 'text'}>


### PR DESCRIPTION
## Description

When user removes the filter condition **within the filter column** using backspace or delete the filter has to be removed. 
The previous change removed the filter condition on the patient search panel when text in the input box was cleared. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3936)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
