### PR TITLE
Cnft1 4240 labels fields association

### DIFF
--- a/apps/modernization-ui/src/apps/search/laboratory-report/GeneralFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/laboratory-report/GeneralFields.spec.tsx
@@ -59,32 +59,32 @@ describe('GeneralFields component ', () => {
         const { getByText, getByRole } = render(<GeneralFieldsWithForm />);
         expect(getByText('Entry method')).toBeInTheDocument();
 
-        expect(getByRole('checkbox', { name: 'Manual' })).toBeInTheDocument();
-        expect(getByRole('checkbox', { name: 'Electronic' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Entry method, Manual' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Entry method, Electronic' })).toBeInTheDocument();
     });
 
     it('renders entered by checkboxes', () => {
         const { getByText, getByRole } = render(<GeneralFieldsWithForm />);
         expect(getByText('Entered by')).toBeInTheDocument();
 
-        expect(getByRole('checkbox', { name: 'External' })).toBeInTheDocument();
-        expect(getByRole('checkbox', { name: 'Internal' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Entered by, External' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Entered by, Internal' })).toBeInTheDocument();
     });
 
     it('renders event status checkboxes', () => {
         const { getByText, getByRole } = render(<GeneralFieldsWithForm />);
         expect(getByText('Event status')).toBeInTheDocument();
 
-        expect(getByRole('checkbox', { name: 'New' })).toBeInTheDocument();
-        expect(getByRole('checkbox', { name: 'Update' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Event status, New' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Event status, Update' })).toBeInTheDocument();
     });
 
     it('renders processing status checkboxes', () => {
         const { getByText, getByRole } = render(<GeneralFieldsWithForm />);
-        expect(getByText('Event status')).toBeInTheDocument();
+        expect(getByText('Processing status')).toBeInTheDocument();
 
-        expect(getByRole('checkbox', { name: 'Unprocessed' })).toBeInTheDocument();
-        expect(getByRole('checkbox', { name: 'Processed' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Processing status, Unprocessed' })).toBeInTheDocument();
+        expect(getByRole('checkbox', { name: 'Processing status, Processed' })).toBeInTheDocument();
     });
 
     it('renders user autocomplete fields', () => {

--- a/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.tsx
+++ b/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.tsx
@@ -83,6 +83,7 @@ export const CheckboxGroup = ({
                         selected={item.selected}
                         disabled={disabled}
                         onBlur={onBlur}
+                        aria-label={`${label}, ${item.value.name}`}
                     />
                 ))}
             </fieldset>

--- a/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.spec.tsx
@@ -21,9 +21,9 @@ describe('DateCriteriaField Component', () => {
         const { getByLabelText, getByRole } = render(<DateCriteriaField {...defaultProps} value={null} />);
         const exactDateRadio = getByLabelText('Exact Date');
         expect(exactDateRadio).toBeChecked();
-        expect(getByRole('spinbutton', { name: 'Month' })).toBeInTheDocument();
-        expect(getByRole('spinbutton', { name: 'Day' })).toBeInTheDocument();
-        expect(getByRole('spinbutton', { name: 'Year' })).toBeInTheDocument();
+        expect(getByRole('spinbutton', { name: 'Test Date Entry, Month' })).toBeInTheDocument();
+        expect(getByRole('spinbutton', { name: 'Test Date Entry, Day' })).toBeInTheDocument();
+        expect(getByRole('spinbutton', { name: 'Test Date Entry, Year' })).toBeInTheDocument();
     });
 
     it('should call onChange when a exact date is selected', async () => {

--- a/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/DateCriteriaField.tsx
@@ -58,6 +58,7 @@ const DateCriteriaField = ({
                         checked={type === 'equals'}
                         sizing={sizing}
                         className={styles.radio}
+                        aria-label={`${label}, Exact Date`}
                     />
                     <Radio
                         id={'between'}
@@ -71,6 +72,7 @@ const DateCriteriaField = ({
                         checked={type === 'between'}
                         sizing={sizing}
                         className={styles.radio}
+                        aria-label={`${label}, Date Range`}
                     />
                 </div>
                 <div key={type}>
@@ -80,6 +82,7 @@ const DateCriteriaField = ({
                             value={asDateEqualsCriteria(value)}
                             onChange={onChange}
                             onBlur={onBlur}
+                            label={label}
                         />
                     </Shown>
                     <Shown when={type === 'between'}>
@@ -89,6 +92,7 @@ const DateCriteriaField = ({
                             value={asDateRangeCriteria(value)}
                             onChange={onChange}
                             onBlur={onBlur}
+                            label={label}
                         />
                     </Shown>
                 </div>

--- a/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.spec.tsx
@@ -5,25 +5,34 @@ import { ExactDateField } from './ExactDateField';
 
 describe('ExactDateField Component', () => {
     it('should render with no accessibility violations', async () => {
-        const { container } = render(<ExactDateField id="testing-exact-date-entry" onChange={jest.fn()} />);
+        const { container } = render(
+            <ExactDateField id="testing-exact-date-entry" onChange={jest.fn()} label="Exact Date" />
+        );
 
         expect(await axe(container)).toHaveNoViolations();
     });
 
     it('should render inputs with correct default month', () => {
-        render(<ExactDateField id="test-id" value={{ equals: { month: 1 } }} onChange={jest.fn()} />);
-        const monthInput = screen.getByRole('spinbutton', { name: 'Month' });
+        render(
+            <ExactDateField id="test-id" value={{ equals: { month: 1 } }} onChange={jest.fn()} label="Exact Date" />
+        );
+        const monthInput = screen.getByRole('spinbutton', { name: 'Exact Date, Month' });
 
         expect(monthInput).toHaveValue(1);
     });
 
     it('should render inputs with correct default values', () => {
         const { getByRole } = render(
-            <ExactDateField id="test-id" value={{ equals: { month: 1, day: 1, year: 1995 } }} onChange={jest.fn()} />
+            <ExactDateField
+                id="test-id"
+                value={{ equals: { month: 1, day: 1, year: 1995 } }}
+                onChange={jest.fn()}
+                label="Exact Date"
+            />
         );
-        const monthInput = getByRole('spinbutton', { name: 'Month' });
-        const dayInput = getByRole('spinbutton', { name: 'Day' });
-        const yearInput = getByRole('spinbutton', { name: 'Year' });
+        const monthInput = getByRole('spinbutton', { name: 'Exact Date, Month' });
+        const dayInput = getByRole('spinbutton', { name: 'Exact Date, Day' });
+        const yearInput = getByRole('spinbutton', { name: 'Exact Date, Year' });
 
         expect(monthInput).toHaveValue(1);
         expect(dayInput).toHaveValue(1);
@@ -33,11 +42,11 @@ describe('ExactDateField Component', () => {
     it('should call onChange when day value is changed', async () => {
         const mockOnChange = jest.fn();
 
-        const { getByRole } = render(<ExactDateField id="test-day" onChange={mockOnChange} />);
+        const { getByRole } = render(<ExactDateField id="test-day" onChange={mockOnChange} label="Exact Date" />);
 
         const user = userEvent.setup();
 
-        const day = getByRole('spinbutton', { name: 'Day' });
+        const day = getByRole('spinbutton', { name: 'Exact Date, Day' });
 
         await user.type(day, '12{tab}');
 
@@ -47,11 +56,11 @@ describe('ExactDateField Component', () => {
     it('should call onChange when month value is changed', async () => {
         const mockOnChange = jest.fn();
 
-        const { getByRole } = render(<ExactDateField id="test-month" onChange={mockOnChange} />);
+        const { getByRole } = render(<ExactDateField id="test-month" onChange={mockOnChange} label="Exact Date" />);
 
         const user = userEvent.setup();
 
-        const month = getByRole('spinbutton', { name: 'Month' });
+        const month = getByRole('spinbutton', { name: 'Exact Date, Month' });
 
         await user.type(month, '4{tab}');
 
@@ -61,10 +70,10 @@ describe('ExactDateField Component', () => {
     it('should call onChange when year value is changed', async () => {
         const mockOnChange = jest.fn();
 
-        const { getByRole } = render(<ExactDateField id="test-year" onChange={mockOnChange} />);
+        const { getByRole } = render(<ExactDateField id="test-year" onChange={mockOnChange} label="Exact Date" />);
         const user = userEvent.setup();
 
-        const year = getByRole('spinbutton', { name: 'Year' });
+        const year = getByRole('spinbutton', { name: 'Exact Date, Year' });
 
         await user.type(year, '1908{tab}');
 

--- a/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { withoutProperty, withProperty } from 'utils/object';
 import { Numeric } from 'design-system/input/numeric/Numeric';

--- a/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { HTMLProps, useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { withoutProperty, withProperty } from 'utils/object';
 import { Numeric } from 'design-system/input/numeric/Numeric';
@@ -17,9 +17,10 @@ type ExactDateFieldProps = {
     value?: DateEqualsCriteria;
     onChange: (value?: DateEqualsCriteria) => void;
     onBlur?: () => void;
+    label?: string;
 };
 
-const ExactDateField = ({ id, value, onChange, onBlur }: ExactDateFieldProps) => {
+const ExactDateField = ({ id, value, onChange, onBlur, label }: ExactDateFieldProps) => {
     const [criteria, setCriteria] = useState<DateEntry | undefined>(value?.equals);
 
     useEffect(() => {
@@ -53,6 +54,7 @@ const ExactDateField = ({ id, value, onChange, onBlur }: ExactDateFieldProps) =>
                     onBlur={onBlur}
                     min={1}
                     max={12}
+                    aria-label={`${label}, Month`}
                 />
             </div>
             <div className={classNames(styles['numeric-wrapper'], styles['day'])}>
@@ -65,6 +67,7 @@ const ExactDateField = ({ id, value, onChange, onBlur }: ExactDateFieldProps) =>
                     onBlur={onBlur}
                     min={1}
                     max={31}
+                    aria-label={`${label}, Day`}
                 />
             </div>
             <div className={classNames(styles['numeric-wrapper'], styles['year'])}>
@@ -76,6 +79,7 @@ const ExactDateField = ({ id, value, onChange, onBlur }: ExactDateFieldProps) =>
                     onChange={handleFieldOnChange('year')}
                     onBlur={onBlur}
                     min={1875}
+                    aria-label={`${label}, Year`}
                 />
             </div>
         </div>

--- a/apps/modernization-ui/src/design-system/date/criteria/range/DateRangeField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/range/DateRangeField.spec.tsx
@@ -21,10 +21,11 @@ describe('DateRangeField Component', () => {
                     }
                 }}
                 onChange={jest.fn()}
+                label="Date Range"
             />
         );
-        const from = getByRole('textbox', { name: 'From' });
-        const to = getByRole('textbox', { name: 'To' });
+        const from = getByRole('textbox', { name: 'Date Range, From' });
+        const to = getByRole('textbox', { name: 'Date Range, To' });
 
         expect(from).toHaveValue('02/17/1990');
         expect(to).toHaveValue('02/17/2000');
@@ -32,9 +33,11 @@ describe('DateRangeField Component', () => {
 
     it('should call from input change handler when the from date is entered', async () => {
         const mockOnChange = jest.fn();
-        const { getByRole } = render(<DateRangeField id="testing-date-range-from-entered" onChange={mockOnChange} />);
+        const { getByRole } = render(
+            <DateRangeField id="testing-date-range-from-entered" onChange={mockOnChange} label="Date Range" />
+        );
 
-        const from = getByRole('textbox', { name: 'From' });
+        const from = getByRole('textbox', { name: 'Date Range, From' });
 
         const user = userEvent.setup();
 
@@ -48,6 +51,7 @@ describe('DateRangeField Component', () => {
         const { getByRole } = render(
             <DateRangeField
                 id="testing-date-range-from-change"
+                label="Date Range"
                 value={{
                     between: {
                         from: '02/17/1990'
@@ -57,7 +61,7 @@ describe('DateRangeField Component', () => {
             />
         );
 
-        const from = getByRole('textbox', { name: 'From' });
+        const from = getByRole('textbox', { name: 'Date Range, From' });
 
         const user = userEvent.setup();
 
@@ -68,9 +72,11 @@ describe('DateRangeField Component', () => {
 
     it('should call from input change handler when the to date is entered', async () => {
         const mockOnChange = jest.fn();
-        const { getByRole } = render(<DateRangeField id="testing-date-range-to-entered" onChange={mockOnChange} />);
+        const { getByRole } = render(
+            <DateRangeField id="testing-date-range-to-entered" onChange={mockOnChange} label="Date Range" />
+        );
 
-        const to = getByRole('textbox', { name: 'To' });
+        const to = getByRole('textbox', { name: 'Date Range, To' });
 
         const user = userEvent.setup();
 
@@ -84,6 +90,7 @@ describe('DateRangeField Component', () => {
         const { getByRole } = render(
             <DateRangeField
                 id="testing-date-range-to-change"
+                label="Date Range"
                 value={{
                     between: {
                         from: '02/17/1990',
@@ -94,7 +101,7 @@ describe('DateRangeField Component', () => {
             />
         );
 
-        const to = getByRole('textbox', { name: 'To' });
+        const to = getByRole('textbox', { name: 'Date Range, To' });
 
         const user = userEvent.setup();
 

--- a/apps/modernization-ui/src/design-system/date/criteria/range/DateRangeField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/range/DateRangeField.tsx
@@ -20,9 +20,10 @@ type DateRangeFieldProps = {
     sizing?: Sizing;
     onChange: (value?: DateBetweenCriteria) => void;
     onBlur?: () => void;
+    label?: string;
 };
 
-const DateRangeField = ({ id, value, sizing, onChange, onBlur }: DateRangeFieldProps) => {
+const DateRangeField = ({ id, value, sizing, onChange, onBlur, label }: DateRangeFieldProps) => {
     const [range, setRange] = useState<DateRange | undefined>(value?.between);
 
     useEffect(() => {
@@ -66,6 +67,7 @@ const DateRangeField = ({ id, value, sizing, onChange, onBlur }: DateRangeFieldP
                     id={`${id}-from`}
                     value={range?.from}
                     onChange={handleFieldOnChange('from')}
+                    aria-label={`${label}, From`}
                 />
             </div>
             <div className={classNames(styles['range-wrapper'])}>
@@ -77,6 +79,7 @@ const DateRangeField = ({ id, value, sizing, onChange, onBlur }: DateRangeFieldP
                     minDate={range?.from}
                     value={range?.to}
                     onChange={handleFieldOnChange('to')}
+                    aria-label={`${label}, To`}
                 />
             </div>
         </div>

--- a/apps/modernization-ui/src/design-system/date/picker/DatePicker.tsx
+++ b/apps/modernization-ui/src/design-system/date/picker/DatePicker.tsx
@@ -107,6 +107,10 @@ const DatePicker = ({
                 }
             };
         }
+
+        if (externalInputRef.current && remaining['aria-label']) {
+            externalInputRef.current.setAttribute('aria-label', remaining['aria-label']);
+        }
     }, [externalInputRef.current]);
 
     useEffect(() => {


### PR DESCRIPTION
## Description

-> Issue- Labels are not programmatically associated with their corresponding fields.

-> I added aria-label to the fields in order to associate it with its corresponding parent label so that the screen reader announces 

-> Use an aria-label attribute or title attribute on the <input> to provide a label when there is no visible label.
Reference https://docs.deque.com/issue-help/1.0.0/en/label-not-associated#rule

## Tickets

* [CNFT1-4240](https://cdc-nbs.atlassian.net/browse/CNFT1-4240)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
