### PR TITLE
Fix for CNFT1-3903 related issue in some cases the error would not clear when switching between exact date and date range

### DIFF
--- a/apps/modernization-ui/src/design-system/date/criteria/range/DateRangeField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/range/DateRangeField.tsx
@@ -35,7 +35,7 @@ const DateRangeField = ({ id, value, sizing, onChange, onBlur }: DateRangeFieldP
             if (between) {
                 onChange({ between });
             } else {
-                onChange();
+                onChange({ between: { from: undefined, to: undefined } });
             }
         },
         [onChange, value?.between]


### PR DESCRIPTION
## Description

Fix CNFT1-3903 issue by providing an object with undefined fields if there is no between value instead of an undefined object. See https://cdc-nbs.atlassian.net/browse/CNFT1-3903?focusedCommentId=31253 video for more info.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-3903)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
