### PR TITLE
Update Patient Descriptor logic

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/patient-summary/PatientSummary.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/patient-summary/PatientSummary.spec.tsx
@@ -6,25 +6,37 @@ import { MergeCandidate } from '../../../../../api/model/MergeCandidate';
 import { PatientMergeForm } from '../../../merge-review/model/PatientMergeForm';
 
 describe('PatientSummary', () => {
-    it('renders the patient summary correctly', () => {
+    it('renders the most recent legal name and other fields correctly', () => {
         const mergeCandidates: MergeCandidate[] = [
             {
                 personUid: '123',
                 personLocalId: '98882',
                 addTime: '2023-05-31T00:00:00Z',
-                general:{},
+                general: {},
                 investigations: [],
                 adminComments: { date: '', comment: '' },
-                names: [{
-                    personUid: '123',
-                    sequence: '1',
-                    asOf: '',
-                    type: '',
-                    first: 'John',
-                    middle: 'Q',
-                    last: 'Public',
-                    suffix: 'Jr.'
-                }],
+                names: [
+                    {
+                        personUid: '123',
+                        sequence: '1',
+                        asOf: '2020-01-01T00:00:00Z',
+                        type: 'Legal',
+                        first: 'John',
+                        middle: 'Q',
+                        last: 'Public',
+                        suffix: 'Jr.'
+                    },
+                    {
+                        personUid: '123',
+                        sequence: '2',
+                        asOf: '2023-05-01T00:00:00Z',
+                        type: 'Legal',
+                        first: 'Johnny',
+                        middle: 'R',
+                        last: 'Citizen',
+                        suffix: ''
+                    }
+                ],
                 addresses: [],
                 phoneEmails: [],
                 identifications: [],
@@ -32,7 +44,7 @@ describe('PatientSummary', () => {
                 ethnicity: {},
                 sexAndBirth: {
                     currentSex: 'Male',
-                    dateOfBirth: '2003-11-10T00:00:00Z'
+                    dateOfBirth: '2003-11-10T12:00:00Z'
                 },
                 mortality: {}
             }
@@ -40,28 +52,46 @@ describe('PatientSummary', () => {
 
         const mergeFormData: PatientMergeForm = {
             survivingRecord: '123',
-            names: [{
-                personUid: '123',
-                sequence: '1',
-                asOf: '',
-                type: '',
-                first: 'John',
-                middle: 'Q',
-                last: 'Public',
-                suffix: 'Jr.'
-            }],
+            names: [
+                { personUid: '123', sequence: '1' },
+                { personUid: '123', sequence: '2' }
+            ],
+            addresses: [],
+            phoneEmails: [],
+            identifications: [],
+            races: [],
+            ethnicity: '',
             sexAndBirth: {
                 currentSex: '123',
                 dateOfBirth: '123'
-            }
-        } as any;
+            },
+            mortality: {},
+            generalInfo: {
+                asOf: '',
+                maritalStatus: '',
+                mothersMaidenName: '',
+                numberOfAdultsInResidence: '',
+                numberOfChildrenInResidence: '',
+                primaryOccupation: '',
+                educationLevel: '',
+                primaryLanguage: '',
+                speaksEnglish: '',
+                stateHivCaseId: ''
+            },
+            adminComments: ''
+        };
 
         render(<PatientSummary mergeCandidates={mergeCandidates} mergeFormData={mergeFormData} />);
 
-        expect(screen.getByRole('heading', { level: 2, name: (_content, element) =>
-                element?.textContent === 'Public, John Q, Jr.'
-        })).toBeInTheDocument();
+        // Most recent legal name: Citizen, Johnny R
+        expect(
+            screen.getByRole('heading', {
+                level: 2,
+                name: (_content, element) => element?.textContent === 'Citizen, Johnny R'
+            })
+        ).toBeInTheDocument();
 
         expect(screen.getByText('Male')).toBeInTheDocument();
+        expect(screen.getByText((text) => text.startsWith('11/10/2003'))).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Description

Bug: Patient Descriptor only shows Surviving patient's name. It should show the selected latest legal name instead 

## Demo


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
