### PR TITLE
Hide AsOf when comment empty

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/administrative-comments/AdministrativeComments.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/administrative-comments/AdministrativeComments.spec.tsx
@@ -75,4 +75,50 @@ describe('AdministrativeComments', () => {
         expect(screen.getByText('05/30/2023')).toBeInTheDocument();
         expect(screen.getByText('This is a test comment')).toBeInTheDocument();
     });
+
+    it('hides the date when comment is empty', () => {
+        const mergeCandidates: MergeCandidate[] = [
+            {
+                personUid: '123',
+                personLocalId: '98882',
+                addTime: '2023-05-31T00:00:00Z',
+                general: {},
+                investigations: [],
+                adminComments: {
+                    date: '2023-05-31T00:00:00Z',
+                    comment: '', // intentionally empty
+                },
+                names: [],
+                addresses: [],
+                phoneEmails: [],
+                identifications: [],
+                races: [],
+                ethnicity: {},
+                sexAndBirth: {},
+                mortality: {},
+            },
+        ];
+
+        const mergeFormData: PatientMergeForm = {
+            survivingRecord: '123',
+            adminComments: '123',
+            names: [],
+            sexAndBirth: {},
+        } as any;
+
+        render(
+            <AdministrativeComments
+                mergeCandidates={mergeCandidates}
+                mergeFormData={mergeFormData}
+            />
+        );
+
+        //Confirm the date is not rendered
+        expect(screen.queryByText('05/31/2023')).not.toBeInTheDocument();
+
+        //Confirm the <p> tag is in the document, but empty
+        const commentParagraph = screen.getByRole('paragraph', { hidden: true }) || screen.getByText((_, el) => el?.tagName === 'P');
+        expect(commentParagraph).toBeInTheDocument();
+        expect(commentParagraph).toBeEmptyDOMElement();
+    });
 });

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/administrative-comments/AdministrativeComments.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/administrative-comments/AdministrativeComments.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { MergeCandidate } from '../../../../../api/model/MergeCandidate';
-import { PatientMergeForm } from '../../../merge-review/model/PatientMergeForm';
+import { format, parseISO, isValid } from 'date-fns';
 import { Card } from 'design-system/card/Card';
 import styles from './AdministrativeComments.module.scss';
-import { format, parseISO } from 'date-fns';
+import { MergeCandidate } from '../../../../../api/model/MergeCandidate';
+import { PatientMergeForm } from '../../../merge-review/model/PatientMergeForm';
 
 type AdministrativeCommentsProps = {
     mergeCandidates: MergeCandidate[];
@@ -11,22 +11,12 @@ type AdministrativeCommentsProps = {
 };
 
 export const AdministrativeComments = ({ mergeCandidates, mergeFormData }: AdministrativeCommentsProps) => {
-    const adminCommentsUid = mergeFormData.adminComments;
-    const adminCandidate = mergeCandidates.find((c) => c.personUid === adminCommentsUid);
+    const candidate = mergeCandidates.find((c) => c.personUid === mergeFormData.adminComments);
+    const comment = candidate?.adminComments?.comment?.trim() ?? '---';
+    const date = candidate?.adminComments?.date;
 
-    if (!adminCandidate || !adminCandidate.adminComments) {
-        return <div className={styles.noComments}>---</div>;
-    }
-
-    const { date = '', comment = '' } = adminCandidate.adminComments;
-    let formattedDate = 'No date available';
-    if (date) {
-        try {
-            formattedDate = format(parseISO(date), 'MM/dd/yyyy');
-        } catch (error) {
-            console.warn('Invalid date format:', date);
-        }
-    }
+    const formattedDate =
+        comment !== '---' && date && isValid(parseISO(date)) ? format(parseISO(date), 'MM/dd/yyyy') : undefined;
 
     return (
         <Card
@@ -36,7 +26,7 @@ export const AdministrativeComments = ({ mergeCandidates, mergeFormData }: Admin
             className={styles.adminCommentsCard}
             level={2}
             collapsible={false}>
-            <p className={styles.comment}>{comment ?? '---'}</p>
+            <p className={styles.comment}>{comment}</p>
         </Card>
     );
 };


### PR DESCRIPTION
## Description

As of should be hidden when Administrative comments is '---'

## Demo

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
