### PR TITLE
[CNFT1-4005]removing results count focus upon search and correcting tab order

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -27,9 +27,9 @@ const SearchTerms = ({ total, terms }: Props) => {
     const { without } = useSearchInteraction();
 
     return (
-        <div className={styles.terms} aria-label={ariaLabel}>
+        <div tabIndex={0} id="resultsCount" className={styles.terms} aria-label={ariaLabel}>
             <div className={styles.term}>
-                <h2 tabIndex={0} id="resultsCount">
+                <h2>
                     {total} {resultsText.toLowerCase()} for:
                 </h2>
                 {terms.map((term, index) => (


### PR DESCRIPTION
## Description

Removing the results count focus when a search is made to not be visible and only be visible for SR 
The first tabable element available after a search is made should be the chips
Problem 
<img width="1472" alt="Screenshot 2025-04-30 at 3 32 43 PM" src="https://github.com/user-attachments/assets/d9add224-7009-49c6-ba2f-89ed44ca16dd" />

Fix
<img width="1321" alt="Screenshot 2025-04-30 at 3 33 09 PM" src="https://github.com/user-attachments/assets/8d318487-246d-4c4b-ae94-ad1b158bc808" />

## Tickets

* [CNFT1-4005](https://cdc-nbs.atlassian.net/browse/CNFT1-4005)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4005]: https://cdc-nbs.atlassian.net/browse/CNFT1-4005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ