### PR TITLE
[CNFT1-4202] Modal styles

### DIFF
--- a/apps/modernization-ui/src/design-system/modal/Modal.tsx
+++ b/apps/modernization-ui/src/design-system/modal/Modal.tsx
@@ -1,10 +1,11 @@
 import { ReactNode, KeyboardEvent as ReactKeyboardEvent, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import classNames from 'classnames';
-
-import sprite from '@uswds/uswds/img/sprite.svg';
+import { Button } from 'design-system/button';
 
 import styles from './modal.module.scss';
-import { createPortal } from 'react-dom';
+import { Heading } from 'components/heading';
+import { Icon } from 'design-system/icon';
 
 type Close = () => void;
 
@@ -75,18 +76,16 @@ const Component = ({
                     data-force-action={forceAction}
                     open>
                     <header id={header} className={'usa-modal__heading'}>
-                        <h2>{title}</h2>
+                        <Heading level={2}>{title}</Heading>
                         {!forceAction && (
-                            <svg
-                                tabIndex={0}
-                                role="button"
-                                width={'2rem'}
-                                height={'2rem'}
+                            <Button
+                                className={styles.closer}
+                                tertiary
                                 aria-label={`Close ${title}`}
+                                icon={<Icon name="close" />}
                                 onClick={onClose}
-                                data-close-modal>
-                                <use xlinkHref={`${sprite}#close`}></use>
-                            </svg>
+                                data-close-modal
+                            />
                         )}
                     </header>
                     <div className={'usa-modal__content'}>

--- a/apps/modernization-ui/src/design-system/modal/modal.module.scss
+++ b/apps/modernization-ui/src/design-system/modal/modal.module.scss
@@ -4,12 +4,12 @@
 @use 'styles/borders';
 @use 'styles/media';
 
-$min-height: 240px;
+$min-height: 15rem;
 $max-height: 90vh;
-$min-width: 480px;
+$min-width: 30rem;
 $max-width: 1100px;
-$header-height: 4.625rem;
-$footer-height: 5.75rem;
+$header-height: 3.625rem;
+$footer-height: 4.75rem;
 
 .overlay {
     z-index: 1000;
@@ -46,16 +46,15 @@ $footer-height: 5.75rem;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        align-items: center;
 
-        padding: 1.5rem;
+        padding: 1rem;
         max-height: $header-height;
 
-        svg {
-            cursor: pointer;
-        }
+        @extend %thin-bottom;
 
-        h2 {
-            margin: 0;
+        button.closer {
+            color: colors.$base-black;
         }
     }
 
@@ -63,7 +62,9 @@ $footer-height: 5.75rem;
         min-height: calc($min-height - $header-height - $footer-height);
         max-height: calc($max-height - $header-height - $footer-height);
 
-        padding: 1.5rem !important;
+        display: flex;
+        align-items: center;
+        padding: 1rem 1.5rem !important;
 
         overflow-y: auto;
     }
@@ -72,7 +73,7 @@ $footer-height: 5.75rem;
         display: flex;
         justify-content: flex-end;
         gap: 0.5rem;
-        padding: 1.5rem;
+        padding: 1rem;
         max-height: $footer-height;
         margin-top: 0;
 


### PR DESCRIPTION
## Description

Updates the `Modal` component to use the updated styles for the header and footer.

![image](https://github.com/user-attachments/assets/867c572e-2e4a-4bf0-87fc-9ff8df17528d)

## Tickets

* [CNFT1-4202](https://cdc-nbs.atlassian.net/browse/CNFT1-4202)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4202]: https://cdc-nbs.atlassian.net/browse/CNFT1-4202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ