### PR TITLE
Cnft1 4110  taborder updates

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/SearchResults.tsx
@@ -42,7 +42,7 @@ const SearchResults = ({ children, total, view, terms, loading = false, sizing }
     }, [total]);
 
     return (
-        <div className={styles.results}>
+        <div className={`search-results-container ${styles.results}`}>
             <div ref={headerRef}>
                 <SearchResultsHeader sizing={sizing} view={view} total={total} terms={terms} />
             </div>

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.spec.tsx
@@ -2,7 +2,7 @@ import { permissions } from "libs/permission";
 import { useAddPatientFromSearch } from "./add"
 import { useFocusAddNewPatientButton } from "./useFocusAddNewPatientButton";
 import { PatientSearchActions } from "./PatientSearchActions";
-import { render } from "@testing-library/react";
+import { getByText, render } from "@testing-library/react";
 import { axe } from "jest-axe";
 
 jest.mock('./add/useAddPatientFromSearch', () => ({
@@ -38,4 +38,33 @@ describe('PatinetSearchActions', () => {
         const { container } = render(<PatientSearchActions disabled={false} />);
         expect(await axe(container)).toHaveNoViolations();
     });
+
+    it('should render the button in disabled state when disabled prop is true', () => {
+        const { getByText } = render(<PatientSearchActions disabled={true} />);
+
+        const button = getByText('Add new patient').closest('button');
+        button?.click();
+    });
+
+    it('should call the add function when the button is clicked', () => {
+        const { getByText } = render(<PatientSearchActions disabled={false} />);
+
+        const button = getByText('Add new patient').closest('button');
+        button?.click();
+        expect(mockAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('should wrap the button with the Permitted component with correct permission', () => {
+        const { container } = render(<PatientSearchActions disabled={false} />);
+
+        const permittedWrapper = container.querySelector('.permitted-wrapper');
+        expect(permittedWrapper).toHaveAttribute('data-permission', permissions.patient.add);
+    });
+
+    it('should initialize the focus hook', () => {
+        render(<PatientSearchActions disabled={false} />);
+
+        expect(useFocusAddNewPatientButton).toHaveBeenCalledTimes(1);
+    })
+
 });    

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.spec.tsx
@@ -2,14 +2,14 @@ import { permissions } from "libs/permission";
 import { useAddPatientFromSearch } from "./add"
 import { useFocusAddNewPatientButton } from "./useFocusAddNewPatientButton";
 import { PatientSearchActions } from "./PatientSearchActions";
-import { getByText, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { axe } from "jest-axe";
 
 jest.mock('./add/useAddPatientFromSearch', () => ({
     useAddPatientFromSearch: jest.fn()
 }));
 
-jest.mock('lib/permission', () => ({
+jest.mock('libs/permission', () => ({
     permissions: {
         patient: {
             add: 'patient:add'

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.spec.tsx
@@ -1,0 +1,41 @@
+import { permissions } from "libs/permission";
+import { useAddPatientFromSearch } from "./add"
+import { useFocusAddNewPatientButton } from "./useFocusAddNewPatientButton";
+import { PatientSearchActions } from "./PatientSearchActions";
+import { render } from "@testing-library/react";
+import { axe } from "jest-axe";
+
+jest.mock('./add/useAddPatientFromSearch', () => ({
+    useAddPatientFromSearch: jest.fn()
+}));
+
+jest.mock('lib/permission', () => ({
+    permissions: {
+        patient: {
+            add: 'patient:add'
+        }
+    },
+    Permitted: ({ children,permission }: { children: React.ReactNode; permission: string }) => (
+        <div className="permitted-wrapper" data-permission={permission}>
+            {children}
+        </div>
+    )
+}));
+
+jest.mock('./useFocusAddNewPatientButton', () => ({
+    useFocusAddNewPatientButton: jest.fn()
+}));
+
+describe('PatinetSearchActions', () => {
+    const mockAdd = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (useAddPatientFromSearch as jest.Mock).mockReturnValue({ add: mockAdd });
+    });
+
+    test('should render with no accessibility violations', async () => {
+        const { container } = render(<PatientSearchActions disabled={false} />);
+        expect(await axe(container)).toHaveNoViolations();
+    });
+});    

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
@@ -15,7 +15,7 @@ const PatientSearchActions = ({ disabled }: Props) => {
     return (
         <Permitted permission={permissions.patient.add}>
             <Button
-            id="add-new-patient-button"
+                id="add-new-patient-button"
                 type="button"
                 onClick={add}
                 disabled={disabled}

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
@@ -2,6 +2,7 @@ import { Button } from 'components/button';
 import { useAddPatientFromSearch } from './add/useAddPatientFromSearch';
 import { permissions, Permitted } from 'libs/permission';
 import { Icon } from 'design-system/icon';
+import { useFocusAddNewPatientButton } from './useFocusAddNewPatientButton';
 
 type Props = {
     disabled: boolean;
@@ -9,15 +10,18 @@ type Props = {
 
 const PatientSearchActions = ({ disabled }: Props) => {
     const { add } = useAddPatientFromSearch();
+    useFocusAddNewPatientButton();
 
     return (
         <Permitted permission={permissions.patient.add}>
             <Button
+            id="add-new-patient-button"
                 type="button"
                 onClick={add}
                 disabled={disabled}
                 icon={<Icon name="add_circle" />}
-                labelPosition="right">
+                labelPosition="right"
+                tabIndex={0}>
                 Add new patient
             </Button>
         </Permitted>

--- a/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
+++ b/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
@@ -13,20 +13,21 @@ function useFocusAddNewPatientButton() {
 
                 if (!resultsContainer || !addButton) return;
 
-                const focusableElement = Array.from(
+                const focusableElements = Array.from(
                     document.querySelectorAll<HTMLElement>(
-                        'a, button, input, textarea, select, svg, [tabindex]:not([tabindex="-1"])'
+                        'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])'
                     )
                 ).filter((element) => {
                     const style = window.getComputedStyle(element);
                     return style.display !== 'none' && style.visibility !== 'hidden';
                 });
-                const resultsElement = focusableElement.filter((element) => resultsContainer.contains(element));
 
-                if (resultsElement.includes(document.activeElement as HTMLElement)) {
-                    const activeElementIndex = resultsElement.indexOf(document.activeElement as HTMLElement);
+                const resultsElements = focusableElements.filter((element) => resultsContainer.contains(element));
 
-                    if (activeElementIndex === resultsElement.length - 1) {
+                if (resultsElements.includes(document.activeElement as HTMLElement)) {
+                    const activeElementIndex = resultsElements.indexOf(document.activeElement as HTMLElement);
+
+                    if (activeElementIndex === resultsElements.length - 1) {
                         event.preventDefault();
                         addButton.focus();
                         return;

--- a/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
+++ b/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+/**
+ * This hook is going to handle the tab interaction for when we have patient results and want the user to be able to navigate 
+ * using the tab keyboard to the "Add new patient" button instead of other elements in between.
+ */
+
+function useFocusAddNewPatientButton() {
+    useEffect(() => {
+        const handleTab = (event: KeyboardEvent) => {
+            if (event.key === 'Tab' && !event.shiftKey) {
+                const resultsContainer = document.querySelector('.search-results-container');
+                const addButton = document.querySelector<HTMLButtonElement>('#add-new-patient-button');
+                
+                if (!resultsContainer || !addButton) return;
+
+                const focusableElement = Array.from(
+                    document.querySelectorAll<HTMLElement>(
+                        'a, button, input, textarea, select, svg, [tabidex]:not((tabindex="-1"])'
+                    )
+                ).filter((element) => {
+                    const style = window.getComputedStyle(element);
+                    return style.display !== 'none' && style.visibility !== 'hidden';
+                });
+                const resultsElement = focusableElement.filter((element) => resultsContainer.contains(element));
+
+                if (resultsElement.includes(document.activeElement as HTMLElement)) {
+                    const activeElementIndex = resultsElement.indexOf(document.activeElement as HTMLElement);
+
+                    if (activeElementIndex === resultsElement.length - 1) {
+                        event.preventDefault();
+                        addButton.focus();
+                        return;
+                    }
+                }
+            }
+        };
+
+        document.addEventListener('keydown', handleTab);
+        return () => {
+            document.removeEventListener('keydown', handleTab);
+        };
+    }, []);
+}
+
+export { useFocusAddNewPatientButton };

--- a/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
+++ b/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
+import { useEffect } from 'react';
 /**
- * This hook is going to handle the tab interaction for when we have patient results and want the user to be able to navigate 
+ * This hook is going to handle the tab interaction for when we have patient results and want the user to be able to navigate
  * using the tab keyboard to the "Add new patient" button instead of other elements in between.
  */
 
@@ -10,7 +10,7 @@ function useFocusAddNewPatientButton() {
             if (event.key === 'Tab' && !event.shiftKey) {
                 const resultsContainer = document.querySelector('.search-results-container');
                 const addButton = document.querySelector<HTMLButtonElement>('#add-new-patient-button');
-                
+
                 if (!resultsContainer || !addButton) return;
 
                 const focusableElement = Array.from(

--- a/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
+++ b/apps/modernization-ui/src/apps/search/patient/useFocusAddNewPatientButton.ts
@@ -15,7 +15,7 @@ function useFocusAddNewPatientButton() {
 
                 const focusableElement = Array.from(
                     document.querySelectorAll<HTMLElement>(
-                        'a, button, input, textarea, select, svg, [tabidex]:not((tabindex="-1"])'
+                        'a, button, input, textarea, select, svg, [tabindex]:not([tabindex="-1"])'
                     )
                 ).filter((element) => {
                     const style = window.getComputedStyle(element);


### PR DESCRIPTION
## Description

Users should navigate to the “Add new patient” button after tabbing from the “Next” button on the pagination if it exists or the last interactive element from the table or list results.

Added a custom hook that is going to handle the tab interaction for when we have patient results and want the user to be able to navigate using the tab keyboard to the "Add new patient" button instead of other elements in between.

## Tickets

* [CNFT1-4110](https://cdc-nbs.atlassian.net/browse/CNFT1-4110)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4110]: https://cdc-nbs.atlassian.net/browse/CNFT1-4110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ