### PR TITLE
[FIX]  DatePicker artifacts in dev mode.

### DIFF
--- a/apps/modernization-ui/src/design-system/date/picker/DatePicker.stories.tsx
+++ b/apps/modernization-ui/src/design-system/date/picker/DatePicker.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { DatePicker } from './DatePicker';
 
 const meta = {
-    title: 'Design System/Date/DatePicker',
+    title: 'Design System/Date/Picker',
     component: DatePicker
 } satisfies Meta<typeof DatePicker>;
 
@@ -12,8 +12,29 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
     args: {
-        id: 'datepicker-default',
+        id: 'dte-picker',
         label: 'Date Picker',
         value: '2024-09-30'
+    }
+};
+
+export const Small: Story = {
+    args: {
+        ...Default.args,
+        sizing: 'small'
+    }
+};
+
+export const Medium: Story = {
+    args: {
+        ...Default.args,
+        sizing: 'medium'
+    }
+};
+
+export const Large: Story = {
+    args: {
+        ...Default.args,
+        sizing: 'large'
     }
 };

--- a/apps/modernization-ui/src/design-system/date/picker/DatePicker.tsx
+++ b/apps/modernization-ui/src/design-system/date/picker/DatePicker.tsx
@@ -84,50 +84,58 @@ const DatePicker = ({
     );
 
     useLayoutEffect(() => {
-        const datePickerElement = datePickerRef.current as HTMLDivElement;
-        const wrapper = datePickerElement.querySelector('.usa-date-picker__wrapper');
+        if (!externalInputRef.current) {
+            const datePickerElement = datePickerRef.current as HTMLDivElement;
+            const wrapper = datePickerElement.querySelector('.usa-date-picker__wrapper');
 
-        datePicker.on(datePickerElement);
+            datePicker.on(datePickerElement);
 
-        const context = datePicker.getDatePickerContext(datePickerElement);
+            const context = datePicker.getDatePickerContext(datePickerElement);
 
-        if (label) {
-            const toggle = context.toggleBtnEl as HTMLButtonElement;
+            if (label) {
+                const toggle = context.toggleBtnEl as HTMLButtonElement;
 
-            toggle.ariaLabel = `Toggle ${label} calendar`;
-        }
-
-        externalInputRef.current = context.externalInputEl as HTMLInputElement;
-
-        return () => {
-            if (wrapper) {
-                datePicker.off(datePickerElement);
+                toggle.ariaLabel = `Toggle ${label} calendar`;
             }
-        };
-    }, []);
+
+            externalInputRef.current = context.externalInputEl as HTMLInputElement;
+
+            return () => {
+                if (wrapper) {
+                    datePicker.off(datePickerElement);
+                    externalInputRef.current = null;
+                }
+            };
+        }
+    }, [externalInputRef.current]);
 
     useEffect(() => {
         if (externalInputRef.current) {
-            externalInputRef.current.addEventListener('blur', handleExternalOnBlur);
-            externalInputRef.current.addEventListener('change', handleExternalOnChange);
-            externalInputRef.current.addEventListener('keyup', handleExternalKeyUp);
-            externalInputRef.current.addEventListener('keydown', onlyNumericKeys);
-        }
+            const external = externalInputRef.current;
 
-        return () => {
-            if (externalInputRef.current) {
-                externalInputRef.current.removeEventListener('blur', handleExternalOnBlur);
-                externalInputRef.current.removeEventListener('change', handleExternalOnChange);
-                externalInputRef.current.removeEventListener('keyup', handleExternalKeyUp);
-                externalInputRef.current.removeEventListener('keydown', onlyNumericKeys);
-            }
-        };
+            external.addEventListener('blur', handleExternalOnBlur);
+            external.addEventListener('change', handleExternalOnChange);
+            external.addEventListener('keyup', handleExternalKeyUp);
+            external.addEventListener('keydown', onlyNumericKeys);
+
+            return () => {
+                external.removeEventListener('blur', handleExternalOnBlur);
+                external.removeEventListener('change', handleExternalOnChange);
+                external.removeEventListener('keyup', handleExternalKeyUp);
+                external.removeEventListener('keydown', onlyNumericKeys);
+            };
+        }
     }, [externalInputRef.current, handleExternalOnBlur, handleExternalOnChange]);
 
     return (
         <div
             ref={datePickerRef}
-            className={classNames(styles[sizing ?? ''], 'usa-date-picker')}
+            className={classNames('usa-date-picker', {
+                [styles.sized]: sizing,
+                [styles.small]: sizing === 'small',
+                [styles.medium]: sizing === 'medium',
+                [styles.large]: sizing === 'large'
+            })}
             data-default-value={date}
             data-max-date={adjustedMaxValue}
             data-min-date={adjustedMinValue}>

--- a/apps/modernization-ui/src/design-system/date/picker/DatePickerInput.stories.tsx
+++ b/apps/modernization-ui/src/design-system/date/picker/DatePickerInput.stories.tsx
@@ -1,0 +1,75 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { DatePickerInput } from './DatePickerInput';
+
+const meta = {
+    title: 'Design System/Date/Picker/Field',
+    component: DatePickerInput
+} satisfies Meta<typeof DatePickerInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        id: 'date-picker-field',
+        label: 'Date Picker Field',
+        onChange: () => {}
+    }
+};
+
+export const Horizontal: Story = {
+    args: {
+        ...Default.args,
+        orientation: 'horizontal'
+    }
+};
+
+export const HorizontalSmall: Story = {
+    args: {
+        ...Horizontal.args,
+        sizing: 'small'
+    }
+};
+
+export const HorizontalMedium: Story = {
+    args: {
+        ...Horizontal.args,
+        sizing: 'medium'
+    }
+};
+
+export const HorizontalLarge: Story = {
+    args: {
+        ...Horizontal.args,
+        sizing: 'large'
+    }
+};
+
+export const Vertical: Story = {
+    args: {
+        ...Default.args,
+        orientation: 'vertical'
+    }
+};
+
+export const VerticalSmall: Story = {
+    args: {
+        ...Vertical.args,
+        sizing: 'small'
+    }
+};
+
+export const VerticalMedium: Story = {
+    args: {
+        ...Vertical.args,
+        sizing: 'medium'
+    }
+};
+
+export const VerticalLarge: Story = {
+    args: {
+        ...Vertical.args,
+        sizing: 'large'
+    }
+};

--- a/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
+++ b/apps/modernization-ui/src/design-system/date/picker/date-picker.module.scss
@@ -1,37 +1,33 @@
-@mixin sizedDatePicker($backgroundSize: 1rem, $calendarWidth: 17.75rem, $calendarHeight: 16.75rem) {
-    & > div > button {
-        background-size: $backgroundSize;
-        background-position: left;
-        width: $backgroundSize;
+.sized {
+    --calendar-icon-width: 1rem;
 
-        &:focus {
-            width: calc($backgroundSize + 0.5rem);
-            background-position: center;
-        }
+    & > div > button {
+        //  usa-date-picker__button
+        background-size: var(--calendar-icon-width);
+        max-width: var(--calendar-icon-width);
     }
 
     & > div > input {
+        // usa-date-picker__external-input
         margin-right: 0.25rem !important;
     }
 
     & > div > div {
-        min-width: $calendarWidth !important;
-        min-height: $calendarHeight !important;
+        // usa-date-picker__calendar
+        min-width: 17.75rem !important;
     }
-}
 
-.small {
-    @include sizedDatePicker(1rem, 17.75rem, 15rem);
+    &.small {
+        --calendar-navigation-padding: 18px;
+        --calendar-day-of-week-padding: 4px;
+        --calendar-date-padding: 8px;
+    }
 
-    --calendar-navigation-padding: 18px;
-    --calendar-day-of-week-padding: 4px;
-    --calendar-date-padding: 8px;
-}
+    &.medium {
+        --calendar-icon-width: 1.125rem;
+    }
 
-.medium {
-    @include sizedDatePicker(1.125rem);
-}
-
-.large {
-    @include sizedDatePicker(1.25rem);
+    &.large {
+        --calendar-icon-width: 1.25rem;
+    }
 }


### PR DESCRIPTION
## Description

Re-arranges the initialization of the `DatePicker` to prevent the "fangs" from appearing in a local dev server due to double initialization.

![image](https://github.com/user-attachments/assets/64b02892-1e47-41ef-80de-17239b33e013)

![image](https://github.com/user-attachments/assets/c1175525-a58f-4b9a-8a60-6de16c4db451)


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
