### PR TITLE
[FIX] Fixes the Administrative Information transformer

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/demographics/administrative/transformer.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/file/demographics/administrative/transformer.spec.ts
@@ -1,0 +1,15 @@
+import { transformer } from './transformer';
+
+describe('Patient File Administrative Information transformer', () => {
+    it('should transform with as of date if present', () => {
+        const actual = transformer({ asOf: '2025-06-09T06:38:09' });
+
+        expect(actual).toEqual(expect.objectContaining({ asOf: new Date('2025-06-09T06:38:09') }));
+    });
+
+    it('should transform with comment if present', () => {
+        const actual = transformer({ comment: 'comment value' });
+
+        expect(actual).toEqual(expect.objectContaining({ comment: 'comment value' }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/file/demographics/administrative/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/file/demographics/administrative/transformer.ts
@@ -1,7 +1,8 @@
 import { Administrative } from 'generated';
 import { AdministrativeInformation } from 'libs/patient/demographics/AdministrativeInformation';
+import { maybeMap } from 'utils/mapping';
 
-const maybeDate = (value: string) => new Date(value);
+const maybeDate = maybeMap((value: string) => new Date(value));
 
 const transformer = (value: Administrative): AdministrativeInformation => ({
     ...value,


### PR DESCRIPTION
## Description

Changes the administrative information transformer to not require an `asOf` property,

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
