### PR TITLE
[Refactor] Navigation guard

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/navigation-guard/NavigationGuard.tsx
+++ b/apps/modernization-ui/src/design-system/entry/navigation-guard/NavigationGuard.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from 'design-system/checkbox';
 type Paths = string | string[];
 
 type NavigationGuardProps<V extends FieldValues, C, D extends FieldValues | undefined = undefined> = {
-    /** unique identifier of the  */
+    /** unique identifier of the storage key used to persist this value */
     id: string;
     /** The form being guarded from navigation  */
     form: UseFormReturn<V, C, D>;

--- a/apps/modernization-ui/src/design-system/entry/navigation-guard/NavigationGuard.tsx
+++ b/apps/modernization-ui/src/design-system/entry/navigation-guard/NavigationGuard.tsx
@@ -19,6 +19,13 @@ type NavigationGuardProps<V extends FieldValues, C, D extends FieldValues | unde
     allowed?: Paths;
 };
 
+/**
+ * Adds a guard to a form that prompts the user to confirm navigation away from a page that contains
+ * pending data.  The guard can be bypassed by the user to prevent any future warnings from appearing.
+ *
+ * @param {NavigationGuardProps} props
+ * @return {NavigationGuard}
+ */
 const NavigationGuard = <V extends FieldValues, C, D extends FieldValues | undefined = undefined>({
     id,
     form,

--- a/apps/modernization-ui/src/design-system/entry/navigation-guard/NavigationGuard.tsx
+++ b/apps/modernization-ui/src/design-system/entry/navigation-guard/NavigationGuard.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+import { FieldValues, UseFormReturn } from 'react-hook-form';
+import { useFormNavigationBlock } from 'navigation';
+import { useLocalStorage } from 'storage';
+import { Shown } from 'conditional-render';
+import { Confirmation } from 'design-system/modal';
+import { Checkbox } from 'design-system/checkbox';
+
+type Paths = string | string[];
+
+type NavigationGuardProps<V extends FieldValues, C, D extends FieldValues | undefined = undefined> = {
+    /** unique identifier of the  */
+    id: string;
+    /** The form being guarded from navigation  */
+    form: UseFormReturn<V, C, D>;
+    /** When true navigating away from the form will be prevented */
+    activated?: boolean;
+    /** A list of routes that do not block navigation. */
+    allowed?: Paths;
+};
+
+const NavigationGuard = <V extends FieldValues, C, D extends FieldValues | undefined = undefined>({
+    id,
+    form,
+    activated = true,
+    allowed
+}: NavigationGuardProps<V, C, D>) => {
+    const { value, save } = useLocalStorage({ key: id, initial: false });
+
+    const blocker = useFormNavigationBlock({ activated: activated ? !value : false, form, allowed });
+
+    const [isPermanent, setPermanent] = useState<boolean>(false);
+
+    const handleConfirm = useCallback(() => {
+        save(isPermanent);
+        blocker.unblock();
+    }, [blocker.unblock, save]);
+
+    return (
+        <Shown when={blocker.blocked}>
+            <Confirmation
+                title="Warning"
+                confirmText="Yes, cancel"
+                cancelText="No, back to form"
+                forceAction
+                onConfirm={handleConfirm}
+                onCancel={blocker.reset}>
+                Canceling the form will result in the loss of all additional data entered. Are you sure you want to
+                cancel?
+                <Checkbox label="Don't show again" id={'cancel-message-bypass'} onChange={setPermanent} />
+            </Confirmation>
+        </Shown>
+    );
+};
+
+export { NavigationGuard };

--- a/apps/modernization-ui/src/design-system/entry/navigation-guard/index.ts
+++ b/apps/modernization-ui/src/design-system/entry/navigation-guard/index.ts
@@ -1,0 +1,1 @@
+export { NavigationGuard } from './NavigationGuard';

--- a/apps/modernization-ui/src/navigation/useNavigationBlock.ts
+++ b/apps/modernization-ui/src/navigation/useNavigationBlock.ts
@@ -58,13 +58,13 @@ const useNavigationBlock = ({
 
     const blockingFn = useCallback<BlockerFunction>(
         ({ currentLocation, nextLocation }) => {
-            return isEngaged
+            return activated && isEngaged
                 ? isNavigating(currentLocation, nextLocation) &&
                       !isAllowedPath(allowed, nextLocation.pathname) &&
                       isBlockedPath(nextLocation.pathname)
                 : false;
         },
-        [isEngaged]
+        [isEngaged, activated]
     );
 
     const { state: blockerState, proceed, reset: blockerReset, location } = useBlocker(blockingFn);


### PR DESCRIPTION
## Description

Introduces a `NavigationGuard` component to encapsulate prompting the user when attempting to navigate away from a form that contains pending data.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
