### PR TITLE
[CNFT1-4239]fix: remove key prop from Select to fix Windows dropdown arrow navigation

### DIFF
--- a/apps/modernization-ui/src/design-system/select/single/Select.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.tsx
@@ -48,7 +48,6 @@ const Select = ({
 
     return (
         <select
-            key={value?.value ?? ''}
             id={id}
             className={classNames('usa-select', className)}
             name={inputProps.name ?? id}

--- a/apps/modernization-ui/src/design-system/select/single/Select.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.tsx
@@ -51,7 +51,7 @@ const Select = ({
             id={id}
             className={classNames('usa-select', className)}
             name={inputProps.name ?? id}
-            value={value?.value}
+            value={value?.value ?? ''}
             onChange={handleChange}
             {...inputProps}>
             {renderOptions(options, placeholder)}


### PR DESCRIPTION
## Description
 
Select dropdown arrow key navigation was broken on Windows due to React remounting the component (which caused it to lose focus) on the select element when the key prop changed 

so I removed the unnecessary `key={value?.value ?? ''}` This prevents react from treating it as a new instance and keeps the focus as well when navigating using the down arrow key

## Tickets

* [CNFT1-4239]([CNFT1-4239](https://cdc-nbs.atlassian.net/browse/CNFT1-4239))

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4239]: https://cdc-nbs.atlassian.net/browse/CNFT1-4239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-4239]: https://cdc-nbs.atlassian.net/browse/CNFT1-4239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ