### PR TITLE
[CNFT1-4211] RepeatingBlock action column centered

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.module.scss
@@ -25,7 +25,6 @@ $large-height: 1.25rem;
             gap: 0.5rem;
             justify-content: center;
             align-items: center;
-            max-width: fit-content;
 
             & > button {
                 --button-padding: 0rem;
@@ -34,7 +33,7 @@ $large-height: 1.25rem;
                 --button-height: #{$medium-height};
                 --button-icon-size: #{$medium-height};
 
-                &.active {
+                &[aria-pressed='true'] {
                     border-radius: 0.25rem;
                     padding: 0.0625rem;
                     color: colors.$base-white;
@@ -83,7 +82,7 @@ $large-height: 1.25rem;
     .controls {
         display: flex;
         gap: 0.5rem;
-        padding-left: 15rem;
+        padding-left: 16rem;
 
         &.small {
             padding-left: 14rem;

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { RepeatingBlock } from './RepeatingBlock';
 import { Controller, useFormContext } from 'react-hook-form';
 import { SingleSelect } from 'design-system/select';
 import { asSelectable, Selectable } from 'options';
-import { Input } from 'components/FormInputs/Input';
-import { Sizing } from 'design-system/field';
-import { ValueView } from 'design-system/data-display/ValueView';
+import { Orientation, Sizing } from 'design-system/field';
+import { TextInputField } from 'design-system/input/text';
+import { RepeatingBlock } from './RepeatingBlock';
+import { DetailValue, DetailView } from './view/DetailView';
 
 type SampleType = {
     firstName: string;
@@ -30,7 +30,7 @@ const options: Selectable[] = [
     asSelectable('tomato', 'Tomato')
 ];
 
-const SampleForm = ({ sizing }: { sizing: Sizing }) => {
+const SampleForm = ({ sizing, orientation = 'horizontal' }: { sizing?: Sizing; orientation?: Orientation }) => {
     const { control } = useFormContext<SampleType>();
     return (
         <section>
@@ -39,15 +39,15 @@ const SampleForm = ({ sizing }: { sizing: Sizing }) => {
                 control={control}
                 rules={{ required: { value: true, message: 'First name is required.' } }}
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
-                    <Input
-                        flexBox
+                    <TextInputField
                         onBlur={onBlur}
                         onChange={onChange}
-                        defaultValue={value}
+                        value={value}
                         type="text"
                         label="First name"
                         id={name}
                         sizing={sizing}
+                        orientation={orientation}
                         error={error?.message}
                         required
                     />
@@ -57,14 +57,14 @@ const SampleForm = ({ sizing }: { sizing: Sizing }) => {
                 name="lastName"
                 control={control}
                 render={({ field: { onBlur, onChange, value, name } }) => (
-                    <Input
-                        flexBox
+                    <TextInputField
                         onBlur={onBlur}
                         onChange={onChange}
-                        defaultValue={value}
+                        value={value}
                         type="text"
                         label="Last name"
                         sizing={sizing}
+                        orientation={orientation}
                         id={name}
                     />
                 )}
@@ -76,7 +76,7 @@ const SampleForm = ({ sizing }: { sizing: Sizing }) => {
                 render={({ field: { onBlur, onChange, value, name }, fieldState: { error } }) => (
                     <SingleSelect
                         label="Favorite veggie"
-                        orientation="horizontal"
+                        orientation={orientation}
                         value={value}
                         onBlur={onBlur}
                         sizing={sizing}
@@ -93,12 +93,12 @@ const SampleForm = ({ sizing }: { sizing: Sizing }) => {
     );
 };
 
-const SampleView = ({ entry, sizing }: { entry: SampleType; sizing: Sizing }) => (
-    <>
-        <ValueView title="First name" value={entry.firstName} sizing={sizing} />
-        <ValueView title="Last name" value={entry.lastName} sizing={sizing} />
-        <ValueView title="Favorite veggie" value={entry.veggie?.name} sizing={sizing} />
-    </>
+const SampleView = ({ entry }: { entry: SampleType }) => (
+    <DetailView>
+        <DetailValue label="First name">{entry.firstName}</DetailValue>
+        <DetailValue label="Last name">{entry.lastName}</DetailValue>
+        <DetailValue label="Favorite veggie">{entry.veggie?.name}</DetailValue>
+    </DetailView>
 );
 
 const columns = [
@@ -125,8 +125,6 @@ const defaultValue: Partial<SampleType> = {
     veggie: undefined
 };
 
-const defaultSizing: Sizing = 'small';
-
 const handleChange = (values: SampleType[]) => {
     console.log('Values:', values);
 };
@@ -141,8 +139,8 @@ export const Default: Story = {
             { firstName: 'test', lastName: 'test', veggie: asSelectable('carrot', 'Carrot') },
             { firstName: 'test1', lastName: 'test1', veggie: asSelectable('eggplant', 'Eggplant') }
         ],
-        formRenderer: () => <SampleForm sizing={defaultSizing} />,
-        viewRenderer: (entry: SampleType) => <SampleView entry={entry} sizing={defaultSizing} />,
+        formRenderer: (_entry, sizing) => <SampleForm sizing={sizing} />,
+        viewRenderer: (entry) => <SampleView entry={entry} />,
         onChange: handleChange,
         isDirty: () => {},
         isValid: () => {}

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useMemo } from 'react';
-import { DefaultValues, FieldValues, FormProvider, useForm } from 'react-hook-form';
+import { DefaultValues, FieldValues, FormProvider, useForm, UseFormReturn } from 'react-hook-form';
 import classNames from 'classnames';
 import { Shown } from 'conditional-render';
 import { Button } from 'design-system/button';
@@ -10,7 +10,7 @@ import { Tag } from 'design-system/tag';
 import { AlertMessage } from 'design-system/message';
 import { Column, DataTable, DataTableFeatures } from 'design-system/table';
 import { Required } from '../required/Required';
-import { Entry, useMultiValueEntry } from './useMultiValueEntry';
+import { Entry, MultiValueEntryInteraction, useMultiValueEntry } from './useMultiValueEntry';
 import { entryIdentifierGenerator } from './entryIdentifierGenerator';
 import { entryColumns } from './entryColumns';
 
@@ -20,16 +20,18 @@ type RepeatingBlockProps<V extends FieldValues> = {
     features?: DataTableFeatures;
     columns: Column<V>[];
     data?: V[];
+    sizing?: Sizing;
+    // view properties
+    viewable?: boolean;
+    viewRenderer: (entry: V, sizing?: Sizing) => ReactNode;
+    // edit properties
+    editable?: boolean;
     defaultValues?: DefaultValues<V>; // Provide all default values to allow `isDirty` to function
     errors?: ReactNode[];
-    sizing?: Sizing;
-    viewable?: boolean;
-    editable?: boolean;
     onChange?: (data: V[]) => void;
     isDirty?: (isDirty: boolean) => void;
     isValid?: (isValid: boolean) => void;
-    formRenderer: (entry?: V) => ReactNode;
-    viewRenderer: (entry: V) => ReactNode;
+    formRenderer: (entry?: V, sizing?: Sizing) => ReactNode;
 } & Pick<CardProps, 'id' | 'title' | 'collapsible'>;
 
 const RepeatingBlock = <V extends FieldValues>({
@@ -40,7 +42,7 @@ const RepeatingBlock = <V extends FieldValues>({
     columns,
     data = [],
     defaultValues,
-    errors,
+    errors = [],
     sizing,
     viewable = true,
     editable = true,
@@ -52,7 +54,7 @@ const RepeatingBlock = <V extends FieldValues>({
 }: RepeatingBlockProps<V>) => {
     const form = useForm<V>({ mode: 'onSubmit', reValidateMode: 'onBlur', defaultValues });
 
-    const { status, entries, selected, using, add, edit, update, remove, view, reset } = useMultiValueEntry<V>({
+    const interaction = useMultiValueEntry<V>({
         values: data,
         identifierGenerator: entryIdentifierGenerator,
         onChange
@@ -60,7 +62,7 @@ const RepeatingBlock = <V extends FieldValues>({
 
     useEffect(() => {
         // if the data changes use the new values
-        using(data);
+        interaction.using(data);
     }, [JSON.stringify(data)]);
 
     useEffect(() => {
@@ -75,41 +77,13 @@ const RepeatingBlock = <V extends FieldValues>({
     useEffect(() => {
         // Perform form reset after status update to allow time for rendering of form
         // fixes issue with coded values not being selected within the form
-        if (status === 'editing' && selected) {
-            form.reset(selected.value);
+        if (interaction.status === 'editing' && interaction.selected) {
+            form.reset(interaction.selected.value);
         } else {
             // Conversely, if status is not editing, reset to default values to clear form between state changes
             form.reset(defaultValues);
         }
-    }, [status, selected, form.reset]);
-
-    const handleReset = () => {
-        form.reset(defaultValues);
-        reset();
-    };
-
-    const handleClear = () => {
-        form.reset(defaultValues);
-    };
-
-    const handleAdd = (value: V) => {
-        // form reset must be triggered prior to `add` call,
-        // otherwise internal form state retains some values and fails to properly reset
-        form.reset(defaultValues);
-        add(value);
-    };
-
-    const handleUpdate = (value: V) => {
-        form.reset(defaultValues);
-        update(value);
-    };
-
-    const handleRemove = (identifier: string) => {
-        if ((status === 'editing' || status === 'viewing') && selected?.id === identifier) {
-            form.reset(defaultValues);
-        }
-        remove(identifier);
-    };
+    }, [interaction.status, interaction.selected?.value, form.reset]);
 
     const adjustedColumns = entryColumns(columns);
 
@@ -117,58 +91,22 @@ const RepeatingBlock = <V extends FieldValues>({
         id: 'actions',
         label: 'Actions',
         className: styles['action-header'],
-        render: (entry: Entry<V>) => (
-            <div className={styles.actions}>
-                {viewable && (
-                    <Button
-                        tertiary
-                        data-tooltip-position="top"
-                        aria-label="View"
-                        onClick={() => view(entry.id)}
-                        className={classNames({
-                            [styles.active]: status === 'viewing' && selected?.id === entry.id
-                        })}
-                        icon={<Icon name="visibility" />}
-                    />
-                )}
-                {editable && (
-                    <>
-                        <Button
-                            tertiary
-                            data-tooltip-position="top"
-                            aria-label="Edit"
-                            onClick={() => edit(entry.id)}
-                            className={classNames({
-                                [styles.active]: status === 'editing' && selected?.id === entry.id
-                            })}
-                            icon={<Icon name="edit" />}
-                        />
-                        <Button
-                            tertiary
-                            data-tooltip-position="top"
-                            aria-label="Delete"
-                            onClick={() => handleRemove(entry.id)}
-                            icon={<Icon name="delete" />}
-                        />
-                    </>
-                )}
-            </div>
-        )
+        render: renderActionColumn({ sizing, interaction, viewable, editable, form, defaultValues })
     };
 
     // Combine error message prop and internal form error messages into an array for display in the banner
     const errorMessages = useMemo<ReactNode[]>(() => {
         const formErrorMessages = Object.values(form.formState.errors).map((error) => error?.message?.toString());
-        const messages: ReactNode[] = [...(errors ?? []), ...formErrorMessages];
+        const messages: ReactNode[] = [...errors, ...formErrorMessages];
 
         return messages.filter((a) => a != undefined);
     }, [JSON.stringify(form.formState.errors), errors]);
 
     useEffect(() => {
-        isValid?.(!errorMessages || errorMessages.length === 0);
-    }, [errorMessages]);
+        isValid?.(errorMessages.length === 0);
+    }, [errorMessages.length]);
 
-    const opened = collapsible ? entries.length > 0 : true;
+    const opened = collapsible ? interaction.entries.length > 0 : true;
 
     return (
         <Card
@@ -176,60 +114,23 @@ const RepeatingBlock = <V extends FieldValues>({
             title={title}
             collapsible={collapsible}
             sizing={sizing}
-            flair={<Tag size={sizing}>{entries.length}</Tag>}
+            flair={<Tag size={sizing}>{interaction.entries.length}</Tag>}
             className={classNames(styles.card)}
             info={editable && <Required />}
             open={opened}
             footer={
-                <Shown when={editable}>
-                    <span
-                        className={classNames(styles.controls, {
-                            [styles.small]: sizing === 'small',
-                            [styles.medium]: sizing === 'medium',
-                            [styles.large]: sizing === 'large'
-                        })}>
-                        <Shown when={status === 'adding'}>
-                            <Button
-                                secondary
-                                icon={<Icon name="add" />}
-                                sizing={sizing}
-                                aria-description={`add ${title.toLowerCase()}`}
-                                onClick={form.handleSubmit(handleAdd)}>
-                                {`Add ${title.toLowerCase()}`}
-                            </Button>
-                            <Shown when={form.formState.isDirty || errorMessages.length !== 0}>
-                                <Button
-                                    secondary
-                                    sizing={sizing}
-                                    aria-description={`clear ${title.toLowerCase()}`}
-                                    onClick={handleClear}
-                                    onMouseDown={
-                                        (e) => e.preventDefault() /* prevent need to double click after blur */
-                                    }>
-                                    Clear
-                                </Button>
-                            </Shown>
-                        </Shown>
-                        <Shown when={status === 'editing'}>
-                            <Button
-                                secondary
-                                sizing={sizing}
-                                aria-description={`update ${title.toLowerCase()}`}
-                                onClick={form.handleSubmit(handleUpdate)}>
-                                {`Update ${title.toLowerCase()}`}
-                            </Button>
-                            <Button
-                                secondary
-                                sizing={sizing}
-                                aria-description={`cancel editing current ${title.toLowerCase()}`}
-                                onClick={handleReset}>
-                                Cancel
-                            </Button>
-                        </Shown>
-                    </span>
+                <Shown when={editable && interaction.status !== 'viewing'}>
+                    <EditFooter
+                        title={title}
+                        sizing={sizing}
+                        form={form}
+                        interaction={interaction}
+                        defaultValues={defaultValues}
+                        clearable={form.formState.isDirty || errorMessages.length !== 0}
+                    />
                 </Shown>
             }>
-            <Shown when={errorMessages && errorMessages.length > 0}>
+            <Shown when={errorMessages.length > 0}>
                 <AlertMessage title="Please fix the following errors:" type="error">
                     <ul className={styles.errorList}>
                         {errorMessages.map((e, i) => (
@@ -246,18 +147,20 @@ const RepeatingBlock = <V extends FieldValues>({
                 })}
                 id={`${id}-table`}
                 columns={[...adjustedColumns, actions]}
-                data={entries}
+                data={interaction.entries}
                 sizing={sizing}
                 features={features}
             />
-            <Shown when={viewable && status === 'viewing'}>
-                {selected && <div className={styles.view}>{viewRenderer(selected.value)}</div>}
+            <Shown when={viewable && interaction.status === 'viewing'}>
+                {interaction.selected && (
+                    <div className={styles.view}>{viewRenderer(interaction.selected.value, sizing)}</div>
+                )}
             </Shown>
 
-            <Shown when={editable && status !== 'viewing'}>
+            <Shown when={editable && interaction.status !== 'viewing'}>
                 <FormProvider {...form}>
                     <div className={classNames(styles.form, { [styles.changed]: form.formState.isDirty })}>
-                        {formRenderer(selected?.value)}
+                        {formRenderer(interaction.selected?.value, sizing)}
                     </div>
                 </FormProvider>
             </Shown>
@@ -267,3 +170,169 @@ const RepeatingBlock = <V extends FieldValues>({
 
 export { RepeatingBlock };
 export type { RepeatingBlockProps };
+
+type ActionColumnOptions<T extends FieldValues> = {
+    form: UseFormReturn<T>;
+    interaction: MultiValueEntryInteraction<T>;
+    viewable: boolean;
+    editable: boolean;
+    defaultValues?: DefaultValues<T>;
+    sizing?: Sizing;
+};
+
+const renderActionColumn = <E extends FieldValues>({
+    form,
+    defaultValues,
+    interaction,
+    viewable,
+    editable,
+    sizing
+}: ActionColumnOptions<E>) => {
+    const handleRemove = (identifier: string) => {
+        if (interaction.selected?.id === identifier) {
+            // the entry being removed is the one currently selected, reset the form.
+            form.reset(defaultValues);
+        }
+        interaction.remove(identifier);
+    };
+
+    // eslint-disable-next-line react/display-name
+    return (entry: Entry<E>) => (
+        <ActionColumn
+            sizing={sizing}
+            viewable={viewable}
+            onView={() => interaction.view(entry.id)}
+            isViewing={interaction.status === 'viewing' && interaction.selected?.id === entry.id}
+            editable={editable}
+            onEdit={() => interaction.edit(entry.id)}
+            isEditing={interaction.status === 'editing' && interaction.selected?.id === entry.id}
+            onRemove={() => handleRemove(entry.id)}
+        />
+    );
+};
+
+type ActionColumnProps = {
+    sizing?: Sizing;
+    viewable: boolean;
+    onView: () => void;
+    isViewing: boolean;
+    editable: boolean;
+    onEdit: () => void;
+    isEditing: boolean;
+    onRemove: () => void;
+};
+
+const ActionColumn = ({ viewable, onView, isViewing, editable, onEdit, isEditing, onRemove }: ActionColumnProps) => (
+    <div className={styles.actions}>
+        {viewable && (
+            <Button
+                tertiary
+                data-tooltip-position="top"
+                aria-label="View"
+                onClick={onView}
+                aria-pressed={isViewing}
+                icon={<Icon name="visibility" />}
+            />
+        )}
+        {editable && (
+            <>
+                <Button
+                    tertiary
+                    data-tooltip-position="top"
+                    aria-label="Edit"
+                    onClick={onEdit}
+                    aria-pressed={isEditing}
+                    icon={<Icon name="edit" />}
+                />
+                <Button
+                    tertiary
+                    data-tooltip-position="top"
+                    aria-label="Delete"
+                    onClick={onRemove}
+                    icon={<Icon name="delete" />}
+                />
+            </>
+        )}
+    </div>
+);
+
+type EditFooterProps<T extends FieldValues> = {
+    form: UseFormReturn<T>;
+    interaction: MultiValueEntryInteraction<T>;
+    title: string;
+    clearable: boolean;
+    defaultValues?: DefaultValues<T>;
+    sizing?: Sizing;
+};
+
+const EditFooter = <E extends FieldValues>({
+    form,
+    interaction,
+    title,
+    clearable,
+    defaultValues,
+    sizing
+}: EditFooterProps<E>) => {
+    const handleClear = () => {
+        form.reset(defaultValues);
+    };
+
+    const handleAdd = (value: E) => {
+        // form reset must be triggered prior to `add` call,
+        // otherwise internal form state retains some values and fails to properly reset
+        form.reset(defaultValues);
+        interaction.add(value);
+    };
+
+    const handleUpdate = (value: E) => {
+        // set the form values to the updated values sync the pending state
+        form.reset(defaultValues);
+        interaction.update(value);
+    };
+
+    return (
+        <span
+            className={classNames(styles.controls, {
+                [styles.small]: sizing === 'small',
+                [styles.medium]: sizing === 'medium',
+                [styles.large]: sizing === 'large'
+            })}>
+            <Shown when={interaction.status === 'adding'}>
+                <Button
+                    secondary
+                    icon={<Icon name="add" />}
+                    sizing={sizing}
+                    aria-description={`add ${title}`}
+                    onClick={form.handleSubmit(handleAdd)}>
+                    {`Add ${title.toLowerCase()}`}
+                </Button>
+                <Shown when={clearable}>
+                    <Button
+                        secondary
+                        sizing={sizing}
+                        aria-description={`clear ${title}`}
+                        onClick={handleClear}
+                        onMouseDown={(e) => e.preventDefault()}>
+                        Clear
+                    </Button>
+                </Shown>
+            </Shown>
+            <Shown when={interaction.status === 'editing'}>
+                <Button
+                    secondary
+                    sizing={sizing}
+                    aria-description={`update ${title}`}
+                    onClick={form.handleSubmit(handleUpdate)}>
+                    {`Update ${title.toLowerCase()}`}
+                </Button>
+                <Button
+                    secondary
+                    sizing={sizing}
+                    aria-description={`cancel editing current ${title}`}
+                    onClick={interaction.reset}>
+                    Cancel
+                </Button>
+            </Shown>
+        </span>
+    );
+};

--- a/apps/modernization-ui/src/design-system/entry/multi-value/useMultiValueEntry.ts
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/useMultiValueEntry.ts
@@ -211,4 +211,4 @@ const useMultiValueEntry = <E>({
 };
 
 export { useMultiValueEntry };
-export type { MultiValueEntrySettings, Entry };
+export type { MultiValueEntrySettings, MultiValueEntryInteraction, Entry };


### PR DESCRIPTION
## Description

The action column that is added to the table within a `RepeatingBlock` is now centered.

![image](https://github.com/user-attachments/assets/73832eff-a371-4c3e-b085-076138086353)

## Tickets

* [CNFT1-4211](https://cdc-nbs.atlassian.net/browse/CNFT1-4211)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
