### PR TITLE
NIS 24 UI patient search results per page preference has to be saved for the user

### DIFF
--- a/apps/modernization-ui/src/apps/search/SearchPage.tsx
+++ b/apps/modernization-ui/src/apps/search/SearchPage.tsx
@@ -5,25 +5,32 @@ import { SortingProvider, SortingSettings } from 'libs/sorting';
 import { SearchResultDisplayProvider } from './useSearchResultDisplay';
 import { ComponentSizingProvider } from 'design-system/sizing';
 import { FilterProvider } from 'design-system/filter';
+import { usePageSizePreference } from './layout/result/pagination/page-size-select/usePageSizePreference';
 
 const SEARCH_PAGE_SIZE = 20;
 
 type SearchPageProviderProps = { sorting?: SortingSettings; paging?: PaginationSettings; children: ReactNode };
 
-const SearchPageProvider = ({ sorting, paging, children }: SearchPageProviderProps) => (
-    <ComponentSizingProvider>
-        <SortingProvider {...sorting} appendToUrl={sorting?.appendToUrl === undefined ? false : sorting.appendToUrl}>
-            <PaginationProvider
-                {...paging}
-                pageSize={paging?.pageSize || SEARCH_PAGE_SIZE}
-                appendToUrl={paging?.appendToUrl === undefined ? false : paging.appendToUrl}>
-                <FilterProvider>
-                    <SearchResultDisplayProvider>{children}</SearchResultDisplayProvider>
-                </FilterProvider>
-            </PaginationProvider>
-        </SortingProvider>
-    </ComponentSizingProvider>
-);
+const SearchPageProvider = ({ sorting, paging, children }: SearchPageProviderProps) => {
+    const { preferencePageSize } = usePageSizePreference(SEARCH_PAGE_SIZE);
+
+    return (
+        <ComponentSizingProvider>
+            <SortingProvider
+                {...sorting}
+                appendToUrl={sorting?.appendToUrl === undefined ? false : sorting.appendToUrl}>
+                <PaginationProvider
+                    {...paging}
+                    pageSize={paging?.pageSize || preferencePageSize}
+                    appendToUrl={paging?.appendToUrl === undefined ? false : paging.appendToUrl}>
+                    <FilterProvider>
+                        <SearchResultDisplayProvider>{children}</SearchResultDisplayProvider>
+                    </FilterProvider>
+                </PaginationProvider>
+            </SortingProvider>
+        </ComponentSizingProvider>
+    );
+};
 
 const SearchPage = (props: Omit<SearchPageProviderProps, 'children'>) => (
     <SearchPageProvider {...props}>

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/SearchResultPagination.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/SearchResultPagination.tsx
@@ -4,6 +4,7 @@ import { Shown } from 'conditional-render';
 import { Pagination } from 'design-system/pagination';
 import { SearchResultPageSizeSelect } from './page-size-select';
 import { SearchResultsShowing } from './showing';
+import { usePageSizePreference } from './page-size-select/usePageSizePreference';
 
 import styles from './search-result-pagination.module.scss';
 
@@ -16,6 +17,7 @@ type SearchPaginationProps = {
 
 const SearchResultPagination = ({ id, elementRef }: SearchPaginationProps) => {
     const { request, resize, page } = usePagination();
+    const { setPreferencePageSize } = usePageSizePreference(Math.min(...pageSizes));
 
     const minimum = Math.min(...pageSizes);
     const visible = page.total > minimum;
@@ -29,7 +31,10 @@ const SearchResultPagination = ({ id, elementRef }: SearchPaginationProps) => {
                     id={`${id}-page-size-select`}
                     value={page.pageSize}
                     selections={pageSizes}
-                    onPageSizeChanged={resize}
+                    onPageSizeChanged={(size) => {
+                        setPreferencePageSize(size);
+                        resize(size);
+                    }}
                 />
                 <SearchResultsShowing className={styles.showing} page={page} />
                 <div className={styles.pages}>

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/page-size-select/SearchResultPageSizeSelect.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/page-size-select/SearchResultPageSizeSelect.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent as ReactChangeEvent } from 'react';
 import classNames from 'classnames';
+import { usePageSizePreference } from './usePageSizePreference';
 
 import styles from './search-result-page-size-select.module.scss';
 
@@ -16,7 +17,9 @@ const SearchResultPageSizeSelect = ({
     value,
     onPageSizeChanged
 }: SearchResultPageSizeSelectProps) => {
-    const current = value ?? Math.min(...selections);
+    const defaultPageSize = Math.min(...selections);
+    const { preferencePageSize } = usePageSizePreference(defaultPageSize);
+    const current = value ?? preferencePageSize;
 
     const handleChange = (event: ReactChangeEvent<HTMLSelectElement>) => {
         const selected = Number(event.target.value);

--- a/apps/modernization-ui/src/apps/search/layout/result/pagination/page-size-select/usePageSizePreference.ts
+++ b/apps/modernization-ui/src/apps/search/layout/result/pagination/page-size-select/usePageSizePreference.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const PAGE_SIZE_PREFERENCE_KEY = 'patient-search-page-size';
+
+export const usePageSizePreference = (defaultPageSize: number) => {
+    const initPageSizePreference = () => {
+        const savedPageSize = localStorage.getItem(PAGE_SIZE_PREFERENCE_KEY);
+        return savedPageSize ? parseInt(savedPageSize, 10) : defaultPageSize;
+    };
+
+    const [preferencePageSize, setPreferencePageSize] = useState(initPageSizePreference);
+
+    useEffect(() => {
+        localStorage.setItem(PAGE_SIZE_PREFERENCE_KEY, preferencePageSize.toString());
+    }, [preferencePageSize]);
+
+    return { preferencePageSize, setPreferencePageSize };
+};


### PR DESCRIPTION
## Description

In Patient search results, currently Results per page preference is not saved for the user and user has to select results per page every time. The results per page now has a value in local storage that gets initialized and then read on reload or re navigation. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/NIS-24)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
