### PR TITLE
[CNFT1-4009] Unclearable values in New patient

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
@@ -6,7 +6,7 @@ import { Shown } from 'conditional-render';
 import { Button } from 'components/button';
 import { sections } from './sections';
 import { AddPatientBasicForm } from './AddPatientBasicForm';
-import { BasicNewPatientEntry } from './entry';
+import { BasicNewPatientEntry, initial } from './entry';
 import { useAddBasicPatient } from './useAddBasicPatient';
 import { AddPatientLayout, DataEntryLayout } from '../layout';
 import { PatientCreatedPanel } from '../PatientCreatedPanel';
@@ -18,14 +18,21 @@ import { useShowCancelModal, CancelAddPatientPanel } from '../cancelAddPatientPa
 import styles from './add-patient-basic.module.scss';
 
 export const AddPatientBasic = () => {
-    const { initialize } = useAddPatientBasicDefaults();
+    const { defaults } = useAddPatientBasicDefaults();
     const { value: bypassBlocker } = useShowCancelModal();
 
     const interaction = useAddBasicPatient();
     const form = useForm<BasicNewPatientEntry>({
-        defaultValues: initialize(),
+        defaultValues: initial(),
         mode: 'onBlur'
     });
+
+    useEffect(() => {
+        if (defaults) {
+            form.reset(defaults, { keepDefaultValues: true });
+        }
+    }, [defaults]);
+    defaults;
     const blocker = useFormNavigationBlock({ activated: !bypassBlocker, form, allowed: '/patient/add/extended' });
 
     const { toExtended } = usePatientDataEntryMethod();

--- a/apps/modernization-ui/src/apps/patient/add/basic/useAddPatientBasicDefaults.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/useAddPatientBasicDefaults.ts
@@ -1,42 +1,36 @@
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 import { useLocation } from 'react-router';
 import { BasicNewPatientEntry, initial } from './entry';
 import { asBasicNewPatientEntry } from './asBasicNewPatientEntry';
 
 type Interaction = {
-    /**
-     * Initializes the values of basic patient data entry based on the current Location state.
-     *
-     *  1. Use the {@code basic} if present
-     *  2. Use the {@code criteria.values} converted to patient entry defaults if present.
-     *  3. Otherwise use the initial values for basic patient data entry.
-     *
-     * @return  {BasicNewPatientEntry} The defaults values.
-     */
-    initialize: () => BasicNewPatientEntry;
+    defaults: BasicNewPatientEntry | undefined;
 };
 
 /**
- * Provides a function to initialize the default form values for New patient - basic.
+ * Provides any defaulted values of basic patient data entry based on the Location state.  Values are currently
+ * defaulted in two ways; from Patient search criteria, or from basic patient entry values that are stored when
+ * transitioning to extended patient entry.
+ *
+ *  1. Use the {@code basic} if present
+ *  2. Use the {@code criteria.values} converted to patient entry defaults if present.
  *
  * @return {Interaction} to initialize the default state of BasicNewPatientEntry
  */
 const useAddPatientBasicDefaults = (): Interaction => {
     const location = useLocation();
 
-    const initialize = useCallback(() => {
+    const defaults = useMemo(() => {
         if (location.state?.basic) {
             //  first check if basic was passed during navigation
-            return { ...location.state?.basic };
+            return { ...location.state?.basic } as BasicNewPatientEntry;
         } else if (location.state?.criteria?.values) {
             //  convert the search criteria values to
             return asBasicNewPatientEntry(initial())({ ...location.state?.criteria?.values });
-        } else {
-            return initial();
         }
-    }, [location.state?.defaults]);
+    }, [location.state?.basic, location.state?.criteria?.values]);
 
-    return { initialize };
+    return { defaults };
 };
 
 export { useAddPatientBasicDefaults };

--- a/apps/modernization-ui/src/design-system/input/text/MaskedTextInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/MaskedTextInput.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { TextInput, TextInputProps } from './TextInput';
 import { masked } from './masked';
-import { orUndefined } from 'utils';
+import { mapOr } from 'utils/mapping';
 
 type MaskedTextInputProps = {
     mask: string;
@@ -9,17 +9,15 @@ type MaskedTextInputProps = {
 
 const MaskedTextInput = ({ mask, value, onChange, ...props }: MaskedTextInputProps) => {
     const [current, setCurrent] = useState(value);
-    const applyMask = useCallback(masked(mask), [mask]);
+    const applyMask = useCallback(mapOr(masked(mask), undefined), [mask]);
 
-    useEffect(() => {
-        if (value === '') {
-            setCurrent(value);
-        }
-    }, [value]);
+    if (current !== value) {
+        setCurrent(applyMask(value));
+    }
 
     const handleChange = (value?: string) => {
         if (value) {
-            const next = orUndefined(applyMask(value));
+            const next = applyMask(value);
             setCurrent(next);
             onChange?.(next);
         } else {

--- a/apps/modernization-ui/src/design-system/input/text/MaskedTextInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/MaskedTextInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { TextInput, TextInputProps } from './TextInput';
 import { masked } from './masked';
 import { mapOr } from 'utils/mapping';
@@ -8,21 +8,27 @@ type MaskedTextInputProps = {
 } & Omit<TextInputProps, 'maxLength'>;
 
 const MaskedTextInput = ({ mask, value, onChange, ...props }: MaskedTextInputProps) => {
-    const [current, setCurrent] = useState(value);
     const applyMask = useCallback(mapOr(masked(mask), undefined), [mask]);
 
-    if (current !== value) {
-        setCurrent(applyMask(value));
-    }
+    const [current, setCurrent] = useState(applyMask(value));
+
+    useEffect(() => {
+        const adjusted = applyMask(value);
+        if (adjusted !== current) {
+            //  the value passed to the component has changed and is out of sync with current
+            //  update current to match the incoming value.
+            setCurrent(adjusted);
+        }
+    }, [value]);
 
     const handleChange = (value?: string) => {
         if (value) {
             const next = applyMask(value);
-            setCurrent(next);
             onChange?.(next);
+            setCurrent(next);
         } else {
-            setCurrent(undefined);
             onChange?.();
+            setCurrent(undefined);
         }
     };
 

--- a/apps/modernization-ui/src/design-system/input/text/MaskedTextInputField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/MaskedTextInputField.spec.tsx
@@ -1,30 +1,13 @@
-import { render } from "@testing-library/react";
-import { MaskedTextInput } from "./MaskedTextInput";
-import userEvent from "@testing-library/user-event";
-
-const PHONE_MASK = '___-___-____';
-const TEST_PHONE_NUMBER = '123-456-7890';
-const TEST_DIGITS = '1234567890';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MaskedTextInputField } from './MaskedTextInputField';
 
 describe('MaskedTextInput', () => {
-    it('should handle input masking correctly', async () => {
-        const handleChange = jest.fn();
-        const { getByRole } = render(
-            <div>
-                <label htmlFor="phone-input">Phone Input</label>
-                <MaskedTextInput
-                    id="phone-input"
-                    mask={PHONE_MASK}
-                    value=""
-                    onChange={handleChange}
-                />
-            </div>
+    it('should render with no accessibility violations', async () => {
+        const { container } = render(
+            <MaskedTextInputField id="testing-masked" label="Masked Input Field" mask="__" onChange={() => {}} />
         );
 
-        const input = getByRole('textbox');
-        await userEvent.type(input, TEST_DIGITS);
-
-        expect(input).toHaveValue(TEST_PHONE_NUMBER);
-        expect(handleChange).toHaveBeenCalledWith(TEST_PHONE_NUMBER);
+        expect(await axe(container)).toHaveNoViolations();
     });
 });

--- a/apps/modernization-ui/src/design-system/input/text/MaskedTextInputField.stories.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/MaskedTextInputField.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { MaskedTextInputField } from './MaskedTextInputField';
 
 const meta = {
-    title: 'Design System/Input/MaskedTextInputField',
+    title: 'Design System/Input/Text/Masked',
     component: MaskedTextInputField
 } satisfies Meta<typeof MaskedTextInputField>;
 
@@ -14,13 +14,9 @@ export const Default: Story = {
     args: {
         id: 'masked-text-input',
         label: 'Masked Text Input',
-        placeholder: 'No Data',
-        value: '12345-67890',
-        mask: '_____-_____',
-        pattern: '^.*$',
-        onChange: (value) => {
-            console.log('Value changed:', value);
-        }
+        helperText: 'Values will be formatted accorded to the given mask',
+        mask: '(_)____-____@_',
+        onChange: () => {}
     }
 };
 

--- a/apps/modernization-ui/src/design-system/input/text/MaskedTextInputField.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/MaskedTextInputField.tsx
@@ -10,10 +10,18 @@ const MaskedTextInputField = ({
     sizing,
     error,
     required,
+    helperText,
     ...remaining
 }: MaskedTextInputFieldProps) => {
     return (
-        <Field orientation={orientation} sizing={sizing} label={label} htmlFor={id} required={required} error={error}>
+        <Field
+            orientation={orientation}
+            sizing={sizing}
+            label={label}
+            htmlFor={id}
+            required={required}
+            error={error}
+            helperText={helperText}>
             <MaskedTextInput id={id} {...remaining} />
         </Field>
     );


### PR DESCRIPTION
## Description

When the "New patient" page was setting defaulted values from search criteria or values stored when transitioning from "New patient" to "New patient - extended" as the default values of the form.  This was causing cleared values to return in the masked input field because it was also not handling value changes external to the component.

## Tickets

* [CNFT1-4009](https://cdc-nbs.atlassian.net/browse/CNFT1-4009)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4009]: https://cdc-nbs.atlassian.net/browse/CNFT1-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ