### PR TITLE
NIS-58: Handle enter key when no search criteria is entered

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
@@ -42,8 +42,8 @@ jest.mock('apps/search', () => ({
     })
 }));
 
-describe('when a search is performed without ', () => {
-    it('should render no input', () => {
+describe('SearchLayout', () => {
+    it('should render no input by default', () => {
         const { getByText } = render(
             <MemoryRouter>
                 <SkipLinkProvider>
@@ -63,5 +63,57 @@ describe('when a search is performed without ', () => {
         );
 
         expect(getByText(/You must enter at least one item to search/)).toBeInTheDocument();
+    });
+
+    it('calls onSearch when Enter is pressed on an input and searchEnabled is true', () => {
+        const onSearch = jest.fn();
+        const { getByTestId } = render(
+            <MemoryRouter>
+                <SkipLinkProvider>
+                    <SearchResultDisplayProvider>
+                        <FilterProvider>
+                            <SearchLayout
+                                criteria={() => <input data-testid="search-input" />}
+                                resultsAsList={jest.fn()}
+                                resultsAsTable={jest.fn()}
+                                onSearch={onSearch}
+                                onClear={jest.fn()}
+                                searchEnabled={true}
+                            />
+                        </FilterProvider>
+                    </SearchResultDisplayProvider>
+                </SkipLinkProvider>
+            </MemoryRouter>
+        );
+        const input = getByTestId('search-input');
+        input.focus();
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(onSearch).toHaveBeenCalled();
+    });
+
+    it('does not call onSearch when Enter is pressed on an input and searchEnabled is false', () => {
+        const onSearch = jest.fn();
+        const { getByTestId } = render(
+            <MemoryRouter>
+                <SkipLinkProvider>
+                    <SearchResultDisplayProvider>
+                        <FilterProvider>
+                            <SearchLayout
+                                criteria={() => <input data-testid="search-input" />}
+                                resultsAsList={jest.fn()}
+                                resultsAsTable={jest.fn()}
+                                onSearch={onSearch}
+                                onClear={jest.fn()}
+                                searchEnabled={false}
+                            />
+                        </FilterProvider>
+                    </SearchResultDisplayProvider>
+                </SkipLinkProvider>
+            </MemoryRouter>
+        );
+        const input = getByTestId('search-input');
+        input.focus();
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(onSearch).not.toHaveBeenCalled();
     });
 });

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -49,8 +49,8 @@ const SearchLayout = <R,>({
 
     const { view } = useSearchResultDisplay();
 
-    const handleKey = (event: ReactKeyboardEvent<HTMLInputElement>) => {
-        if (event.key === 'Enter') {
+    const handleKey = (event: ReactKeyboardEvent<HTMLElement>) => {
+        if (event.key === 'Enter' && event.target instanceof HTMLInputElement && searchEnabled) {
             onSearch();
         }
     };


### PR DESCRIPTION
## Description

When pressing Enter in the patient search form with no search criteria entered, the form searches anyway with no criteria. Fix to show no criteria entered message instead. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/NIS-58)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests