### PR TITLE
Update MatchingBounds validation

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/PassForm.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/PassForm.tsx
@@ -74,13 +74,6 @@ export const PassForm = ({ passCount, dataElements, onCancel, onDelete, onSave }
         }
     };
 
-    const { trigger } = useFormContext();
-
-    useEffect(() => {
-        // When matchingCriteria changes, revalidate bounds
-        trigger(['lowerBound', 'upperBound']);
-    }, [matchingCriteria, trigger]);
-
     return (
         <div className={styles.passForm}>
             <Shown when={panelState.content === 'blocking'}>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/PassForm.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/PassForm.tsx
@@ -74,6 +74,13 @@ export const PassForm = ({ passCount, dataElements, onCancel, onDelete, onSave }
         }
     };
 
+    const { trigger } = useFormContext();
+
+    useEffect(() => {
+        // When matchingCriteria changes, revalidate bounds
+        trigger(['lowerBound', 'upperBound']);
+    }, [matchingCriteria, trigger]);
+
     return (
         <div className={styles.passForm}>
             <Shown when={panelState.content === 'blocking'}>

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.spec.tsx
@@ -110,4 +110,22 @@ describe('MatchingBounds', () => {
 
         expect(await findByText('Cannot be greater than total log odds.')).toBeInTheDocument();
     });
+
+    it('should not show validation error when only one bound is present', async () => {
+        const user = userEvent.setup();
+        const { getByLabelText, queryByText } = render(<Fixture />);
+
+        const lowerBoundInput = getByLabelText('Lower bound');
+
+        await user.type(lowerBoundInput, '2').then(() => user.tab());
+
+        // Should not trigger error about being greater than upper or total log odds
+        expect(queryByText('Cannot be greater than upper bound.')).not.toBeInTheDocument();
+        expect(queryByText('Cannot be greater than total log odds.')).not.toBeInTheDocument();
+    });
+
+    it('should calculate and display total log odds when matching criteria exists', () => {
+        const { getByText } = render(<Fixture />);
+        expect(getByText(/Total log odds:/)).toHaveTextContent('Total log odds: 3');
+    });
 });

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
@@ -19,8 +19,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
     const { matchingCriteria } = useWatch<Pass>(form);
     const [disabled, setDisabled] = useState<boolean>(true);
     const [totalLogOdds, setTotalLogOdds] = useState<number | undefined>();
-    const [hasInteractedLower, setHasInteractedLower] = useState(false);
-    const [hasInteractedUpper, setHasInteractedUpper] = useState(false);
+    const hasMatchingCriteria = matchingCriteria && matchingCriteria?.length > 0;
 
     useEffect(() => {
         setDisabled(
@@ -41,7 +40,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
     }, [matchingCriteria, disabled]);
 
     useEffect(() => {
-        if (matchingCriteria && matchingCriteria.length > 0) {
+        if (hasMatchingCriteria) {
             form.trigger(['lowerBound', 'upperBound']);
         }
     }, [totalLogOdds, matchingCriteria]);
@@ -76,7 +75,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                             control={form.control}
                             name={'lowerBound'}
                             rules={{
-                                required: hasInteractedLower
+                                required: hasMatchingCriteria
                                     ? { value: true, message: 'Lower bound is required.' }
                                     : undefined,
                                 validate: validateLowerBound
@@ -93,7 +92,6 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                                         </span>
                                     }
                                     onBlur={() => {
-                                        setHasInteractedLower(true);
                                         onBlur();
                                         if (form.getValues('upperBound') !== undefined) form.trigger('upperBound');
                                     }}
@@ -109,7 +107,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                             control={form.control}
                             name={'upperBound'}
                             rules={{
-                                required: hasInteractedUpper
+                                required: hasMatchingCriteria
                                     ? { value: true, message: 'Upper bound is required.' }
                                     : undefined,
                                 max: {
@@ -133,7 +131,6 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                                         </span>
                                     }
                                     onBlur={() => {
-                                        setHasInteractedUpper(true);
                                         onBlur();
                                         form.trigger('lowerBound');
                                     }}

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
@@ -19,6 +19,8 @@ export const MatchingBounds = ({ dataElements }: Props) => {
     const { matchingCriteria } = useWatch<Pass>(form);
     const [disabled, setDisabled] = useState<boolean>(true);
     const [totalLogOdds, setTotalLogOdds] = useState<number | undefined>();
+    const [hasInteractedLower, setHasInteractedLower] = useState(false);
+    const [hasInteractedUpper, setHasInteractedUpper] = useState(false);
 
     useEffect(() => {
         setDisabled(
@@ -39,11 +41,10 @@ export const MatchingBounds = ({ dataElements }: Props) => {
     }, [matchingCriteria, disabled]);
 
     useEffect(() => {
-        if (form.formState.dirtyFields.lowerBound || form.formState.dirtyFields.upperBound) {
-            form.trigger('lowerBound');
-            form.trigger('upperBound');
+        if (matchingCriteria && matchingCriteria.length > 0) {
+            form.trigger(['lowerBound', 'upperBound']);
         }
-    }, [totalLogOdds]);
+    }, [totalLogOdds, matchingCriteria]);
 
     const validateLowerBound = (value?: number): string | undefined => {
         if (value == undefined) {
@@ -75,7 +76,9 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                             control={form.control}
                             name={'lowerBound'}
                             rules={{
-                                required: { value: true, message: 'Lower bound is required.' },
+                                required: hasInteractedLower
+                                    ? { value: true, message: 'Lower bound is required.' }
+                                    : undefined,
                                 validate: validateLowerBound
                             }}
                             render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
@@ -90,6 +93,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                                         </span>
                                     }
                                     onBlur={() => {
+                                        setHasInteractedLower(true);
                                         onBlur();
                                         if (form.getValues('upperBound') !== undefined) form.trigger('upperBound');
                                     }}
@@ -105,7 +109,9 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                             control={form.control}
                             name={'upperBound'}
                             rules={{
-                                required: { value: true, message: 'Upper bound is required.' },
+                                required: hasInteractedUpper
+                                    ? { value: true, message: 'Upper bound is required.' }
+                                    : undefined,
                                 max: {
                                     value: totalLogOdds ?? 0,
                                     message: 'Cannot be greater than total log odds.'
@@ -127,6 +133,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                                         </span>
                                     }
                                     onBlur={() => {
+                                        setHasInteractedUpper(true);
                                         onBlur();
                                         form.trigger('lowerBound');
                                     }}

--- a/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/match-configuration/pass-configuration/pass-form/matching-bounds/MatchingBounds.tsx
@@ -20,6 +20,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
     const [disabled, setDisabled] = useState<boolean>(true);
     const [totalLogOdds, setTotalLogOdds] = useState<number | undefined>();
     const hasMatchingCriteria = matchingCriteria && matchingCriteria?.length > 0;
+    const exists = (value: unknown): boolean => value !== undefined && value !== null && value !== '';
 
     useEffect(() => {
         setDisabled(
@@ -40,10 +41,10 @@ export const MatchingBounds = ({ dataElements }: Props) => {
     }, [matchingCriteria, disabled]);
 
     useEffect(() => {
-        if (hasMatchingCriteria) {
+        if (hasMatchingCriteria && exists(lowerBound) && exists(upperBound)) {
             form.trigger(['lowerBound', 'upperBound']);
         }
-    }, [totalLogOdds, matchingCriteria]);
+    }, [totalLogOdds, matchingCriteria, lowerBound, upperBound]);
 
     const validateLowerBound = (value?: number): string | undefined => {
         if (value == undefined) {
@@ -75,9 +76,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                             control={form.control}
                             name={'lowerBound'}
                             rules={{
-                                required: hasMatchingCriteria
-                                    ? { value: true, message: 'Lower bound is required.' }
-                                    : undefined,
+                                required: { value: true, message: 'Lower bound is required.' },
                                 validate: validateLowerBound
                             }}
                             render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
@@ -107,9 +106,7 @@ export const MatchingBounds = ({ dataElements }: Props) => {
                             control={form.control}
                             name={'upperBound'}
                             rules={{
-                                required: hasMatchingCriteria
-                                    ? { value: true, message: 'Upper bound is required.' }
-                                    : undefined,
+                                required: { value: true, message: 'Upper bound is required.' },
                                 max: {
                                     value: totalLogOdds ?? 0,
                                     message: 'Cannot be greater than total log odds.'


### PR DESCRIPTION
## Description
Bug:
In order to save the matching criteria configuration the First name element needs to be removed from active pass configurations. User is unable to Save pass configuration when deleting First name from an active pass configuration. 

Steps to Reproduce: 

    Select DateofBirth_Identifier_Sex pass configuration.

    Delete the First name matching criteria. 

    Click Save pass configuration. 

    Update Pass title, description or leave it as it and observe. 

Actual Results: Save button is disabled on the Save pass configuration modal. 

## Demo
Before:
![image](https://github.com/user-attachments/assets/5fecb64b-1205-4736-9cf7-b0828f088fe7)

After:
![fix(1)](https://github.com/user-attachments/assets/e9cdb73d-af10-4ec6-96fd-8cf2ed604b11)

## Tickets

* [Bug](https://cdc-nbs.atlassian.net/browse/CND-264?focusedCommentId=31807)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
