### PR TITLE
[CNFT1-4225] Patient file delete button padding

### DIFF
--- a/apps/modernization-ui/src/design-system/modal/Modal.tsx
+++ b/apps/modernization-ui/src/design-system/modal/Modal.tsx
@@ -1,8 +1,10 @@
-import { ReactNode, KeyboardEvent as ReactKeyboardEvent, useRef, useEffect, ReactElement } from 'react';
+import { ReactNode, KeyboardEvent as ReactKeyboardEvent, useRef, useEffect } from 'react';
 import classNames from 'classnames';
+
 import sprite from '@uswds/uswds/img/sprite.svg';
 
 import styles from './modal.module.scss';
+import { createPortal } from 'react-dom';
 
 type Close = () => void;
 
@@ -11,8 +13,11 @@ type FooterRenderer = (close: Close) => ReactNode;
 type ModalProps = {
     id: string;
     title: string;
-    size?: 'small' | 'large' | 'auto';
-    /** Whether to force interaction on the modal. This also hides the "X" button. */
+    size?: 'small' | 'large';
+    /**
+     * Whether to force interaction on the modal. A modal with a forced action does not display the
+     *  close button nor will it close when the escape button is pressed.
+     */
     forceAction?: boolean;
     className?: string;
     ariaDescribedBy?: string;
@@ -21,17 +26,19 @@ type ModalProps = {
     footer?: FooterRenderer;
 };
 
-const Modal = ({
+const Modal = (props: ModalProps) => createPortal(<Component {...props} />, document.body);
+
+const Component = ({
     id,
     title,
-    size = 'auto',
+    size,
     forceAction = false,
     children,
     className,
     ariaDescribedBy,
     onClose,
     footer
-}: ModalProps): ReactElement<ModalProps> => {
+}: ModalProps) => {
     const focused = useRef<boolean>(false);
     const element = useRef<HTMLDialogElement>(null);
     const header = `${id}-header`;
@@ -51,7 +58,10 @@ const Modal = ({
     };
 
     return (
-        <div className="usa-modal-wrapper" onKeyDown={(!forceAction && handleKeyDown) || undefined}>
+        <div
+            id={`${id}-wrapper`}
+            className="usa-modal-wrapper"
+            onKeyDown={(!forceAction && handleKeyDown) || undefined}>
             <div className={classNames('usa-modal-overlay', styles.overlay)}>
                 <dialog
                     ref={element}


### PR DESCRIPTION
## Description

The modal wrapper element was being placed next to the button component causing the parent flex container to insert another gap.

![cnft1-4225](https://github.com/user-attachments/assets/ad5ad908-c006-410c-be66-ec706a25ed6e)


## Tickets

* [CNFT1-4225](https://cdc-nbs.atlassian.net/browse/CNFT1-4225)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4225]: https://cdc-nbs.atlassian.net/browse/CNFT1-4225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ