### PR TITLE
NIS-3 NIS-5 NIS-41 Reset NBS6 Session Timeout When Resetting NBS7 Timeout

### DIFF
--- a/apps/modernization-ui/src/authorization/IdleTimer.spec.tsx
+++ b/apps/modernization-ui/src/authorization/IdleTimer.spec.tsx
@@ -10,7 +10,7 @@ const timeout = 5000;
 const warningTimeout = 2000;
 
 const Fixture: React.FC<FixtureProps> = ({ onIdle }) => {
-    return <IdleTimer timeout={timeout} nbs6KeepAlivePath="/foo" warningTimeout={warningTimeout} onIdle={onIdle} />;
+    return <IdleTimer timeout={timeout} keepAlivePath="/foo" warningTimeout={warningTimeout} onIdle={onIdle} />;
 };
 
 describe('IdleTimer Component', () => {

--- a/apps/modernization-ui/src/authorization/IdleTimer.tsx
+++ b/apps/modernization-ui/src/authorization/IdleTimer.tsx
@@ -9,14 +9,14 @@ interface IdleTimerProps {
     timeout: number;
     /** Warning Timeout in milliseconds: amount of time modal shows before onIdle event is fired */
     warningTimeout: number;
-    nbs6KeepAlivePath: string;
+    keepAlivePath: string;
     /** Callback function to execute when idle */
     onIdle: () => void;
     /** Callback function to execute when user clicks continue */
     onContinue?: () => void;
 }
 
-const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, warningTimeout, nbs6KeepAlivePath, onIdle, onContinue }) => {
+const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, warningTimeout, keepAlivePath, onIdle, onContinue }) => {
     const [idle, setIdle] = useState(false);
     const idleTimer = useTimeout();
     const warningTimer = useTimeout();
@@ -47,7 +47,7 @@ const IdleTimer: React.FC<IdleTimerProps> = ({ timeout, warningTimeout, nbs6Keep
             true
         );
         countdown.clear();
-        fetch(nbs6KeepAlivePath);
+        fetch(keepAlivePath);
     }, [timeout, startWarningTimer]);
     const debouncedResetIdleTimer = useCallback(debounce(resetIdleTimer, 100), [resetIdleTimer]);
 

--- a/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
+++ b/apps/modernization-ui/src/authorization/ProtectedLayout.tsx
@@ -33,7 +33,7 @@ const ProtectedLayout = () => {
             <ConfigurationProvider initial={configuration}>
                 <IdleTimer
                     onIdle={handleIdle}
-                    nbs6KeepAlivePath={configuration.settings.session.nbs6KeepAlivePath}
+                    keepAlivePath={configuration.settings.session.keepAlivePath}
                     onContinue={handleIdleContinue}
                     timeout={configuration.settings.session.warning}
                     warningTimeout={configuration.settings.session.expiration - configuration.settings.session.warning}

--- a/apps/modernization-ui/src/configuration/configuration.ts
+++ b/apps/modernization-ui/src/configuration/configuration.ts
@@ -10,7 +10,7 @@ type Settings = {
     session: {
         warning: number;
         expiration: number;
-        nbs6KeepAlivePath: string;
+        keepAlivePath: string;
     };
     smarty?: {
         key: string;

--- a/apps/modernization-ui/src/configuration/defaults.ts
+++ b/apps/modernization-ui/src/configuration/defaults.ts
@@ -72,7 +72,7 @@ const defaultSettings: Settings = {
     session: {
         warning: 1000 * 60 * 18,
         expiration: 1000 * 60 * 20,
-        nbs6KeepAlivePath: '/nbs/HomePage.do?method=loadHomePage'
+        keepAlivePath: '/nbs/HomePage.do?method=loadHomePage'
     },
     defaults: {
         sizing: 'large'


### PR DESCRIPTION
## Description

Make a call to NBS6 on NBS7 idle timer reset.  That call to NBS6 should reset the JAVA session timeout.  make it configurable under `configuration.settings.session.nbs6KeepAlivePath` and default it to `/nbs/HomePage.do?method=loadHomePage`

## Tickets

* [NIS-3](https://cdc-nbs.atlassian.net/browse/NIS-3)
* [NIS-5](https://cdc-nbs.atlassian.net/browse/NIS-5)
 * [NIS-41](https://cdc-nbs.atlassian.net/browse/NIS-41)
 
## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[NIS-3]: https://cdc-nbs.atlassian.net/browse/NIS-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NIS-5]: https://cdc-nbs.atlassian.net/browse/NIS-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NIS-41]: https://cdc-nbs.atlassian.net/browse/NIS-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ