### PR TITLE
NIS-8 display of error messages for date of birth

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientCriteria/BasicInformation.tsx
@@ -65,6 +65,7 @@ export const BasicInformation = ({ sizing, orientation }: EntryFieldsProps) => {
                         sizing={sizing}
                         orientation={orientation}
                         error={error?.message}
+                        showAdditionalDateCriteriaErrors
                     />
                 )}
             />

--- a/apps/modernization-ui/src/design-system/date/criteria/AdditionalDateCriteriaErrors.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/AdditionalDateCriteriaErrors.tsx
@@ -1,0 +1,35 @@
+import { validateMonth, validateDay, validateYear } from '../validateDateEntry';
+import { DateCriteria, DateEqualsCriteria } from './dateCriteria';
+
+const NAME = 'Date of birth';
+
+type AdditionalDateCriteriaErrorsProps = {
+    value: DateCriteria | null | undefined;
+    error: string | undefined;
+};
+
+const AdditionalDateCriteriaErrors = (props: AdditionalDateCriteriaErrorsProps) => {
+    const { value, error } = props;
+    const isDateEqualsCriteria = (x: DateCriteria): x is DateEqualsCriteria => {
+        return Object.keys(x).includes('equals');
+    };
+
+    // If no value or error is present, there are no additional errors to display.
+    // Date must be in the DateEqualsCriteria format at this time to display additional errrors.
+    if (!value || !error || !isDateEqualsCriteria(value)) {
+        return undefined;
+    }
+
+    const monthValidation = validateMonth(NAME)(value.equals);
+    const dayValidation = validateDay(NAME)(value.equals);
+    const yearValidation = validateYear(NAME)(value.equals);
+    console.log(JSON.stringify({ monthValidation, dayValidation, yearValidation }));
+
+    const errorArr = [monthValidation]
+        .concat(dayValidation)
+        .concat(yearValidation)
+        .filter((v) => typeof v !== 'boolean');
+
+    return <div style={{ color: '#b51d09', fontWeight: 'bold' }}>{errorArr}</div>;
+};
+export default AdditionalDateCriteriaErrors;

--- a/apps/modernization-ui/src/design-system/date/criteria/AdditionalDateCriteriaErrors.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/AdditionalDateCriteriaErrors.tsx
@@ -8,11 +8,12 @@ type AdditionalDateCriteriaErrorsProps = {
     error: string | undefined;
 };
 
+const isDateEqualsCriteria = (x: DateCriteria): x is DateEqualsCriteria => {
+    return Object.keys(x).includes('equals');
+};
+
 const AdditionalDateCriteriaErrors = (props: AdditionalDateCriteriaErrorsProps) => {
     const { value, error } = props;
-    const isDateEqualsCriteria = (x: DateCriteria): x is DateEqualsCriteria => {
-        return Object.keys(x).includes('equals');
-    };
 
     // If no value or error is present, there are no additional errors to display.
     // Date must be in the DateEqualsCriteria format at this time to display additional errrors.
@@ -20,16 +21,25 @@ const AdditionalDateCriteriaErrors = (props: AdditionalDateCriteriaErrorsProps) 
         return undefined;
     }
 
-    const monthValidation = validateMonth(NAME)(value.equals);
-    const dayValidation = validateDay(NAME)(value.equals);
+    // Use the same validation functions as the primary.
     const yearValidation = validateYear(NAME)(value.equals);
-    console.log(JSON.stringify({ monthValidation, dayValidation, yearValidation }));
+    const dayValidation = validateDay(NAME)(value.equals);
+    const monthValidation = validateMonth(NAME)(value.equals);
 
+    // Combine potential errors into an error array.
     const errorArr = [monthValidation]
         .concat(dayValidation)
         .concat(yearValidation)
         .filter((v) => typeof v !== 'boolean');
 
-    return <div style={{ color: '#b51d09', fontWeight: 'bold' }}>{errorArr}</div>;
+    return (
+        <div>
+            {errorArr.map((v) => (
+                <p key={v} style={{ color: '#b51d09', fontWeight: 'bold', margin: 0 }}>
+                    {v}
+                </p>
+            ))}
+        </div>
+    );
 };
 export default AdditionalDateCriteriaErrors;

--- a/apps/modernization-ui/src/design-system/date/criteria/AdditionalDateCriteriaErrors.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/AdditionalDateCriteriaErrors.tsx
@@ -1,10 +1,13 @@
+import { InlineErrorMessage } from 'design-system/field/InlineErrorMessage';
 import { validateMonth, validateDay, validateYear } from '../validateDateEntry';
 import { DateCriteria, DateEqualsCriteria } from './dateCriteria';
+import styles from './additional-date-criteria-errors.module.scss';
 
 const NAME = 'Date of birth';
 
 type AdditionalDateCriteriaErrorsProps = {
     value: DateCriteria | null | undefined;
+    fieldId: string;
     error: string | undefined;
 };
 
@@ -13,7 +16,7 @@ const isDateEqualsCriteria = (x: DateCriteria): x is DateEqualsCriteria => {
 };
 
 const AdditionalDateCriteriaErrors = (props: AdditionalDateCriteriaErrorsProps) => {
-    const { value, error } = props;
+    const { value, fieldId, error } = props;
 
     // If no value or error is present, there are no additional errors to display.
     // Date must be in the DateEqualsCriteria format at this time to display additional errrors.
@@ -35,9 +38,9 @@ const AdditionalDateCriteriaErrors = (props: AdditionalDateCriteriaErrorsProps) 
     return (
         <div>
             {errorArr.map((v) => (
-                <p key={v} style={{ color: '#b51d09', fontWeight: 'bold', margin: 0 }}>
+                <InlineErrorMessage key={v} id={`${fieldId}-error`} className={styles.inlineErrorMessage}>
                     {v}
-                </p>
+                </InlineErrorMessage>
             ))}
         </div>
     );

--- a/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.tsx
@@ -46,8 +46,16 @@ const DateCriteriaField = ({
     const type = resolveInitialCriteriaType(value);
 
     return (
-        <Field error={error} orientation={orientation} label={label} htmlFor={id} sizing={sizing}>
-            {showAdditionalDateCriteriaErrors && <AdditionalDateCriteriaErrors error={error} value={value} />}
+        <Field
+            error={error}
+            displayErrorsExternally={true}
+            orientation={orientation}
+            label={label}
+            htmlFor={id}
+            sizing={sizing}>
+            {showAdditionalDateCriteriaErrors && (
+                <AdditionalDateCriteriaErrors fieldId={id} error={error} value={value} />
+            )}
             <div className={styles.content}>
                 <div className={styles.operators} data-range-operator={type}>
                     <Radio

--- a/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.tsx
@@ -6,6 +6,7 @@ import { Field, FieldProps } from 'design-system/field';
 import { Shown } from 'conditional-render';
 
 import styles from './date-criteria.module.scss';
+import AdditionalDateCriteriaErrors from './AdditionalDateCriteriaErrors';
 
 type CriteriaType = 'equals' | 'between';
 
@@ -27,6 +28,7 @@ type DateCriteriaFieldProps = {
     onChange: (value?: DateCriteria) => void;
     onBlur?: () => void;
     clearErrors?: () => void;
+    showAdditionalDateCriteriaErrors?: boolean;
 } & FieldProps;
 
 const DateCriteriaField = ({
@@ -38,12 +40,14 @@ const DateCriteriaField = ({
     error,
     onChange,
     onBlur,
-    clearErrors
+    clearErrors,
+    showAdditionalDateCriteriaErrors
 }: DateCriteriaFieldProps) => {
     const type = resolveInitialCriteriaType(value);
 
     return (
         <Field error={error} orientation={orientation} label={label} htmlFor={id} sizing={sizing}>
+            {showAdditionalDateCriteriaErrors && <AdditionalDateCriteriaErrors error={error} value={value} />}
             <div className={styles.content}>
                 <div className={styles.operators} data-range-operator={type}>
                     <Radio

--- a/apps/modernization-ui/src/design-system/date/criteria/additional-date-criteria-errors.module.scss
+++ b/apps/modernization-ui/src/design-system/date/criteria/additional-date-criteria-errors.module.scss
@@ -1,0 +1,4 @@
+.inlineErrorMessage {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+}

--- a/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
@@ -35,7 +35,11 @@ const validateDay = (name: string) => (value: DateEntry) => {
         } else if (value.day < 1) {
             return `The ${name} should be at least the first day of the month.`;
         }
+        if (value.day > 31) {
+            return `The ${name} should have at most 31 days.`;
+        }
     }
+
     return true;
 };
 
@@ -52,4 +56,4 @@ const validateDateEntry =
     (value: DateEntry): boolean | string =>
         validateAll(validateYear(name), validateMonth(name), validateDay(name), occursInThePast(name))(value);
 
-export { validateDateEntry };
+export { validateDateEntry, validateYear, validateMonth, validateDay };

--- a/apps/modernization-ui/src/design-system/field/Field.tsx
+++ b/apps/modernization-ui/src/design-system/field/Field.tsx
@@ -14,6 +14,7 @@ type FieldProps = {
     sizing?: Sizing;
     helperText?: string;
     error?: string;
+    displayErrorsExternally?: boolean;
     required?: boolean;
     warning?: string;
 };

--- a/apps/modernization-ui/src/design-system/field/VerticalField.tsx
+++ b/apps/modernization-ui/src/design-system/field/VerticalField.tsx
@@ -12,12 +12,23 @@ type Props = {
     label: string;
     helperText?: string;
     error?: string;
+    displayErrorsExternally?: boolean;
     required?: boolean;
     warning?: string;
     children: ReactNode;
 };
 
-const VerticalField = ({ className, htmlFor, label, helperText, required, error, warning, children }: Props) => (
+const VerticalField = ({
+    className,
+    htmlFor,
+    label,
+    helperText,
+    required,
+    error,
+    displayErrorsExternally,
+    warning,
+    children
+}: Props) => (
     <span className={classNames(styles.entry, className)}>
         <span className={styles.labels}>
             <label className={classNames({ [styles.required]: required })} htmlFor={htmlFor}>
@@ -26,7 +37,7 @@ const VerticalField = ({ className, htmlFor, label, helperText, required, error,
             {helperText && <HelperText id={`${htmlFor}-hint`}>{helperText}</HelperText>}
         </span>
         {warning && <InlineWarningMessage id={`${htmlFor}-warning`}>{warning}</InlineWarningMessage>}
-        {error && <InlineErrorMessage id={`${htmlFor}-error`}>{error}</InlineErrorMessage>}
+        {error && !displayErrorsExternally && <InlineErrorMessage id={`${htmlFor}-error`}>{error}</InlineErrorMessage>}
 
         {children}
     </span>


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/f2a8ed59-8e3b-40ae-a2cb-618cafda126f)

In order to display multiple errors within the Exact Date Date of Birth patient search, while simultaneously maintaining overall validations for edge case events like leap year dates, this change overrides the default error message that comes internal to the form logic to instead use an external error message that is customizable. 

To preserve maintainability of the overall form and to continue to use validations that require the entire date to be fully validated by the form validation logic (like leap years) the internal validation has not been changed, the only change has been to what is shown to the user. 

To change what is shown to the user, whenever the `DateCriteria` value passed to the `DateCriteriaField` is changed, the `AdditionalDateCriteriaErrors` component runs the validations within `validateDateEntry` for month, day and year individually. To validate the date internally using the form logic, the same `validateDateEntry` functions are used in a combined function called `validateDateEntry`. 

This provides the user with a more detailed error message, while also using the same validation as the overall form. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/NIS-8)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
