### PR TITLE
[FIX] Patient Demographic Summary Endpoint most recent phone

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryEmailFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryEmailFinder.java
@@ -1,9 +1,8 @@
 package gov.cdc.nbs.patient.file.demographics.summary;
 
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -11,59 +10,57 @@ import java.util.Optional;
 class PatientDemographicsSummaryEmailFinder {
 
   private static final String QUERY = """
-      select
-          [email_address].email_address    as [email_address]
-      from Entity_locator_participation [locators]
+      with emails(patient, locator_uid, as_of_date, [type], [use], [email]) as (
+          select
+              [locators].entity_uid,
+              [locators].locator_uid,
+              [locators].as_of_date,
+              [locators].cd,
+              [locators].use_cd,
+              [email_address].email_address
+          from Entity_locator_participation [locators]
       
           join Tele_locator [email_address] on
                   [email_address].[tele_locator_uid] = [locators].[locator_uid]
               and [email_address].record_status_cd   = [locators].[record_status_cd]
               and [email_address].email_address is not null
       
-      where [locators].entity_uid = ?
-          and [locators].[class_cd] = 'TELE'
-          and [locators].record_status_cd = 'ACTIVE'
-          and [locators].as_of_date = (
-                          select
-                              max(eff_as_of.as_of_date)
-                          from Entity_locator_participation [eff_as_of]
+          where   [locators].entity_uid = ?
+              and [locators].[class_cd] = 'TELE'
+              and [locators].record_status_cd = 'ACTIVE'
+      )
+      select
+          [emails].email  as [email_address]
+      from emails
       
-                          where   [eff_as_of].[entity_uid]         = [locators].entity_uid
-                              and [eff_as_of].[class_cd]           = [locators].[class_cd]
-                              and [eff_as_of].[record_status_cd]   = [locators].[record_status_cd]
-                              and [eff_as_of].[as_of_date]         <= ?
-                      )
-              and [locators].locator_uid = (
-                  select
-                      max(eff_seq.locator_uid)
-                  from Entity_locator_participation [eff_seq]\s
-                                  where   [eff_seq].[entity_uid] = [locators].entity_uid
-                              and [eff_seq].[class_cd]           = [locators].[class_cd]
-                              and [eff_seq].[record_status_cd]   = [locators].[record_status_cd]
-                              and [eff_seq].[as_of_date]         = [locators].as_of_date
+      where [emails].as_of_date = (
+              select
+                  max(eff_as_of.as_of_date)
+              from emails [eff_as_of]
+              where   [eff_as_of].patient     = [emails].patient
+                  and [eff_as_of].[as_of_date] <= ?
+          )
+      and [emails].locator_uid = (
+          select
+              max(eff_seq.locator_uid)
+          from emails [eff_seq]
+          where   [eff_seq].patient     = [emails].patient
+              and [eff_seq].[as_of_date]  = [emails].as_of_date
       )
       """;
 
-  private static final int PATIENT_PARAMETER = 1;
-  private static final int AS_OF_PARAMETER = 2;
-  private static final int EMAIL_COLUMN = 1;
+  private final JdbcClient client;
 
-  private final JdbcTemplate template;
-
-  PatientDemographicsSummaryEmailFinder(final JdbcTemplate template) {
-    this.template = template;
-
+  PatientDemographicsSummaryEmailFinder(final JdbcClient client) {
+    this.client = client;
   }
 
   Optional<String> find(final long patient, final LocalDate asOf) {
-    return this.template.query(
-            QUERY, statement -> {
-              statement.setLong(PATIENT_PARAMETER, patient);
-              statement.setTimestamp(AS_OF_PARAMETER, Timestamp.valueOf(asOf.atStartOfDay()));
-            },
-            (rs, row) -> rs.getString(EMAIL_COLUMN)
-        ).stream()
-        .findFirst();
+    return this.client.sql(QUERY)
+        .param(patient)
+        .param(asOf)
+        .query(String.class)
+        .optional();
   }
 
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryPhoneFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryPhoneFinder.java
@@ -2,11 +2,10 @@ package gov.cdc.nbs.patient.file.demographics.summary;
 
 import gov.cdc.nbs.demographics.phone.DisplayablePhone;
 import gov.cdc.nbs.demographics.phone.DisplayablePhoneRowMapper;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -14,78 +13,85 @@ import java.util.Optional;
 class PatientDemographicsSummaryPhoneFinder {
 
   private static final String QUERY = """
-      select
-          coalesce(
-              [type].code_short_desc_txt,
+      with phones(patient, locator_uid, as_of_date, [type], [use], [phone]) as (
+          select
+              [locators].entity_uid,
+              [locators].locator_uid,
+              [locators].as_of_date,
               [locators].cd,
-              ''
-          )                               as [type],
-          coalesce(
-              [use].code_short_desc_txt,
-              [locators].[use_cd],
-              ''
-          )                               as [use],
-          [phone_number].phone_nbr_txt    as [phone_number]
-      from Entity_locator_participation [locators]
+              [locators].use_cd,
+              [phone_number].phone_nbr_txt
+          from Entity_locator_participation [locators]
       
           join Tele_locator [phone_number] on
                   [phone_number].[tele_locator_uid] = [locators].[locator_uid]
               and [phone_number].record_status_cd   = [locators].[record_status_cd]
               and [phone_number].phone_nbr_txt is not null
       
+          where [locators].entity_uid = ?
+          and [locators].[class_cd] = 'TELE'
+          and [locators].record_status_cd = 'ACTIVE'
+      )
+      select
+          coalesce(
+              [type].code_short_desc_txt,
+              [phones].[type],
+              ''
+          )                               as [type],
+          case [phones].[use]
+              when 'WP' then 'Work'
+              when 'SB' then 'Work'
+              when 'H' then 'Home'
+              when 'MC' then 'Cell'
+              else\s
+                  coalesce(
+                      [use].code_short_desc_txt,
+                      [phones].[use],
+                      ''
+                  )
+          end as [use],
+          [phones].phone                   as [phone_number]
+      from phones [phones]
+      
           left join  NBS_SRTE..Code_value_general [type] on
       
                   [type].code_set_nm = 'EL_TYPE_TELE_PAT'
-              and [type].code = [locators].cd
+              and [type].code = [phones].[type]
       
           left join NBS_SRTE..Code_value_general [use] on
                   [use].code_set_nm = 'EL_USE_TELE_PAT'
-              and [use].code = [locators].[use_cd]
+              and [use].code = [phones].[use]
       
-      where [locators].entity_uid = ?
-          and [locators].[class_cd] = 'TELE'
-          and [locators].record_status_cd = 'ACTIVE'
-          and [locators].as_of_date = (
-                          select
-                              max(eff_as_of.as_of_date)
-                          from Entity_locator_participation [eff_as_of]
-      
-                          where   [eff_as_of].[entity_uid]         = [locators].entity_uid
-                              and [eff_as_of].[class_cd]           = [locators].[class_cd]
-                              and [eff_as_of].[record_status_cd]   = [locators].[record_status_cd]
-                              and [eff_as_of].[as_of_date]         <= ?
-                      )
-              and [locators].locator_uid = (
-                  select
-                      max(eff_seq.locator_uid)
-                  from Entity_locator_participation [eff_seq]\s
-                                  where   [eff_seq].[entity_uid] = [locators].entity_uid
-                              and [eff_seq].[class_cd]           = [locators].[class_cd]
-                              and [eff_seq].[record_status_cd]   = [locators].[record_status_cd]
-                              and [eff_seq].[as_of_date]         = [locators].as_of_date
+      where [phones].as_of_date = (
+              select
+                  max(eff_as_of.as_of_date)
+              from phones [eff_as_of]
+              where   [eff_as_of].patient     = [phones].patient
+                  and [eff_as_of].[as_of_date] <= ?
           )
+          and [phones].locator_uid = (
+              select
+                  max(eff_seq.locator_uid)
+              from phones [eff_seq]
+              where   [eff_seq].patient     = [phones].patient
+                  and [eff_seq].[as_of_date]  = [phones].as_of_date
+      )
       """;
 
-  private static final int PATIENT_PARAMETER = 1;
-  private static final int AS_OF_PARAMETER = 2;
-
-  private final JdbcTemplate template;
+  private final JdbcClient template;
   private final RowMapper<DisplayablePhone> mapper;
 
-  PatientDemographicsSummaryPhoneFinder(final JdbcTemplate template) {
-    this.template = template;
+  PatientDemographicsSummaryPhoneFinder(final JdbcClient client) {
+    this.template = client;
     this.mapper = new DisplayablePhoneRowMapper();
   }
 
   Optional<DisplayablePhone> find(final long patient, final LocalDate asOf) {
-    return this.template.query(
-            QUERY, statement -> {
-              statement.setLong(PATIENT_PARAMETER, patient);
-              statement.setTimestamp(AS_OF_PARAMETER, Timestamp.valueOf(asOf.atStartOfDay()));
-            },
-            this.mapper
-        ).stream()
-        .findFirst();
+    return this.template.sql(QUERY)
+        .param(patient)
+        .param(asOf)
+        .query(this.mapper)
+        .optional();
   }
 
 }

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
@@ -37,6 +37,7 @@ Feature: Summarizing the demographics of a patient
     Given the patient has the Email Address - Home number of "555-555-5555" as of 11/07/2023
     And the patient has the Fax - Home number of "555-444-4444" as of 11/07/2024
     And the patient has the Phone - Home number of "555-111-1111" as of 11/07/2024
+    And the patient has the Email Address - Home email address of "xyz@test.com" as of 11/07/2024
     When I view the demographics summary of the patient
     Then the demographics summary of the patient has a phone with a type of "Phone"
     And the demographics summary of the patient has a phone with a use of "Home"

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
@@ -46,6 +46,7 @@ Feature: Summarizing the demographics of a patient
   Scenario: I can view the patient's most recent email address in the summarized demographics
     Given the patient has the Email Address - Home email address of "other@ema.il" as of 11/07/2024
     And the patient has the Phone - Home email address of "abc@test.com" as of 11/07/2024
+    And the patient has the Phone - Home number of "555-111-1111" as of 11/07/2024
     And the patient has the Email Address - Home email address of "xyz@test.com" as of 11/07/2023
     When I view the demographics summary of the patient
     Then the demographics summary of the patient has an email address of "abc@test.com"


### PR DESCRIPTION
## Description

Fixes an issue where the most recent phone number was not included in the response when there was an email address for the same date.  This is due to the emails and phone numbers being stored in the same tables with the same participation `class_cd`.

The `I can view the patient's most recent phone number in the summarized demographics` feature test was updated to include this scenario.

The same issue occurred with the most recent email

## Tickets

* [CNFT1-4062](https://cdc-nbs.atlassian.net/browse/CNFT1-4062)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4062]: https://cdc-nbs.atlassian.net/browse/CNFT1-4062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ