### PR TITLE
[FIX] Repeating Block borders

### DIFF
--- a/apps/modernization-ui/src/design-system/card/collapsible.module.scss
+++ b/apps/modernization-ui/src/design-system/card/collapsible.module.scss
@@ -13,6 +13,8 @@
 .collapsible {
     @include expanded('height');
     overflow: hidden;
+    border-end-start-radius: inherit;
+    border-end-end-radius: inherit;
 
     &.collapsed {
         @include collapsed('height');

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -7,7 +7,6 @@ $medium-height: 1.125rem;
 $large-height: 1.25rem;
 
 .card {
-    @extend %thin;
     background-color: colors.$base-white;
 
     .errorList {


### PR DESCRIPTION
## Description

Removes the border from `RepeatingBlock` to match the default `Card` designs.

![image](https://github.com/user-attachments/assets/27b16d21-147e-4e16-a6eb-62930ef67100)


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
