### PR TITLE
Icons/drag

### DIFF
--- a/apps/modernization-ui/src/design-system/card/table/TableCard.tsx
+++ b/apps/modernization-ui/src/design-system/card/table/TableCard.tsx
@@ -24,7 +24,7 @@ export type TableCardProps<V> = {
 /**
  * Represents a specialized card component that contains a DataTable and settings to manage the column preferences.
  * @param {TableCardProps} props Component props
- * @return TableCard component
+ * @return {TableCard} component
  */
 export const TableCard = <V,>({
     id,
@@ -79,7 +79,7 @@ export const TableCard = <V,>({
  * Higher-order component to wrap a DataTable component with columns applied according to column preferences.
  * If there is no column preferences context, the original columns are used.
  * @param {FC} WrappedComponent DataTable component
- * @return A modified DataTable component with columns applied
+ * @return {FC<DataTableProps<V>>} A modified DataTable component with columns applied
  */
 const withColumnPreferencesDataTable = <V,>(WrappedComponent: ComponentType<DataTableProps<V>>) => {
     const EnhancedComponent: FC<DataTableProps<V>> = (props) => {

--- a/apps/modernization-ui/src/design-system/icon/Icon.spec.tsx
+++ b/apps/modernization-ui/src/design-system/icon/Icon.spec.tsx
@@ -321,6 +321,7 @@ describe('When displaying Icons', () => {
     });
 
     it.each([
+        'drag',
         'table',
         'file',
         'file-pdf',
@@ -342,7 +343,6 @@ describe('When displaying Icons', () => {
         'calendar',
         'down-arrow-blue',
         'down-arrow-white',
-        'drag',
         'expand',
         'expand-more',
         'group',

--- a/apps/modernization-ui/src/design-system/icon/Icon.stories.tsx
+++ b/apps/modernization-ui/src/design-system/icon/Icon.stories.tsx
@@ -1,12 +1,12 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Icon } from './Icon';
-import { IconsArray } from './types';
+import { Icon, IconProps } from './Icon';
+import { available } from './types';
 
 const meta = {
     title: 'Design System/Icon',
     component: Icon,
     argTypes: {
-        name: { control: 'select', options: IconsArray },
+        name: { control: 'select', options: available },
         color: { control: 'color' }
     }
 } satisfies Meta<typeof Icon>;
@@ -15,15 +15,20 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const sizes = (args: IconProps) => (
+    <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+        <Icon sizing="small" {...args} />
+        <Icon sizing="medium" {...args} />
+        <Icon sizing="large" {...args} />
+    </div>
+);
+
 export const Default: Story = {
     args: {
         name: 'check'
-    }
+    },
+    render: sizes
 };
 
-/*
-
-Double check
-aria-hidden={props['aria-hidden'] || !props['aria-label'] || !props['aria-labelledby']}
-
-*/
+//  Double check
+//  aria-hidden={props['aria-hidden'] || !props['aria-label'] || !props['aria-labelledby']}

--- a/apps/modernization-ui/src/design-system/icon/Icon.tsx
+++ b/apps/modernization-ui/src/design-system/icon/Icon.tsx
@@ -31,6 +31,7 @@ const Icon = ({ name, sizing, role = 'img', className, ...props }: IconProps) =>
 
 const resolveLocation = (name: Icons) => {
     switch (name) {
+        case 'drag':
         case 'table':
         case 'file':
         case 'file-pdf':
@@ -45,7 +46,6 @@ const resolveLocation = (name: Icons) => {
         case 'calendar':
         case 'down-arrow-blue':
         case 'down-arrow-white':
-        case 'drag':
         case 'expand':
         case 'expand-more':
         case 'group':

--- a/apps/modernization-ui/src/design-system/icon/extended-sprite.svg
+++ b/apps/modernization-ui/src/design-system/icon/extended-sprite.svg
@@ -44,4 +44,13 @@
   <symbol id="sort_des_default" viewBox="0 0 36 36">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M21.3164 28.6186L21.3164 11.3839L24.9331 15.0008L27.2831 12.6506L19.6498 5L11.9998 12.6506L14.3664 15.0008L17.9831 11.3839L17.9831 28.6186V35.0024H21.3164V28.6186Z" />
   </symbol>
+
+  <symbol id="drag" viewBox="0 0 21 20">
+    <path d="M14.7266 17C14.1744 17 13.7266 17.4477 13.7266 18C13.7266 18.5523 14.1744 19 14.7266 19C15.2788 19 15.7266 18.5523 15.7266 18C15.7266 17.4477 15.2788 17 14.7266 17Z" fill="#A9AEB1" stroke="#A9AEB1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M14.7266 9C14.1744 9 13.7266 9.4478 13.7266 10C13.7266 10.5522 14.1744 11 14.7266 11C15.2788 11 15.7266 10.5522 15.7266 10C15.7266 9.4478 15.2788 9 14.7266 9Z" fill="#A9AEB1" stroke="#A9AEB1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M14.7266 1C14.1744 1 13.7266 1.4478 13.7266 2C13.7266 2.5522 14.1744 3 14.7266 3C15.2788 3 15.7266 2.5522 15.7266 2C15.7266 1.4478 15.2788 1 14.7266 1Z" fill="#A9AEB1" stroke="#A9AEB1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M6.72658 17C6.17438 17 5.72658 17.4477 5.72658 18C5.72658 18.5523 6.17438 19 6.72658 19C7.27878 19 7.72658 18.5523 7.72658 18C7.72658 17.4477 7.27878 17 6.72658 17Z" fill="#A9AEB1" stroke="#A9AEB1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M6.72658 9C6.17438 9 5.72658 9.4478 5.72658 10C5.72658 10.5522 6.17438 11 6.72658 11C7.27878 11 7.72658 10.5522 7.72658 10C7.72658 9.4478 7.27878 9 6.72658 9Z" fill="#A9AEB1" stroke="#A9AEB1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M6.72658 1C6.17438 1 5.72658 1.4478 5.72658 2C5.72658 2.5522 6.17438 3 6.72658 3C7.27878 3 7.72658 2.5522 7.72658 2C7.72658 1.4478 7.27878 1 6.72658 1Z" fill="#A9AEB1" stroke="#A9AEB1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
 </svg>

--- a/apps/modernization-ui/src/design-system/icon/index.ts
+++ b/apps/modernization-ui/src/design-system/icon/index.ts
@@ -1,5 +1,6 @@
-export { Icon } from './Icon';
-export type { IconProps } from './Icon';
-export { IconsArray } from './types';
 export type { Icons } from './types';
+
+export type { IconProps } from './Icon';
+export { Icon } from './Icon';
+
 export { ActionIcon } from './actionIcon/ActionIcon';

--- a/apps/modernization-ui/src/design-system/icon/types.ts
+++ b/apps/modernization-ui/src/design-system/icon/types.ts
@@ -1,6 +1,4 @@
-export type Icons = USWDSIcons | ExtendedIcons;
-
-export const ExtendedIconsArray = [
+const AvailableExtended = [
     'calendar',
     'down-arrow-blue',
     'down-arrow-white',
@@ -31,9 +29,9 @@ export const ExtendedIconsArray = [
     'sort_des_default'
 ] as const;
 
-export type ExtendedIcons = (typeof ExtendedIconsArray)[number];
+type ExtendedIcons = (typeof AvailableExtended)[number];
 
-export const USWDSIconsArray = [
+const AvailableUSWDS = [
     'accessibility_new',
     'accessible_forward',
     'account_balance',
@@ -280,6 +278,12 @@ export const USWDSIconsArray = [
     'zoom_out_map'
 ] as const;
 
-export type USWDSIcons = (typeof USWDSIconsArray)[number];
+type USWDSIcons = (typeof AvailableUSWDS)[number];
 
-export const IconsArray = [...USWDSIconsArray, ...ExtendedIconsArray] as const;
+type Icons = USWDSIcons | ExtendedIcons;
+
+export type { Icons };
+
+const available: readonly string[] = [...AvailableUSWDS, ...AvailableExtended].sort((a, b) => a.localeCompare(b));
+
+export { available };

--- a/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
+++ b/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import { DragDropContext, Droppable, Draggable, DraggableProvided, DropResult } from 'react-beautiful-dnd';
-import { Icon as TrussworksIcon } from '@trussworks/react-uswds';
 import { useColumnPreferences, ColumnPreference } from 'design-system/table/preferences';
 import { Checkbox } from 'design-system/checkbox';
+import { ActionIcon, Icon } from 'design-system/icon';
 import { Button } from 'components/button';
-import { Icon } from 'components/Icon/Icon';
+
 import styles from './column-preference-panel.module.scss';
 
 const swap =
@@ -63,7 +63,12 @@ const ColumnPreferencesPanel = ({ close }: Props) => {
         <div className={styles.panel}>
             <header>
                 <h2>Columns</h2>
-                <TrussworksIcon.Close size={3} onClick={close} />
+                <ActionIcon
+                    name="close"
+                    className={styles.close}
+                    aria-label="close the column preferences"
+                    onAction={close}
+                />
             </header>
             <DragDropContext onDragEnd={handleDragEnd}>
                 <Droppable droppableId="preferences">

--- a/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
@@ -8,17 +8,22 @@
     header {
         display: flex;
         justify-content: space-between;
+        align-items: center;
 
-        padding: 1.5rem;
+        padding: 1rem;
+        padding-right: 0.5rem;
 
         @extend %thin-bottom;
 
-        svg {
-            cursor: pointer;
-        }
-
         h2 {
             margin: 0;
+        }
+
+        .close {
+            width: 1.5rem;
+            height: 1.5rem;
+
+            cursor: pointer;
         }
     }
 
@@ -57,8 +62,6 @@
     .handle {
         cursor: pointer;
         display: flex;
-        width: 2.625rem;
-        height: 2.625rem;
         justify-content: center;
         align-items: center;
         flex-shrink: 0;


### PR DESCRIPTION
## Description

Adds the `drag` icon to the `design-system/icon` component so that the `ColumnPreferencesPanel` component can use the `Icon` component.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
