### PR TITLE
Fix styling in AdminComments and style date of death

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/administrative-comments/AdministrativeComments.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/administrative-comments/AdministrativeComments.module.scss
@@ -15,6 +15,7 @@
   font-weight: 400;
   color: colors.$base-black;
   white-space: pre-wrap;
+  word-break: break-word;
   padding-top: 0;
 }
 

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/mortality/PreviewMortality.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/mortality/PreviewMortality.spec.tsx
@@ -104,6 +104,6 @@ const mergeFormData: PatientMergeForm = {
 describe('PreviewMortality Component', () => {
     it('renders the mortality table', () => {
         const { getByText } = render(<Fixture />);
-        expect(getByText('2025-01-02')).toBeInTheDocument();
+        expect(getByText('01/02/2025')).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/mortality/PreviewMortality.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/mortality/PreviewMortality.tsx
@@ -23,7 +23,7 @@ export const PreviewMortality = ({
     const items = [
         { label: 'As of', text: formatDate(getField(m.asOf, 'asOf') as string), lined: true },
         { label: 'Is the patient deceased', text: getField(m.deceased, 'deceased'), lined: true },
-        { label: 'Date of death', text: getField(m.dateOfDeath, 'dateOfDeath'), lined: true },
+        { label: 'Date of death', text: formatDate(getField(m.dateOfDeath, 'dateOfDeath') as string), lined: true },
         { label: 'City of death', text: getField(m.deathCity, 'deathCity'), lined: true },
         { label: 'State of death', text: getField(m.deathState, 'deathState'), lined: true },
         { label: 'County of death', text: getField(m.deathState, 'deathCounty'), lined: true },


### PR DESCRIPTION
## Description
Bugs 🐞:
  1. Date of Death - timestamp is being added/timestamp is not required
  2. Admin Comments don't wrap when a large paragraph is typed in

## Tickets
* [CND-328](https://cdc-nbs.atlassian.net/browse/CND-328?focusedCommentId=33164)

## Demo
<img width="587" alt="image" src="https://github.com/user-attachments/assets/8c134a6b-a91c-42f0-a2a1-46a53a12f464" />

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CND-328]: https://cdc-nbs.atlassian.net/browse/CND-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ