### PR TITLE
Cnft1 4209 repeating block

### DIFF
--- a/apps/modernization-ui/src/design-system/data-display/ValueView.tsx
+++ b/apps/modernization-ui/src/design-system/data-display/ValueView.tsx
@@ -7,11 +7,12 @@ type Props = {
     required?: boolean;
     value?: string | null;
     sizing?: Sizing;
+    centerAlign?: boolean;
 };
 
-export const ValueView = ({ title, value, required = false, sizing }: Props) => {
+export const ValueView = ({ title, value, required = false, sizing, centerAlign = false }: Props) => {
     return (
-        <div className={classNames(styles.dataRow, sizing && styles[sizing])}>
+        <div className={classNames(styles.dataRow, sizing && styles[sizing], { [styles.center]: centerAlign })}>
             <span className={classNames(styles.title, { required: required })}>{title}</span>
             <span className={styles.value}>{value}</span>
         </div>

--- a/apps/modernization-ui/src/design-system/data-display/value-view.module.scss
+++ b/apps/modernization-ui/src/design-system/data-display/value-view.module.scss
@@ -43,3 +43,7 @@
         min-height: 3.25rem;
     }
 }
+
+.center {
+    justify-content: center;
+}

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -64,10 +64,21 @@
             padding-left: 16.75rem;
         }
     }
+
+    .viewMode {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+
+        .centerAlign {
+            width: 100%;
+            justify-content: center;
+        }
+    }
 }
 
 .iconColumn {
     div {
         visibility: hidden !important;
-    }   
+    }
 }

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -64,17 +64,6 @@
             padding-left: 16.75rem;
         }
     }
-
-    .viewMode {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-
-        .centerAlign {
-            width: 100%;
-            justify-content: center;
-        }
-    }
 }
 
 .iconColumn {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
@@ -164,6 +164,25 @@ export const ReadOnlyRepeatingBlock: Story = {
     }
 };
 
+export const PatientFileBlock: Story = {
+    args: {
+        id: 'repeating-block-default',
+        title: 'Person',
+        defaultValues: defaultValue,
+        columns,
+        values: [],
+        formRenderer: () => <SampleForm sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        onChange: handleChange,
+        isDirty: () => {},
+        isValid: () => {},
+        edit: false,
+        delete: false,
+        onViewCenter: true,
+        sizing: defaultSizing
+    }
+};
+
 export const ViewOnlyBlock: Story = {
     args: {
         id: 'repeating-block-default',

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
@@ -153,16 +153,27 @@ export const ReadOnlyRepeatingBlock: Story = {
         title: 'Person',
         defaultValues: defaultValue,
         columns,
-        values: [],
+        values: [{ firstName: 'test', lastName: 'test', veggie: asSelectable('carrot', 'Carrot') }],
         formRenderer: () => <SampleForm sizing={defaultSizing} />,
         viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {},
         readonly: true,
+        edit: false,
+        view: false,
+        delete: false,
         sizing: defaultSizing
     }
 };
+
+const SampleViewPatientFile = ({ entry, sizing }: { entry: SampleType; sizing: Sizing }) => (
+    <>
+        <ValueView title="First name" value={entry.firstName} sizing={sizing} required centerAlign />
+        <ValueView title="Last name" value={entry.lastName} sizing={sizing} centerAlign />
+        <ValueView title="Favorite veggie" value={entry.veggie?.name} sizing={sizing} required centerAlign />
+    </>
+);
 
 export const PatientFileBlock: Story = {
     args: {
@@ -170,15 +181,15 @@ export const PatientFileBlock: Story = {
         title: 'Person',
         defaultValues: defaultValue,
         columns,
-        values: [],
+        values: [{ firstName: 'test', lastName: 'test', veggie: asSelectable('carrot', 'Carrot') }],
         formRenderer: () => <SampleForm sizing={defaultSizing} />,
-        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleViewPatientFile entry={entry} sizing={defaultSizing} />,
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {},
         edit: false,
         delete: false,
-        onViewCenter: true,
+        readonly: true,
         sizing: defaultSizing
     }
 };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
@@ -159,7 +159,6 @@ export const ReadOnlyBlock: Story = {
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {},
-        readonly: true,
         editable: false,
         viewable: false,
         sizing: defaultSizing
@@ -190,24 +189,7 @@ export const ViewOnlyBlock: Story = {
         isDirty: () => {},
         isValid: () => {},
         editable: false,
-        readonly: true,
-        sizing: defaultSizing
-    }
-};
-
-export const ViewableBlock: Story = {
-    args: {
-        id: 'repeating-block-default',
-        title: 'Person',
-        defaultValues: defaultValue,
-        columns,
-        values: [],
-        formRenderer: () => <SampleForm sizing={defaultSizing} />,
-        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
-        onChange: handleChange,
-        isDirty: () => {},
-        isValid: () => {},
-        editable: false,
+        viewable: true,
         sizing: defaultSizing
     }
 };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
@@ -146,3 +146,74 @@ export const Default: Story = {
         sizing: defaultSizing
     }
 };
+
+export const ReadOnlyRepeatingBlock: Story = {
+    args: {
+        id: 'repeating-block-default',
+        title: 'Person',
+        defaultValues: defaultValue,
+        columns,
+        values: [],
+        formRenderer: () => <SampleForm sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        onChange: handleChange,
+        isDirty: () => {},
+        isValid: () => {},
+        readonly: true,
+        sizing: defaultSizing
+    }
+};
+
+export const ViewOnlyBlock: Story = {
+    args: {
+        id: 'repeating-block-default',
+        title: 'Person',
+        defaultValues: defaultValue,
+        columns,
+        values: [],
+        formRenderer: () => <SampleForm sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        onChange: handleChange,
+        isDirty: () => {},
+        isValid: () => {},
+        edit: false,
+        delete: false,
+        sizing: defaultSizing
+    }
+};
+
+export const EditOnlyBlock: Story = {
+    args: {
+        id: 'repeating-block-default',
+        title: 'Person',
+        defaultValues: defaultValue,
+        columns,
+        values: [],
+        formRenderer: () => <SampleForm sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        onChange: handleChange,
+        isDirty: () => {},
+        isValid: () => {},
+        view: false,
+        delete: false,
+        sizing: defaultSizing
+    }
+};
+
+export const DeleteOnlyBlock: Story = {
+    args: {
+        id: 'repeating-block-default',
+        title: 'Person',
+        defaultValues: defaultValue,
+        columns,
+        values: [],
+        formRenderer: () => <SampleForm sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        onChange: handleChange,
+        isDirty: () => {},
+        isValid: () => {},
+        edit: false,
+        view: false,
+        sizing: defaultSizing
+    }
+};

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
@@ -147,7 +147,7 @@ export const Default: Story = {
     }
 };
 
-export const ReadOnlyRepeatingBlock: Story = {
+export const ReadOnlyBlock: Story = {
     args: {
         id: 'repeating-block-default',
         title: 'Person',
@@ -160,9 +160,8 @@ export const ReadOnlyRepeatingBlock: Story = {
         isDirty: () => {},
         isValid: () => {},
         readonly: true,
-        edit: false,
-        view: false,
-        delete: false,
+        editable: false,
+        viewable: false,
         sizing: defaultSizing
     }
 };
@@ -175,44 +174,28 @@ const SampleViewPatientFile = ({ entry, sizing }: { entry: SampleType; sizing: S
     </>
 );
 
-export const PatientFileBlock: Story = {
-    args: {
-        id: 'repeating-block-default',
-        title: 'Person',
-        defaultValues: defaultValue,
-        columns,
-        values: [{ firstName: 'test', lastName: 'test', veggie: asSelectable('carrot', 'Carrot') }],
-        formRenderer: () => <SampleForm sizing={defaultSizing} />,
-        viewRenderer: (entry: SampleType) => <SampleViewPatientFile entry={entry} sizing={defaultSizing} />,
-        onChange: handleChange,
-        isDirty: () => {},
-        isValid: () => {},
-        edit: false,
-        delete: false,
-        readonly: true,
-        sizing: defaultSizing
-    }
-};
-
 export const ViewOnlyBlock: Story = {
     args: {
         id: 'repeating-block-default',
         title: 'Person',
         defaultValues: defaultValue,
         columns,
-        values: [],
+        values: [
+            { firstName: 'test', lastName: 'test', veggie: asSelectable('carrot', 'Carrot') },
+            { firstName: 'test1', lastName: 'test1', veggie: asSelectable('eggplant', 'Eggplant') }
+        ],
         formRenderer: () => <SampleForm sizing={defaultSizing} />,
-        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        viewRenderer: (entry: SampleType) => <SampleViewPatientFile entry={entry} sizing={defaultSizing} />,
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {},
-        edit: false,
-        delete: false,
+        editable: false,
+        readonly: true,
         sizing: defaultSizing
     }
 };
 
-export const EditOnlyBlock: Story = {
+export const ViewableBlock: Story = {
     args: {
         id: 'repeating-block-default',
         title: 'Person',
@@ -224,13 +207,12 @@ export const EditOnlyBlock: Story = {
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {},
-        view: false,
-        delete: false,
+        editable: false,
         sizing: defaultSizing
     }
 };
 
-export const DeleteOnlyBlock: Story = {
+export const EditableBlock: Story = {
     args: {
         id: 'repeating-block-default',
         title: 'Person',
@@ -242,8 +224,7 @@ export const DeleteOnlyBlock: Story = {
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {},
-        edit: false,
-        view: false,
+        viewable: false,
         sizing: defaultSizing
     }
 };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -22,7 +22,6 @@ type RepeatingBlockProps<V extends FieldValues> = {
     sizing?: Sizing;
     viewable?: boolean;
     editable?: boolean;
-    readonly?: boolean;
     onChange?: (data: V[]) => void;
     isDirty?: (isDirty: boolean) => void;
     isValid?: (isValid: boolean) => void;
@@ -40,7 +39,6 @@ const RepeatingBlock = <V extends FieldValues>({
     sizing,
     viewable = true,
     editable = true,
-    readonly = false,
     onChange,
     isDirty,
     isValid,
@@ -187,10 +185,13 @@ const RepeatingBlock = <V extends FieldValues>({
                 />
             </div>
 
-            <Shown when={status === 'viewing'}>
-                {selected && <div className={styles.viewMode}>{viewRenderer(selected)}</div>}
-            </Shown>
-            {readonly === false && (
+            {viewable && (
+                <Shown when={status === 'viewing'}>
+                    {selected && <div className={styles.viewMode}>{viewRenderer(selected)}</div>}
+                </Shown>
+            )}
+
+            {editable && (
                 <>
                     <Shown when={status !== 'viewing'}>
                         <FormProvider {...form}>

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -20,9 +20,8 @@ type RepeatingBlockProps<V extends FieldValues> = {
     errors?: ReactNode[];
     values?: V[];
     sizing?: Sizing;
-    view?: boolean;
-    edit?: boolean;
-    delete?: boolean;
+    viewable?: boolean;
+    editable?: boolean;
     readonly?: boolean;
     onChange?: (data: V[]) => void;
     isDirty?: (isDirty: boolean) => void;
@@ -39,9 +38,8 @@ const RepeatingBlock = <V extends FieldValues>({
     columns,
     errors,
     sizing,
-    view: viewBtn = true,
-    edit: editBtn = true,
-    delete: deleteBtn = true,
+    viewable = true,
+    editable = true,
     readonly = false,
     onChange,
     isDirty,
@@ -112,8 +110,12 @@ const RepeatingBlock = <V extends FieldValues>({
         className: styles.iconColumn,
         render: (value: V) => (
             <div className={classNames(styles.actions, sizing && styles[sizing])}>
-                {viewBtn && (
-                    <div data-tooltip-position="top" aria-label="View" role="button" onClick={() => view(value)}>
+                {viewable && (
+                    <div
+                        data-tooltip-position="top"
+                        aria-label="View"
+                        role="button"
+                        onClick={() => (status === 'viewing' && selected === value ? reset() : view(value))}>
                         <Icon
                             name="visibility"
                             sizing={sizing}
@@ -123,25 +125,25 @@ const RepeatingBlock = <V extends FieldValues>({
                         />
                     </div>
                 )}
-                {editBtn && (
-                    <div data-tooltip-position="top" aria-label="Edit" role="button" onClick={() => edit(value)}>
-                        <Icon
-                            name="edit"
-                            sizing={sizing}
-                            className={classNames({
-                                [styles.active]: status === 'editing' && value === selected
-                            })}
-                        />
-                    </div>
-                )}
-                {deleteBtn && (
-                    <div
-                        data-tooltip-position="top"
-                        aria-label="Delete"
-                        role="button"
-                        onClick={() => handleRemove(value)}>
-                        <Icon name="delete" sizing={sizing} />
-                    </div>
+                {editable && (
+                    <>
+                        <div data-tooltip-position="top" aria-label="Edit" role="button" onClick={() => edit(value)}>
+                            <Icon
+                                name="edit"
+                                sizing={sizing}
+                                className={classNames({
+                                    [styles.active]: status === 'editing' && value === selected
+                                })}
+                            />
+                        </div>
+                        <div
+                            data-tooltip-position="top"
+                            aria-label="Delete"
+                            role="button"
+                            onClick={() => handleRemove(value)}>
+                            <Icon name="delete" sizing={sizing} />
+                        </div>
+                    </>
                 )}
             </div>
         )

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -24,6 +24,7 @@ type RepeatingBlockProps<V extends FieldValues> = {
     edit?: boolean;
     delete?: boolean;
     readonly?: boolean;
+    onViewCenter?: boolean;
     onChange?: (data: V[]) => void;
     isDirty?: (isDirty: boolean) => void;
     isValid?: (isValid: boolean) => void;
@@ -43,6 +44,7 @@ const RepeatingBlock = <V extends FieldValues>({
     edit: editBtn = true,
     delete: deleteBtn = true,
     readonly = false,
+    onViewCenter = false,
     onChange,
     isDirty,
     isValid,
@@ -183,7 +185,13 @@ const RepeatingBlock = <V extends FieldValues>({
             {readonly === false && (
                 <>
                     <Shown when={status === 'viewing'}>
-                        {selected && <div className={styles.viewMode}>{viewRenderer(selected)}</div>}
+                        {selected && (
+                            <div className={styles.viewMode}>
+                                <div className={classNames({ [styles.centerAlign]: onViewCenter })}>
+                                    {viewRenderer(selected)}
+                                </div>
+                            </div>
+                        )}
                     </Shown>
                     <Shown when={status !== 'viewing'}>
                         <FormProvider {...form}>

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -24,7 +24,6 @@ type RepeatingBlockProps<V extends FieldValues> = {
     edit?: boolean;
     delete?: boolean;
     readonly?: boolean;
-    onViewCenter?: boolean;
     onChange?: (data: V[]) => void;
     isDirty?: (isDirty: boolean) => void;
     isValid?: (isValid: boolean) => void;
@@ -44,7 +43,6 @@ const RepeatingBlock = <V extends FieldValues>({
     edit: editBtn = true,
     delete: deleteBtn = true,
     readonly = false,
-    onViewCenter = false,
     onChange,
     isDirty,
     isValid,
@@ -119,7 +117,9 @@ const RepeatingBlock = <V extends FieldValues>({
                         <Icon
                             name="visibility"
                             sizing={sizing}
-                            className={classNames({ [styles.active]: status === 'viewing' && value === selected })}
+                            className={classNames({
+                                [styles.active]: status === 'viewing' && value === selected
+                            })}
                         />
                     </div>
                 )}
@@ -128,7 +128,9 @@ const RepeatingBlock = <V extends FieldValues>({
                         <Icon
                             name="edit"
                             sizing={sizing}
-                            className={classNames({ [styles.active]: status === 'editing' && value === selected })}
+                            className={classNames({
+                                [styles.active]: status === 'editing' && value === selected
+                            })}
                         />
                     </div>
                 )}
@@ -182,17 +184,12 @@ const RepeatingBlock = <V extends FieldValues>({
                     noDataFallback
                 />
             </div>
+
+            <Shown when={status === 'viewing'}>
+                {selected && <div className={styles.viewMode}>{viewRenderer(selected)}</div>}
+            </Shown>
             {readonly === false && (
                 <>
-                    <Shown when={status === 'viewing'}>
-                        {selected && (
-                            <div className={styles.viewMode}>
-                                <div className={classNames({ [styles.centerAlign]: onViewCenter })}>
-                                    {viewRenderer(selected)}
-                                </div>
-                            </div>
-                        )}
-                    </Shown>
                     <Shown when={status !== 'viewing'}>
                         <FormProvider {...form}>
                             <div className={classNames(styles.form, { [styles.changed]: form.formState.isDirty })}>
@@ -200,6 +197,7 @@ const RepeatingBlock = <V extends FieldValues>({
                             </div>
                         </FormProvider>
                     </Shown>
+
                     <footer>
                         <Shown when={status === 'adding'}>
                             <Button


### PR DESCRIPTION
## Description

Center aligned the view mode

Added some booleans to be able to choose either a readonly, viewable, and editable modes

## Tickets

* [CNFT1-4209](https://cdc-nbs.atlassian.net/browse/CNFT1-4209)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4209]: https://cdc-nbs.atlassian.net/browse/CNFT1-4209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ