### PR TITLE
CNFT1-3992-aria-role-button

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -357,11 +357,11 @@ describe('RepeatingBlock', () => {
         expect(getByText('Render view first value: first-value')).toBeInTheDocument();
         expect(getByText('Render view second value: second-value')).toBeInTheDocument();
 
-        const buttons = getAllByRole('button');
-        expect(buttons).toHaveLength(4);
-        expect(buttons[3]).toHaveTextContent('Add test title');
-        expect(buttons[3].innerHTML).toContain('svg');
-        expect(buttons[3]).toHaveAttribute('aria-description');
+        const buttons = getAllByRole('button', { name: /Add/ });
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0]).toHaveTextContent('Add test title');
+        expect(buttons[0].innerHTML).toContain('svg');
+        expect(buttons[0]).toHaveAttribute('aria-description');
     });
 
     it('should render edit when edit icon clicked', async () => {
@@ -385,13 +385,13 @@ describe('RepeatingBlock', () => {
         expect(getByLabelText('First Input')).toBeInTheDocument();
         expect(getByLabelText('Second Input')).toBeInTheDocument();
 
-        const buttons = getAllByRole('button');
-        expect(buttons).toHaveLength(5);
-        expect(buttons[3]).toHaveTextContent('Update test title');
-        expect(buttons[3]).toHaveAttribute('aria-description');
-        expect(buttons[3].innerHTML).not.toContain('svg');
-        expect(buttons[4]).toHaveTextContent('Cancel');
-        expect(buttons[4]).toHaveAttribute('aria-description');
+        const buttons = getAllByRole('button', { name: /(Update.*|Cancel)/ });
+        expect(buttons).toHaveLength(2);
+        expect(buttons[0]).toHaveTextContent('Update test title');
+        expect(buttons[0]).toHaveAttribute('aria-description');
+        expect(buttons[0].innerHTML).not.toContain('svg');
+        expect(buttons[1]).toHaveTextContent('Cancel');
+        expect(buttons[1]).toHaveAttribute('aria-description');
     });
 
     it('should delete row when delete icon clicked', async () => {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -358,10 +358,10 @@ describe('RepeatingBlock', () => {
         expect(getByText('Render view second value: second-value')).toBeInTheDocument();
 
         const buttons = getAllByRole('button');
-        expect(buttons).toHaveLength(1);
-        expect(buttons[0]).toHaveTextContent('Add test title');
-        expect(buttons[0].innerHTML).toContain('svg');
-        expect(buttons[0]).toHaveAttribute('aria-description');
+        expect(buttons).toHaveLength(4);
+        expect(buttons[3]).toHaveTextContent('Add test title');
+        expect(buttons[3].innerHTML).toContain('svg');
+        expect(buttons[3]).toHaveAttribute('aria-description');
     });
 
     it('should render edit when edit icon clicked', async () => {
@@ -386,12 +386,12 @@ describe('RepeatingBlock', () => {
         expect(getByLabelText('Second Input')).toBeInTheDocument();
 
         const buttons = getAllByRole('button');
-        expect(buttons).toHaveLength(2);
-        expect(buttons[0]).toHaveTextContent('Update test title');
-        expect(buttons[0]).toHaveAttribute('aria-description');
-        expect(buttons[0].innerHTML).not.toContain('svg');
-        expect(buttons[1]).toHaveTextContent('Cancel');
-        expect(buttons[1]).toHaveAttribute('aria-description');
+        expect(buttons).toHaveLength(5);
+        expect(buttons[3]).toHaveTextContent('Update test title');
+        expect(buttons[3]).toHaveAttribute('aria-description');
+        expect(buttons[3].innerHTML).not.toContain('svg');
+        expect(buttons[4]).toHaveTextContent('Cancel');
+        expect(buttons[4]).toHaveAttribute('aria-description');
     });
 
     it('should delete row when delete icon clicked', async () => {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.spec.tsx
@@ -337,7 +337,7 @@ describe('RepeatingBlock', () => {
     });
 
     it('should render view when view icon clicked', async () => {
-        const { getByLabelText, getByText, getAllByRole } = render(
+        const { getByLabelText, getByText, getByRole } = render(
             <Fixture
                 values={[
                     {
@@ -357,15 +357,14 @@ describe('RepeatingBlock', () => {
         expect(getByText('Render view first value: first-value')).toBeInTheDocument();
         expect(getByText('Render view second value: second-value')).toBeInTheDocument();
 
-        const buttons = getAllByRole('button', { name: /Add/ });
-        expect(buttons).toHaveLength(1);
-        expect(buttons[0]).toHaveTextContent('Add test title');
-        expect(buttons[0].innerHTML).toContain('svg');
-        expect(buttons[0]).toHaveAttribute('aria-description');
+        const addButton = getByRole('button', { name: 'Add test title' });
+        expect(addButton).toBeInTheDocument();
+        expect(addButton.innerHTML).toContain('svg');
+        expect(addButton).toHaveAttribute('aria-description');
     });
 
     it('should render edit when edit icon clicked', async () => {
-        const { getByLabelText, getAllByRole } = render(
+        const { getByLabelText, getByRole } = render(
             <Fixture
                 values={[
                     {
@@ -385,13 +384,14 @@ describe('RepeatingBlock', () => {
         expect(getByLabelText('First Input')).toBeInTheDocument();
         expect(getByLabelText('Second Input')).toBeInTheDocument();
 
-        const buttons = getAllByRole('button', { name: /(Update.*|Cancel)/ });
-        expect(buttons).toHaveLength(2);
-        expect(buttons[0]).toHaveTextContent('Update test title');
-        expect(buttons[0]).toHaveAttribute('aria-description');
-        expect(buttons[0].innerHTML).not.toContain('svg');
-        expect(buttons[1]).toHaveTextContent('Cancel');
-        expect(buttons[1]).toHaveAttribute('aria-description');
+        const updateButton = getByRole('button', { name: 'Update test title' });
+        expect(updateButton).toBeInTheDocument();
+        expect(updateButton).toHaveAttribute('aria-description');
+        expect(updateButton.innerHTML).not.toContain('svg');
+
+        const cancelButton = getByRole('button', { name: 'Cancel' });
+        expect(cancelButton).toBeInTheDocument();
+        expect(cancelButton).toHaveAttribute('aria-description');
     });
 
     it('should delete row when delete icon clicked', async () => {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -104,21 +104,21 @@ const RepeatingBlock = <V extends FieldValues>({
         className: styles.iconColumn,
         render: (value: V) => (
             <div className={classNames(styles.actions, sizing && styles[sizing])}>
-                <div data-tooltip-position="top" aria-label="View" onClick={() => view(value)}>
+                <div data-tooltip-position="top" aria-label="View" role="button" onClick={() => view(value)}>
                     <Icon
                         name="visibility"
                         sizing={sizing}
                         className={classNames({ [styles.active]: status === 'viewing' && value === selected })}
                     />
                 </div>
-                <div data-tooltip-position="top" aria-label="Edit" onClick={() => edit(value)}>
+                <div data-tooltip-position="top" aria-label="Edit" role="button" onClick={() => edit(value)}>
                     <Icon
                         name="edit"
                         sizing={sizing}
                         className={classNames({ [styles.active]: status === 'editing' && value === selected })}
                     />
                 </div>
-                <div data-tooltip-position="top" aria-label="Delete" onClick={() => handleRemove(value)}>
+                <div data-tooltip-position="top" aria-label="Delete" role="button" onClick={() => handleRemove(value)}>
                     <Icon name="delete" sizing={sizing} />
                 </div>
             </div>

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/patient/PatientFeaturesConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/patient/PatientFeaturesConfiguration.java
@@ -35,7 +35,7 @@ class PatientFeaturesConfiguration {
 
   @Bean
   @Scope("prototype")
-  Patient.File patientFileFeatures(@Value("${nbs.ui.features.patient.file.enabled:true}") final boolean enabled) {
+  Patient.File patientFileFeatures(@Value("${nbs.ui.features.patient.file.enabled:false}") final boolean enabled) {
     return new Patient.File(enabled);
   }
 

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/patient/PatientFeaturesConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/patient/PatientFeaturesConfiguration.java
@@ -35,7 +35,7 @@ class PatientFeaturesConfiguration {
 
   @Bean
   @Scope("prototype")
-  Patient.File patientFileFeatures(@Value("${nbs.ui.features.patient.file.enabled:false}") final boolean enabled) {
+  Patient.File patientFileFeatures(@Value("${nbs.ui.features.patient.file.enabled:true}") final boolean enabled) {
     return new Patient.File(enabled);
   }
 


### PR DESCRIPTION
adding aria role of button and fixing tests to match amount of  getAllByRole('button') expected (buttons) count for in the repeating block spec file

**ARIA label has to be updated for the Repeating block table -icons:**

> View
> Edit
> Delete
### AXE Scan before Fix
<img width="1512" alt="Screenshot 2025-04-21 at 1 29 17 PM" src="https://github.com/user-attachments/assets/4abb754f-a9d4-401a-b250-997d424129da" />


### AXE Scan after Fix
<img width="1510" alt="Screenshot 2025-04-21 at 1 27 16 PM" src="https://github.com/user-attachments/assets/c76296bd-7dfa-4294-b009-3c5921d9cd23" />


## Tickets

* [CNFT1-3992](https://cdc-nbs.atlassian.net/browse/CNFT1-3992)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-3992]: https://cdc-nbs.atlassian.net/browse/CNFT1-3992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ