### PR TITLE
[CNFT1-4245] Makes Patient file header sticky

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/PatientFile.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFile.tsx
@@ -7,8 +7,6 @@ import { Icon } from 'design-system/icon';
 import { Patient } from './patient';
 import { PatientLoaderResult } from './loader';
 import { PatientFileLayout } from './PatientFileLayout';
-
-import styles from './patient-file.module.scss';
 import { DeleteAction } from './delete';
 
 const PatientFile = () => {
@@ -26,7 +24,7 @@ export { PatientFile };
 const ViewActions = (patient: Patient) => {
     return (
         <>
-            <DeleteAction buttonClassName={styles['usa-button']} />
+            <DeleteAction />
             <Button
                 onClick={openPrintableView(patient.id.toString())}
                 aria-label="Print"

--- a/apps/modernization-ui/src/apps/patient/file/PatientFileHeader.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileHeader.tsx
@@ -11,9 +11,9 @@ type PatientFileHeaderProps = {
 
 export const PatientFileHeader = ({ patient, actions }: PatientFileHeaderProps) => {
     return (
-        <header className={styles.header}>
+        <div className={styles.header}>
             <PatientDescriptor headingLevel={1} patient={patient} />
             <div className={styles.actions}>{actions}</div>
-        </header>
+        </div>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/file/PatientFileLayout.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileLayout.tsx
@@ -16,8 +16,10 @@ const PatientFileLayout = ({ patient, actions, navigation, children }: PatientFi
     return (
         <PatientProvider patient={patient}>
             <div className={styles.file}>
-                <PatientFileHeader patient={patient} actions={actions(patient)} />
-                <nav>{navigation(patient)}</nav>
+                <header>
+                    <PatientFileHeader patient={patient} actions={actions(patient)} />
+                    <nav>{navigation(patient)}</nav>
+                </header>
                 <main>{children}</main>
             </div>
         </PatientProvider>

--- a/apps/modernization-ui/src/apps/patient/file/patient-file-layout.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/patient-file-layout.module.scss
@@ -1,6 +1,12 @@
 @use 'styles/colors';
 
 .file {
+    & > header {
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+    }
+
     & > main {
         padding: 1rem;
     }

--- a/apps/modernization-ui/src/apps/patient/file/patient-file.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/patient-file.module.scss
@@ -1,7 +1,1 @@
 @use 'styles/colors';
-
-.icon-button:disabled {
-    color: colors.$disabled-darker !important;
-    background: none !important;
-    box-shadow: inset 0 0 0 2px colors.$disabled !important;
-}


### PR DESCRIPTION
## Description

The Patient file header now remains sticky when scrolling.

![cnft1-4245](https://github.com/user-attachments/assets/c4bf7df1-437b-4d9c-b729-0645075a7c83)


## Tickets

* [CNFT1-4245](https://cdc-nbs.atlassian.net/browse/CNFT1-4245)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
