### PR TITLE
CNFT1-4201: Column settings reset button

### DIFF
--- a/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.stories.tsx
+++ b/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.stories.tsx
@@ -40,3 +40,13 @@ export const Default: Story = {
         close: () => {}
     }
 };
+
+export const InPanel: Story = {
+    decorators: Default.decorators,
+    args: Default.args,
+    render: (args) => (
+        <div style={{ width: '300px', height: 'auto', backgroundColor: 'white', border: '1px solid black' }}>
+            <ColumnPreferencesPanel {...args} />
+        </div>
+    )
+};

--- a/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
+++ b/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
@@ -110,7 +110,7 @@ const ColumnPreferencesPanel = ({ close, sizing = 'small' }: Props) => {
                 </Droppable>
             </DragDropContext>
             <footer>
-                <Button className={styles.reset} tertiary sizing={sizing} onClick={handleReset}>
+                <Button tertiary sizing={sizing} onClick={handleReset}>
                     Reset
                 </Button>
                 <Button type="button" id="save-column-preferences" outline sizing={sizing} onClick={handleSave}>

--- a/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
+++ b/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
@@ -6,6 +6,7 @@ import { ActionIcon, Icon } from 'design-system/icon';
 import { Button } from 'design-system/button';
 
 import styles from './column-preference-panel.module.scss';
+import { Sizing } from 'design-system/field';
 
 const swap =
     <I,>(items: I[]) =>
@@ -16,10 +17,11 @@ const swap =
     };
 
 type Props = {
+    sizing?: Sizing;
     close: () => void;
 };
 
-const ColumnPreferencesPanel = ({ close }: Props) => {
+const ColumnPreferencesPanel = ({ close, sizing = 'small' }: Props) => {
     const { preferences, save, reset } = useColumnPreferences();
 
     const [pending, setPending] = useState<ColumnPreference[]>([]);
@@ -108,10 +110,10 @@ const ColumnPreferencesPanel = ({ close }: Props) => {
                 </Droppable>
             </DragDropContext>
             <footer>
-                <Button className={styles.reset} onClick={handleReset}>
+                <Button className={styles.reset} tertiary sizing={sizing} onClick={handleReset}>
                     Reset
                 </Button>
-                <Button type="button" id="save-column-preferences" outline onClick={handleSave}>
+                <Button type="button" id="save-column-preferences" outline sizing={sizing} onClick={handleSave}>
                     Save columns
                 </Button>
             </footer>

--- a/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
@@ -29,19 +29,21 @@
 
     footer {
         display: flex;
-        justify-content: center;
-        padding: 1.5rem;
-        gap: 2.2rem;
+        justify-content: space-between;
+        padding: 1rem;
 
         @extend %thin-top;
 
-        .reset {
+        .resetxxx {
             padding: 0;
+            box-shadow: none;
             background-color: transparent;
             color: colors.$primary;
 
             &:hover {
                 text-decoration: underline;
+                background-color: transparent;
+                color: colors.$primary;
             }
         }
     }

--- a/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
@@ -33,19 +33,6 @@
         padding: 1rem;
 
         @extend %thin-top;
-
-        .resetxxx {
-            padding: 0;
-            box-shadow: none;
-            background-color: transparent;
-            color: colors.$primary;
-
-            &:hover {
-                text-decoration: underline;
-                background-color: transparent;
-                color: colors.$primary;
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Fix the `ColumnPreferencesPanel` footer styling:
- Use new tertiary property for reset button
- Flexbox justify to space between 
- Fix sizing to small and allow sizing changes

![image](https://github.com/user-attachments/assets/4a75c36f-bd60-43e0-b624-d6d5e1ca2147)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-4201)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
