### PR TITLE
Nis 8 display error messages for date of birth validations

### DIFF
--- a/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
@@ -1,7 +1,6 @@
 import { getDaysInMonth } from 'date-fns';
 import { DateEntry } from './entry';
 import { occursInThePast } from './occursInThePast';
-import { validateAll } from 'validation';
 import { now } from './clock';
 
 const validateYear = (name: string) => (value: DateEntry) => {
@@ -49,7 +48,16 @@ const validateDay = (name: string) => (value: DateEntry) => {
  */
 const validateDateEntry =
     (name: string) =>
-    (value: DateEntry): boolean | string =>
-        validateAll(validateYear(name), validateMonth(name), validateDay(name), occursInThePast(name))(value);
+    (value: DateEntry): boolean | string => {
+        const validators = [validateYear(name), validateMonth(name), validateDay(name), occursInThePast(name)];
+        const errors = validators
+            .map((validator) => validator(value))
+            .filter((result) => typeof result === 'string') as string[];
+
+        if (errors.length > 0) {
+            return errors.join('\n');
+        }
+        return true;
+    };
 
 export { validateDateEntry };

--- a/apps/modernization-ui/src/design-system/field/inline-message.module.scss
+++ b/apps/modernization-ui/src/design-system/field/inline-message.module.scss
@@ -3,4 +3,5 @@
 .message {
     display: block;
     font-weight: 700;
+    white-space: pre-line;
 }


### PR DESCRIPTION
## Description

Instead of using a display change, we can replace the `validateAll` function here with a validator array that collects all of the errors that we need to check against and puts them into a single array that we show to the user.

This will show the errors in the way that matches the updated figma design:

![image](https://github.com/user-attachments/assets/6d713aec-1d11-498c-9bda-a556d64af86a)


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/NIS-8)


