### PR TITLE
[FIX] Adds initial focus component

### DIFF
--- a/apps/modernization-ui/src/layout/Layout.tsx
+++ b/apps/modernization-ui/src/layout/Layout.tsx
@@ -9,16 +9,15 @@ import { PageProvider } from 'page';
 const Layout = () => {
     return (
         <ApolloWrapper>
-            <ScrollToTop>
-                <AlertProvider>
-                    <SkipLinkProvider>
-                        <PageProvider>
-                            <NavBar />
-                            <Outlet />
-                        </PageProvider>
-                    </SkipLinkProvider>
-                </AlertProvider>
-            </ScrollToTop>
+            <ScrollToTop />
+            <AlertProvider>
+                <SkipLinkProvider>
+                    <PageProvider>
+                        <NavBar />
+                        <Outlet />
+                    </PageProvider>
+                </SkipLinkProvider>
+            </AlertProvider>
         </ApolloWrapper>
     );
 };

--- a/apps/modernization-ui/src/layout/ScrollToTop.tsx
+++ b/apps/modernization-ui/src/layout/ScrollToTop.tsx
@@ -1,54 +1,22 @@
-import { ReactNode, useEffect, useState, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
 
-const ScrollToTop = ({ children }: { children: ReactNode }) => {
-    const location = useLocation();
-    const [initialTabPress, setInitialTabPress] = useState(false);
-    const [prevPathname, setPrevPathname] = useState(location.pathname);
-    const focusRef = useRef<HTMLDivElement>(null);
+import styles from './scroll-to-top.module.scss';
+
+const ScrollToTop = () => {
+    const { pathname } = useLocation();
+    const initialFocusRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
         window.scrollTo(0, 0);
 
-        if (location.pathname !== prevPathname) {
-            setInitialTabPress(false);
-            setPrevPathname(location.pathname);
-
-            if (focusRef.current) {
-                focusRef.current.focus();
-            }
+        if (initialFocusRef.current) {
+            initialFocusRef.current.focus();
         }
-
-        const handleFirstTab = (event: KeyboardEvent) => {
-            const activeElement = document.activeElement;
-            const isBodyOrNonFocusable = activeElement === document.body || activeElement === null;
-
-            if (event.code === 'Tab') {
-                if (!initialTabPress && isBodyOrNonFocusable) {
-                    setInitialTabPress(true);
-                    const skipLinkElement: HTMLElement | null = document.querySelector('.usa-skipnav');
-                    if (skipLinkElement) {
-                        requestAnimationFrame(() => {
-                            skipLinkElement.focus();
-                        });
-                    }
-                }
-                window.removeEventListener('keydown', handleFirstTab);
-            }
-        };
-
-        window.addEventListener('keydown', handleFirstTab);
-
-        return () => {
-            window.removeEventListener('keydown', handleFirstTab);
-        };
-    }, [location.pathname, initialTabPress, prevPathname]);
+    }, [pathname]);
 
     return (
-        <>
-            <div ref={focusRef} tabIndex={-1} style={{ outline: 'none' }} aria-hidden="true" />
-            {children}
-        </>
+        <span id="initial-focus" ref={initialFocusRef} tabIndex={-1} aria-hidden="true" className={styles.initial} />
     );
 };
 

--- a/apps/modernization-ui/src/layout/scroll-to-top.module.scss
+++ b/apps/modernization-ui/src/layout/scroll-to-top.module.scss
@@ -1,0 +1,5 @@
+.initial {
+    position: absolute;
+    top: -10rem;
+    z-index: 100;
+}


### PR DESCRIPTION
## Description

The `ScrollToTop` component was changed to switch focus to an off page component above the skip link whenever the `pathname` changes.  The component was also changed to remove the `children`.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
