### PR TITLE
Set deceased in MortalitySelection

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/mortality/MortalitySelection.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/mortality/MortalitySelection.tsx
@@ -26,6 +26,7 @@ export const MortalitySelection = ({ mergeCandidates }: Props) => {
         // going from deceased 'Yes' to 'Yes' does NOT update all values
         const newIsDeceased = deceasedEntries.some((m) => m.personUid === selectedPerson);
         if (!previousWasDeceased || !newIsDeceased) {
+            form.setValue('mortality.deceased', selectedPerson);
             form.setValue('mortality.dateOfDeath', selectedPerson);
             form.setValue('mortality.deathCity', selectedPerson);
             form.setValue('mortality.deathState', selectedPerson);


### PR DESCRIPTION
## Description

Bug 🐞: If there is are two records on the comparison screen where one patient is deceased and one is not, when you select the as of date for the deceased both records become deceased.

## Tickets
* [CND-353](https://cdc-nbs.atlassian.net/browse/CND-353?atlOrigin=eyJpIjoiZWYwNWIwYzVmMWZkNDExZThhZmIyYTBiZWEwMjJhZTAiLCJwIjoiaiJ9)

## Demo


## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CND-353]: https://cdc-nbs.atlassian.net/browse/CND-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ