### PR TITLE
[FIX] Change morbidity treatment finder to use map extractor

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/morbidity/MorbidityReportRequiringReviewResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/morbidity/MorbidityReportRequiringReviewResolver.java
@@ -36,7 +36,7 @@ public class MorbidityReportRequiringReviewResolver {
           .map(DocumentRequiringReview::id)
           .toList();
 
-      Map<Long, List<String>> treatments = treatments(criteria);
+      Map<Long, Collection<String>> treatments = treatments(criteria);
 
       Map<Long, Collection<ResultedTest>> resultedTests = resultedTests(identifiers);
 
@@ -55,7 +55,7 @@ public class MorbidityReportRequiringReviewResolver {
     return Collections.emptyList();
   }
 
-  private Map<Long, List<String>> treatments(final DocumentsRequiringReviewCriteria criteria) {
+  private Map<Long, Collection<String>> treatments(final DocumentsRequiringReviewCriteria criteria) {
     return criteria.treatmentScope().allowed()
         ? this.treatmentFinder.find(criteria.patient(), criteria.morbidityReportScope())
         : Collections.emptyMap();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/morbidity/MorbidityTreatment.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/morbidity/MorbidityTreatment.java
@@ -1,4 +1,0 @@
-package gov.cdc.nbs.patient.file.summary.drr.morbidity;
-
-record MorbidityTreatment(long morbidity, String treatment) {
-}


### PR DESCRIPTION
## Description

The finder used to resolve treatments for a morbidity report was streaming results from the database and not closing the connection.  The finder was changed to use a `ResultExtractor` instead of grouping via a `Stream`

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
