### PR TITLE
[CNFT1-4176] Ensures that a race only appears once

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryRaceFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryRaceFinder.java
@@ -16,9 +16,11 @@ class PatientDemographicsSummaryRaceFinder {
               left join NBS_SRTE..Code_value_general [race] on
                   [race].code_set_nm = 'RACE_CALCULATED'
               and [race].[code] = [patient].race_category_cd
+                                                              
       
       where [patient].person_uid = ?
           and [patient].record_status_cd = 'ACTIVE'
+          and [patient].race_category_cd = [patient].race_cd
       order by
           [patient].[as_of_date] desc
       """;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryVerificationSteps.java
@@ -5,6 +5,7 @@ import io.cucumber.java.en.Then;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 public class PatientDemographicsSummaryVerificationSteps {
@@ -159,6 +160,7 @@ public class PatientDemographicsSummaryVerificationSteps {
       throws Exception {
     int position = nth - 1;
     this.results.active()
+        .andDo(print())
         .andExpect(jsonPath("$.races[%d]", position).value(value));
   }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
@@ -64,6 +64,8 @@ Feature: Summarizing the demographics of a patient
   Scenario: I can view the patient's races in the summarized demographics
     Given the patient's race is Unknown as of 07/24/1974
     And the patient's race is Asian as of 11/05/2022
+    And the patient race of Asian includes Japanese
+    And the patient race of Asian includes Burmese
     And the patient's race is Other as of 08/17/2000
     When I view the demographics summary of the patient
     Then the 1st race in the demographics summary of the patient is "Asian"


### PR DESCRIPTION
## Description

The query to obtain the races of a patient was including the category of the detailed races also.

Enhanced the feature tests to include this scenario

```cucumber
  Scenario: I can view the patient's races in the summarized demographics
    Given the patient's race is Unknown as of 07/24/1974
    And the patient's race is Asian as of 11/05/2022
    And the patient race of Asian includes Japanese
    And the patient race of Asian includes Burmese
    And the patient's race is Other as of 08/17/2000
    When I view the demographics summary of the patient
    Then the 1st race in the demographics summary of the patient is "Asian"
    And the 2nd race in the demographics summary of the patient is "Other"
    And the 3rd race in the demographics summary of the patient is "Unknown"
```

## Tickets

* [CNFT1-4176](https://cdc-nbs.atlassian.net/browse/CNFT1-4176)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4176]: https://cdc-nbs.atlassian.net/browse/CNFT1-4176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ