### PR TITLE
Cnft1 4153 skiplink component

### DIFF
--- a/apps/modernization-ui/src/SkipLink/SkipLink.tsx
+++ b/apps/modernization-ui/src/SkipLink/SkipLink.tsx
@@ -1,0 +1,23 @@
+import { focusedTarget } from 'utils';
+import { useSkipLink } from './SkipLinkContext';
+import { useEffect } from 'react';
+
+interface SkipLinkProps {
+    id: string;
+    focus?: boolean;
+}
+
+export const SkipLink = ({ id, focus = false }: SkipLinkProps) => {
+    const { skipTo, remove } = useSkipLink();
+
+    useEffect(() => {
+        skipTo(id);
+        if (focus) {
+            focusedTarget(id);
+        }
+
+        return () => remove(id);
+    }, []);
+
+    return null;
+};

--- a/apps/modernization-ui/src/SkipLink/SkipLink.tsx
+++ b/apps/modernization-ui/src/SkipLink/SkipLink.tsx
@@ -4,15 +4,15 @@ import { useEffect } from 'react';
 
 interface SkipLinkProps {
     id: string;
-    focus?: boolean;
+    autoFocus?: boolean;
 }
 
-export const SkipLink = ({ id, focus = false }: SkipLinkProps) => {
+export const SkipLink = ({ id, autoFocus = false }: SkipLinkProps) => {
     const { skipTo, remove } = useSkipLink();
 
     useEffect(() => {
         skipTo(id);
-        if (focus) {
+        if (autoFocus) {
             focusedTarget(id);
         }
 

--- a/apps/modernization-ui/src/SkipLink/SkipLink.tsx
+++ b/apps/modernization-ui/src/SkipLink/SkipLink.tsx
@@ -19,5 +19,5 @@ export const SkipLink = ({ id, focus = false }: SkipLinkProps) => {
         return () => remove(id);
     }, []);
 
-    return null;
+    return <></>;
 };

--- a/apps/modernization-ui/src/SkipLink/index.ts
+++ b/apps/modernization-ui/src/SkipLink/index.ts
@@ -1,0 +1,2 @@
+export { SkipLink } from './SkipLink';
+export { SkipLinkContext, SkipLinkProvider, useSkipLink } from './SkipLinkContext';

--- a/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/basic/AddPatientBasic.tsx
@@ -15,7 +15,7 @@ import { useAddPatientBasicDefaults } from './useAddPatientBasicDefaults';
 import { useSearchFromAddPatient } from '../useSearchFromAddPatient';
 
 import styles from './add-patient-basic.module.scss';
-import { useSkipLink } from 'SkipLink/SkipLinkContext';
+import { SkipLink } from 'SkipLink';
 
 export const AddPatientBasic = () => {
     const { defaults } = useAddPatientBasicDefaults();
@@ -40,7 +40,6 @@ export const AddPatientBasic = () => {
 
     const { toSearch } = useSearchFromAddPatient();
     const location = useLocation();
-    const { skipTo } = useSkipLink();
 
     const backToSearch = useCallback(
         () => toSearch(location.state?.criteria?.encrypted),
@@ -58,12 +57,9 @@ export const AddPatientBasic = () => {
 
     const working = !form.formState.isValid || !interaction.canSave || interaction.status !== 'waiting';
 
-    useEffect(() => {
-        skipTo('administrative.asOf');
-    }, []);
-
     return (
         <DataEntryLayout>
+            <SkipLink id="administrative.asOf" />
             <Shown when={interaction.status === 'created'}>
                 {interaction.status === 'created' && <PatientCreatedPanel created={interaction.created} />}
             </Shown>

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.tsx
@@ -14,7 +14,7 @@ import { CancelAddPatientPanel, useShowCancelModal } from '../cancelAddPatientPa
 import { useAddPatientExtendedDefaults } from './useAddPatientExtendedDefaults';
 import { useAddExtendedPatient } from './useAddExtendedPatient';
 import { AddExtendedPatientInteractionProvider } from './useAddExtendedPatientInteraction';
-import { useSkipLink } from 'SkipLink/SkipLinkContext';
+import { SkipLink } from 'SkipLink';
 
 import styles from './add-patient-extended.module.scss';
 
@@ -23,7 +23,6 @@ export const AddPatientExtended = () => {
     const { initialize } = useAddPatientExtendedDefaults();
     const { value: bypassBlocker } = useShowCancelModal();
     const { toBasic } = usePatientDataEntryMethod();
-    const { skipTo } = useSkipLink();
 
     const created = useMemo<CreatedPatient | undefined>(
         () => (interaction.status === 'created' ? interaction.created : undefined),
@@ -60,12 +59,9 @@ export const AddPatientExtended = () => {
         }
     }, [interaction.status]);
 
-    useEffect(() => {
-        skipTo('administrative.asOf');
-    }, []);
-
     return (
         <AddExtendedPatientInteractionProvider interaction={interaction}>
+            <SkipLink id="administrative.asOf" />
             <Shown when={interaction.status === 'created'}>
                 {created && <PatientCreatedPanel created={created} />}
             </Shown>

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -20,7 +20,7 @@ const SearchTerms = ({ total, terms }: Props) => {
 
     return (
         <div tabIndex={0} id="resultsCount" className={styles.terms} aria-label={ariaLabel}>
-            <SkipLink id="resultsCount" focus />
+            <SkipLink id="resultsCount" autoFocus />
             <div className={styles.term}>
                 <h2>
                     {total} {resultsText.toLowerCase()} for:

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -1,11 +1,10 @@
 import { Chip } from 'design-system/chips';
 import { useSearchInteraction } from 'apps/search';
 import { Term } from 'apps/search/terms';
-import { focusedTarget, pluralize } from 'utils';
+import { pluralize } from 'utils';
 
 import styles from './search-terms.module.scss';
-import { useSkipLink } from 'SkipLink/SkipLinkContext';
-import { useEffect } from 'react';
+import { SkipLink } from 'SkipLink';
 
 type Props = {
     total: number;
@@ -18,16 +17,10 @@ const SearchTerms = ({ total, terms }: Props) => {
     const ariaLabel = `${total} ${resultsText} ${verbText} been found`;
 
     const { without } = useSearchInteraction();
-    const { skipTo, remove } = useSkipLink();
-
-    useEffect(() => {
-        skipTo('resultsCount');
-        focusedTarget('resultsCount');
-        return () => remove('resultsCount');
-    }, []);
 
     return (
         <div tabIndex={0} id="resultsCount" className={styles.terms} aria-label={ariaLabel}>
+            <SkipLink id="resultsCount" focus />
             <div className={styles.term}>
                 <h2>
                     {total} {resultsText.toLowerCase()} for:

--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -10,21 +10,14 @@ import { PatientCriteriaEntry, statusOptions } from 'apps/search/patient/criteri
 import { Permitted } from 'libs/permission';
 import { searchableGenders } from './searchableGenders';
 import { TextInputField } from 'design-system/input';
-import { useSkipLink } from 'SkipLink/SkipLinkContext';
-import { useEffect } from 'react';
+import { SkipLink } from 'SkipLink';
 
 export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
     const { control, clearErrors } = useFormContext<PatientCriteriaEntry, Partial<PatientCriteriaEntry>>();
-    const { skipTo, remove } = useSkipLink();
-
-    useEffect(() => {
-        skipTo('name.lastOperator');
-
-        return () => remove('name.lastOperator');
-    }, []);
 
     return (
         <SearchCriteria sizing={sizing}>
+            <SkipLink id="name.lastOperator" />
             <Controller
                 control={control}
                 name="name.last"


### PR DESCRIPTION
## Description

I want a simple SkipLink component that I can add to my content sections, so that I can easily implement accessible navigation without repeating effect hooks and cleanup logic across many components.

- Acceptance Criteria
- When there is no search results on the search page the last name operator should be focused upon using the skip link 
- With the results on the search page the user should be redirected or focused to the results count
- In the add patient the skip link should focus the information as of field when used.
- In the add  add extended patient the skip link should focus the information as of field when used.

## Tickets

* [CNFT1-4153](https://cdc-nbs.atlassian.net/browse/CNFT1-4153)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4153]: https://cdc-nbs.atlassian.net/browse/CNFT1-4153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ