### PR TITLE
[CNFT1-4101]: centering x icon in chips

### DIFF
--- a/apps/modernization-ui/src/design-system/chips/chip.module.scss
+++ b/apps/modernization-ui/src/design-system/chips/chip.module.scss
@@ -6,6 +6,8 @@
     background-color: colors.$primary-lighter;
     color: colors.$primary-dark;
     border-radius: 2px;
+    display: flex;
+    align-items: center;
 
     .name {
         text-transform: uppercase;


### PR DESCRIPTION
## Description
**Centering icon** 
<img width="766" alt="Screenshot 2025-05-02 at 10 24 54 AM" src="https://github.com/user-attachments/assets/572b4bd2-e056-46ed-bb50-f450e17e2ce9" />
Previously it was elevated next to the label within the chip like so
<img width="504" alt="Screenshot 2025-05-02 at 10 25 49 AM" src="https://github.com/user-attachments/assets/23fdf079-ff81-4132-8089-c17056a369f1" />



## Tickets

* [CNFT1-4101](https://cdc-nbs.atlassian.net/browse/CNFT1-4101)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4101]: https://cdc-nbs.atlassian.net/browse/CNFT1-4101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ