### PR TITLE
[FIX] all patient profile redirects are now 307

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/AddInvestigationRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/investigation/AddInvestigationRedirector.java
@@ -2,14 +2,12 @@ package gov.cdc.nbs.patient.profile.investigation;
 
 import gov.cdc.nbs.patient.profile.redirect.outgoing.ClassicPatientProfileRedirector;
 import io.swagger.v3.oas.annotations.Hidden;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import java.net.URISyntaxException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 
@@ -17,7 +15,10 @@ import java.net.URI;
 @RestController
 class AddInvestigationRedirector {
 
-  private static final String LOCATION = "/nbs/LoadSelectCondition1.do?ContextAction=AddInvestigation";
+  private static final URI LOCATION = UriComponentsBuilder.fromPath("/nbs/LoadSelectCondition1.do")
+      .queryParam("ContextAction", "AddInvestigation")
+      .build()
+      .toUri();
 
   private final ClassicPatientProfileRedirector redirector;
 
@@ -27,11 +28,8 @@ class AddInvestigationRedirector {
 
   @PreAuthorize("hasAuthority('ADD-INVESTIGATION')")
   @GetMapping("/nbs/api/profile/{patient}/investigation")
-  @ResponseStatus(value = HttpStatus.TEMPORARY_REDIRECT)
-  ResponseEntity<Void> add(@PathVariable final long patient) throws URISyntaxException {
-    URI uri = new URI(LOCATION);
-
-    return redirector.preparedRedirect(patient, uri);
+  ResponseEntity<Void> add(@PathVariable final long patient) {
+    return redirector.preparedRedirect(patient, LOCATION);
   }
 }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/redirect/outgoing/ClassicPatientProfileRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/redirect/outgoing/ClassicPatientProfileRedirector.java
@@ -24,7 +24,7 @@ public class ClassicPatientProfileRedirector {
   public ResponseEntity<Void> preparedRedirect(final long patient, final URI location) {
     prepare(patient);
     return ResponseEntity
-        .status(HttpStatus.CREATED)
+        .status(HttpStatus.TEMPORARY_REDIRECT)
         .location(location)
         .headers(new ReturningPatientCookie(patient).apply())
         .build();

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileViewInvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/profile/investigation/PatientProfileViewInvestigationSteps.java
@@ -1,8 +1,6 @@
 package gov.cdc.nbs.patient.profile.investigation;
 
 import gov.cdc.nbs.event.investigation.InvestigationIdentifier;
-import gov.cdc.nbs.event.investigation.TestInvestigations;
-import gov.cdc.nbs.patient.TestPatients;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.testing.interaction.http.Authenticated;
 import gov.cdc.nbs.testing.support.Active;

--- a/apps/modernization-api/src/test/resources/features/patient/profile/event/investigation/PatientProfileInvestigation.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/profile/event/investigation/PatientProfileInvestigation.feature
@@ -34,7 +34,6 @@ Feature: Patient Profile Investigations
     Given I can "Find" any "Patient" for "STD" within all jurisdictions
     Then the profile investigations are not accessible
 
-  @web-interaction
   Scenario: An investigation is viewed from the Patient Profile
     Given I am logged into NBS
     And I can "Find" any "Patient" for "STD" within all jurisdictions
@@ -44,25 +43,21 @@ Feature: Patient Profile Investigations
     Then the classic profile is prepared to view an investigation
     And I am redirected to Classic NBS to view an Investigation
 
-  @web-interaction
   Scenario: An investigation is viewed from the Patient Profile without required permissions
     Given the patient is a subject of an investigation
     When the investigation is viewed from the Patient Profile
     Then I am not allowed to view a Classic NBS Investigation
 
-  @web-interaction
   Scenario: An investigation is added from the Patient Profile
     Given I can "Add" any "INVESTIGATION" for "STD" within all jurisdictions
     When an investigation is added from a Patient Profile
     Then the classic profile is prepared to add an investigation
     And I am redirected to Classic NBS to add an Investigation
 
-  @web-interaction
   Scenario: An investigation is added from the Patient Profile without required permissions
     When an investigation is added from a Patient Profile
     Then I am not allowed to add a Classic NBS Investigation
 
-  @web-interaction
   Scenario: Investigations are compared from the Patient Profile
     Given I can "MERGEINVESTIGATION" any "INVESTIGATION" for "STD" within all jurisdictions
     And the patient is a subject of 2 investigations
@@ -70,7 +65,6 @@ Feature: Patient Profile Investigations
     Then the classic profile is prepared to compare investigations
     And I am redirected to Classic NBS to compare Investigation
 
-  @web-interaction
   Scenario: Investigations are compared from the Patient Profile without required permissions
     Given the patient is a subject of 2 investigations
     When the investigations are compared from a Patient Profile


### PR DESCRIPTION
## Description

Changes the `ClassicPatientProfileRedirector` to always return a "Temporary Redirect" status over "Created" so that the browser can handle the redirects.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
