### PR TITLE
Apply default selection to merge review

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.spec.tsx
@@ -1,12 +1,361 @@
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { MergeDetails } from './MergeDetails';
-import { render } from '@testing-library/react';
+import { getAllByRole, render, within } from '@testing-library/react';
+
+const response = [
+    {
+        personLocalId: '89003',
+        personUid: '10052298',
+        addTime: '2022-05-19 18:34:42.363', // oldest record
+        adminComments: {
+            date: null,
+            comment: null
+        },
+        ethnicity: {
+            asOf: '2025-05-30T00:00:00',
+            ethnicity: 'Hispanic or Latino',
+            reasonUnknown: null,
+            spanishOrigin: 'Central American | Cuban'
+        },
+        sexAndBirth: {
+            asOf: '2022-06-07T00:00:00',
+            dateOfBirth: '1952-07-20T00:00:00',
+            currentSex: 'Unknown',
+            sexUnknown: 'Refused',
+            transgender: null,
+            additionalGender: null,
+            birthGender: null,
+            multipleBirth: null,
+            birthOrder: null,
+            birthCity: null,
+            birthState: null,
+            birthCounty: null,
+            birthCountry: null
+        },
+        mortality: {
+            asOf: '2025-06-09T00:00:00',
+            deceased: 'No',
+            dateOfDeath: null,
+            deathCity: null,
+            deathState: null,
+            deathCounty: null,
+            deathCountry: null
+        },
+        general: {
+            asOf: '2022-06-07T00:00:00',
+            maritalStatus: 'Single, never married',
+            mothersMaidenName: null,
+            numberOfAdultsInResidence: null,
+            numberOfChildrenInResidence: null,
+            primaryOccupation: null,
+            educationLevel: null,
+            primaryLanguage: null,
+            speaksEnglish: null,
+            stateHivCaseId: null
+        },
+        investigations: [],
+        addresses: [
+            {
+                id: '10052299',
+                asOf: '2022-06-07T14:24:44.970',
+                type: 'House',
+                use: 'Home',
+                address: '9 TRUMPET LN',
+                address2: null,
+                city: 'GORDONSVILLE',
+                state: 'Tennessee',
+                zipcode: '38563-0000',
+                county: null,
+                censusTract: null,
+                country: 'United States',
+                comments: null
+            }
+        ],
+        phoneEmails: [
+            {
+                id: '10052300',
+                asOf: '2022-06-07T14:24:44.970',
+                type: 'Phone',
+                use: 'Home',
+                countryCode: '1',
+                phoneNumber: '6154899999',
+                extension: null,
+                email: null,
+                url: null,
+                comments: null
+            },
+            {
+                id: '10052301',
+                asOf: '2022-06-07T14:24:44.970',
+                type: 'Cellular Phone',
+                use: 'Mobile Contact',
+                countryCode: '1',
+                phoneNumber: '6154899999',
+                extension: null,
+                email: null,
+                url: null,
+                comments: null
+            }
+        ],
+        names: [
+            {
+                personUid: '10052298',
+                sequence: '1',
+                asOf: '2022-06-07T00:00:00',
+                type: 'Legal',
+                prefix: null,
+                first: 'RONALD',
+                middle: null,
+                secondMiddle: null,
+                last: 'WESLEY',
+                secondLast: null,
+                suffix: null,
+                degree: null
+            }
+        ],
+        identifications: [
+            {
+                personUid: '10052298',
+                sequence: '1',
+                asOf: '2018-04-18T00:00:00',
+                type: 'WIC identifier',
+                assigningAuthority: 'NH',
+                value: 'WIC123'
+            },
+            {
+                personUid: '10052298',
+                sequence: '2',
+                asOf: '2025-05-28T00:00:00',
+                type: 'Account number',
+                assigningAuthority: '',
+                value: '23123132'
+            }
+        ],
+        races: [
+            {
+                personUid: '10052298',
+                raceCode: '2028-9',
+                asOf: '2025-05-28T00:00:00',
+                race: 'Asian',
+                detailedRaces: 'Asian Indian | Bangladeshi | Bhutanese | Burmese'
+            },
+            {
+                personUid: '10052298',
+                raceCode: '2106-3',
+                asOf: '2022-06-07T00:00:00',
+                race: 'White',
+                detailedRaces: 'European | Middle Eastern or North African'
+            }
+        ]
+    },
+    {
+        personLocalId: '91000',
+        personUid: '10055283',
+        addTime: '2025-05-27 14:56:50.523',
+        adminComments: {
+            date: '2025-05-27T00:00',
+            comment: 'Some admin comment goes here'
+        },
+        ethnicity: {
+            asOf: null,
+            ethnicity: null,
+            reasonUnknown: null,
+            spanishOrigin: null
+        },
+        sexAndBirth: {
+            asOf: '2025-06-05T00:00:00',
+            dateOfBirth: '2025-05-04T00:00:00',
+            currentSex: 'Male',
+            sexUnknown: null,
+            transgender: 'Did not ask',
+            additionalGender: 'Add Gender',
+            birthGender: 'Male',
+            multipleBirth: 'No',
+            birthOrder: '1',
+            birthCity: 'Birth City',
+            birthState: 'Tennessee',
+            birthCounty: 'Monroe County',
+            birthCountry: 'United States'
+        },
+        mortality: {
+            asOf: '2025-06-05T00:00:00',
+            deceased: 'Yes',
+            dateOfDeath: '2025-05-11T00:00:00',
+            deathCity: 'Death city',
+            deathState: 'Texas',
+            deathCounty: 'Anderson County',
+            deathCountry: 'Afghanistan'
+        },
+        general: {
+            asOf: '2025-06-05T00:00:00',
+            maritalStatus: 'Annulled',
+            mothersMaidenName: 'MotherMaiden',
+            numberOfAdultsInResidence: '2',
+            numberOfChildrenInResidence: '0',
+            primaryOccupation: 'Mining',
+            educationLevel: '10th grade',
+            primaryLanguage: 'Eastern Frisian',
+            speaksEnglish: 'Yes',
+            stateHivCaseId: null
+        },
+        investigations: [
+            {
+                id: 'CAS10001000GA01',
+                startDate: '2025-06-05T00:00:00',
+                condition: '2019 Novel Coronavirus'
+            },
+            {
+                id: 'CAS10001001GA01',
+                startDate: null,
+                condition: 'Cholera'
+            }
+        ],
+        addresses: [
+            {
+                id: '10055291',
+                asOf: '2025-05-27T00:00:00',
+                type: 'Dormitory',
+                use: 'Primary Business',
+                address: '1112 Another address',
+                address2: null,
+                city: 'Atlanta',
+                state: 'Georgia',
+                zipcode: '12345',
+                county: null,
+                censusTract: null,
+                country: null,
+                comments: null
+            },
+            {
+                id: '10055292',
+                asOf: '2025-05-13T00:00:00',
+                type: 'House',
+                use: 'Home',
+                address: '111 Main st',
+                address2: 'Block 2',
+                city: 'City ',
+                state: 'Georgia',
+                zipcode: '11111',
+                county: 'Atkinson County',
+                censusTract: '0111',
+                country: 'United States',
+                comments: 'Address comment 1'
+            },
+            {
+                id: '10056288',
+                asOf: '2025-06-05T00:00:00',
+                type: 'House',
+                use: 'Home',
+                address: '111 Main st',
+                address2: 'Block 2',
+                city: 'City ',
+                state: 'Georgia',
+                zipcode: '11111',
+                county: 'Atkinson County',
+                censusTract: null,
+                country: 'United States',
+                comments: null
+            },
+            {
+                id: '10056294',
+                asOf: '2025-06-05T00:00:00',
+                type: 'House',
+                use: 'Home',
+                address: '111 Main st',
+                address2: 'Block 2',
+                city: 'City',
+                state: 'Georgia',
+                zipcode: '11111',
+                county: 'Atkinson County',
+                censusTract: null,
+                country: 'United States',
+                comments: null
+            }
+        ],
+        phoneEmails: [
+            {
+                id: '10055285',
+                asOf: '2025-05-27T00:00:00',
+                type: 'Answering service',
+                use: 'Alternate Work Place',
+                countryCode: '1',
+                phoneNumber: '1111111111',
+                extension: '1',
+                email: 'oneEmail@email.com',
+                url: '1Url.com',
+                comments: '1 phone comment'
+            },
+            {
+                id: '10055293',
+                asOf: '2025-05-28T00:00:00',
+                type: 'Cellular Phone',
+                use: 'Temporary',
+                countryCode: null,
+                phoneNumber: '123',
+                extension: null,
+                email: null,
+                url: null,
+                comments: null
+            }
+        ],
+        names: [
+            {
+                personUid: '10055283',
+                sequence: '1',
+                asOf: '2025-05-27T00:00:00',
+                type: 'Legal',
+                prefix: 'Bishop',
+                first: 'John',
+                middle: 'R',
+                secondMiddle: '2M',
+                last: 'Smith',
+                secondLast: '2Last',
+                suffix: 'Esquire',
+                degree: 'PHD'
+            }
+        ],
+        identifications: [
+            {
+                personUid: '10055283',
+                sequence: '1',
+                asOf: '2025-05-28T00:00:00',
+                type: 'Account number',
+                assigningAuthority: 'AZ',
+                value: '444111'
+            },
+            {
+                personUid: '10055283',
+                sequence: '2',
+                asOf: '2025-05-05T00:00:00',
+                type: "Driver's license number",
+                assigningAuthority: 'TN',
+                value: '001111'
+            }
+        ],
+        races: [
+            {
+                personUid: '10055283',
+                raceCode: '2106-3',
+                asOf: '2025-05-27T00:00:00',
+                race: 'White',
+                detailedRaces: 'European'
+            },
+            {
+                personUid: '10055283',
+                raceCode: '2106-3',
+                asOf: '2025-06-05T00:00:00',
+                race: 'White',
+                detailedRaces: null
+            }
+        ]
+    }
+];
 
 const mockFetch = jest.fn();
 let mockLoading = false;
 jest.mock('apps/deduplication/api/useMergeDetails', () => ({
     useMergeDetails: () => {
-        return { fetchPatientMergeDetails: mockFetch, loading: mockLoading };
+        return { fetchPatientMergeDetails: mockFetch, loading: mockLoading, response: response };
     }
 }));
 
@@ -39,5 +388,21 @@ describe('MergeDetails', () => {
         const { getByText } = render(<Fixture />);
 
         expect(getByText('Patient matches requiring review')).toBeInTheDocument();
+    });
+
+    it('should apply default selection of the oldest patient', () => {
+        const { getAllByRole } = render(<Fixture />);
+
+        // all checked radio buttons should have the oldest record id for value
+        const allChecked = getAllByRole('radio', { checked: true });
+        allChecked.forEach((c) => expect(c).toHaveAttribute('value', '10052298'));
+
+        // unchecked radio buttons should have the newer record id for value
+        const allNotChecked = getAllByRole('radio', { checked: false });
+        allNotChecked.forEach((c) => expect(c).toHaveAttribute('value', '10055283'));
+
+        // All repeating block values (old and new) should be selected
+        const checkboxes = getAllByRole('checkbox', { hidden: true });
+        checkboxes.forEach((c) => expect(c).toBeChecked());
     });
 });

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/MergeDetails.tsx
@@ -1,30 +1,119 @@
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router';
-import { Shown } from 'conditional-render';
-import { MergeReview } from './merge-review/MergeReview';
-import { MergePreview } from './merge-preview/MergePreview';
+import { MergeCandidate } from 'apps/deduplication/api/model/MergeCandidate';
 import { useMergeDetails } from 'apps/deduplication/api/useMergeDetails';
-import styles from './MergeDetails.module.scss';
 import { Loading } from 'components/Spinner';
-import { FormProvider, useForm, useWatch } from 'react-hook-form';
-import { PatientMergeForm } from './merge-review/model/PatientMergeForm';
+import { Shown } from 'conditional-render';
+import { parseISO } from 'date-fns/fp';
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useParams } from 'react-router';
+import { MergePreview } from './merge-preview/MergePreview';
+import { MergeReview } from './merge-review/MergeReview';
+import {
+    AddressId,
+    IdentificationId,
+    NameId,
+    PatientMergeForm,
+    PhoneEmailId,
+    RaceId
+} from './merge-review/model/PatientMergeForm';
+import styles from './MergeDetails.module.scss';
 
 export const MergeDetails = () => {
     const [pageState, setPageState] = useState<'review' | 'preview'>('review');
     const { matchId } = useParams();
     const { response, loading, fetchPatientMergeDetails } = useMergeDetails();
     const form = useForm<PatientMergeForm>({ mode: 'onBlur' });
-    const watch = useWatch(form);
-
-    useEffect(() => {
-        console.log('watch', watch);
-    }, [watch]);
 
     useEffect(() => {
         if (matchId !== undefined) {
             fetchPatientMergeDetails(matchId);
         }
     }, [matchId]);
+
+    useEffect(() => {
+        if (response && response.length > 0) {
+            const oldestRecord = response.reduce((a, b) =>
+                parseISO(a.addTime).getTime() < parseISO(b.addTime).getTime() ? a : b
+            );
+            if (oldestRecord) {
+                setDefaultValues(oldestRecord.personUid, response);
+            }
+        }
+    }, [response]);
+
+    const setDefaultValues = (oldestRecordId: string, mergeCandidates: MergeCandidate[]) => {
+        const nameValues: NameId[] = mergeCandidates.flatMap((m) =>
+            m.names.map((n) => {
+                return { personUid: n.personUid, sequence: n.sequence };
+            })
+        );
+        const addressValues: AddressId[] = mergeCandidates.flatMap((m) =>
+            m.addresses.map((a) => {
+                return { locatorId: a.id };
+            })
+        );
+        const phoneEmalValues: PhoneEmailId[] = mergeCandidates.flatMap((m) =>
+            m.phoneEmails.map((p) => {
+                return { locatorId: p.id };
+            })
+        );
+        const identificationValues: IdentificationId[] = mergeCandidates.flatMap((m) =>
+            m.identifications.map((n) => {
+                return { personUid: n.personUid, sequence: n.sequence };
+            })
+        );
+        const raceValues: RaceId[] = mergeCandidates.flatMap((m) =>
+            m.races.map((r) => {
+                return { personUid: r.personUid, raceCode: r.raceCode };
+            })
+        );
+
+        form.reset(
+            {
+                survivingRecord: oldestRecordId,
+                adminComments: oldestRecordId,
+                names: nameValues,
+                addresses: addressValues,
+                phoneEmails: phoneEmalValues,
+                identifications: identificationValues,
+                races: raceValues,
+                ethnicity: oldestRecordId,
+                sexAndBirth: {
+                    asOf: oldestRecordId,
+                    dateOfBirth: oldestRecordId,
+                    currentSex: oldestRecordId,
+                    transgenderInfo: oldestRecordId,
+                    additionalGender: oldestRecordId,
+                    birthGender: oldestRecordId,
+                    multipleBirth: oldestRecordId,
+                    birthCity: oldestRecordId,
+                    birthState: oldestRecordId,
+                    birthCountry: oldestRecordId
+                },
+                mortality: {
+                    asOf: oldestRecordId,
+                    deceased: oldestRecordId,
+                    dateOfDeath: oldestRecordId,
+                    deathCity: oldestRecordId,
+                    deathState: oldestRecordId,
+                    deathCountry: oldestRecordId
+                },
+                generalInfo: {
+                    asOf: oldestRecordId,
+                    maritalStatus: oldestRecordId,
+                    mothersMaidenName: oldestRecordId,
+                    numberOfAdultsInResidence: oldestRecordId,
+                    numberOfChildrenInResidence: oldestRecordId,
+                    primaryOccupation: oldestRecordId,
+                    educationLevel: oldestRecordId,
+                    primaryLanguage: oldestRecordId,
+                    speaksEnglish: oldestRecordId,
+                    stateHivCaseId: oldestRecordId
+                }
+            },
+            { keepDefaultValues: false }
+        );
+    };
 
     const handleRemovePatient = (personUid: string) => {
         console.log('Remove patient NYI', personUid);


### PR DESCRIPTION
## Description

1. Adds default selection to merge review form. 
    a. Oldest record is selected by default
    b. All repeating block data is selected by default


## Tickets

* [CND-337](https://cdc-nbs.atlassian.net/browse/CND-337)

## Demo
![defaultSelection](https://github.com/user-attachments/assets/30b00ca9-6159-4aa3-ad6d-5cae23890774)


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-337]: https://cdc-nbs.atlassian.net/browse/CND-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ