### PR TITLE
[CNFT1-4030] Searchable gender no value label

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/asNewExtendedPatientEntry.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/asNewExtendedPatientEntry.spec.ts
@@ -82,18 +82,18 @@ describe('Basic form to extended transfer', () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     phoneNumber: '1231231234',
-                    type: expect.objectContaining({ label: 'Phone' }),
-                    use: expect.objectContaining({ label: 'Home' })
+                    type: expect.objectContaining({ name: 'Phone' }),
+                    use: expect.objectContaining({ name: 'Home' })
                 }),
                 expect.objectContaining({
                     phoneNumber: '1231231234',
-                    type: expect.objectContaining({ label: 'Cellular phone' }),
-                    use: expect.objectContaining({ label: 'Mobile contact' })
+                    type: expect.objectContaining({ name: 'Cellular phone' }),
+                    use: expect.objectContaining({ name: 'Mobile contact' })
                 }),
                 expect.objectContaining({
                     phoneNumber: '1231231234',
-                    type: expect.objectContaining({ label: 'Phone' }),
-                    use: expect.objectContaining({ label: 'Primary work place' })
+                    type: expect.objectContaining({ name: 'Phone' }),
+                    use: expect.objectContaining({ name: 'Primary work place' })
                 }),
                 expect.objectContaining({
                     email: 'test@test.com'
@@ -147,7 +147,7 @@ describe('Basic form to extended transfer', () => {
             expect.objectContaining({
                 detailed: [],
                 asOf: date,
-                ethnicGroup: { label: 'Test', name: 'Test', value: 'T' }
+                ethnicGroup: { name: 'Test', value: 'T' }
             })
         );
     });

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/searchableGenders.ts
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/searchableGenders.ts
@@ -1,7 +1,7 @@
 import { asSelectable } from 'options';
 import { genders } from 'options/gender';
 
-const NO_VALUE = asSelectable('NO_VALUE', 'No value');
+const NO_VALUE = asSelectable('NO_VALUE', '---', 'Null or blank values');
 
 const searchableGenders = [...genders, NO_VALUE];
 

--- a/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.spec.tsx
+++ b/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.spec.tsx
@@ -5,9 +5,9 @@ import { MultiSelectInput } from './MultiSelectInput';
 
 describe('Given a MultiSelectInput component', () => {
     const options = [
-        { name: 'label-one', value: '1' },
-        { name: 'label-two', value: '2' },
-        { name: 'label-three', value: '3' }
+        { name: 'name-one', value: '1' },
+        { name: 'name-two', value: '2' },
+        { name: 'name-three', value: '3' }
     ];
 
     it('should display options when clicked', async () => {
@@ -21,37 +21,37 @@ describe('Given a MultiSelectInput component', () => {
 
         await user.click(component);
 
-        expect(getByText('label-one')).toBeInTheDocument();
-        expect(getByText('label-two')).toBeInTheDocument();
-        expect(getByText('label-three')).toBeInTheDocument();
+        expect(getByText('name-one')).toBeInTheDocument();
+        expect(getByText('name-two')).toBeInTheDocument();
+        expect(getByText('name-three')).toBeInTheDocument();
     });
 
     it('should display single selected value', () => {
         const { getByText, queryByText } = render(<MultiSelectInput options={options} value={['2']} />);
 
-        expect(getByText('label-two')).toBeInTheDocument();
+        expect(getByText('name-two')).toBeInTheDocument();
 
-        expect(queryByText('label-one')).not.toBeInTheDocument();
-        expect(queryByText('label-three')).not.toBeInTheDocument();
+        expect(queryByText('name-one')).not.toBeInTheDocument();
+        expect(queryByText('name-three')).not.toBeInTheDocument();
     });
 
     it('should display multiple selected value', () => {
         const { getByText, queryByText } = render(<MultiSelectInput options={options} value={['2', '1']} />);
 
-        expect(getByText('label-two')).toBeInTheDocument();
+        expect(getByText('name-two')).toBeInTheDocument();
 
-        expect(queryByText('label-three')).not.toBeInTheDocument();
+        expect(queryByText('name-three')).not.toBeInTheDocument();
     });
 
     it('should remove the selected item when clicked', async () => {
         const { queryByText, getByLabelText } = render(<MultiSelectInput options={options} value={['2']} />);
 
-        const selected = getByLabelText('Remove label-two');
+        const selected = getByLabelText('Remove name-two');
 
         const user = userEvent.setup();
 
         await user.click(selected);
 
-        expect(queryByText('label-two')).not.toBeInTheDocument();
+        expect(queryByText('name-two')).not.toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.tsx
+++ b/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.tsx
@@ -1,7 +1,7 @@
-import { FocusEventHandler, useEffect, useMemo, useState } from 'react';
+import { FocusEventHandler, useEffect, useState } from 'react';
 import ReactSelect, { MultiValue } from 'react-select';
 import { mapNonNull } from 'utils';
-import { Selectable, asSelectable, asValue as asSelectableValue } from 'options';
+import { Selectable, asValues, asValue, asName } from 'options';
 import { EntryWrapper } from 'components/Entry';
 
 import { theme, styles, CheckboxOption } from 'design-system/select/multi';
@@ -11,15 +11,13 @@ import './MultiSelectInput.scss';
 const asSelected = (selectables: Selectable[]) => (item: string) =>
     selectables.find((option) => option.value === item) || null;
 
-type Options = { name: string; value: string };
-
 type MultiSelectInputProps = {
     label?: string;
     id?: string;
     name?: string;
     placeholder?: string;
     orientation?: 'horizontal' | 'vertical';
-    options?: Options[];
+    options?: Selectable[];
     value?: string[];
     onChange?: (value: any) => void;
     onBlur?: FocusEventHandler<HTMLInputElement> | undefined;
@@ -42,23 +40,18 @@ export const MultiSelectInput = ({
     orientation = 'vertical',
     disabled = false
 }: MultiSelectInputProps) => {
-    const selectableOptions = useMemo(
-        () => options.map((item) => asSelectable(item.value, item.name)),
-        [JSON.stringify(options)]
-    );
-
     const [selectedOptions, setSelectedOptions] = useState<Selectable[]>([]);
     const [searchText, setSearchText] = useState('');
 
     useEffect(() => {
-        const selected = mapNonNull(asSelected(selectableOptions), value);
+        const selected = mapNonNull(asSelected(options), value);
         setSelectedOptions(selected);
-    }, [JSON.stringify(value), selectableOptions]);
+    }, [...value, ...options]);
 
     const handleOnChange = (newValue: MultiValue<Selectable>) => {
         setSelectedOptions([...newValue]);
         if (onChange) {
-            const values = newValue.map((item) => item.value);
+            const values = asValues(newValue as Selectable[]);
             onChange(values);
         }
     };
@@ -91,11 +84,12 @@ export const MultiSelectInput = ({
                 closeMenuOnScroll={false}
                 onChange={handleOnChange}
                 onBlur={onBlur}
-                options={selectableOptions}
+                options={options}
                 components={{ Option: CheckboxOption }}
                 inputValue={searchText}
                 onInputChange={handleInputChange}
-                getOptionValue={asSelectableValue}
+                getOptionValue={asValue}
+                getOptionLabel={asName}
                 isDisabled={disabled}
             />
         </EntryWrapper>

--- a/apps/modernization-ui/src/design-system/select/single/Select.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.tsx
@@ -16,12 +16,12 @@ type SelectProps = {
 const renderOptions = (options: Selectable[], placeholder?: string) => (
     <>
         {placeholder && (
-            <option key={-1} value="">
+            <option key={-1} value="" aria-label="no value selected">
                 {placeholder}
             </option>
         )}
         {options?.map((item, index) => (
-            <option key={index} value={item.value}>
+            <option key={index} value={item.value} aria-label={item.label}>
                 {item.name}
             </option>
         ))}

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.spec.tsx
@@ -47,10 +47,10 @@ describe('when selecting a single item from a specific set of items', () => {
                 id="test-id"
                 label="Test Label"
                 options={[
-                    { name: 'name-one', value: 'value-one', label: 'label-one' },
-                    { name: 'name-two', value: 'value-two', label: 'label-two' },
-                    { name: 'name-three', value: 'value-three', label: 'label-three' },
-                    { name: 'name-four', value: 'value-four', label: 'label-four' }
+                    { name: 'name-one', value: 'value-one' },
+                    { name: 'name-two', value: 'value-two' },
+                    { name: 'name-three', value: 'value-three' },
+                    { name: 'name-four', value: 'value-four' }
                 ]}
                 value={{ name: 'name-three', value: 'value-three', label: 'label-three' }}
             />

--- a/apps/modernization-ui/src/design-system/select/single/SingleSelect.stories.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/SingleSelect.stories.tsx
@@ -3,7 +3,7 @@ import { SingleSelect } from './SingleSelect';
 import { asSelectable, Selectable } from 'options';
 
 const meta = {
-    title: 'Design System/Select/SingleSelect',
+    title: 'Design System/Select/Single',
     component: SingleSelect
 } satisfies Meta<typeof SingleSelect>;
 
@@ -12,11 +12,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const options: Selectable[] = [
-    asSelectable('apple', 'Apple'),
-    asSelectable('banana', 'Banana'),
-    asSelectable('mango', 'Mango'),
-    asSelectable('orange', 'Orange'),
-    asSelectable('watermelon', 'Watermelon')
+    asSelectable('Apple'),
+    asSelectable('Banana'),
+    asSelectable('Mango'),
+    asSelectable('Orange'),
+    asSelectable('Watermelon')
 ];
 
 export const Default: Story = {
@@ -24,18 +24,20 @@ export const Default: Story = {
         id: 'single-select',
         label: 'Single Select',
         options: options,
-        onChange: (selected) => {
-            console.log('Selected options:', selected);
-        }
+        onChange: () => {}
     }
 };
 
 export const Horizontal: Story = {
     args: {
         ...Default.args,
-        id: 'horizontal-single-select',
-        name: 'HorizontalSingleSelect',
-        label: 'Single Select',
         orientation: 'horizontal'
+    }
+};
+
+export const Vertical: Story = {
+    args: {
+        ...Default.args,
+        orientation: 'vertical'
     }
 };

--- a/apps/modernization-ui/src/options/selectable.ts
+++ b/apps/modernization-ui/src/options/selectable.ts
@@ -1,18 +1,17 @@
-import { Mapping, Maybe } from 'utils';
+import { Mapping } from 'utils';
 
 type Selectable = {
     value: string;
     name: string;
     label?: string;
-    order?: number;
 };
 
 export type { Selectable };
 
 /* eslint-disable no-redeclare */
 function mapExisting<V>(mapping: Mapping<Selectable, V>, selectable: Selectable): V;
-function mapExisting<V>(mapping: Mapping<Selectable, V>, selectable: null | undefined): undefined;
-function mapExisting<V>(mapping: Mapping<Selectable, V>, selectable: Maybe<Selectable>) {
+function mapExisting<V>(mapping: Mapping<Selectable, V>, selectable?: null): undefined;
+function mapExisting<V>(mapping: Mapping<Selectable, V>, selectable?: Selectable | null) {
     return selectable ? mapping(selectable) : undefined;
 }
 
@@ -25,9 +24,8 @@ function mapAllExisting<V>(items: Selectable[] | undefined, mapping: Mapping<Sel
 
 /* eslint-disable no-redeclare */
 function asNumericValue(selectable: Selectable): number;
-function asNumericValue(selectable: null | undefined): undefined;
-function asNumericValue(selectable: Maybe<Selectable>): undefined;
-function asNumericValue(selectable: Maybe<Selectable>) {
+function asNumericValue(selectable?: null): undefined;
+function asNumericValue(selectable?: Selectable | null) {
     return selectable ? mapExisting((s) => Number(s.value), selectable) : undefined;
 }
 
@@ -42,9 +40,9 @@ export { asNumericValue, asNumericValues };
 
 /* eslint-disable no-redeclare */
 function asValue(selectable: Selectable): string;
-function asValue(selectable: null | undefined): undefined;
-function asValue(selectable: Maybe<Selectable>): undefined;
-function asValue(selectable: Maybe<Selectable>) {
+function asValue(selectable?: null | undefined): undefined;
+function asValue(selectable?: Selectable | null): undefined;
+function asValue(selectable?: Selectable | null) {
     return selectable ? mapExisting((s) => s?.value, selectable) : undefined;
 }
 
@@ -59,18 +57,18 @@ export { asValue, asValues };
 
 /* eslint-disable no-redeclare */
 function asName(selectable: Selectable): string;
-function asName(selectable: null | undefined): undefined;
-function asName(selectable: Maybe<Selectable>): undefined;
-function asName(selectable: Maybe<Selectable>) {
+function asName(selectable?: null): undefined;
+function asName(selectable?: Selectable | null): undefined;
+function asName(selectable?: Selectable | null) {
     return selectable ? mapExisting((s) => s?.name, selectable) : undefined;
 }
 
 export { asName };
 
-const asSelectable = (value: string, name?: string): Selectable => ({
+const asSelectable = (value: string, name?: string, label?: string): Selectable => ({
+    value,
     name: name ?? value,
-    label: name ?? value,
-    value
+    label
 });
 
 export { asSelectable };


### PR DESCRIPTION
## Description

Changes the label for the "No value" searchable gender to "---" with an aria-label of "Null or blank values".

![image](https://github.com/user-attachments/assets/b884df8d-9bac-4efe-b309-b61f6f6a97ad)


## Tickets

* [CNFT1-4030](https://cdc-nbs.atlassian.net/browse/CNFT1-4030)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4030]: https://cdc-nbs.atlassian.net/browse/CNFT1-4030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ