### PR TITLE
[CNFT1-4216] Patient identification demographics

### DIFF
--- a/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
+++ b/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
@@ -4087,6 +4087,28 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "Identifications",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{base}}/nbs/api/patients/{{patient}}/demographics/identifications",
+											"host": [
+												"{{base}}"
+											],
+											"path": [
+												"nbs",
+												"api",
+												"patients",
+												"{{patient}}",
+												"demographics",
+												"identifications"
+											]
+										}
+									},
+									"response": []
 								}
 							]
 						},

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/data/selectable/Selectable.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/data/selectable/Selectable.java
@@ -9,4 +9,7 @@ public record Selectable(
     String value,
     String name
 ) {
+    public Selectable {
+        name = name == null ? value : name;
+    }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/data/selectable/SelectableRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/data/selectable/SelectableRowMapper.java
@@ -22,6 +22,6 @@ public class SelectableRowMapper implements RowMapper<Selectable> {
     String value = resultSet.getString(columns.value());
     String name = resultSet.getString(columns.name());
 
-    return (value != null) ? new Selectable(value, name) : null;
+    return (value != null && !value.isBlank()) ? new Selectable(value, name) : null;
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/demographics/identification/IdentificationDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/demographics/identification/IdentificationDemographic.java
@@ -9,6 +9,11 @@ public record IdentificationDemographic(
     @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
     String type,
     String issuer,
-    String id
+    String value
 ) {
+
+  public IdentificationDemographic withIssuer(final String issuer) {
+    return new IdentificationDemographic(asOf(), type(), issuer, value());
+  }
+
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/demographics/identification/IdentificationDemographicPatientCommandMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/demographics/identification/IdentificationDemographicPatientCommandMapper.java
@@ -14,7 +14,7 @@ public class IdentificationDemographicPatientCommandMapper {
     return new PatientCommand.AddIdentification(
         patient,
         demographic.asOf(),
-        demographic.id(),
+        demographic.value(),
         demographic.issuer(),
         demographic.type(),
         context.requestedBy(),

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographic.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographic.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cdc.nbs.data.selectable.Selectable;
+import gov.cdc.nbs.time.json.FormattedLocalDateJsonDeserializer;
+
+import java.time.LocalDate;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+record PatientIdentificationDemographic(
+    @JsonProperty(required = true)
+    long identifier,
+    @JsonProperty(required = true)
+    @JsonDeserialize(using = FormattedLocalDateJsonDeserializer.class) LocalDate asOf,
+    @JsonProperty(required = true)
+    Selectable type,
+    Selectable issuer,
+    @JsonProperty(required = true)
+    String value
+) {
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicController.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+class PatientIdentificationDemographicController {
+
+  private final PatientIdentificationDemographicFinder finder;
+
+  PatientIdentificationDemographicController(final PatientIdentificationDemographicFinder finder) {
+    this.finder = finder;
+  }
+
+  @Operation(
+      summary = "Patient File Identification Demographics",
+      description = "Provides the identification demographics for a patient",
+      tags = "PatientFile"
+  )
+  @GetMapping("/nbs/api/patients/{patient}/demographics/identifications")
+  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  List<PatientIdentificationDemographic> identifications(@PathVariable("patient") long patient) {
+    return this.finder.find(patient);
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicFinder.java
@@ -1,0 +1,49 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+class PatientIdentificationDemographicFinder {
+
+  private static final String QUERY = """
+      select
+          [identification].[entity_id_seq]        as [identifier],
+          [identification].[as_of_date]           as [as_of],
+          [identification].[type_cd]              as [type_value],
+          [type].code_short_desc_txt              as [type_name],
+          [identification].assigning_authority_cd as [authority_value],
+          [authority].code_short_desc_txt         as [authority_name],
+          [identification].root_extension_txt     as [value]
+      from [Entity_id] [identification]\s
+      
+          join NBS_SRTE..Code_value_general [type] with (nolock) on
+                  [type].code_set_nm = 'EI_TYPE_PAT'
+              and [type].code = [identification].[type_cd]
+      
+          left join NBS_SRTE..Code_value_general [authority] with (nolock) on
+                  [authority].[code_set_nm] = 'EI_AUTH_PAT'
+              and [authority].[code] = [identification].assigning_authority_cd
+      
+      where   [identification].[entity_uid] = ?
+          and [identification].[record_status_cd] = 'ACTIVE'
+      """;
+
+  private final JdbcClient client;
+  private final RowMapper<PatientIdentificationDemographic> mapper;
+
+  PatientIdentificationDemographicFinder(final JdbcClient client) {
+    this.client = client;
+    this.mapper = new PatientIdentificationDemographicRowMapper();
+  }
+
+  List<PatientIdentificationDemographic> find(final long patient) {
+    return this.client.sql(QUERY)
+        .param(patient)
+        .query(this.mapper)
+        .list();
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicRowMapper.java
@@ -1,0 +1,64 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+import gov.cdc.nbs.data.selectable.Selectable;
+import gov.cdc.nbs.data.selectable.SelectableRowMapper;
+import gov.cdc.nbs.data.time.LocalDateColumnMapper;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+class PatientIdentificationDemographicRowMapper implements RowMapper<PatientIdentificationDemographic> {
+
+  record Column(
+      int identifier,
+      int asOf,
+      SelectableRowMapper.Column type,
+      SelectableRowMapper.Column issuer,
+      int value
+  ) {
+    Column() {
+      this(
+          1,
+          2,
+          new SelectableRowMapper.Column(3, 4),
+          new SelectableRowMapper.Column(5, 6),
+          7
+      );
+    }
+  }
+
+
+  private final Column columns;
+  private final SelectableRowMapper typeMapper;
+  private final SelectableRowMapper issuerMapper;
+
+  PatientIdentificationDemographicRowMapper() {
+    this(new Column());
+  }
+
+  PatientIdentificationDemographicRowMapper(final Column columns) {
+    this.columns = columns;
+    this.typeMapper = new SelectableRowMapper(columns.type());
+    this.issuerMapper = new SelectableRowMapper(columns.issuer());
+  }
+
+  @Override
+  public PatientIdentificationDemographic mapRow(final ResultSet resultSet, int rowNum) throws SQLException {
+    long identifier = resultSet.getLong(columns.identifier());
+    LocalDate asOf = LocalDateColumnMapper.map(resultSet, columns.asOf());
+    Selectable type = typeMapper.mapRow(resultSet, rowNum);
+    Selectable issuer = issuerMapper.mapRow(resultSet, rowNum);
+
+    String value = resultSet.getString(columns.value());
+
+    return new PatientIdentificationDemographic(
+        identifier,
+        asOf,
+        type,
+        issuer,
+        value
+    );
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/identification/IdentificationDemographicEntrySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/identification/IdentificationDemographicEntrySteps.java
@@ -21,4 +21,10 @@ public class IdentificationDemographicEntrySteps {
   ) {
     this.active.active(new IdentificationDemographic(asOf, type, null, value));
   }
+
+  @Given("the entered identification was issued by {assigningAuthority}")
+  public void authorizedBy(final String authority) {
+    this.active.active(demographic -> demographic.withIssuer(authority));
+  }
+
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/identification/PatientFileIdentificationDemographicRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/identification/PatientFileIdentificationDemographicRequester.java
@@ -1,0 +1,40 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.interaction.http.Authenticated;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@Component
+class PatientFileIdentificationDemographicRequester {
+
+  private final MockMvc mvc;
+  private final Authenticated authenticated;
+
+  PatientFileIdentificationDemographicRequester(
+      final MockMvc mvc,
+      final Authenticated authenticated
+  ) {
+    this.mvc = mvc;
+    this.authenticated = authenticated;
+  }
+
+  ResultActions request(final PatientIdentifier patient) {
+    try {
+      return mvc.perform(
+          this.authenticated.withUser(
+              get("/nbs/api/patients/{patient}/demographics/identifications", patient.id())
+
+          )
+      );
+    } catch (Exception exception) {
+      throw new IllegalStateException(
+          "An unexpected error occurred when viewing the patient phone demographics.",
+          exception
+      );
+    }
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/identification/PatientFileIdentificationDemographicSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/identification/PatientFileIdentificationDemographicSteps.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Then;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class PatientFileIdentificationDemographicSteps {
+
+  private final PatientFileIdentificationDemographicRequester requester;
+
+  private final Active<PatientIdentifier> activePatient;
+  private final Active<ResultActions> response;
+
+  PatientFileIdentificationDemographicSteps(
+      final PatientFileIdentificationDemographicRequester requester,
+      final Active<PatientIdentifier> activePatient,
+      final Active<ResultActions> response
+  ) {
+    this.requester = requester;
+    this.activePatient = activePatient;
+    this.response = response;
+  }
+
+  @Then("I view the patient's identification demographics")
+  public void i_view_the_patient_file_administration() {
+    this.activePatient.maybeActive()
+        .map(requester::request)
+        .ifPresent(this.response::active);
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/identification/PatientFileIdentificationDemographicVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/identification/PatientFileIdentificationDemographicVerificationSteps.java
@@ -1,0 +1,49 @@
+package gov.cdc.nbs.patient.file.demographics.identification;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Then;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+public class PatientFileIdentificationDemographicVerificationSteps {
+
+  private final Active<ResultActions> response;
+
+  PatientFileIdentificationDemographicVerificationSteps(final Active<ResultActions> response) {
+    this.response = response;
+  }
+
+  @Then(
+      "the patient file identification demographics includes a(n) {identificationType} of {string} as of {localDate}")
+  public void includesIdentification(
+      final String type,
+      final String value,
+      final LocalDate asOf
+  ) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath(
+                "$.[?(@.asOf=='%s' && @.type.value=='%s' &&  @.value=='%s' )]",
+                asOf, type, value
+            ).exists()
+        );
+  }
+
+  @Then("the patient file identification demographics includes a(n) {identificationType} issued by {assigningAuthority}")
+  public void includesIdentification(
+      final String type,
+      final String issuer
+  ) throws Exception {
+    this.response.active()
+        .andExpect(
+            jsonPath(
+                "$.[?(@.type.value=='%s' &&  @.issuer.value=='%s' )]",
+                type, issuer
+            ).exists()
+        );
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/support/concept/identification/IdentificationTypeSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/support/concept/identification/IdentificationTypeSteps.java
@@ -6,6 +6,8 @@ import io.cucumber.java.ParameterType;
 public class IdentificationTypeSteps {
 
   private static final String IDENTIFICATION_TYPE_CODE_SET = "EI_TYPE_PAT";
+  private static final String AUTHORITY_CODE_SET = "EI_AUTH_PAT";
+
   private final ConceptParameterResolver resolver;
 
   IdentificationTypeSteps(final ConceptParameterResolver resolver) {
@@ -19,6 +21,14 @@ public class IdentificationTypeSteps {
         IDENTIFICATION_TYPE_CODE_SET,
         adjusted
     ).orElse(adjusted);
+  }
+
+  @ParameterType(name = "assigningAuthority", value = ".*")
+  public String assigningAuthority(final String type) {
+    return this.resolver.resolve(
+        AUTHORITY_CODE_SET,
+        type
+    ).orElse(type);
   }
 
 }

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/identification/PatientFile.identification.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/identification/PatientFile.identification.feature
@@ -1,0 +1,16 @@
+@patient-file @patient-identification-demographics
+Feature: Viewing the identification demographics of a patient
+
+  Background:
+    Given I am logged into NBS
+    And I can "view" any "patient"
+    And I have a patient
+
+  Scenario: I can view the patient's identification demographics
+    Given the patient can be identified with a Medicare number of "1051" as of 02/11/2020
+    When I view the patient's identification demographics
+    Then the patient file identification demographics includes a Medicare number of "1051" as of 02/11/2020
+
+  Scenario: No identification demographics are return when a patient does not have any Identification demographics
+    When I view the patient's identification demographics
+    Then no values are returned

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/identification/PatientFile.identification.permissions.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/identification/PatientFile.identification.permissions.feature
@@ -1,0 +1,15 @@
+@patient-file @patient-identification-demographics
+Feature: Permissions for viewing the identification demographics of a patient
+
+  Background:
+    Given I have a patient
+
+  Scenario: I cannot view a Patient's identification demographics without logging in
+    Given I am not logged in at all
+    When I view the patient's identification demographics
+    Then I am not allowed due to insufficient permissions
+
+  Scenario: I cannot view a Patient's identification demographics without  permission
+    Given I am logged into NBS
+    When I view the patient's identification demographics
+    Then I am not allowed due to insufficient permissions

--- a/apps/modernization-api/src/test/resources/features/patient/profile/create/NewPatient.identification.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/create/NewPatient.identification.feature
@@ -10,3 +10,14 @@ Feature: Creation of Patients with identification demographics
     Given I am entering a Driver's license number identification of "00123" as of 05/13/1997
     And the identification is included with the extended patient data
     When I create a patient with extended data
+    And I view the patient's identification demographics
+    Then the patient file identification demographics includes a Driver's license number of "00123" as of 05/13/1997
+
+  Scenario: I can create a patient with an identification demographic with an assigning authority
+    Given I am entering a Person number identification of "2751063" as of 05/13/1997
+    And the entered identification was issued by Other
+    And the identification is included with the extended patient data
+    When I create a patient with extended data
+    And I view the patient's identification demographics
+    Then the patient file identification demographics includes a Person number of "2751063" as of 05/13/1997
+    And the patient file identification demographics includes a Person number issued by Other

--- a/apps/modernization-ui/src/apps/patient/add/basic/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/transformer.spec.ts
@@ -573,7 +573,7 @@ describe('when transforming entered basic patient data', () => {
                     identifications: expect.arrayContaining([
                         expect.objectContaining({
                             asOf: '11/07/2019',
-                            id: 'id-value',
+                            value: 'id-value',
                             type: 'identification-type-value',
                             issuer: 'issuer-value'
                         })

--- a/apps/modernization-ui/src/apps/patient/add/basic/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/add/basic/transformer.ts
@@ -277,7 +277,7 @@ const asIdentification =
             return {
                 asOf,
                 type: asValue(type),
-                id,
+                value: id,
                 issuer: asValue(issuer)
             };
         }

--- a/apps/modernization-ui/src/apps/patient/data/api.ts
+++ b/apps/modernization-ui/src/apps/patient/data/api.ts
@@ -48,7 +48,7 @@ type PhoneEmail = EffectiveDated &
 
 type Identification = EffectiveDated & {
     type: string;
-    id: string;
+    value: string;
     issuer?: string;
 };
 

--- a/apps/modernization-ui/src/apps/patient/data/identification/asIdentification.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/data/identification/asIdentification.spec.ts
@@ -34,7 +34,7 @@ describe('when mapping an identification entry to a format accepted by the API',
 
         const actual = asIdentification(entry);
 
-        expect(actual).toEqual(expect.objectContaining({ id: 'id-value' }));
+        expect(actual).toEqual(expect.objectContaining({ value: 'id-value' }));
     });
 
     it('should include the issuer', () => {
@@ -47,7 +47,7 @@ describe('when mapping an identification entry to a format accepted by the API',
 
         const actual = asIdentification(entry);
 
-        expect(actual).toEqual(expect.objectContaining({ id: 'id-value' }));
+        expect(actual).toEqual(expect.objectContaining({ value: 'id-value' }));
     });
 
     it('should not map when type is null', () => {

--- a/apps/modernization-ui/src/apps/patient/data/identification/asIdentification.ts
+++ b/apps/modernization-ui/src/apps/patient/data/identification/asIdentification.ts
@@ -10,7 +10,7 @@ const asIdentification = (entry: IdentificationEntry): Identification | undefine
         return {
             asOf,
             type: asValue(type),
-            id,
+            value: id,
             issuer: asValue(issuer)
         };
     }

--- a/apps/modernization-ui/src/apps/patient/file/PatientFile.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFile.tsx
@@ -7,8 +7,6 @@ import { Icon } from 'design-system/icon';
 import { Patient } from './patient';
 import { PatientLoaderResult } from './loader';
 import { PatientFileLayout } from './PatientFileLayout';
-
-import styles from './patient-file.module.scss';
 import { DeleteAction } from './delete';
 
 const PatientFile = () => {
@@ -26,7 +24,7 @@ export { PatientFile };
 const ViewActions = (patient: Patient) => {
     return (
         <>
-            <DeleteAction buttonClassName={styles['usa-button']} />
+            <DeleteAction />
             <Button
                 onClick={openPrintableView(patient.id.toString())}
                 aria-label="Print"

--- a/apps/modernization-ui/src/apps/patient/file/PatientFileHeader.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileHeader.tsx
@@ -11,9 +11,9 @@ type PatientFileHeaderProps = {
 
 export const PatientFileHeader = ({ patient, actions }: PatientFileHeaderProps) => {
     return (
-        <header className={styles.header}>
+        <div className={styles.header}>
             <PatientDescriptor headingLevel={1} patient={patient} />
             <div className={styles.actions}>{actions}</div>
-        </header>
+        </div>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/file/PatientFileLayout.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileLayout.tsx
@@ -16,8 +16,10 @@ const PatientFileLayout = ({ patient, actions, navigation, children }: PatientFi
     return (
         <PatientProvider patient={patient}>
             <div className={styles.file}>
-                <PatientFileHeader patient={patient} actions={actions(patient)} />
-                <nav>{navigation(patient)}</nav>
+                <header>
+                    <PatientFileHeader patient={patient} actions={actions(patient)} />
+                    <nav>{navigation(patient)}</nav>
+                </header>
                 <main>{children}</main>
             </div>
         </PatientProvider>

--- a/apps/modernization-ui/src/apps/patient/file/patient-file-layout.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/patient-file-layout.module.scss
@@ -1,6 +1,12 @@
 @use 'styles/colors';
 
 .file {
+    & > header {
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+    }
+
     & > main {
         padding: 1rem;
     }

--- a/apps/modernization-ui/src/apps/patient/file/patient-file.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/patient-file.module.scss
@@ -1,7 +1,1 @@
 @use 'styles/colors';
-
-.icon-button:disabled {
-    color: colors.$disabled-darker !important;
-    background: none !important;
-    box-shadow: inset 0 0 0 2px colors.$disabled !important;
-}

--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -41,6 +41,7 @@ export type { OrderingProvider } from './models/OrderingProvider';
 export type { PatientAddressDemographic } from './models/PatientAddressDemographic';
 export type { PatientDemographicsSummary } from './models/PatientDemographicsSummary';
 export { PatientFile } from './models/PatientFile';
+export type { PatientIdentificationDemographic } from './models/PatientIdentificationDemographic';
 export type { PatientInvestigation } from './models/PatientInvestigation';
 export type { PatientLabReport } from './models/PatientLabReport';
 export type { PatientPhoneDemographic } from './models/PatientPhoneDemographic';

--- a/apps/modernization-ui/src/generated/models/IdentificationDemographic.ts
+++ b/apps/modernization-ui/src/generated/models/IdentificationDemographic.ts
@@ -6,6 +6,6 @@ export type IdentificationDemographic = {
     asOf?: string;
     type?: string;
     issuer?: string;
-    id?: string;
+    value?: string;
 };
 

--- a/apps/modernization-ui/src/generated/models/PatientIdentificationDemographic.ts
+++ b/apps/modernization-ui/src/generated/models/PatientIdentificationDemographic.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Selectable } from './Selectable';
+export type PatientIdentificationDemographic = {
+    identifier: number;
+    asOf: string;
+    type: Selectable;
+    issuer?: Selectable;
+    value: string;
+};
+

--- a/apps/modernization-ui/src/generated/services/PatientFileService.ts
+++ b/apps/modernization-ui/src/generated/services/PatientFileService.ts
@@ -7,6 +7,7 @@ import type { DocumentRequiringReview } from '../models/DocumentRequiringReview'
 import type { PatientAddressDemographic } from '../models/PatientAddressDemographic';
 import type { PatientDemographicsSummary } from '../models/PatientDemographicsSummary';
 import type { PatientFile } from '../models/PatientFile';
+import type { PatientIdentificationDemographic } from '../models/PatientIdentificationDemographic';
 import type { PatientPhoneDemographic } from '../models/PatientPhoneDemographic';
 import type { StandardResponse } from '../models/StandardResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -65,6 +66,25 @@ export class PatientFileService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/nbs/api/patients/{patient}/demographics/phones',
+            path: {
+                'patient': patient,
+            },
+        });
+    }
+    /**
+     * Patient File Identification Demographics
+     * Provides the identification demographics for a patient
+     * @returns PatientIdentificationDemographic OK
+     * @throws ApiError
+     */
+    public static identifications({
+        patient,
+    }: {
+        patient: number,
+    }): CancelablePromise<Array<PatientIdentificationDemographic>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/patients/{patient}/demographics/identifications',
             path: {
                 'patient': patient,
             },


### PR DESCRIPTION
## Description

Adds the `/nbs/api/patients/{patient}/demographics/identification` endpoint to the `modernization-api`.

- Updates Postman collection
- Adds Feature tests

```cucumber
Feature: Permissions for viewing the identification demographics of a patient

  Background:
    Given I have a patient

  Scenario: I cannot view a Patient's identification demographics without logging in
    Given I am not logged in at all
    When I view the patient's identification demographics
    Then I am not allowed due to insufficient permissions

  Scenario: I cannot view a Patient's identification demographics without  permission
    Given I am logged into NBS
    When I view the patient's identification demographics
    Then I am not allowed due to insufficient permissions
```

```cucumber
Feature: Viewing the identification demographics of a patient

  Background:
    Given I am logged into NBS
    And I can "view" any "patient"
    And I have a patient

  Scenario: I can view the patient's identification demographics
    Given the patient can be identified with a Medicare number of "1051" as of 02/11/2020
    When I view the patient's identification demographics
    Then the patient file identification demographics includes a Medicare number of "1051" as of 02/11/2020

  Scenario: No identification demographics are return when a patient does not have any Identification demographics
    When I view the patient's identification demographics
    Then no values are returned
```

## Tickets

* [CNFT1-4216](https://cdc-nbs.atlassian.net/browse/CNFT1-4216)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4216]: https://cdc-nbs.atlassian.net/browse/CNFT1-4216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ