### PR TITLE
[Refactor] Design System/Datatable rendering when empty

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/events/investigations/Investigations.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/investigations/Investigations.tsx
@@ -140,7 +140,6 @@ export const Investigations = () => {
                     children: 'Compare investigations'
                 }
             ]}
-            noDataFallback
             data={data ?? []}
             defaultColumnPreferences={columnPreferences}
         />

--- a/apps/modernization-ui/src/apps/patient/file/summary/openInvestigations/OpenInvestigationsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/summary/openInvestigations/OpenInvestigationsCard.tsx
@@ -98,7 +98,6 @@ const OpenInvestigationsCard = () => {
             columns={columns}
             columnPreferencesKey="patient-file-open-investigations-table-card-column-preferences"
             defaultColumnPreferences={columnPreferences}
-            noDataFallback
         />
     );
 };

--- a/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/table/PatientSearchResultTable.tsx
@@ -123,6 +123,7 @@ const PatientSearchResultTable = ({ results, sizing }: Props) => {
             data={results}
             sizing={sizing}
             features={{ sorting, filtering }}
+            onEmpty={() => <></>}
         />
     );
 };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -159,7 +159,6 @@ const RepeatingBlock = <V extends FieldValues>({
                     columns={[...columns, iconColumn]}
                     data={entries}
                     sizing={sizing}
-                    noDataFallback
                 />
             </div>
             <Shown when={status === 'viewing'}>{selected && viewRenderer(selected)}</Shown>

--- a/apps/modernization-ui/src/design-system/table/DataTable.spec.tsx
+++ b/apps/modernization-ui/src/design-system/table/DataTable.spec.tsx
@@ -8,21 +8,6 @@ type TestData = {
     name: string;
 };
 
-const columns: Column<TestData>[] = [
-    {
-        id: 'id',
-        name: 'ID',
-        className: 'id-header',
-        render: (value) => value.id
-    },
-    {
-        id: 'name',
-        name: 'Name',
-        className: 'name-header',
-        render: (value) => value.name
-    }
-];
-
 const data: TestData[] = [
     { id: 1, name: 'John Doe' },
     { id: 2, name: 'Jane Smith' }
@@ -30,6 +15,24 @@ const data: TestData[] = [
 
 describe('DataTable', () => {
     it('should render with no accessibility violations', async () => {
+        const columns = [
+            {
+                id: 'id',
+                name: 'ID',
+                render: () => 'id-value'
+            },
+            {
+                id: 'name',
+                name: 'Name',
+                render: () => `name-value`
+            },
+            {
+                id: 'other',
+                name: 'Other',
+                render: () => 'other-value'
+            }
+        ];
+
         const { container } = render(<DataTable id="test-table" columns={columns} data={data} />);
         expect(await axe(container)).toHaveNoViolations();
     });
@@ -100,6 +103,24 @@ describe('DataTable', () => {
     });
 
     it('displays the data', () => {
+        const columns: Column<TestData>[] = [
+            {
+                id: 'id',
+                name: 'ID',
+                value: (value) => value.id
+            },
+            {
+                id: 'name',
+                name: 'Name',
+                value: (value) => value.name
+            },
+            {
+                id: 'combined',
+                name: 'Combined values',
+                render: (value) => `${value.name} (${value.id})`
+            }
+        ];
+
         const data = [
             { id: 2, name: 'name-two', value: 'two-value' },
             { id: 5, name: 'name-five', value: 'five-value' },
@@ -111,25 +132,109 @@ describe('DataTable', () => {
         const two = screen.getByRole('row', { name: /2/ });
         expect(two).not.toBeNull();
         expect(within(two!).getByText('name-two'));
+        expect(within(two!).getByText('name-two (2)'));
 
         const five = screen.getByRole('row', { name: /5/ });
         expect(five).not.toBeNull();
         expect(within(five!).getByText('name-five'));
+        expect(within(five!).getByText('name-five (5)'));
 
         const three = screen.getByRole('row', { name: /3/ });
-        expect(three).not.toBeNull();
+        expect(within(three!).getByText('name-three (3)'));
         expect(within(three!).getByText('name-three'));
 
         expect(screen.getAllByRole('row')).toHaveLength(4); //  header row + data rows
     });
 
+    it('displays the data using the render function over the value function', () => {
+        const columns: Column<TestData>[] = [
+            {
+                id: 'id',
+                name: 'ID',
+                value: (value) => value.id,
+                render: (value) => `Rendered ${value.id}`
+            },
+            {
+                id: 'name',
+                name: 'Name',
+                value: (value) => value.name,
+                render: (value) => `Rendered ${value.name}`
+            }
+        ];
+
+        const data = [
+            { id: 2, name: 'name-two', value: 'two-value' },
+            { id: 5, name: 'name-five', value: 'five-value' },
+            { id: 3, name: 'name-three', value: 'three-value' }
+        ];
+
+        render(<DataTable id="test-table" columns={columns} data={data} />);
+
+        const two = screen.getByRole('row', { name: /2/ });
+        expect(within(two!).getByText('Rendered name-two'));
+
+        const five = screen.getByRole('row', { name: /5/ });
+        expect(within(five!).getByText('Rendered name-five'));
+
+        const three = screen.getByRole('row', { name: /3/ });
+        expect(within(three!).getByText('Rendered name-three'));
+    });
+
     it('displays the default empty table message', () => {
-        render(<DataTable id="test-table" columns={columns} data={[]} noDataFallback />);
+        const columns: Column<TestData>[] = [
+            {
+                id: 'id',
+                name: 'ID',
+                value: (value) => value.id
+            },
+            {
+                id: 'name',
+                name: 'Name',
+                value: (value) => value.name
+            }
+        ];
+
+        render(<DataTable id="test-table" columns={columns} data={[]} />);
 
         expect(screen.getByText('No data has been added.')).toBeInTheDocument();
     });
 
+    it('defers to the provided onEmpty when the table is empty', () => {
+        const columns: Column<TestData>[] = [
+            {
+                id: 'id',
+                name: 'ID',
+                value: (value) => value.id
+            },
+            {
+                id: 'name',
+                name: 'Name',
+                value: (value) => value.name
+            },
+            {
+                id: 'combined',
+                name: 'Combined values',
+                render: (value) => `${value.name} (${value.id})`
+            }
+        ];
+
+        const onEmpty = jest.fn();
+        render(<DataTable id="test-table" columns={columns} data={[]} onEmpty={onEmpty} />);
+
+        expect(onEmpty).toHaveBeenCalledWith(3);
+
+        expect(screen.queryByText('No data has been added.')).not.toBeInTheDocument();
+    });
+
     it.each(['small', 'medium', 'large'] as Sizing[])('applies the sizing classes for %s', (sizing) => {
+        const columns: Column<TestData>[] = [
+            {
+                id: 'id',
+                name: 'ID',
+                value: (value) => value.id
+            }
+        ];
+
         render(<DataTable id="test-table" columns={columns} data={[]} sizing={sizing} />);
         const table = screen.getByRole('table').closest('div');
         expect(table).toHaveClass(sizing);

--- a/apps/modernization-ui/src/design-system/table/DataTable.tsx
+++ b/apps/modernization-ui/src/design-system/table/DataTable.tsx
@@ -33,6 +33,8 @@ type Column<R, C = CellValue> = {
     sortIconType?: SortIconType;
 } & RenderMethod<R, C>;
 
+type EmptyRenderer = (columns: number) => ReactNode | ReactNode[] | undefined;
+
 type DataTableFeatures = {
     sorting?: SortingInteraction;
     filtering?: FilterInteraction;
@@ -44,11 +46,19 @@ type DataTableProps<V> = {
     columns: Column<V>[];
     data: V[];
     sizing?: Sizing;
-    noDataFallback?: boolean;
+    onEmpty?: EmptyRenderer;
     features?: DataTableFeatures;
 };
 
-const DataTable = <V,>({ id, className, columns, data, sizing, features = {}, noDataFallback }: DataTableProps<V>) => {
+const DataTable = <V,>({
+    id,
+    className,
+    columns,
+    data,
+    sizing,
+    onEmpty = defaultEmptyHandler,
+    features = {}
+}: DataTableProps<V>) => {
     const resolvedClasses = classNames('usa-table--borderless', styles.table, {
         [styles.sized]: sizing,
         [styles.small]: sizing === 'small',
@@ -65,7 +75,7 @@ const DataTable = <V,>({ id, className, columns, data, sizing, features = {}, no
                     sorting={features.sorting}
                 />
                 <tbody>
-                    <Shown when={data.length > 0} fallback={noDataFallback && <NoDataRow colSpan={columns.length} />}>
+                    <Shown when={data.length > 0} fallback={onEmpty(columns.length)}>
                         {data.map((row, index) => (
                             <DataTableRow
                                 sorting={features.sorting}
@@ -82,6 +92,8 @@ const DataTable = <V,>({ id, className, columns, data, sizing, features = {}, no
         </div>
     );
 };
+
+const defaultEmptyHandler = (columns: number) => <NoDataRow columns={columns}>No data has been added.</NoDataRow>;
 
 export { DataTable };
 

--- a/apps/modernization-ui/src/design-system/table/NoDataRow.tsx
+++ b/apps/modernization-ui/src/design-system/table/NoDataRow.tsx
@@ -1,15 +1,17 @@
+import { ReactNode } from 'react';
 import styles from './data-table.module.scss';
 
-type Props = {
-    colSpan: number;
+type NoDataRowProps = {
+    columns: number;
+    children: ReactNode;
 };
 
-export const NoDataRow = ({ colSpan }: Props) => {
-    return (
-        <tr>
-            <td colSpan={colSpan} className={styles.noData}>
-                No data has been added.
-            </td>
-        </tr>
-    );
-};
+const NoDataRow = ({ columns, children }: NoDataRowProps) => (
+    <tr>
+        <td colSpan={columns} className={styles.noData}>
+            {children}
+        </td>
+    </tr>
+);
+
+export { NoDataRow };


### PR DESCRIPTION
## Description

Specialized rendering of rows for an empty table is now handled by the `onEmpty` function.  By default a `DataTable` will render the message "No data has been added." if the provided data array is empty.

Previously, the user of a `DataTable` would have to enable the "No data has been added." message using the `noDataFallback` property. 

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
