### PR TITLE
Cnft1 4140 add patient actions buttons update

### DIFF
--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.spec.tsx
@@ -105,8 +105,8 @@ describe('AddPatientExtended', () => {
         const { getAllByRole } = renderWithRouter();
 
         const buttons = getAllByRole('button');
-        expect(buttons[0]).toHaveTextContent('Cancel');
-        expect(buttons[1]).toHaveTextContent('Save');
+        expect(buttons[buttons.length - 2]).toHaveTextContent('Cancel');
+        expect(buttons[buttons.length - 1]).toHaveTextContent('Save');
     });
 
     it('should not be showing modal by default', () => {

--- a/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/extended/AddPatientExtended.spec.tsx
@@ -102,11 +102,13 @@ describe('AddPatientExtended', () => {
     });
 
     it('should have cancel and save buttons', () => {
-        const { getAllByRole } = renderWithRouter();
+        const { getByRole } = renderWithRouter();
 
-        const buttons = getAllByRole('button');
-        expect(buttons[buttons.length - 2]).toHaveTextContent('Cancel');
-        expect(buttons[buttons.length - 1]).toHaveTextContent('Save');
+        const cancelButton = getByRole('button', { name: 'Cancel' });
+        const saveButton = getByRole('button', { name: 'Save' });
+        
+        expect(cancelButton).toBeInTheDocument();
+        expect(saveButton).toBeInTheDocument();
     });
 
     it('should not be showing modal by default', () => {

--- a/apps/modernization-ui/src/apps/patient/add/layout/AddPatientLayout.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/layout/AddPatientLayout.tsx
@@ -20,10 +20,10 @@ export const AddPatientLayout = ({ actions, title, sections, children }: AddPati
                     <Heading level={1}>{title}</Heading>
                 </header>
                 <main>
-                    <div className={styles.content}>{children}</div>
                     <aside>
                         <InPageNavigation sections={sections} />
                     </aside>
+                    <div className={styles.content}>{children}</div>
                 </main>
                 <div className={styles.actions}>{actions()}</div>
             </div>

--- a/apps/modernization-ui/src/apps/patient/add/layout/AddPatientLayout.tsx
+++ b/apps/modernization-ui/src/apps/patient/add/layout/AddPatientLayout.tsx
@@ -18,7 +18,6 @@ export const AddPatientLayout = ({ actions, title, sections, children }: AddPati
             <div className={styles.layout}>
                 <header className={styles.header}>
                     <Heading level={1}>{title}</Heading>
-                    <div className={styles.actions}>{actions()}</div>
                 </header>
                 <main>
                     <div className={styles.content}>{children}</div>
@@ -26,6 +25,7 @@ export const AddPatientLayout = ({ actions, title, sections, children }: AddPati
                         <InPageNavigation sections={sections} />
                     </aside>
                 </main>
+                <div className={styles.actions}>{actions()}</div>
             </div>
         </DataEntryLayout>
     );

--- a/apps/modernization-ui/src/apps/patient/add/layout/add-patient-layout.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/layout/add-patient-layout.module.scss
@@ -6,6 +6,7 @@ $in-page-navigation-width: 12.1875rem;
 
 .layout {
     background-color: colors.$background;
+    position: relative;
 
     .header {
         display: flex;
@@ -17,11 +18,6 @@ $in-page-navigation-width: 12.1875rem;
         background-color: colors.$base-white;
 
         @extend %thin-bottom;
-
-        .actions {
-            display: flex;
-            gap: 0.5rem;
-        }
     }
 
     & > main {
@@ -42,6 +38,14 @@ $in-page-navigation-width: 12.1875rem;
             top: 0;
             min-width: $in-page-navigation-width;
             max-width: $in-page-navigation-width;
+        }
+
+        .actions {
+            display: flex;
+            gap: 0.5rem;
+            position: absolute;
+            right: 1rem;
+            top: 1rem;
         }
     }
 }

--- a/apps/modernization-ui/src/apps/patient/add/layout/add-patient-layout.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/layout/add-patient-layout.module.scss
@@ -24,13 +24,13 @@ $in-page-navigation-width: 12.1875rem;
         height: calc(100vh - #{$header-height} - var(--nav-bar-height, 75px));
         display: flex;
         gap: 1rem;
-
         padding: 1rem 1rem 0 1rem;
         overflow-y: scroll;
 
         .content {
             min-width: 36rem;
             width: 100%;
+            order: 1;
         }
 
         & > aside {
@@ -38,6 +38,7 @@ $in-page-navigation-width: 12.1875rem;
             top: 0;
             min-width: $in-page-navigation-width;
             max-width: $in-page-navigation-width;
+            order: 2;
         }
     }
     

--- a/apps/modernization-ui/src/apps/patient/add/layout/add-patient-layout.module.scss
+++ b/apps/modernization-ui/src/apps/patient/add/layout/add-patient-layout.module.scss
@@ -39,13 +39,13 @@ $in-page-navigation-width: 12.1875rem;
             min-width: $in-page-navigation-width;
             max-width: $in-page-navigation-width;
         }
-
-        .actions {
-            display: flex;
-            gap: 0.5rem;
-            position: absolute;
-            right: 1rem;
-            top: 1rem;
-        }
+    }
+    
+    .actions {
+        display: flex;
+        gap: 0.5rem;
+        position: absolute;
+        right: 1rem;
+        top: 1rem;
     }
 }

--- a/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.module.scss
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.module.scss
@@ -23,7 +23,6 @@ nav {
             border-left: 4px solid transparent !important;
 
             &:focus {
-                outline: none !important;
                 background-color: transparent !important;
             }
 

--- a/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
@@ -22,7 +22,6 @@ export const InPageNavigation: React.FC<InPageNavigationProps> = ({ sections, ti
             <div className={styles.navOptions}>
                 {sections.map((section) => (
                     <a
-                        tabIndex={-1}
                         key={section.id}
                         id={`inPageNav-${section.id}`}
                         href={`#${section.id}`}

--- a/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
@@ -22,6 +22,7 @@ export const InPageNavigation: React.FC<InPageNavigationProps> = ({ sections, ti
             <div className={styles.navOptions}>
                 {sections.map((section) => (
                     <a
+                        tabIndex={-1}
                         key={section.id}
                         id={`inPageNav-${section.id}`}
                         href={`#${section.id}`}


### PR DESCRIPTION


https://github.com/user-attachments/assets/9cd90f6b-564e-439d-903b-1e963121211c

## Description

As a visual user and screen reader navigating through the Add patient form when the user finishes navigating through the form I would like to be able to tab towards the Add extended data button.

Ensure the Add extended data button is located as the last element within the DOM tree structure to allow users to tab naturally towards it after having navigated through out the form.

This pr will also fix the extended data entry form's desired tab order as the action buttons in the header need to also be the final elements on the page

## Tickets

* [CNFT1-4140](https://cdc-nbs.atlassian.net/browse/CNFT1-4140)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4140]: https://cdc-nbs.atlassian.net/browse/CNFT1-4140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ