### PR TITLE
CNFT1-4026: Update current age calculation logic when deceased date provided

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/personalDetails/BasicPersonalDetailsFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/personalDetails/BasicPersonalDetailsFields.spec.tsx
@@ -132,6 +132,34 @@ describe('when entering patient sex and birth demographics', () => {
         expect(getByLabelText('Date of death')).toBeInTheDocument();
     });
 
+    it('should not enable Date of death when deceased is false', async () => {
+        const { getByLabelText, queryByLabelText } = render(<Fixture />);
+
+        const deceased = getByLabelText('Is the patient deceased?');
+        expect(queryByLabelText('Date of death')).not.toBeInTheDocument();
+
+        const user = userEvent.setup();
+
+        await user.selectOptions(deceased, 'N');
+
+        expect(queryByLabelText('Date of death')).not.toBeInTheDocument();
+    });
+
+    it('should calculate currentAge against the deceasedOn date when provided', async () => {
+        const { getByLabelText, getByText } = render(<Fixture />);
+        const dateOfBirth = getByLabelText('Date of birth');
+        const deceased = getByLabelText('Is the patient deceased?');
+
+        const user = userEvent.setup();
+        await user.selectOptions(deceased, 'Y');
+
+        const deceasedOn = getByLabelText('Date of death');
+        await user.clear(dateOfBirth).then(() => user.type(dateOfBirth, '12012012{tab}'));
+        await user.clear(deceasedOn).then(() => user.type(deceasedOn, '01012018{tab}'));
+
+        expect(getByText('5 years')).toBeInTheDocument();
+    });
+
     it('should not render the HIV case ID when user does not have permission', async () => {
         mockPermissions.hivAccess = false;
         const { queryByLabelText } = render(<Fixture />);

--- a/apps/modernization-ui/src/apps/patient/add/basic/personalDetails/BasicPersonalDetailsFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/personalDetails/BasicPersonalDetailsFields.tsx
@@ -3,7 +3,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { SingleSelect } from 'design-system/select';
 import { Input } from 'components/FormInputs/Input';
-import { displayAgeAsOfToday } from 'date/displayAge';
+import { displayAgeAsOfToday, displayAgeAsOf } from 'date/displayAge';
 import { maxLengthRule } from 'validation/entry';
 import { EntryFieldsProps } from 'design-system/entry';
 import { ValueView } from 'design-system/data-display/ValueView';
@@ -21,8 +21,12 @@ const ENTRY_FIELD_PLACEHOLDER = '';
 export const BasicPersonalDetailsFields = ({ orientation = 'horizontal', sizing = 'medium' }: EntryFieldsProps) => {
     const { control, formState, getFieldState } = useFormContext<{ personalDetails: BasicPersonalDetailsEntry }>();
     const currentBirthday = useWatch({ control, name: 'personalDetails.bornOn' });
+    const deceasedOn = useWatch({ control, name: 'personalDetails.deceasedOn' });
     const selectedDeceased = useWatch({ control, name: 'personalDetails.deceased' });
-    const age = useMemo(() => displayAgeAsOfToday(currentBirthday), [currentBirthday]);
+    const age = useMemo(
+        () => (deceasedOn ? displayAgeAsOf(currentBirthday, deceasedOn) : displayAgeAsOfToday(currentBirthday)),
+        [currentBirthday, deceasedOn]
+    );
     const { hivAccess } = usePatientProfilePermissions();
     const { invalid: bornOnInvalid } = getFieldState('personalDetails.bornOn', formState);
 

--- a/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.tsx
@@ -32,6 +32,8 @@ export const MortalityEntryFields = ({ orientation = 'horizontal', sizing = 'med
         }
     }, [selectedDeceased?.value]);
 
+    console.log('selectedDeceased', selectedDeceased, Indicator.Yes);
+
     return (
         <section>
             <Controller

--- a/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
@@ -4,7 +4,7 @@ import { useSexBirthCodedValues } from './useSexBirthCodedValues';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { SingleSelect } from 'design-system/select';
 import { Input } from 'components/FormInputs/Input';
-import { displayAgeAsOfToday } from 'date/displayAge';
+import { displayAgeAsOf, displayAgeAsOfToday } from 'date/displayAge';
 import { maxLengthRule, validateRequiredRule } from 'validation/entry';
 import { BirthEntry, SexEntry } from 'apps/patient/data/entry';
 import { EntryFieldsProps } from 'design-system/entry';
@@ -20,11 +20,16 @@ const ENTRY_FIELD_PLACEHOLDER = '';
 
 export const SexAndBirthEntryFields = ({ orientation = 'horizontal', sizing = 'medium' }: EntryFieldsProps) => {
     const { control, setValue } = useFormContext<{ birthAndSex: BirthEntry & SexEntry }>();
+    //const { watch } = useFormContext<{ mortality: MortalityEntry }>();
     const currentBirthday = useWatch({ control, name: 'birthAndSex.bornOn' });
     const selectedCurrentGender = useWatch({ control, name: 'birthAndSex.current' });
     const selectedState = useWatch({ control, name: 'birthAndSex.state' });
     const selectedMultipleBirth = useWatch({ control, name: 'birthAndSex.multiple' });
-    const age = useMemo(() => displayAgeAsOfToday(currentBirthday), [currentBirthday]);
+    const deceasedOn = '12/25/2024'; //useWatch({ control, name: 'mortality.deceasedOn' });
+    const age = useMemo(
+        () => (deceasedOn ? displayAgeAsOf(currentBirthday, deceasedOn) : displayAgeAsOfToday(currentBirthday)),
+        [currentBirthday, deceasedOn]
+    );
 
     const coded = useSexBirthCodedValues();
 

--- a/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
@@ -6,7 +6,7 @@ import { SingleSelect } from 'design-system/select';
 import { Input } from 'components/FormInputs/Input';
 import { displayAgeAsOf, displayAgeAsOfToday } from 'date/displayAge';
 import { maxLengthRule, validateRequiredRule } from 'validation/entry';
-import { BirthEntry, SexEntry } from 'apps/patient/data/entry';
+import { BirthEntry, MortalityEntry, SexEntry } from 'apps/patient/data/entry';
 import { EntryFieldsProps } from 'design-system/entry';
 import { ValueView } from 'design-system/data-display/ValueView';
 import { useCountryOptions, useCountyOptions, useStateOptions } from 'options/location';
@@ -19,13 +19,12 @@ const BIRTH_CITY_LABEL = 'Birth city';
 const ENTRY_FIELD_PLACEHOLDER = '';
 
 export const SexAndBirthEntryFields = ({ orientation = 'horizontal', sizing = 'medium' }: EntryFieldsProps) => {
-    const { control, setValue } = useFormContext<{ birthAndSex: BirthEntry & SexEntry }>();
-    //const { watch } = useFormContext<{ mortality: MortalityEntry }>();
+    const { control, setValue } = useFormContext<{ birthAndSex: BirthEntry & SexEntry; mortality: MortalityEntry }>();
     const currentBirthday = useWatch({ control, name: 'birthAndSex.bornOn' });
     const selectedCurrentGender = useWatch({ control, name: 'birthAndSex.current' });
     const selectedState = useWatch({ control, name: 'birthAndSex.state' });
     const selectedMultipleBirth = useWatch({ control, name: 'birthAndSex.multiple' });
-    const deceasedOn = '12/25/2024'; //useWatch({ control, name: 'mortality.deceasedOn' });
+    const deceasedOn = useWatch({ control, name: 'mortality.deceasedOn' });
     const age = useMemo(
         () => (deceasedOn ? displayAgeAsOf(currentBirthday, deceasedOn) : displayAgeAsOfToday(currentBirthday)),
         [currentBirthday, deceasedOn]

--- a/apps/modernization-ui/src/date/displayAge.spec.ts
+++ b/apps/modernization-ui/src/date/displayAge.spec.ts
@@ -1,5 +1,5 @@
 import { differenceInYears } from 'date-fns';
-import { displayAgeAsOf, displayAgeAsOfToday } from './displayAge';
+import { asDate, displayAgeAsOf, displayAgeAsOfToday } from './displayAge';
 
 describe('displayAgeAsOf', () => {
     it('should display age in years', () => {
@@ -55,6 +55,24 @@ describe('displayAgeAsOf', () => {
 
         expect(actual).toBeUndefined();
     });
+
+    it('should display 1 year when from is string', () => {
+        const actual = displayAgeAsOf('1984-09-01', '1985-09-01');
+
+        expect(actual).toEqual('1 year');
+    });
+
+    it('should display age in years when from is string', () => {
+        const actual = displayAgeAsOf('1984-09-01', '2023-01-01');
+
+        expect(actual).toEqual('38 years');
+    });
+
+    it('should display age in months when from is string', () => {
+        const actual = displayAgeAsOf('2022-10-01', '2022-12-01');
+
+        expect(actual).toEqual('2 months');
+    });
 });
 
 describe('displayAgeAsOfToday', () => {
@@ -62,4 +80,30 @@ describe('displayAgeAsOfToday', () => {
     const actual = displayAgeAsOfToday(birthDate);
     const expected = `${differenceInYears(new Date(), birthDate)} years`;
     expect(actual).toEqual(expected);
+});
+
+describe('asDate', () => {
+    it('should convert a valid date string to a Date object', () => {
+        const dateString = '2023-10-01';
+        const result = asDate(dateString);
+        expect(result).toEqual(new Date(dateString));
+    });
+
+    it('should convert a Date object to a Date object', () => {
+        const dateObject = new Date('2023-10-01');
+        const result = asDate(dateObject);
+        expect(result).toEqual(dateObject);
+    });
+
+    it('should return undefined for an invalid date string', () => {
+        const invalidDateString = 'invalid-date';
+        const result = asDate(invalidDateString);
+        expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for an invalid Date object', () => {
+        const invalidDateObject = new Date('invalid-date');
+        const result = asDate(invalidDateObject);
+        expect(result).toBeUndefined();
+    });
 });

--- a/apps/modernization-ui/src/date/displayAge.ts
+++ b/apps/modernization-ui/src/date/displayAge.ts
@@ -2,32 +2,63 @@ import { now } from 'design-system/date/clock';
 import { differenceInDays, differenceInMonths, differenceInYears } from 'date-fns';
 import { Maybe } from 'utils';
 
-const displayAgeAsOf = (dateOfBirth: Maybe<string | Date>, from: Date) => {
-    if (typeof dateOfBirth === 'string') {
-        if (dateOfBirth.length < 10) {
+/**
+ * Converts a string or Date to a Date object.
+ * If the input is a string, it must be in a valid date format.
+ * @param date - The date to be converted
+ * @return {Date | undefined} - The converted Date object or undefined if the input is invalid
+ */
+const asDate = (date: Maybe<string | Date>): Date | undefined => {
+    if (typeof date === 'string') {
+        if (date.length < 10) {
             return undefined;
         }
-        dateOfBirth = new Date(dateOfBirth);
+        date = new Date(date);
     }
 
-    if (!(dateOfBirth instanceof Date) || isNaN(dateOfBirth.getTime()) || dateOfBirth > from) {
+    if (!(date instanceof Date) || isNaN(date.getTime())) {
         return undefined;
     }
 
-    const years = differenceInYears(from, dateOfBirth);
+    return date;
+};
+
+/**
+ * Converts the given date of birth and the reference date to a human-readable age string.
+ * The age is calculated as the difference in years, months, or days.
+ * If the date of birth is invalid or greater than the reference date, it returns undefined.
+ * @param dateOfBirth The date of birth to be converted
+ * @param from The reference date to calculate the age from
+ * @return {string | undefined} - The human-readable age string or undefined if the input is invalid
+ * @example
+ * displayAgeAsOf('2000-01-01', '2023-10-01') // returns '23 years'
+ */
+const displayAgeAsOf = (dateOfBirth: Maybe<string | Date>, from: Maybe<string | Date>) => {
+    const dateOfBirthDate = asDate(dateOfBirth);
+    const fromDate = asDate(from);
+    if (!dateOfBirthDate || !fromDate || dateOfBirthDate > fromDate) {
+        return undefined;
+    }
+
+    const years = differenceInYears(fromDate, dateOfBirthDate);
     if (years > 0) {
         return years > 1 ? `${years} years` : `${years} year`;
     }
 
-    const months = differenceInMonths(from, dateOfBirth);
+    const months = differenceInMonths(fromDate, dateOfBirthDate);
     if (months > 0) {
         return months > 1 ? `${months} months` : `${months} month`;
     }
 
-    const days = differenceInDays(from, dateOfBirth);
+    const days = differenceInDays(fromDate, dateOfBirthDate);
     return days > 1 || days === 0 ? `${days} days` : `${days} day`;
 };
 
+/**
+ * Converts the given date of birth from now to a human-readable age string.
+ * @param dateOfBirth The date of birth to be converted
+ * @return {string | undefined} - The human-readable age string as of today or undefined if the dateOfBirth is invalid
+ */
 const displayAgeAsOfToday = (dateOfBirth: Maybe<string | Date>) => displayAgeAsOf(dateOfBirth, now());
 
-export { displayAgeAsOf, displayAgeAsOfToday };
+export { asDate, displayAgeAsOf, displayAgeAsOfToday };


### PR DESCRIPTION
## Description

For New Patient and New Patient Extended, when the deceased date is provided use that as the basis for calculating current age.

![image](https://github.com/user-attachments/assets/9f7309d2-8097-41fa-b667-698b618ff6e1)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-4026)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
