### PR TITLE
[FIX ] Removes classic links from Patient file

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/events/labReports/LabReportsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/labReports/LabReportsCard.tsx
@@ -1,4 +1,3 @@
-import { ClassicLink } from 'classic';
 import { TableCard } from 'design-system/card';
 import { Column } from 'design-system/table';
 import { ColumnPreference } from 'design-system/table/preferences';
@@ -80,9 +79,7 @@ const LabReportsCard = ({ patient }: LabReportsCardProps) => {
             sortable: true,
             value: (value) => value.eventId,
             render: (value: PatientLabReport) => (
-                <ClassicLink id="condition" url={`/nbs/api/profile/${patient}/report/lab/${value.id}`}>
-                    {value.eventId}
-                </ClassicLink>
+                <a href={`/nbs/api/profile/${patient}/report/lab/${value.id}`}>{value.eventId}</a>
             )
         },
         {
@@ -129,10 +126,9 @@ const LabReportsCard = ({ patient }: LabReportsCardProps) => {
             render: (value: PatientLabReport) =>
                 value.associatedInvestigation && (
                     <div>
-                        <ClassicLink
-                            url={`/nbs/api/profile/${patient}/investigation/${value.associatedInvestigation.id}`}>
+                        <a href={`/nbs/api/profile/${patient}/investigation/${value.associatedInvestigation.id}`}>
                             {value.associatedInvestigation.id}
-                        </ClassicLink>
+                        </a>
                         <p className="margin-0">
                             <b>{value.associatedInvestigation.condition}</b>
                         </p>

--- a/apps/modernization-ui/src/apps/patient/file/summary/documentRequiringReview/PatientDocumentRequiringReview.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/summary/documentRequiringReview/PatientDocumentRequiringReview.tsx
@@ -3,7 +3,6 @@ import { Column } from 'design-system/table';
 import { ColumnPreference } from 'design-system/table/preferences';
 import { usePatientFileDocumentRequiringReview } from './usePatientFileDocumentRequiringReview';
 import { DocumentRequiringReview } from 'generated';
-import { ClassicLink } from 'classic';
 import { internalizeDate } from 'date';
 import { internalizeDateTime } from 'date/InternalizeDateTime';
 import { renderFacilityProvider, renderLabReports, renderMorbidity } from '../../renderPatientFile';
@@ -41,11 +40,7 @@ const renderEventDate = (value?: string) => {
 const renderEventId = (value: DocumentRequiringReview) => {
     const classicUrl = resolveUrl(value);
 
-    return (
-        <ClassicLink id="eventId" url={classicUrl} destination="current">
-            {value.local}
-        </ClassicLink>
-    );
+    return <a href={classicUrl}>{value.local}</a>;
 };
 
 const columns: Column<DocumentRequiringReview>[] = [

--- a/apps/modernization-ui/src/apps/patient/file/summary/openInvestigations/OpenInvestigationsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/summary/openInvestigations/OpenInvestigationsCard.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { ClassicLink } from 'classic';
 import { Column } from 'design-system/table';
 import { ColumnPreference } from 'design-system/table/preferences';
 import { TableCard } from 'design-system/card';
@@ -37,9 +36,7 @@ const createColumns = (patient: number): Column<PatientInvestigation>[] => [
         sortable: true,
         value: (row) => row.investigationId,
         render: (value) => (
-            <ClassicLink id="condition" url={`/nbs/api/profile/${patient}/investigation/${value.identifier}`}>
-                {value.investigationId}
-            </ClassicLink>
+            <a href={`/nbs/api/profile/${patient}/investigation/${value.identifier}`}>{value.investigationId}</a>
         )
     },
     {


### PR DESCRIPTION
## Description

Now that redirects are returned the `ClassicLink` component isn't needed for links to NBS6 from the Patient File.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
