### PR TITLE
CNFT1-4244 Headers in the add patient and extended forms should be links in order for them to be focused when user s navigate towards them via the in page navigation element

### DIFF
--- a/apps/modernization-ui/src/design-system/card/CardHeader.tsx
+++ b/apps/modernization-ui/src/design-system/card/CardHeader.tsx
@@ -21,9 +21,11 @@ const CardHeader = ({ id, title, level = 2, flair, control, actions, info, subte
         <header className={styles.header}>
             <div className={styles.titles}>
                 <span className={styles.title}>
-                    <Heading id={id} level={level}>
-                        {title}
-                    </Heading>
+                    <a href={`#${id}`} className={styles.titleLink}>
+                        <Heading id={id} level={level}>
+                            {title}
+                        </Heading>
+                    </a>
                     {flair}
                 </span>
                 {subtext && <div className={styles.subtext}>{subtext}</div>}

--- a/apps/modernization-ui/src/design-system/card/card-header.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card-header.module.scss
@@ -22,6 +22,26 @@
             display: flex;
             align-items: center;
             gap: 0.5rem;
+
+            .titleLink {
+                color: inherit;
+                text-decoration: none;
+                cursor: pointer;
+                border-radius: 0.15rem;
+
+                &:hover {
+                    text-decoration: underline;
+                }
+
+                &:focus {
+                    outline: 2px solid colors.$primary;
+                    outline-offset: 0.3rem;
+                }
+
+                &:focus:not(:focus-visible) {
+                    outline: none;
+                }
+            }
         }
     }
 

--- a/apps/modernization-ui/src/design-system/card/card-header.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card-header.module.scss
@@ -37,10 +37,6 @@
                     outline: 2px solid colors.$primary;
                     outline-offset: 0.3rem;
                 }
-
-                &:focus:not(:focus-visible) {
-                    outline: none;
-                }
             }
         }
     }

--- a/apps/modernization-ui/src/design-system/inPageNavigation/useInPageNavigation.ts
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/useInPageNavigation.ts
@@ -24,11 +24,22 @@ const useInPageNavigation = (threshold: number = 0) => {
 
         sections.forEach((section) => observer.observe(section));
 
-        const smoothScroll = (element: HTMLElement) => {
-            element.scrollIntoView({
+        const smoothScrollAndFocus = (section: HTMLElement) => {
+            // First scroll to the section.
+            section.scrollIntoView({
                 behavior: 'smooth',
                 block: 'start'
             });
+
+            // Focus on the header link after scroll complete.
+            setTimeout(() => {
+                const headerLink = section.querySelector('a[href^="#"]');
+                if (headerLink instanceof HTMLElement) {
+                    headerLink.focus();
+                }
+
+                // 500ms delay to allow scrolling to complete.
+            }, 500);
         };
 
         sections.forEach((section) => {
@@ -37,7 +48,7 @@ const useInPageNavigation = (threshold: number = 0) => {
             if (sectionLink) {
                 sectionLink.addEventListener('click', (event) => {
                     event.preventDefault();
-                    smoothScroll(section as HTMLElement);
+                    smoothScrollAndFocus(section as HTMLElement);
                 });
             }
         });


### PR DESCRIPTION
## Description

We need to have the headers be addressable by the in page navigation menu, in order to target them for focusing when the user clicks on the nav menu link. 

Wrapped the heading tag in an `a` tag with a hash route based on what the heading is.
Added styling to remove default link colors from headings and show focus. 

Focus on the header link after scroll complete.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNFT1-4244)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
