### PR TITLE
Remove max width

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/data-elements/form/DataElementsForm/DataElementsForm.module.scss
@@ -4,7 +4,6 @@
 .dataElementsForm {
     height: 100%;
     width: 100%;
-    max-width: 92.5rem;
     overflow: hidden;
     display: block;
     text-align: left;


### PR DESCRIPTION
## Description

Removes unnecessary `max-width` on data elements table.

## Tickets

* [CND-262](https://cdc-nbs.atlassian.net/browse/CND-262)

## Before
![image](https://github.com/user-attachments/assets/30398444-edd3-4e8e-a0c3-e2b0da6d2a64)

## After
![image](https://github.com/user-attachments/assets/0bd64648-a056-4055-93d1-746158b7c1da)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-262]: https://cdc-nbs.atlassian.net/browse/CND-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ