### PR TITLE
[FIX] Permitted

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/PatientCreatedPanel.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/PatientCreatedPanel.tsx
@@ -21,17 +21,17 @@ const PatientCreatedPanel = ({ created }: Props) => (
         onClose={() => {}}
         footer={() => (
             <>
-                <Permitted include={[permissions.morbidityReport.add]}>
+                <Permitted permission={permissions.morbidityReport.add}>
                     <ClassicButton outline url={`/nbs/api/profile/${created.id}/report/morbidity`}>
                         Add morbidity report
                     </ClassicButton>
                 </Permitted>
-                <Permitted include={[permissions.labReport.add]}>
+                <Permitted permission={permissions.labReport.add}>
                     <ClassicButton outline url={`/nbs/api/profile/${created.id}/report/lab`}>
                         Add lab report
                     </ClassicButton>
                 </Permitted>
-                <Permitted include={[permissions.investigation.add]}>
+                <Permitted permission={permissions.investigation.add}>
                     <ClassicButton outline url={`/nbs/api/profile/${created.id}/investigation`}>
                         Add investigation
                     </ClassicButton>

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
@@ -11,7 +11,7 @@ const PatientSearchActions = ({ disabled }: Props) => {
     const { add } = useAddPatientFromSearch();
 
     return (
-        <Permitted include={[permissions.patient.add]}>
+        <Permitted permission={permissions.patient.add}>
             <Button
                 type="button"
                 onClick={add}

--- a/apps/modernization-ui/src/apps/search/patient/result/none/NoPatientResults.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/none/NoPatientResults.tsx
@@ -18,7 +18,7 @@ const NoPatientResults = ({ sizing }: Props) => {
                     <div className={styles.noResultsContent}>
                         <span className={styles.noResultsHeader}> No result found</span>
                         <span className={styles.noResultsSubHeading}>
-                            <Permitted include={[permissions.patient.add]} fallback="Try refining your search.">
+                            <Permitted permission={permissions.patient.add} fallback="Try refining your search.">
                                 Try refining your search, or{' '}
                                 <a className={styles.link} onClick={add}>
                                     add a new patient.

--- a/apps/modernization-ui/src/libs/permission/Permitted.spec.tsx
+++ b/apps/modernization-ui/src/libs/permission/Permitted.spec.tsx
@@ -26,86 +26,14 @@ describe('Permitted', () => {
         expect(queryByText('Content')).toBeInTheDocument();
     });
 
-    it('should not render children when not all permission is included', () => {
-        const { queryByText } = render(<Permitted include={['permitted', 'not-permitted']}>Content</Permitted>);
-
-        expect(queryByText('Content')).not.toBeInTheDocument();
-    });
-
-    it('should render children when any permission is included', () => {
-        const { queryByText } = render(
-            <Permitted include={['permitted', 'not-permitted']} mode="any">
-                Content
-            </Permitted>
-        );
+    it('should render children when the permission predicate passes', () => {
+        const { queryByText } = render(<Permitted permission={() => true}>Content</Permitted>);
 
         expect(queryByText('Content')).toBeInTheDocument();
     });
 
-    it('should not render children when permission is excluded', () => {
-        const { queryByText } = render(<Permitted exclude={['permitted']}>Content</Permitted>);
-
-        expect(queryByText('Content')).not.toBeInTheDocument();
-    });
-
-    it('should not render children when all permissions are excluded', () => {
-        const { queryByText } = render(<Permitted exclude={['permitted', 'other-permitted']}>Content</Permitted>);
-
-        expect(queryByText('Content')).not.toBeInTheDocument();
-    });
-
-    it('should not render children when any permissions are excluded', () => {
-        const { queryByText } = render(
-            <Permitted exclude={['permitted', 'some-permitted']} mode="any">
-                Content
-            </Permitted>
-        );
-
-        expect(queryByText('Content')).not.toBeInTheDocument();
-    });
-
-    it('should not render children when any of the permissions are excluded', () => {
-        const { queryByText } = render(
-            <Permitted exclude={['permitted', 'some-permitted']} mode="any">
-                Content
-            </Permitted>
-        );
-
-        expect(queryByText('Content')).not.toBeInTheDocument();
-    });
-
-    it('should render children when any of the permissions excluded are not in user permission list', () => {
-        const { queryByText } = render(<Permitted exclude={['not-permitted']}>Content</Permitted>);
-
-        expect(queryByText('Content')).toBeInTheDocument();
-    });
-
-    it('should render children when not all permissions are excluded', () => {
-        const { queryByText } = render(
-            <Permitted exclude={['some-permitted', 'other-permitted']} mode="all">
-                Content
-            </Permitted>
-        );
-
-        expect(queryByText('Content')).toBeInTheDocument();
-    });
-
-    it('should render children when included and excluded are set', () => {
-        const { queryByText } = render(
-            <Permitted include={['permitted']} exclude={['not-permitted']}>
-                Content
-            </Permitted>
-        );
-
-        expect(queryByText('Content')).toBeInTheDocument();
-    });
-
-    it('should not render children when included and excluded overlap', () => {
-        const { queryByText } = render(
-            <Permitted include={['permitted']} exclude={['permitted']}>
-                Content
-            </Permitted>
-        );
+    it('should render children when the permission predicate fails', () => {
+        const { queryByText } = render(<Permitted permission={() => false}>Content</Permitted>);
 
         expect(queryByText('Content')).not.toBeInTheDocument();
     });

--- a/apps/modernization-ui/src/libs/permission/index.ts
+++ b/apps/modernization-ui/src/libs/permission/index.ts
@@ -1,2 +1,5 @@
 export { Permitted } from './Permitted';
 export { permissions } from './permissions';
+export { permits } from './permits';
+export { permitsAll } from './permitsAll';
+export { permitsAny } from './permitsAny';

--- a/apps/modernization-ui/src/libs/permission/permits.spec.ts
+++ b/apps/modernization-ui/src/libs/permission/permits.spec.ts
@@ -1,0 +1,19 @@
+import { permits } from './permits';
+
+describe('when testing that a permission is permitted', () => {
+    it('should pass when the permission is permitted', () => {
+        const permitted = permits('l');
+
+        const actual = permitted(['a', 'b', 'c', 'l', 'm', 'o', 'w']);
+
+        expect(actual).toBe(true);
+    });
+
+    it('should fail when the permission is not permitted', () => {
+        const permitted = permits('l');
+
+        const actual = permitted(['a', 'b', 'c', 'm', 'o', 'w']);
+
+        expect(actual).toBe(false);
+    });
+});

--- a/apps/modernization-ui/src/libs/permission/permits.ts
+++ b/apps/modernization-ui/src/libs/permission/permits.ts
@@ -1,0 +1,16 @@
+import { equalsIgnoreCase, Predicate } from 'utils/predicate';
+
+/**
+ * Returns a {@link Predicate} that evaluates to true when a permission is permitted.
+ * A permission is considered permitted if it exists (regardless of case) within the
+ * permissions passed.
+ *
+ * @param {string} permission The name of the permission to test for
+ * @return {Predicate<string[]>}
+ */
+const permits =
+    (permission: string): Predicate<string[]> =>
+    (permissions: string[]) =>
+        permissions.find(equalsIgnoreCase(permission)) !== undefined;
+
+export { permits };

--- a/apps/modernization-ui/src/libs/permission/permitsAll.spec.ts
+++ b/apps/modernization-ui/src/libs/permission/permitsAll.spec.ts
@@ -1,0 +1,35 @@
+import { permitsAll } from './permitsAll';
+
+describe('when testing that all permissions are permitted for a user', () => {
+    it('should pass when all permissions are permitted', () => {
+        const permitted = permitsAll('A', 'l', 'o', 'w');
+
+        const actual = permitted(['a', 'b', 'c', 'l', 'm', 'o', 'w']);
+
+        expect(actual).toBe(true);
+    });
+
+    it('should fail when at least one permissions is not permitted', () => {
+        const permitted = permitsAll('A', 'l', 'o', 'w');
+
+        const actual = permitted(['a', 'b', 'c', 'm', 'o', 'w']);
+
+        expect(actual).toBe(false);
+    });
+
+    it('should fail when there are no permissions', () => {
+        const permitted = permitsAll('A', 'l', 'o', 'w');
+
+        const actual = permitted([]);
+
+        expect(actual).toBe(false);
+    });
+
+    it('should fail when no permissions are permitted', () => {
+        const permitted = permitsAll('A', 'l', 'o', 'w');
+
+        const actual = permitted(['d', 'e', 'n', 'y']);
+
+        expect(actual).toBe(false);
+    });
+});

--- a/apps/modernization-ui/src/libs/permission/permitsAll.ts
+++ b/apps/modernization-ui/src/libs/permission/permitsAll.ts
@@ -1,0 +1,12 @@
+import { allOf, Predicate } from 'utils/predicate';
+import { permits } from './permits';
+
+/**
+ * Returns a {@link Predicate} that evaluates to true when all of the required permissions are permitted.
+ *
+ * @param {string[]} required An array of required permissions
+ * @return {Predicate<string[]>}
+ */
+const permitsAll = (...required: string[]): Predicate<string[]> => allOf(...required.map(permits));
+
+export { permitsAll };

--- a/apps/modernization-ui/src/libs/permission/permitsAny.spec.ts
+++ b/apps/modernization-ui/src/libs/permission/permitsAny.spec.ts
@@ -1,0 +1,27 @@
+import { permitsAny } from './permitsAny';
+
+describe('when testing that any permissions are permitted for a user', () => {
+    it('should pass when at least one permissions is permitted', () => {
+        const permitted = permitsAny('A', 'l', 'o', 'w');
+
+        const actual = permitted(['a', 'b', 'c', 'm', 'o', 'w']);
+
+        expect(actual).toBe(true);
+    });
+
+    it('should fail when there are no permissions', () => {
+        const permitted = permitsAny('A', 'l', 'o', 'w');
+
+        const actual = permitted([]);
+
+        expect(actual).toBe(false);
+    });
+
+    it('should fail when no permissions are permitted', () => {
+        const permitted = permitsAny('A', 'l', 'o', 'w');
+
+        const actual = permitted(['d', 'e', 'n', 'y']);
+
+        expect(actual).toBe(false);
+    });
+});

--- a/apps/modernization-ui/src/libs/permission/permitsAny.ts
+++ b/apps/modernization-ui/src/libs/permission/permitsAny.ts
@@ -1,0 +1,12 @@
+import { anyOf, Predicate } from 'utils/predicate';
+import { permits } from './permits';
+
+/**
+ * Returns a {@link Predicate} that evaluates to true at least of the required permissions are permitted.
+ *
+ * @param {string[]} required An array of required permissions
+ * @return {Predicate<string[]>}
+ */
+const permitsAny = (...required: string[]): Predicate<string[]> => anyOf(...required.map(permits));
+
+export { permitsAny };

--- a/apps/modernization-ui/src/libs/permission/usePermissions.ts
+++ b/apps/modernization-ui/src/libs/permission/usePermissions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useUser } from 'user';
 import { Predicate } from 'utils';
+import { permits } from './permits';
 
 type Interaction = {
     permissions: string[];
@@ -13,11 +14,7 @@ const usePermissions = (): Interaction => {
     } = useUser();
 
     const permissions = useMemo(() => user?.permissions ?? [], [user?.identifier]);
-    const allows = useCallback(
-        (permission: string) =>
-            permissions.find((granted) => granted.toUpperCase() == permission.toUpperCase()) !== undefined,
-        [user?.identifier]
-    );
+    const allows = useCallback((permission: string) => permits(permission)(permissions), [user?.identifier]);
 
     return { permissions, allows };
 };

--- a/apps/modernization-ui/src/utils/predicate/allOf.spec.ts
+++ b/apps/modernization-ui/src/utils/predicate/allOf.spec.ts
@@ -1,10 +1,10 @@
 import { allOf } from './allOf';
 
 describe('allOf', () => {
-    it('should return true no predicates are given', () => {
+    it('should return true when no predicates are given', () => {
         const actual = allOf()(3);
 
-        expect(actual).toBe(true);
+        expect(actual).toBe(false);
     });
 
     it('should return true if all predicates pass', () => {

--- a/apps/modernization-ui/src/utils/predicate/allOf.ts
+++ b/apps/modernization-ui/src/utils/predicate/allOf.ts
@@ -1,8 +1,20 @@
 import { Predicate } from './predicate';
 
+/**
+ * Returns a single {@link Predicate} that evaluates to true if all of the given predicates
+ * evaluates to true.  If no predicates are passed then the resulting predicate always evaluates
+ * to false.
+ *
+ * @param {Predicate<R>[]} predicates The predicates to evaluate.
+ * @return {Predicate<R>}
+ */
 const allOf =
     <R>(...predicates: Predicate<R>[]) =>
     (item: R) => {
+        if (predicates.length === 0) {
+            return false;
+        }
+
         for (const predicate of predicates) {
             const result = predicate(item);
 

--- a/apps/modernization-ui/src/utils/predicate/anyOf.spec.ts
+++ b/apps/modernization-ui/src/utils/predicate/anyOf.spec.ts
@@ -1,0 +1,41 @@
+import { anyOf } from './anyOf';
+
+describe('anyOf', () => {
+    it('should return false when no predicates are given', () => {
+        const actual = anyOf()(3);
+
+        expect(actual).toBe(false);
+    });
+
+    it('should return false if all predicates fail', () => {
+        const first = jest.fn().mockReturnValue(false);
+        const second = jest.fn().mockReturnValue(false);
+        const third = jest.fn().mockReturnValue(false);
+        const fourth = jest.fn().mockReturnValue(false);
+
+        const actual = anyOf<number>(first, second, third, fourth)(6);
+
+        expect(actual).toBe(false);
+
+        expect(first).toBeCalledWith(6);
+        expect(second).toBeCalledWith(6);
+        expect(third).toBeCalledWith(6);
+        expect(fourth).toBeCalledWith(6);
+    });
+
+    it('should return true,  when the first predicate succeeds', () => {
+        const first = jest.fn().mockReturnValue(false);
+        const second = jest.fn().mockReturnValue(true);
+        const third = jest.fn().mockReturnValue(true);
+        const fourth = jest.fn().mockReturnValue(true);
+
+        const actual = anyOf<number>(first, second, third, fourth, () => true)(6);
+
+        expect(actual).toBe(true);
+
+        expect(first).toBeCalledWith(6);
+        expect(second).toBeCalledWith(6);
+        expect(third).not.toBeCalled();
+        expect(fourth).not.toBeCalled();
+    });
+});

--- a/apps/modernization-ui/src/utils/predicate/anyOf.ts
+++ b/apps/modernization-ui/src/utils/predicate/anyOf.ts
@@ -1,5 +1,13 @@
 import { Predicate } from './predicate';
 
+/**
+ * Returns a single {@link Predicate} that evaluates to true when any of the given predicates
+ * evaluates to true.  If no predicates are passed then the resulting predicate always evaluates
+ * to false.
+ *
+ * @param {Predicate<R>[]} predicates The predicates to evaluate.
+ * @return {Predicate<R>}
+ */
 const anyOf =
     <R>(...predicates: Predicate<R>[]) =>
     (item: R) => {

--- a/apps/modernization-ui/src/utils/predicate/anyOf.ts
+++ b/apps/modernization-ui/src/utils/predicate/anyOf.ts
@@ -1,0 +1,17 @@
+import { Predicate } from './predicate';
+
+const anyOf =
+    <R>(...predicates: Predicate<R>[]) =>
+    (item: R) => {
+        for (const predicate of predicates) {
+            const result = predicate(item);
+
+            if (result) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+export { anyOf };

--- a/apps/modernization-ui/src/utils/predicate/both.ts
+++ b/apps/modernization-ui/src/utils/predicate/both.ts
@@ -1,0 +1,8 @@
+import { Predicate } from './predicate';
+
+const both =
+    <V>(first: Predicate<V>, second: Predicate<V>): Predicate<V> =>
+    (value) =>
+        first(value) && second(value);
+
+export { both };

--- a/apps/modernization-ui/src/utils/predicate/either.ts
+++ b/apps/modernization-ui/src/utils/predicate/either.ts
@@ -1,0 +1,8 @@
+import { Predicate } from './predicate';
+
+const either =
+    <V>(first: Predicate<V>, second: Predicate<V>): Predicate<V> =>
+    (value) =>
+        first(value) || second(value);
+
+export { either };

--- a/apps/modernization-ui/src/utils/predicate/equals.spec.ts
+++ b/apps/modernization-ui/src/utils/predicate/equals.spec.ts
@@ -1,0 +1,19 @@
+import { equals } from './equals';
+
+describe('equals', () => {
+    it.each([2, 'string', false])('should return true when the values are equal', (value) => {
+        const actual = equals(value)(value);
+
+        expect(actual).toBe(true);
+    });
+
+    it.each([
+        [2, 3],
+        ['string', 'other'],
+        [false, true]
+    ])('should return false when the values are not equal', (criteria, value) => {
+        const actual = equals(criteria)(value);
+
+        expect(actual).toBe(false);
+    });
+});

--- a/apps/modernization-ui/src/utils/predicate/equals.ts
+++ b/apps/modernization-ui/src/utils/predicate/equals.ts
@@ -1,0 +1,8 @@
+import { Predicate } from './predicate';
+
+const equals =
+    <V>(criteria: V): Predicate<V> =>
+    (value: V) =>
+        criteria === value;
+
+export { equals };

--- a/apps/modernization-ui/src/utils/predicate/equalsIgnoreCase.spec.ts
+++ b/apps/modernization-ui/src/utils/predicate/equalsIgnoreCase.spec.ts
@@ -1,0 +1,21 @@
+import { equalsIgnoreCase } from './equalsIgnoreCase';
+
+describe('equalsIgnoreCase', () => {
+    it('should return true when the string values are equal', () => {
+        const actual = equalsIgnoreCase('value')('value');
+
+        expect(actual).toBe(true);
+    });
+
+    it('should return true when the string values are equal with differing cases', () => {
+        const actual = equalsIgnoreCase('ValUe')('vAluE');
+
+        expect(actual).toBe(true);
+    });
+
+    it('should return false when the string values are not equal', () => {
+        const actual = equalsIgnoreCase('criteria')('value');
+
+        expect(actual).toBe(false);
+    });
+});

--- a/apps/modernization-ui/src/utils/predicate/equalsIgnoreCase.ts
+++ b/apps/modernization-ui/src/utils/predicate/equalsIgnoreCase.ts
@@ -1,0 +1,8 @@
+import { Predicate } from './predicate';
+
+const equalsIgnoreCase =
+    (criteria: string): Predicate<string> =>
+    (value: string) =>
+        criteria.toUpperCase() === value.toUpperCase();
+
+export { equalsIgnoreCase };

--- a/apps/modernization-ui/src/utils/predicate/index.ts
+++ b/apps/modernization-ui/src/utils/predicate/index.ts
@@ -1,3 +1,9 @@
 export type { Predicate } from './predicate';
 
+export { equals } from './equals';
+export { equalsIgnoreCase } from './equalsIgnoreCase';
+
 export { allOf } from './allOf';
+export { anyOf } from './anyOf';
+
+export { not } from './not';

--- a/apps/modernization-ui/src/utils/predicate/index.ts
+++ b/apps/modernization-ui/src/utils/predicate/index.ts
@@ -3,6 +3,8 @@ export type { Predicate } from './predicate';
 export { equals } from './equals';
 export { equalsIgnoreCase } from './equalsIgnoreCase';
 
+export { both } from './both';
+export { either } from './either';
 export { allOf } from './allOf';
 export { anyOf } from './anyOf';
 

--- a/apps/modernization-ui/src/utils/predicate/not.spec.ts
+++ b/apps/modernization-ui/src/utils/predicate/not.spec.ts
@@ -1,0 +1,23 @@
+import { not } from './not';
+
+describe('not', () => {
+    it('should return false when the given predicate returns true', () => {
+        const predicate = jest.fn(() => true);
+
+        const actual = not(predicate)(7);
+
+        expect(actual).toBe(false);
+
+        expect(predicate).toBeCalledWith(7);
+    });
+
+    it('should return true when the given predicate returns false', () => {
+        const predicate = jest.fn(() => false);
+
+        const actual = not(predicate)(7);
+
+        expect(actual).toBe(true);
+
+        expect(predicate).toBeCalledWith(7);
+    });
+});

--- a/apps/modernization-ui/src/utils/predicate/not.ts
+++ b/apps/modernization-ui/src/utils/predicate/not.ts
@@ -1,0 +1,8 @@
+import { Predicate } from './predicate';
+
+const not =
+    <V>(predicate: Predicate<V>): Predicate<V> =>
+    (value) =>
+        !predicate(value);
+
+export { not };


### PR DESCRIPTION
## Description

Changes the API of the `Permitted` component to accept a `string` or a `Predicate<string[]>`.  This simplifies the most common use case of a single permission being required to view a component.  

```react
   <Permitted permission="protected">
               <div>Protected</div>
   </Permitted>
```

is equivalent to 

```react
   <Permitted permission={permits("protected")}>
               <div>Protected</div>
   </Permitted>
```

A few predicates have been added to replace the existing functionality of the `includes`, `excludes` and `mode` properties.

Requiring all permissions to be present changes from 

```react
   <Permitted include=["A", "B", "C"]>
               <div>Protected</div>
   </Permitted>
```

to 

```react
   <Permitted permission={permitsAll("A", "B", "C")}>
               <div>Protected</div>
   </Permitted>
```

Requiring any permissions to be present changes from 

```react
   <Permitted include=["A", "B", "C"] mode="any">
               <div>Protected</div>
   </Permitted>
```

to 

```react
   <Permitted permission={permitsAny("A", "B", "C")}>
               <div>Protected</div>
   </Permitted>
```

Exclusions can be handled by negating the permission predicate with `not`.


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
