### PR TITLE
[Refactor] usePage to usePagination

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/PageBuilderRouting.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/PageBuilderRouting.tsx
@@ -1,5 +1,5 @@
 import { FeatureGuard, FeatureLayout } from 'feature';
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { Navigate, RouteObject } from 'react-router';
 import { PageLibrary } from './page/library/PageLibrary';
 import { Edit } from './page/management/edit/Edit';
@@ -65,9 +65,9 @@ const routing: RouteObject[] = [
                                     {
                                         index: true,
                                         element: (
-                                            <PageProvider>
+                                            <PaginationProvider>
                                                 <BusinessRulesLibrary />
-                                            </PageProvider>
+                                            </PaginationProvider>
                                         )
                                     },
                                     {

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/AddQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/AddQuestion.tsx
@@ -3,7 +3,7 @@ import { useAlert } from 'alert';
 import { CreateCodedQuestionRequest } from 'apps/page-builder/generated';
 import { CreateQuestionRequest, useCreateQuestion } from 'apps/page-builder/hooks/api/useCreateQuestion';
 import classNames from 'classnames';
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import { ButtonBar } from '../ButtonBar/ButtonBar';
@@ -55,13 +55,13 @@ export const AddQuestion = ({ onBack, onClose, onQuestionCreated }: Props) => {
                 />
             )}
             {state === 'findValueset' && (
-                <PageProvider>
+                <PaginationProvider>
                     <FindValueSet
                         onCancel={() => setState('create')}
                         onClose={onClose}
                         onCreateNew={() => setState('createValueset')}
                     />
-                </PageProvider>
+                </PaginationProvider>
             )}
             {state === 'createValueset' && (
                 <CreateEditValueset

--- a/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/valueset/ValuesetSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/AddQuestion/valueset/ValuesetSearch.tsx
@@ -4,7 +4,7 @@ import { ButtonBar } from '../../ButtonBar/ButtonBar';
 import { CloseableHeader } from '../../CloseableHeader/CloseableHeader';
 import { ValuesetSearchTable } from '../../ValuesetSearchTable/ValuesetSearchTable';
 import styles from './valueset-search.module.scss';
-import { Status, usePage } from 'page';
+import { Status, usePagination } from 'pagination';
 import { ValuesetSort, useFindValuesets } from 'apps/page-builder/hooks/api/useFindValueset';
 
 type Props = {
@@ -15,7 +15,7 @@ type Props = {
 };
 export const ValuesetSearch = ({ onCancel, onClose, onAccept, onCreateNew }: Props) => {
     const [selectedValueset, setSelectedValueset] = useState<number | undefined>(undefined);
-    const { page, ready, firstPage, reload } = usePage();
+    const { page, ready, firstPage, reload } = usePagination();
     const [query, setQuery] = useState<string>('');
     const [sort, setSort] = useState<ValuesetSort | undefined>(undefined);
     const { isLoading, search, response } = useFindValuesets();

--- a/apps/modernization-ui/src/apps/page-builder/components/EditValueset/EditValueset.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/EditValueset/EditValueset.tsx
@@ -1,6 +1,6 @@
 import { Concept, Valueset } from 'apps/page-builder/generated';
 import { ConceptSort, useFindConcepts } from 'apps/page-builder/hooks/api/useFindConcepts';
-import { PageProvider, Status, usePage } from 'page';
+import { PaginationProvider, Status, usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 import { EditValuesetDetails } from './EditValuesetDetails';
 import { ViewValueset } from './ViewValueset';
@@ -17,9 +17,9 @@ type Props = {
 };
 export const EditValueset = (props: Props) => {
     return (
-        <PageProvider>
+        <PaginationProvider>
             <EditValuesetContent {...props}></EditValuesetContent>
-        </PageProvider>
+        </PaginationProvider>
     );
 };
 
@@ -27,7 +27,7 @@ const EditValuesetContent = ({ valueset, onClose, onAccept, onCancel, onValueset
     const [state, setState] = useState<'view' | 'create-concept' | 'edit-concept' | 'edit-valueset'>('view');
     const [editedConcept, setEditedConcept] = useState<Concept | undefined>(undefined);
     const { response, isLoading, search } = useFindConcepts();
-    const { page, ready, firstPage, reload } = usePage();
+    const { page, ready, firstPage, reload } = usePagination();
 
     const [sort, setSort] = useState<ConceptSort | undefined>(undefined);
 

--- a/apps/modernization-ui/src/apps/page-builder/components/EditValueset/concept/ConceptTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/EditValueset/concept/ConceptTable.tsx
@@ -3,7 +3,7 @@ import { Concept } from 'apps/page-builder/generated';
 import { ConceptSort, SortField } from 'apps/page-builder/hooks/api/useFindConcepts';
 import { TableBody, TableComponent } from 'components/Table';
 import { internalizeDate } from 'date';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 import { Direction } from 'sorting/Sort';
 import styles from './concept-table.module.scss';
@@ -30,7 +30,7 @@ type Props = {
     onEditConcept: (concept: Concept) => void;
 };
 export const ConceptTable = ({ concepts, loading, onSort, onEditConcept }: Props) => {
-    const { page, request } = usePage();
+    const { page, request } = usePagination();
     const [tableRows, setTableRows] = useState<TableBody[]>([]);
 
     const toRow = (concept: Concept): TableBody => {

--- a/apps/modernization-ui/src/apps/page-builder/components/ValuesetSearchTable/ValuesetSearchTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/ValuesetSearchTable/ValuesetSearchTable.tsx
@@ -3,7 +3,7 @@ import { ValueSetOption } from 'apps/page-builder/generated';
 import { SortField, ValuesetSort } from 'apps/page-builder/hooks/api/useFindValueset';
 import { Search } from 'components/Search/Search';
 import { TableBody, TableComponent } from 'components/Table';
-import { Status, usePage } from 'page';
+import { Status, usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 import { Direction } from 'sorting';
 import styles from './valueset-search-table.module.scss';
@@ -40,7 +40,7 @@ export const ValuesetSearchTable = ({
     onSortChange,
     onCreateNew
 }: Props) => {
-    const { page, request } = usePage();
+    const { page, request } = usePagination();
     const [tableRows, setTableRows] = useState<TableBody[]>([]);
 
     const doQuerySearch = (query?: string) => {

--- a/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionSearch.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon } from '@trussworks/react-uswds';
 import { ConditionSort, useConditionSearch } from 'apps/page-builder/condition/search/useConditionSearch';
 import { Search } from 'components/Search';
-import { PageProvider, Status, usePage } from 'page';
+import { PaginationProvider, Status, usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 import { ConditionTable } from './ConditionTable';
 import styles from './condition-search.module.scss';
@@ -13,19 +13,19 @@ type Props = {
 };
 export const ConditionSearch = ({ onConditionSelect, onCancel, onCreateNew }: Props) => {
     return (
-        <PageProvider>
+        <PaginationProvider>
             <ConditionSearchContent
                 onCreateNew={onCreateNew}
                 onCancel={onCancel}
                 onConditionSelect={onConditionSelect}
             />
-        </PageProvider>
+        </PaginationProvider>
     );
 };
 
 const ConditionSearchContent = ({ onConditionSelect, onCancel, onCreateNew }: Props) => {
     const { search, response, isLoading, keyword, reset } = useConditionSearch();
-    const { page, ready, request } = usePage();
+    const { page, ready, request } = usePagination();
     const [sort, setSort] = useState<ConditionSort | undefined>();
     const [selected, setSelected] = useState<number[]>([]);
     const [resetTable, setResetTable] = useState<boolean>(false);

--- a/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/condition/search/ConditionTable.tsx
@@ -1,7 +1,7 @@
 import { ConditionSort, ConditionSortField } from 'apps/page-builder/condition/search/useConditionSearch';
 import { Condition } from 'apps/page-builder/generated';
 import { TableBody, TableComponent } from 'components/Table';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { Direction } from 'sorting';
 
@@ -68,7 +68,7 @@ type Props = {
     onSort?: (sort?: ConditionSort) => void;
 };
 export const ConditionTable = ({ conditions, isLoading, onSelectionChange, onSort }: Props) => {
-    const { page, request } = usePage();
+    const { page, request } = usePagination();
     const [tableRows, setTableRows] = useState<TableBody[]>([]);
     const [selected, setSelected] = useState<number[]>([]);
 

--- a/apps/modernization-ui/src/apps/page-builder/page/library/table/PageLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/table/PageLibraryTable.tsx
@@ -1,7 +1,7 @@
 import { PageSummary } from 'apps/page-builder/generated';
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { internalizeDate } from 'date';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { Direction } from 'sorting';
@@ -68,7 +68,7 @@ export const PageLibraryTable = ({ enableEdit, summaries, searching = false, onS
     const {
         page: { pageSize, total, current },
         request
-    } = usePage();
+    } = usePagination();
 
     useEffect(() => {
         setTableRows(asTableRows(summaries, enableEdit));

--- a/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
+++ b/apps/modernization-ui/src/apps/page-builder/page/library/usePageSummarySearch.ts
@@ -1,7 +1,7 @@
 import { useEffect, useReducer } from 'react';
 
 import { PageSummary, PageSummaryService, Date, DateRange, MultiValue, SingleValue } from 'apps/page-builder/generated';
-import { Status as PageStatus, usePage } from 'page';
+import { Status as PageStatus, usePagination } from 'pagination';
 import { Filter, externalize } from 'filters';
 import { useSorting } from 'sorting';
 
@@ -49,7 +49,7 @@ const initial: State = {
 const usePageSummarySearch = () => {
     const [state, dispatch] = useReducer(reducer, initial);
 
-    const { page, firstPage, ready } = usePage();
+    const { page, firstPage, ready } = usePagination();
     const { sorting } = useSorting();
 
     useEffect(() => {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/modal/AddQuestionModal.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/modal/AddQuestionModal.tsx
@@ -1,5 +1,5 @@
 import { Modal, ModalRef } from '@trussworks/react-uswds';
-import { PageProvider, usePage } from 'page';
+import { PaginationProvider, usePagination } from 'pagination';
 import { RefObject, useEffect, useState } from 'react';
 import { usePageManagement } from '../../../usePageManagement';
 import { QuestionSearch } from '../search/QuestionSearch';
@@ -36,13 +36,13 @@ export const AddQuestionModal = ({ modal, onAddQuestion }: Props) => {
             aria-describedby="modal-1-description">
             <div className={styles.modal}>
                 {state === 'search' ? (
-                    <PageProvider>
+                    <PaginationProvider>
                         <QuestionSearchWrapper
                             onClose={handleClose}
                             onAccept={handleAccept}
                             onCreateNew={() => setState('add')}
                         />
-                    </PageProvider>
+                    </PaginationProvider>
                 ) : (
                     <AddQuestion
                         onBack={() => setState('search')}
@@ -61,7 +61,7 @@ type WrapperProps = {
     onCreateNew: () => void;
 };
 const QuestionSearchWrapper = ({ onClose, onCreateNew, onAccept }: WrapperProps) => {
-    const { firstPage } = usePage();
+    const { firstPage } = usePagination();
     const { page } = usePageManagement();
 
     useEffect(() => {

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/QuestionSearch.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/QuestionSearch.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@trussworks/react-uswds';
 import { AddableQuestionSort, useFindAddableQuestions } from 'apps/page-builder/hooks/api/useFindAvailableQuestions';
 import { SelectionMode } from 'components/Table';
-import { Status, usePage } from 'page';
+import { Status, usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 
 import { QuestionSearchTable } from './table/QuestionSearchTable';
@@ -17,7 +17,7 @@ type Props = {
     onAccept: (questions: number[]) => void;
 };
 export const QuestionSearch = ({ pageId, onCreateNew, onCancel, onAccept }: Props) => {
-    const { page, ready, firstPage, reload } = usePage();
+    const { page, ready, firstPage, reload } = usePagination();
     const [query, setQuery] = useState<string>('');
     const [sort, setSort] = useState<AddableQuestionSort | undefined>(undefined);
     const { isLoading, search, response, error } = useFindAddableQuestions();

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/table/QuestionSearchTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/table/QuestionSearchTable.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { MemoryRouter } from 'react-router';
 import { QuestionSearchTable } from './QuestionSearchTable';
 
@@ -8,9 +8,9 @@ describe('question search table tests', () => {
     it('should render No Data when empty', () => {
         const { getByText } = render(
             <MemoryRouter>
-                <PageProvider>
+                <PaginationProvider>
                     <QuestionSearchTable questions={[]} onCreateNew={jest.fn()} />
-                </PageProvider>
+                </PaginationProvider>
             </MemoryRouter>
         );
         expect(getByText('No Data')).toBeInTheDocument();
@@ -19,9 +19,9 @@ describe('question search table tests', () => {
     it('should render headers when empty', () => {
         const { getAllByRole } = render(
             <MemoryRouter>
-                <PageProvider>
+                <PaginationProvider>
                     <QuestionSearchTable questions={[]} onCreateNew={jest.fn()} />
-                </PageProvider>
+                </PaginationProvider>
             </MemoryRouter>
         );
 
@@ -35,7 +35,7 @@ describe('question search table tests', () => {
     it('should display proper values for a question', async () => {
         const { findAllByRole } = render(
             <MemoryRouter>
-                <PageProvider>
+                <PaginationProvider>
                     <QuestionSearchTable
                         questions={[
                             {
@@ -49,7 +49,7 @@ describe('question search table tests', () => {
                         ]}
                         onCreateNew={jest.fn()}
                     />
-                </PageProvider>
+                </PaginationProvider>
             </MemoryRouter>
         );
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/table/QuestionSearchTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/add-question/search/table/QuestionSearchTable.tsx
@@ -3,7 +3,7 @@ import { AvailableQuestion } from 'apps/page-builder/generated';
 import { AddableQuestionSort, SortField } from '../../../../../../hooks/api/useFindAvailableQuestions';
 import { Search } from 'components/Search';
 import { SelectionMode, TableBody, TableComponent } from 'components/Table';
-import { Status, usePage } from 'page';
+import { Status, usePagination } from 'pagination';
 import { useEffect, useState } from 'react';
 import { Direction } from 'sorting';
 import { ExpandedQuestion } from './ExpandedQuestion';
@@ -27,7 +27,7 @@ export const QuestionSearchTable = ({
     onSelectionChange,
     onCreateNew
 }: Props) => {
-    const { page, request } = usePage();
+    const { page, request } = usePagination();
     const [tableRows, setTableRows] = useState<TableBody[]>([]);
     const [expanded, setExpanded] = useState<number | undefined>(undefined);
 

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/change-valueset/ChangeValuesetModal.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/change-valueset/ChangeValuesetModal.tsx
@@ -1,7 +1,7 @@
 import { Modal, ModalRef } from '@trussworks/react-uswds';
 import { ValuesetSearch } from 'apps/page-builder/components/AddQuestion/valueset/ValuesetSearch';
 import { PagesQuestion } from 'apps/page-builder/generated';
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { RefObject, useEffect } from 'react';
 import './ChangeValuesetModal.scss';
 import styles from './change-valueset-modal.module.scss';
@@ -53,9 +53,9 @@ export const ChangeValuesetModal = ({ modal, question, page, onValuesetChanged }
                         <Spinner />
                     </div>
                 )}
-                <PageProvider>
+                <PaginationProvider>
                     <ValuesetSearch onCancel={handleClose} onClose={handleClose} onAccept={handleSetValueset} />
-                </PageProvider>
+                </PaginationProvider>
             </div>
         </Modal>
     );

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.tsx
@@ -3,7 +3,7 @@ import './BusinessRulesLibrary.scss';
 import { BusinessRulesLibraryTable } from './BusinessRulesLibraryTable';
 import { Breadcrumb } from 'breadcrumb';
 import { useGetPageDetails } from 'apps/page-builder/page/management';
-import { Status, usePage } from 'page';
+import { Status, usePagination } from 'pagination';
 import { BusinessRuleSort, RuleSortField, useFetchPageRules } from 'apps/page-builder/hooks/api/useFetchPageRules';
 import { useAlert } from 'alert';
 import { useDownloadPageLibrary } from 'apps/page-builder/hooks/api/useDownloadPageLibrary';
@@ -11,7 +11,7 @@ import { Direction } from '../../../../sorting';
 
 export const BusinessRulesLibrary = ({ modalRef }: any) => {
     const { search, response, error, isLoading } = useFetchPageRules();
-    const { page: curPage, ready, firstPage, reload } = usePage();
+    const { page: curPage, ready, firstPage, reload } = usePagination();
     const [sort, setSort] = useState<BusinessRuleSort | undefined>({
         field: RuleSortField.FUNCTION,
         direction: Direction.Descending

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.spec.tsx
@@ -2,7 +2,7 @@ import { screen, render } from '@testing-library/react';
 import { BusinessRulesLibraryTable } from './BusinessRulesLibraryTable';
 import { BrowserRouter } from 'react-router';
 import { Rule } from 'apps/page-builder/generated';
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 
 describe('BusinessRulesLibraryTable', () => {
     const modalRef = { current: null };
@@ -25,7 +25,7 @@ describe('BusinessRulesLibraryTable', () => {
             const summaries = [rulesSummary];
             render(
                 <BrowserRouter>
-                    <PageProvider>
+                    <PaginationProvider>
                         <BusinessRulesLibraryTable
                             rules={summaries}
                             qtnModalRef={modalRef}
@@ -34,7 +34,7 @@ describe('BusinessRulesLibraryTable', () => {
                             onDownloadCsv={jest.fn()}
                             onDownloadPdf={jest.fn()}
                         />
-                    </PageProvider>
+                    </PaginationProvider>
                 </BrowserRouter>
             );
 
@@ -69,7 +69,7 @@ describe('BusinessRulesLibraryTable', () => {
 
             const { findAllByRole } = render(
                 <BrowserRouter>
-                    <PageProvider>
+                    <PaginationProvider>
                         <BusinessRulesLibraryTable
                             rules={summaries}
                             qtnModalRef={modalRef}
@@ -78,7 +78,7 @@ describe('BusinessRulesLibraryTable', () => {
                             onDownloadCsv={jest.fn()}
                             onDownloadPdf={jest.fn()}
                         />
-                    </PageProvider>
+                    </PaginationProvider>
                 </BrowserRouter>
             );
 

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibraryTable.tsx
@@ -5,7 +5,7 @@ import { BusinessRuleSort, RuleSortField } from 'apps/page-builder/hooks/api/use
 import { useGetPageDetails } from 'apps/page-builder/page/management';
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { NavLinkButton } from 'components/button/nav/NavLinkButton';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import React, { RefObject, useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { Direction } from 'sorting';
@@ -56,7 +56,7 @@ export const BusinessRulesLibraryTable = ({
     const [selectedQuestion, setSelectedQuestion] = useState<Rule[]>([]);
 
     const { page } = useGetPageDetails();
-    const { page: curPage, request } = usePage();
+    const { page: curPage, request } = usePagination();
 
     const getSubsections = () => {
         if (page) {

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.spec.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/ViewBusinessRule/ViewBusinessRule.spec.tsx
@@ -1,16 +1,16 @@
-import { screen, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ViewBusinessRule } from './ViewBusinessRule';
 import { BrowserRouter } from 'react-router';
-import { Rule } from 'apps/page-builder/generated';
-import { PageProvider } from 'page';
+
+import { PaginationProvider } from 'pagination';
 
 describe('when ViewBusinessRule rendered', () => {
     it('should display heading', () => {
         const { container } = render(
             <BrowserRouter>
-                <PageProvider>
+                <PaginationProvider>
                     <ViewBusinessRule />
-                </PageProvider>
+                </PaginationProvider>
             </BrowserRouter>
         );
         const heading = container.querySelector('h2');
@@ -20,9 +20,9 @@ describe('when ViewBusinessRule rendered', () => {
     it('should display table headers', async () => {
         const { findAllByRole } = render(
             <BrowserRouter>
-                <PageProvider>
+                <PaginationProvider>
                     <ViewBusinessRule />
-                </PageProvider>
+                </PaginationProvider>
             </BrowserRouter>
         );
 
@@ -33,9 +33,9 @@ describe('when ViewBusinessRule rendered', () => {
     it('should rule fields', async () => {
         const { findAllByRole } = render(
             <BrowserRouter>
-                <PageProvider>
+                <PaginationProvider>
                     <ViewBusinessRule />
-                </PageProvider>
+                </PaginationProvider>
             </BrowserRouter>
         );
 

--- a/apps/modernization-ui/src/apps/patient/profile/contact/PatientContactContainer.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/contact/PatientContactContainer.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { Tracing, Headers } from './PatientContacts';
 import { PatientContactTable } from './PatientContactTable';
 
@@ -14,7 +14,7 @@ type Props = {
 
 export const PatientContactsContainer = ({ source, patient, title, headings }: Props) => {
     const tracing = source(patient);
-    const { firstPage } = usePage();
+    const { firstPage } = usePagination();
 
     useEffect(() => {
         if (patient) {

--- a/apps/modernization-ui/src/apps/patient/profile/contact/PatientContactTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/contact/PatientContactTable.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { ClassicLink, ClassicModalLink } from 'classic';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { Direction } from 'sorting';
 import { AssociatedWith, Tracing, Contact, Headers } from './PatientContacts';
 import { SortCriteria, sort } from './PatientContactSorter';
@@ -55,7 +55,7 @@ type Props = {
 };
 
 export const PatientContactTable = ({ patient, tracings, title, headings }: Props) => {
-    const { page, request, reload } = usePage();
+    const { page, request, reload } = usePagination();
     const [criteria, setCriteria] = useState<SortCriteria>({});
 
     const [bodies, setBodies] = useState<TableBody[]>([]);

--- a/apps/modernization-ui/src/apps/patient/profile/contact/PatientProfileContactsNamedByPatient.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/contact/PatientProfileContactsNamedByPatient.tsx
@@ -1,4 +1,4 @@
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { Headers } from './PatientContacts';
 import { PatientContactsContainer } from './PatientContactContainer';
 import { usePatientProfileContactNamedByPatientAPI } from './usePatientProfileContactNamedByPatientAPI';
@@ -21,14 +21,14 @@ type Props = {
 export const PatientProfileContactsNamedByPatient = ({ patient, pageSize }: Props) => {
     return (
         <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-            <PageProvider pageSize={pageSize}>
+            <PaginationProvider pageSize={pageSize}>
                 <PatientContactsContainer
                     source={usePatientProfileContactNamedByPatientAPI}
                     patient={patient}
                     title={title}
                     headings={headings}
                 />
-            </PageProvider>
+            </PaginationProvider>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/profile/contact/PatientProfilePatientNamedByContact.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/contact/PatientProfilePatientNamedByContact.tsx
@@ -1,4 +1,4 @@
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { Headers } from './PatientContacts';
 import { PatientContactsContainer } from './PatientContactContainer';
 import { usePatientProfilePatientNamedByContactAPI } from './usePatientProfilePatientNamedByContactAPI';
@@ -21,14 +21,14 @@ type Props = {
 export const PatientProfilePatientNamedByContact = ({ patient, pageSize }: Props) => {
     return (
         <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-            <PageProvider pageSize={pageSize}>
+            <PaginationProvider pageSize={pageSize}>
                 <PatientContactsContainer
                     source={usePatientProfilePatientNamedByContactAPI}
                     patient={patient}
                     title={title}
                     headings={headings}
                 />
-            </PageProvider>
+            </PaginationProvider>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/profile/contact/usePatientProfileContactNamedByPatientAPI.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/contact/usePatientProfileContactNamedByPatientAPI.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { FindContactsNamedByPatientQuery, useFindContactsNamedByPatientLazyQuery } from 'generated/graphql/schema';
-import { Status, usePage } from 'page';
+import { Status, usePagination } from 'pagination';
 import { Tracing } from './PatientContacts';
 import { transform } from './PatientContactTransformer';
 
 export const usePatientProfileContactNamedByPatientAPI = (patient?: string): Tracing[] => {
     const [tracings, setTracings] = useState<Tracing[]>([]);
-    const { page, ready } = usePage();
+    const { page, ready } = usePagination();
 
     const handleComplete = (data: FindContactsNamedByPatientQuery) => {
         const total = data?.findContactsNamedByPatient?.total || 0;

--- a/apps/modernization-ui/src/apps/patient/profile/contact/usePatientProfilePatientNamedByContactAPI.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/contact/usePatientProfilePatientNamedByContactAPI.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
 import { FindPatientNamedByContactQuery, useFindPatientNamedByContactLazyQuery } from 'generated/graphql/schema';
-import { usePage, Status } from 'page';
+import { usePagination, Status } from 'pagination';
 import { Tracing } from './PatientContacts';
 import { transform } from './PatientContactTransformer';
 
 export const usePatientProfilePatientNamedByContactAPI = (patient?: string): Tracing[] => {
     const [tracings, setTracings] = useState<Tracing[]>([]);
-    const { page, ready } = usePage();
+    const { page, ready } = usePagination();
 
     const handleComplete = (data: FindPatientNamedByContactQuery) => {
         const total = data?.findPatientNamedByContact?.total || 0;

--- a/apps/modernization-ui/src/apps/patient/profile/document/PatientDocumentContainer.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/document/PatientDocumentContainer.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { Document } from './PatientDocuments';
 import { PatientDocumentTable } from './PatientDocumentTable';
 
@@ -10,7 +10,7 @@ type Props = {
 
 export const PatientDocumentContainer = ({ source, patient }: Props) => {
     const documents = source(patient);
-    const { firstPage } = usePage();
+    const { firstPage } = usePagination();
 
     useEffect(() => {
         if (patient) {

--- a/apps/modernization-ui/src/apps/patient/profile/document/PatientDocumentTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/document/PatientDocumentTable.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { Direction } from 'sorting';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { ClassicLink } from 'classic';
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { Document, AssociatedWith, Headers } from './PatientDocuments';
@@ -62,7 +62,7 @@ type Props = {
 };
 
 export const PatientDocumentTable = ({ patient, documents }: Props) => {
-    const { page, request } = usePage();
+    const { page, request } = usePagination();
     const [criteria, setCriteria] = useState<SortCriteria>({});
 
     const [bodies, setBodies] = useState<TableBody[]>([]);

--- a/apps/modernization-ui/src/apps/patient/profile/document/PatientProfileDocuments.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/document/PatientProfileDocuments.tsx
@@ -1,4 +1,4 @@
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 
 import { usePatientProfileDocumentsAPI } from './usePatientProfileDocumentsAPI';
 import { PatientDocumentContainer } from './PatientDocumentContainer';
@@ -11,9 +11,9 @@ type Props = {
 export const PatientProfileDocuments = ({ patient, pageSize }: Props) => {
     return (
         <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-            <PageProvider pageSize={pageSize}>
+            <PaginationProvider pageSize={pageSize}>
                 <PatientDocumentContainer source={usePatientProfileDocumentsAPI} patient={patient} />
-            </PageProvider>
+            </PaginationProvider>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/profile/document/usePatientProfileDocumentsAPI.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/document/usePatientProfileDocumentsAPI.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { FindDocumentsForPatientQuery, useFindDocumentsForPatientLazyQuery } from 'generated/graphql/schema';
-import { usePage, Status } from 'page';
+import { usePagination, Status } from 'pagination';
 import { Document } from './PatientDocuments';
 import { transform } from './PatientDocumentTransformer';
 
@@ -13,7 +13,7 @@ import { transform } from './PatientDocumentTransformer';
 export const usePatientProfileDocumentsAPI = (patient?: string) => {
     const [documents, setDocuments] = useState<Document[]>([]);
 
-    const { page, ready } = usePage();
+    const { page, ready } = usePagination();
 
     const handleComplete = (data: FindDocumentsForPatientQuery) => {
         const total = data?.findDocumentsForPatient?.total || 0;

--- a/apps/modernization-ui/src/apps/patient/profile/documentsRequiringReview/DocumentRequiringReviewTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/documentsRequiringReview/DocumentRequiringReviewTable.tsx
@@ -1,6 +1,6 @@
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { format } from 'date-fns';
-import { usePage } from 'page/usePage';
+import { usePagination } from 'pagination/usePagination';
 import { useEffect, useState } from 'react';
 import { Direction } from 'sorting/Sort';
 import { ClassicLink } from 'classic';
@@ -163,7 +163,7 @@ export const DocumentsRequiringReviewTable = ({
     documents: DocumentReview[] | undefined;
     patient: string | undefined;
 }) => {
-    const { page, request } = usePage();
+    const { page, request } = usePagination();
     const [bodies, setBodies] = useState<TableBody[]>([]);
     const [criteria, setCriteria] = useState<SortCriteria>({});
 

--- a/apps/modernization-ui/src/apps/patient/profile/documentsRequiringReview/DocumentsRequiringReview.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/documentsRequiringReview/DocumentsRequiringReview.tsx
@@ -1,5 +1,5 @@
 import { DocumentRequiringReviewSortableField, SortDirection } from 'generated/graphql/schema';
-import { PageProvider, usePage } from 'page';
+import { PaginationProvider, usePagination } from 'pagination';
 import { useEffect } from 'react';
 import { DocumentsRequiringReviewTable } from './DocumentRequiringReviewTable';
 import { useDocumentsRequiringReviewApi } from './useDocumentsRequiringReviewApi';
@@ -14,15 +14,15 @@ export type Sort = {
 };
 export const DocumentRequiringReview = ({ patient }: Props) => {
     return (
-        <PageProvider pageSize={10}>
+        <PaginationProvider pageSize={10}>
             <DocumentsRequiringReviewContainer patient={patient} />
-        </PageProvider>
+        </PaginationProvider>
     );
 };
 
 const DocumentsRequiringReviewContainer = ({ patient }: Props) => {
     const documents = useDocumentsRequiringReviewApi(patient);
-    const { firstPage } = usePage();
+    const { firstPage } = usePagination();
 
     useEffect(() => {
         if (patient) {

--- a/apps/modernization-ui/src/apps/patient/profile/documentsRequiringReview/useDocumentsRequiringReviewApi.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/documentsRequiringReview/useDocumentsRequiringReviewApi.ts
@@ -3,14 +3,14 @@ import {
     FindDocumentsRequiringReviewForPatientQuery,
     useFindDocumentsRequiringReviewForPatientLazyQuery
 } from 'generated/graphql/schema';
-import { usePage, Status } from 'page';
+import { usePagination, Status } from 'pagination';
 import { transform } from './DocumentRequiringReviewTransformer';
 import { DocumentReview } from './ReviewDocuments';
 
 export const useDocumentsRequiringReviewApi = (patient?: string) => {
     const [documents, setDocuments] = useState<DocumentReview[]>();
 
-    const { page, ready } = usePage();
+    const { page, ready } = usePagination();
 
     const handleComplete = (data: FindDocumentsRequiringReviewForPatientQuery) => {
         const total = data?.findDocumentsRequiringReviewForPatient?.total || 0;

--- a/apps/modernization-ui/src/apps/patient/profile/vaccination/PatientProfileVaccinations.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/vaccination/PatientProfileVaccinations.tsx
@@ -1,4 +1,4 @@
-import { PageProvider } from 'page';
+import { PaginationProvider } from 'pagination';
 import { PatientVaccinationContainer } from './PatientVaccinationContainer';
 import { usePatientProfileVaccinationAPI } from './usePatientProfileVaccinationAPI';
 
@@ -11,13 +11,13 @@ type Props = {
 export const PatientProfileVaccinations = ({ patient, pageSize, allowAdd = false }: Props) => {
     return (
         <div className="margin-top-6 margin-bottom-2 flex-row common-card">
-            <PageProvider pageSize={pageSize}>
+            <PaginationProvider pageSize={pageSize}>
                 <PatientVaccinationContainer
                     source={usePatientProfileVaccinationAPI}
                     patient={patient}
                     allowAdd={allowAdd}
                 />
-            </PageProvider>
+            </PaginationProvider>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/profile/vaccination/PatientVaccinationContainer.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/vaccination/PatientVaccinationContainer.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { Vaccination } from './PatientVaccination';
 import { PatientVaccinationTable } from './PatientVaccinationTable';
 
@@ -13,7 +13,7 @@ type Props = {
 
 export const PatientVaccinationContainer = ({ source, patient, allowAdd }: Props) => {
     const tracing = source(patient);
-    const { firstPage } = usePage();
+    const { firstPage } = usePagination();
 
     useEffect(() => {
         if (patient) {

--- a/apps/modernization-ui/src/apps/patient/profile/vaccination/PatientVaccinationTable.tsx
+++ b/apps/modernization-ui/src/apps/patient/profile/vaccination/PatientVaccinationTable.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Icon } from '@trussworks/react-uswds';
 import { TableBody, TableComponent } from 'components/Table/Table';
 import { format } from 'date-fns';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { Direction } from 'sorting';
 import { ClassicLink, ClassicModalButton, ClassicModalLink } from 'classic';
 import { Vaccination, AssociatedWith, Headers } from './PatientVaccination';
@@ -34,7 +34,7 @@ type Props = {
 };
 
 export const PatientVaccinationTable = ({ patient, vaccinations, allowAdd = false }: Props) => {
-    const { page, request, reload } = usePage();
+    const { page, request, reload } = usePagination();
     const [criteria, setCriteria] = useState<SortCriteria>({});
 
     const [bodies, setBodies] = useState<TableBody[]>([]);

--- a/apps/modernization-ui/src/apps/patient/profile/vaccination/usePatientProfileVaccinationAPI.ts
+++ b/apps/modernization-ui/src/apps/patient/profile/vaccination/usePatientProfileVaccinationAPI.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
 import { FindVaccinationsForPatientQuery, useFindVaccinationsForPatientLazyQuery } from 'generated/graphql/schema';
-import { usePage, Status } from 'page';
+import { usePagination, Status } from 'pagination';
 import { Vaccination } from './PatientVaccination';
 import { transform } from './PatientVaccinationTransformer';
 
 export const usePatientProfileVaccinationAPI = (patient?: string): Vaccination[] => {
     const [tracings, setTracings] = useState<Vaccination[]>([]);
-    const { page, ready } = usePage();
+    const { page, ready } = usePagination();
 
     const handleComplete = (data: FindVaccinationsForPatientQuery) => {
         const total = data?.findVaccinationsForPatient?.total || 0;

--- a/apps/modernization-ui/src/apps/search/SearchPage.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchPage.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Outlet } from 'react-router';
-import { PageProvider, PagingSettings } from 'page';
+import { PaginationProvider, PaginationSettings } from 'pagination';
 import { SortingProvider, SortingSettings } from 'sorting';
 import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 import { ComponentSizingProvider } from 'design-system/sizing';
@@ -8,19 +8,19 @@ import { FilterProvider } from 'design-system/filter';
 
 const SEARCH_PAGE_SIZE = 20;
 
-type SearchPageProviderProps = { sorting?: SortingSettings; paging?: PagingSettings; children: ReactNode };
+type SearchPageProviderProps = { sorting?: SortingSettings; paging?: PaginationSettings; children: ReactNode };
 
 const SearchPageProvider = ({ sorting, paging, children }: SearchPageProviderProps) => (
     <ComponentSizingProvider>
         <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? false : sorting.appendToUrl}>
-            <PageProvider
+            <PaginationProvider
                 {...paging}
                 pageSize={paging?.pageSize || SEARCH_PAGE_SIZE}
                 appendToUrl={paging?.appendToUrl === undefined ? false : paging.appendToUrl}>
                 <FilterProvider>
                     <SearchResultDisplayProvider>{children}</SearchResultDisplayProvider>
                 </FilterProvider>
-            </PageProvider>
+            </PaginationProvider>
         </SortingProvider>
     </ComponentSizingProvider>
 );

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
@@ -5,8 +5,8 @@ import { SkipLinkProvider } from 'SkipLink/SkipLinkContext';
 import { SearchResultDisplayProvider } from '../useSearchResultDisplay';
 import { FilterProvider } from 'design-system/filter/useFilter';
 
-jest.mock('page', () => ({
-    usePage: () => ({
+jest.mock('pagination', () => ({
+    usePagination: () => ({
         page: {
             status: 0,
             pageSize: 1,

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/SearchResultPagination.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/SearchResultPagination.spec.tsx
@@ -8,8 +8,8 @@ let mockTotal: number;
 let mockPageSize: number;
 let mockCurrent: number;
 
-jest.mock('page', () => ({
-    usePage: () => ({
+jest.mock('pagination', () => ({
+    usePagination: () => ({
         request: mockRequest,
         page: {
             total: mockTotal,

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/SearchResultPagination.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/SearchResultPagination.tsx
@@ -1,5 +1,5 @@
 import { RefObject } from 'react';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import { Shown } from 'conditional-render';
 import { Pagination } from 'design-system/pagination';
 import { SearchResultPageSizeSelect } from './page-size-select';
@@ -15,7 +15,7 @@ type SearchPaginationProps = {
 };
 
 const SearchResultPagination = ({ id, elementRef }: SearchPaginationProps) => {
-    const { request, resize, page } = usePage();
+    const { request, resize, page } = usePagination();
 
     const minimum = Math.min(...pageSizes);
     const visible = page.total > minimum;

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/showing/SearchResultsShowing.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/showing/SearchResultsShowing.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { SearchResultsShowing } from './SearchResultsShowing';
-import { Page } from 'page';
+import { Page } from 'pagination';
 
 describe('when displaying search results totals', () => {
     it('should render with no accessibility violations', async () => {

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/showing/SearchResultsShowing.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/showing/SearchResultsShowing.tsx
@@ -1,4 +1,4 @@
-import { Page } from 'page';
+import { Page } from 'pagination';
 
 type SearchResultsShowingProps = {
     className?: string;

--- a/apps/modernization-ui/src/apps/search/useSearchResults.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/useSearchResults.spec.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, act } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { SearchResultSettings, useSearchResults } from './useSearchResults';
-import { Page } from 'page';
+import { Page } from 'pagination';
 import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 
 let mockCriteria: Criteria | undefined = undefined;
@@ -16,7 +16,7 @@ jest.mock('./useSearchCriteria', () => ({
     })
 }));
 
-const { Status } = jest.requireActual('page');
+const { Status } = jest.requireActual('pagination');
 
 const mockPage: Page = {
     status: Status.Ready,
@@ -32,8 +32,8 @@ const mockReady = jest.fn();
 const mockResize = jest.fn();
 const mockPageReset = jest.fn();
 
-jest.mock('page', () => ({
-    usePage: () => ({
+jest.mock('pagination', () => ({
+    usePagination: () => ({
         page: mockPage,
         firstPage: mockFirstPage,
         reload: mockReload,

--- a/apps/modernization-ui/src/apps/search/useSearchResults.ts
+++ b/apps/modernization-ui/src/apps/search/useSearchResults.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
-import { usePage, Status as PageStatus } from 'page';
+import { usePagination, Status as PageStatus } from 'pagination';
 import { useSorting } from 'sorting';
 import { Predicate } from 'utils';
 import { Filter, maybeUseFilter } from 'design-system/filter';
@@ -180,7 +180,7 @@ const useSearchResults = <C extends object, A extends object, R extends object>(
     noInputCheck = defaultNoInputCheck,
     defaultValues
 }: SearchResultSettings<C, A, R>): SearchResultsInteraction<C, R> => {
-    const { page, ready, reset: pageReset } = usePage();
+    const { page, ready, reset: pageReset } = usePagination();
 
     const { property, direction } = useSorting();
 

--- a/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.tsx
+++ b/apps/modernization-ui/src/components/Table/RangeToggle/RangeToggle.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { usePage } from 'page';
+import { usePagination } from 'pagination';
 import styles from './range-toggle.module.scss';
 
 export type SupportedContext = 'pages' | 'conditions' | 'questions' | 'valuesets' | 'templates' | 'businessRules';
@@ -15,7 +15,7 @@ export const RangeToggle = ({
     name = 'range-toggle',
     ...props
 }: RangeToggleProps) => {
-    const pagination = usePage();
+    const pagination = usePagination();
     const [range, setRange] = useState(Number(initial));
 
     useEffect(() => {

--- a/apps/modernization-ui/src/components/Table/TableProvider.tsx
+++ b/apps/modernization-ui/src/components/Table/TableProvider.tsx
@@ -1,19 +1,19 @@
 import { ReactNode } from 'react';
-import { PageProvider, PagingSettings } from 'page';
+import { PaginationProvider, PaginationSettings } from 'pagination';
 import { SortingProvider, SortingSettings } from 'sorting';
 
 type TableProviderProps = {
     children: ReactNode;
     sorting?: SortingSettings;
-    paging?: PagingSettings;
+    paging?: PaginationSettings;
 };
 
 const TableProvider = ({ sorting, paging, children }: TableProviderProps) => {
     return (
         <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? true : sorting.appendToUrl}>
-            <PageProvider {...paging} appendToUrl={paging?.appendToUrl === undefined ? true : paging.appendToUrl}>
+            <PaginationProvider {...paging} appendToUrl={paging?.appendToUrl === undefined ? true : paging.appendToUrl}>
                 {children}
-            </PageProvider>
+            </PaginationProvider>
         </SortingProvider>
     );
 };

--- a/apps/modernization-ui/src/components/Table/testing/WithinTableProvider.tsx
+++ b/apps/modernization-ui/src/components/Table/testing/WithinTableProvider.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { PagingSettings } from 'page';
+import { PaginationSettings } from 'pagination';
 import { SortingSettings } from 'sorting';
 import { MemoryRouter } from 'react-router';
 import { TableProvider } from '../TableProvider';
@@ -7,7 +7,7 @@ import { TableProvider } from '../TableProvider';
 type WithinTableProviderProps = {
     children: ReactNode;
     sorting?: SortingSettings;
-    paging?: PagingSettings;
+    paging?: PaginationSettings;
 };
 
 const WithinTableProvider = ({ sorting, paging, children }: WithinTableProviderProps) => (

--- a/apps/modernization-ui/src/page/index.ts
+++ b/apps/modernization-ui/src/page/index.ts
@@ -1,1 +1,0 @@
-export * from './usePage';

--- a/apps/modernization-ui/src/pagination/index.ts
+++ b/apps/modernization-ui/src/pagination/index.ts
@@ -1,0 +1,2 @@
+export { usePagination, PaginationProvider, Status } from './usePagination';
+export type { Page, PaginationSettings } from './usePagination';

--- a/apps/modernization-ui/src/pagination/usePagination.tsx
+++ b/apps/modernization-ui/src/pagination/usePagination.tsx
@@ -60,18 +60,22 @@ type PageContextState = {
     reset: () => void;
 };
 
-const PageContext = createContext<PageContextState | undefined>(undefined);
+const PaginationContext = createContext<PageContextState | undefined>(undefined);
 
-type PagingSettings = {
+type PaginationSettings = {
     appendToUrl?: boolean;
     pageSize?: number;
 };
 
-type PageProviderProps = {
-    children: ReactNode;
-} & PagingSettings;
+type PaginationProviderProps = {
+    children: ReactNode | ReactNode[];
+} & PaginationSettings;
 
-const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, children }: PageProviderProps) => {
+const PaginationProvider = ({
+    pageSize = TOTAL_TABLE_DATA,
+    appendToUrl = false,
+    children
+}: PaginationProviderProps) => {
     const [page, dispatch] = useReducer(pageReducer, pageSize, initialize);
 
     const [searchParams, setSearchParams] = useSearchParams();
@@ -109,26 +113,20 @@ const PageProvider = ({ pageSize = TOTAL_TABLE_DATA, appendToUrl = false, childr
 
     const value = { page, firstPage, reload, request, ready, resize, reset };
 
-    return <PageContext.Provider value={value}>{children}</PageContext.Provider>;
+    return <PaginationContext.Provider value={value}>{children}</PaginationContext.Provider>;
 };
 
-const usePage = () => {
-    const context = useContext(PageContext);
+const usePagination = () => {
+    const context = useContext(PaginationContext);
 
     if (context === undefined) {
-        throw new Error('usePage must be used within a PageProvider');
+        throw new Error('usePagination must be used within a PaginationProvider');
     }
 
     return context;
 };
 
-const usePageMaybe = () => {
-    const context = useContext(PageContext);
-
-    return context;
-};
-
-export { PageProvider, usePage, usePageMaybe };
+export { PaginationProvider, usePagination };
 
 export { Status };
-export type { PageState as Page, PagingSettings };
+export type { PageState as Page, PaginationSettings };


### PR DESCRIPTION
## Description

Renames the `usePage` hook to `usePagination`.  Any associated typed that were named `PageX` or `PagingX` were renamed to `PaginationX`.  This was done to make the intention of the hook more clear and to resolve a naming conflict that may arise from [CNFT1-4011](https://cdc-nbs.atlassian.net/browse/CNFT1-4011).

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4011]: https://cdc-nbs.atlassian.net/browse/CNFT1-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ