### PR TITLE
[CNFT1-3950]: fix filter empty value when entered

### DIFF
--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.spec.tsx
@@ -58,16 +58,4 @@ describe('when filtering table data from the header', () => {
 
         expect(mockAdd).toHaveBeenCalledWith('applying-value', 't');
     });
-
-    it('should clear the filter when the clear button is pressed', async () => {
-        const { getByRole } = render(<Fixture id="clearing-value" />);
-        const input = getByRole('textbox');
-
-        const user = userEvent.setup();
-        await user.clear(input).then(() => user.type(input, '{Enter}'));
-
-        expect(mockClear).toHaveBeenCalledWith('clearing-value');
-
-        expect(input).toHaveValue('');
-    });
 });

--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.spec.tsx
@@ -58,4 +58,31 @@ describe('when filtering table data from the header', () => {
 
         expect(mockAdd).toHaveBeenCalledWith('applying-value', 't');
     });
+
+    it('should clear the filter when clearing text from an input with existing value', async () => {
+        mockValueOf.mockReturnValue('existing value');
+        
+        const { getByRole } = render(<Fixture id="clearing-value" />);
+        const input = getByRole('textbox');
+
+        const user = userEvent.setup();
+        await user.clear(input);
+
+        expect(mockAdd).toHaveBeenCalledWith('clearing-value', undefined);
+        expect(mockClear).toHaveBeenCalledWith('clearing-value');
+    });
+    
+    it('should not clear the filter when there is no existing filter value', async () => {
+        mockValueOf.mockReturnValue('');
+        
+        const { getByRole } = render(<Fixture id="clearing-value" />);
+        const input = getByRole('textbox');
+
+        mockClear.mockClear();
+        
+        const user = userEvent.setup();
+        await user.clear(input);
+
+        expect(mockClear).not.toHaveBeenCalled();
+    });
 });

--- a/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/filter/HeaderFilterField.tsx
@@ -20,12 +20,7 @@ const HeaderFilterField = ({ descriptor, label, filtering, sizing }: HeaderFilte
     const handleKey = (event: ReactKeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'Enter') {
             event.stopPropagation();
-            const next = (event.target as HTMLInputElement).value;
-            if (next) {
-                apply();
-            } else {
-                clear(descriptor.id);
-            }
+            apply();
         }
     };
 


### PR DESCRIPTION
## Description

When the user is on a field in the filter fields and has no value entered but presses enter the previously enter text from other fields must be applied as a filter

## Tickets

* [CNFT1-3950](https://cdc-nbs.atlassian.net/browse/CNFT1-3950)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
