### PR TITLE
Add patient merge details page

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
@@ -1,8 +1,9 @@
+import { FeatureGuard } from 'feature';
+import { PageTitle } from 'page';
 import { MatchConfigurationLandingPage } from './configuration/MatchConfigurationLandingPage';
 import { DataElementConfig } from './data-elements/DataElementConfig';
-import { FeatureGuard } from 'feature';
+import { MergeDetails } from './patient-merge/details/MergeDetails';
 import { MergeLanding } from './patient-merge/landing/MergeLanding';
-import { PageTitle } from 'page';
 
 const routing = [
     {
@@ -31,6 +32,16 @@ const routing = [
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
                 <PageTitle title="Patient Merge">
                     <MergeLanding />
+                </PageTitle>
+            </FeatureGuard>
+        )
+    },
+    {
+        path: '/deduplication/merge/:patientId',
+        element: (
+            <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
+                <PageTitle title="Patient matches requiring review">
+                    <MergeDetails />
                 </PageTitle>
             </FeatureGuard>
         )

--- a/apps/modernization-ui/src/apps/deduplication/api/useMergeDetails.ts
+++ b/apps/modernization-ui/src/apps/deduplication/api/useMergeDetails.ts
@@ -1,0 +1,41 @@
+import { Config } from 'config';
+import { useState } from 'react';
+
+export const useMergeDetails = () => {
+    const [loading, setLoading] = useState(false);
+    const [response, setResponse] = useState('');
+    const [error, setError] = useState<string | undefined>(undefined);
+
+    const fetchPatientMergeDetails = (patientId: string) => {
+        setLoading(true);
+
+        fetch(`${Config.deduplicationUrl}/merge/${patientId}`, {
+            method: 'GET',
+            headers: {
+                Accept: 'application/json'
+            }
+        })
+            .then((response) => {
+                response
+                    .json()
+                    .then((response) => {
+                        setResponse(response);
+                    })
+                    .catch(() => {
+                        console.error('Failed to extract json for patient merge details.');
+                    });
+            })
+            .catch((error) => {
+                console.error(error);
+                setError('Failed to retrieve matches requiring review');
+            })
+            .finally(() => setLoading(false));
+    };
+
+    return {
+        loading,
+        error,
+        response,
+        fetchPatientMergeDetails
+    };
+};

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.module.scss
@@ -1,0 +1,5 @@
+.mergeDetails {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 75px); // 75px is height of NavBar. This prevents unnecessary scrollbar
+}

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.spec.tsx
@@ -1,0 +1,43 @@
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { MergeDetails } from './MergeDetails';
+import { render } from '@testing-library/react';
+
+const mockFetch = jest.fn();
+let mockLoading = false;
+jest.mock('apps/deduplication/api/useMergeDetails', () => ({
+    useMergeDetails: () => {
+        return { fetchPatientMergeDetails: mockFetch, loading: mockLoading };
+    }
+}));
+
+const Fixture = () => {
+    return (
+        <MemoryRouter initialEntries={['/deduplication/merge/1234']}>
+            <Routes>
+                <Route path="/deduplication/merge/:patientId" element={<MergeDetails />} />
+            </Routes>
+        </MemoryRouter>
+    );
+};
+describe('MergeDetails', () => {
+    beforeEach(() => {
+        mockLoading = false;
+    });
+
+    it('should fetch the patient merge details specified in the path', () => {
+        render(<Fixture />);
+        expect(mockFetch).toHaveBeenCalledWith('1234');
+    });
+
+    it('should render a loading indicator', () => {
+        mockLoading = true;
+        const { getByText } = render(<Fixture />);
+        expect(getByText('Loading')).toBeInTheDocument();
+    });
+
+    it('should default to review display', () => {
+        const { getByText } = render(<Fixture />);
+
+        expect(getByText('Matches requiring review')).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import { Shown } from 'conditional-render';
+import { MergeReview } from './merge-review/MergeReview';
+import { useMergeDetails } from 'apps/deduplication/api/useMergeDetails';
+import styles from './MergeDetails.module.scss';
+import { Loading } from 'components/Spinner';
+
+export const MergeDetails = () => {
+    const [pageState] = useState<'review' | 'preview'>('review');
+    const { patientId } = useParams();
+    const { loading, fetchPatientMergeDetails } = useMergeDetails();
+
+    useEffect(() => {
+        if (patientId !== undefined) {
+            fetchPatientMergeDetails(patientId);
+        }
+    }, [patientId]);
+
+    return (
+        <div className={styles.mergeDetails}>
+            <Shown when={loading === false} fallback={<Loading center />}>
+                <Shown when={pageState === 'review'}>
+                    <MergeReview />
+                </Shown>
+            </Shown>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/MergeReview.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/MergeReview.spec.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { MergeReview } from './MergeReview';
+import { MemoryRouter } from 'react-router';
+
+const Fixture = () => (
+    <MemoryRouter>
+        <MergeReview />
+    </MemoryRouter>
+);
+describe('MergeReview', () => {
+    it('should display proper header', () => {
+        const { getByRole } = render(<Fixture />);
+        expect(getByRole('heading')).toHaveTextContent('Matches requiring review');
+    });
+
+    it('should display buttons in header', () => {
+        const { getAllByRole } = render(<Fixture />);
+        const buttons = getAllByRole('button');
+
+        expect(buttons[0]).toHaveTextContent('Back');
+        expect(buttons[0]).toHaveClass('secondary');
+        expect(buttons[1]).toHaveTextContent('Preview merge');
+        expect(buttons[1]).toHaveClass('secondary');
+        expect(buttons[2]).toHaveTextContent('Keep all separate');
+        expect(buttons[2]).not.toHaveClass('secondary');
+        expect(buttons[3]).toHaveTextContent('Merge all');
+        expect(buttons[3]).not.toHaveClass('secondary');
+    });
+
+    it('should display informational text', () => {
+        const { getByText } = render(<Fixture />);
+        expect(
+            getByText(
+                'Only one record is selected for Patient ID. By default, the oldest record is selected as the surviving ID. If this is not correct, select the appropriate record.'
+            )
+        ).toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/MergeReview.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/MergeReview.tsx
@@ -1,0 +1,31 @@
+import { Heading } from 'components/heading';
+import { Button } from 'design-system/button';
+import { useNavigate } from 'react-router';
+import styles from './merge-review.module.scss';
+
+export const MergeReview = () => {
+    const nav = useNavigate();
+    return (
+        <div className={styles.mergeReview}>
+            <header>
+                <Heading level={1}>Matches requiring review</Heading>
+                <div className={styles.buttons}>
+                    <Button secondary onClick={() => nav('/deduplication/merge')}>
+                        Back
+                    </Button>
+                    <Button secondary onClick={() => console.log('Preview merge NYI')}>
+                        Preview merge
+                    </Button>
+                    <Button onClick={() => console.log('Keep all separate NYI')}>Keep all separate</Button>
+                    <Button onClick={() => console.log('Merge all NYI')}>Merge all</Button>
+                </div>
+            </header>
+            <main>
+                <div className={styles.infoText}>
+                    Only one record is selected for Patient ID. By default, the oldest record is selected as the
+                    surviving ID. If this is not correct, select the appropriate record.
+                </div>
+            </main>
+        </div>
+    );
+};

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/merge-review.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/merge-review.module.scss
@@ -1,0 +1,30 @@
+@use 'styles/colors';
+@use 'styles/borders';
+
+.mergeReview {
+    header {
+        display: flex;
+        justify-content: space-between;
+        padding: 1rem;
+        background-color: colors.$base-white;
+        @extend %thin-bottom;
+
+        .buttons {
+            display: flex;
+            gap: 0.5rem;
+        }
+    }
+
+    main {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 1rem 1rem 6.25rem 1rem;
+
+        .infoText {
+            color: var colors.$base-darkest;
+            font-size: 0.875rem;
+            line-height: 1.4175rem;
+        }
+    }
+}

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/landing/MergeLanding.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/landing/MergeLanding.spec.tsx
@@ -1,17 +1,16 @@
 import { render, within } from '@testing-library/react';
 import { MergeLanding } from './MergeLanding';
-import { MemoryRouter } from 'react-router';
-import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useSearchParams } from 'react-router';
+import userEvent from '@testing-library/user-event';
 import { useExportMatches } from '../../api/useExportMatches';
-import { useSearchParams } from "react-router";
 
 jest.mock('../../api/useExportMatches', () => ({
-    useExportMatches: jest.fn(),
+    useExportMatches: jest.fn()
 }));
 
 jest.mock('react-router', () => ({
     ...jest.requireActual('react-router'),
-    useSearchParams: jest.fn(),
+    useSearchParams: jest.fn()
 }));
 
 const mockExportMatchesCSV = jest.fn();
@@ -23,7 +22,7 @@ beforeEach(() => {
 
     (useExportMatches as jest.Mock).mockReturnValue({
         exportCSV: mockExportMatchesCSV,
-        exportPDF: mockExportMatchesPDF,
+        exportPDF: mockExportMatchesPDF
     });
 
     (useSearchParams as jest.Mock).mockReturnValue([new URLSearchParams(), jest.fn()]);

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/landing/matches-requiring-review-table/MatchesRequiringReviewTable.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/landing/matches-requiring-review-table/MatchesRequiringReviewTable.tsx
@@ -11,6 +11,7 @@ import { useEffect } from 'react';
 import styles from './matches-requiring-review.module.scss';
 import { Shown } from 'conditional-render';
 import { SortingProvider, useSorting } from 'sorting';
+import { useNavigate } from 'react-router';
 
 const DATE_FORMAT = 'MM/dd/yyyy h:mm a';
 
@@ -25,6 +26,7 @@ export const MatchesRequiringReviewTable = () => {
 };
 
 const SortableMatchesRequiringReviewTable = () => {
+    const nav = useNavigate();
     const { response, fetchMatchesRequiringReview } = useMatchesRequiringReview();
     const { sorting } = useSorting();
     const { page, ready, request, resize, firstPage } = usePagination();
@@ -96,7 +98,7 @@ const SortableMatchesRequiringReviewTable = () => {
                     <Button
                         sizing="small"
                         className={styles.reviewButton}
-                        onClick={() => console.log('clicked review for patient', match.patientId)}>
+                        onClick={() => nav(`/deduplication/merge/${match.patientId}`)}>
                         Review
                     </Button>
                 );


### PR DESCRIPTION
## Description

Adds the initial shell for the `Patient merge details` page located at `/deduplication/merge/:patientId`

## Tickets

* [CND-307](https://cdc-nbs.atlassian.net/browse/CND-307)

## Demo
![reviewLanding](https://github.com/user-attachments/assets/93bd3590-418e-4a99-85eb-4549c2697ae2)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-307]: https://cdc-nbs.atlassian.net/browse/CND-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ