### PR TITLE
[CNFT1-4141]: adding action button to search layout as the last element of the Dom

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -106,7 +106,7 @@ const SearchLayout = <R,>({
                 </div>
             </div>
             <Shown when={!!actions}>
-                <div className={styles.actionsContainer}>{actions?.()}</div>
+                <div className={styles.actions}>{actions?.()}</div>
             </Shown>
         </section>
     );

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -60,7 +60,7 @@ const SearchLayout = <R,>({
             <FeatureToggle
                 guard={(features) => features?.search?.events?.enabled}
                 fallback={<SearchNavigation className={styles.navigation} actions={actions} />}>
-                <PatientSearchHeader className={styles.navigation} actions={actions} />
+                <PatientSearchHeader className={styles.navigation} />
             </FeatureToggle>
 
             <div className={styles.content}>
@@ -105,6 +105,9 @@ const SearchLayout = <R,>({
                     </Shown>
                 </div>
             </div>
+            <Shown when={!!actions}>
+                <div className={styles.actionButtons}>{actions?.()}</div>
+            </Shown>
         </section>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -106,7 +106,7 @@ const SearchLayout = <R,>({
                 </div>
             </div>
             <Shown when={!!actions}>
-                <div className={styles.actionButtons}>{actions?.()}</div>
+                <div className={styles.actionsContainer}>{actions?.()}</div>
             </Shown>
         </section>
     );

--- a/apps/modernization-ui/src/apps/search/layout/patientSearchHeader/PatientSearchHeader.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/patientSearchHeader/PatientSearchHeader.tsx
@@ -1,17 +1,13 @@
 import { Link } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { Hint } from 'design-system/hint';
-import { ReactNode } from 'react';
 import styles from './patient-search-header.module.scss';
-
-type ActionsRenderer = () => ReactNode;
 
 type Props = {
     className?: string;
-    actions?: ActionsRenderer;
 };
 
-const PatientSearchHeader = ({ className, actions }: Props) => {
+const PatientSearchHeader = ({ className }: Props) => {
     return (
         <nav className={classNames(styles.navigation, className)}>
             <h1>Patient Search 7 Beta</h1>
@@ -33,8 +29,6 @@ const PatientSearchHeader = ({ className, actions }: Props) => {
                     </div>
                 </div>
             </div>
-
-            {actions?.()}
         </nav>
     );
 };

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -13,6 +13,7 @@ $content-height: calc($search-height - $navigation-height - 3rem);
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    position: relative;
 
     .navigation {
         height: $navigation-height;
@@ -61,5 +62,12 @@ $content-height: calc($search-height - $navigation-height - 3rem);
             flex-grow: 1;
             min-width: calc(100% - $criteria-width);
         }
+    }
+
+    .actionButtons {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        z-index: 100;
     }
 }

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -64,7 +64,7 @@ $content-height: calc($search-height - $navigation-height - 3rem);
         }
     }
 
-    .actionButtons {
+    .actionsContainer {
         position: absolute;
         top: 1rem;
         right: 1rem;

--- a/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
+++ b/apps/modernization-ui/src/apps/search/layout/search-layout.module.scss
@@ -64,7 +64,7 @@ $content-height: calc($search-height - $navigation-height - 3rem);
         }
     }
 
-    .actionsContainer {
+    .actions {
         position: absolute;
         top: 1rem;
         right: 1rem;


### PR DESCRIPTION
## Description

As a visual user and screen reader navigating through the patient search page when there are results on the screen for both table view and list view I would like to be able to tab towards the Add new patient button after navigating through the search results.

Ensure the Add new patient button is located as the last element within the DOM tree structure to allow users to tab naturally towards it after having navigated through out the search results. 

## Tickets

* [CNFT1-4141](https://cdc-nbs.atlassian.net/browse/CNFT1-4141)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4141]: https://cdc-nbs.atlassian.net/browse/CNFT1-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ