### PR TITLE
[CNFT1-4258] DataTable sort icons

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/events/labReports/LabReportsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/labReports/LabReportsCard.tsx
@@ -53,21 +53,20 @@ const LabReportsCard = ({ patient }: LabReportsCardProps) => {
             ...EVENT_ID,
             sortable: true,
             value: (value) => value.eventId,
-            render: (value: PatientLabReport) => (
-                <a href={`/nbs/api/profile/${patient}/report/lab/${value.id}`}>{value.eventId}</a>
-            )
+            render: (value) => <a href={`/nbs/api/profile/${patient}/report/lab/${value.id}`}>{value.eventId}</a>
         },
         {
             ...DATE_RECEIVED,
             sortable: true,
             value: (value) => value.receivedDate,
-            render: (value: PatientLabReport) => internalizeDateTime(value.receivedDate)
+            render: (value) => internalizeDateTime(value.receivedDate),
+            sortIconType: 'numeric'
         },
         {
             ...FACILITY_PROVIDER,
             sortable: true,
             value: (value) => value.reportingFacility,
-            render: (value: PatientLabReport) =>
+            render: (value) =>
                 renderFacilityProvider(
                     value.reportingFacility,
                     value.orderingProvider,
@@ -79,7 +78,8 @@ const LabReportsCard = ({ patient }: LabReportsCardProps) => {
             ...DATE_COLLECTED,
             sortable: true,
             value: (value) => value.collectedDate,
-            render: (value: PatientLabReport) => internalizeDate(value.collectedDate)
+            render: (value) => internalizeDate(value.collectedDate),
+            sortIconType: 'numeric'
         },
         {
             ...TEST_RESULTS,
@@ -90,7 +90,7 @@ const LabReportsCard = ({ patient }: LabReportsCardProps) => {
             ...ASSOCIATED_WITH,
             sortable: true,
             value: (value) => value.associatedInvestigation?.id,
-            render: (value: PatientLabReport) =>
+            render: (value) =>
                 value.associatedInvestigation && (
                     <div>
                         <a href={`/nbs/api/profile/${patient}/investigation/${value.associatedInvestigation.id}`}>

--- a/apps/modernization-ui/src/apps/patient/file/summary/documentRequiringReview/PatientDocumentRequiringReview.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/summary/documentRequiringReview/PatientDocumentRequiringReview.tsx
@@ -56,6 +56,7 @@ const columns: Column<DocumentRequiringReview>[] = [
     {
         ...DATE_RECEIVED,
         sortable: true,
+        sortIconType: 'numeric',
         value: (value) => value.dateReceived,
         render: (value) => renderDateReceived(value.dateReceived)
     },
@@ -67,6 +68,7 @@ const columns: Column<DocumentRequiringReview>[] = [
     {
         ...EVENT_DATE,
         sortable: true,
+        sortIconType: 'numeric',
         value: (value) => value.eventDate,
         render: (value) => renderEventDate(value.eventDate)
     },

--- a/apps/modernization-ui/src/apps/patient/file/summary/openInvestigations/OpenInvestigationsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/summary/openInvestigations/OpenInvestigationsCard.tsx
@@ -36,7 +36,8 @@ const columns: Column<PatientInvestigation>[] = [
     {
         ...START_DATE,
         sortable: true,
-        value: (value) => value.startedOn
+        value: (value) => value.startedOn,
+        sortIconType: 'numeric'
     },
     {
         ...CONDITION,

--- a/apps/modernization-ui/src/design-system/table/header/ColumnHeader.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/ColumnHeader.tsx
@@ -129,27 +129,9 @@ const resolveSortIcon = (direction: Direction, type?: SortIconType) => {
     }
 };
 
-const resolveAscendingIcon = (type?: SortIconType) => {
-    switch (type) {
-        case 'alpha':
-            return 'sort_asc_alpha';
-        case 'numeric':
-            return 'sort_asc_numeric';
-        default:
-            return 'sort_asc_default';
-    }
-};
+const resolveAscendingIcon = (type?: SortIconType) => (type === 'numeric' ? 'sort_asc_numeric' : 'sort_asc_alpha');
 
-const resolveDescendingIcon = (type?: SortIconType) => {
-    switch (type) {
-        case 'alpha':
-            return 'sort_des_alpha';
-        case 'numeric':
-            return 'sort_des_numeric';
-        default:
-            return 'sort_des_default';
-    }
-};
+const resolveDescendingIcon = (type?: SortIconType) => (type === 'numeric' ? 'sort_des_numeric' : 'sort_des_alpha');
 
 const resolveSortAria = (direction: Direction) => {
     switch (direction) {

--- a/apps/modernization-ui/src/design-system/table/header/column.ts
+++ b/apps/modernization-ui/src/design-system/table/header/column.ts
@@ -2,7 +2,7 @@ import { FilterDescriptor } from 'design-system/filter';
 import { ReactNode } from 'react';
 import { Mapping } from 'utils/mapping';
 
-type SortIconType = 'default' | 'alpha' | 'numeric';
+type SortIconType = 'alpha' | 'numeric';
 
 type CellValue = string | number | boolean | Date;
 
@@ -17,13 +17,15 @@ type Rendered<R, C = CellValue> =
 type BaseColumn<R, C> = {
     id: string;
     fixed?: boolean;
-    sortable?: boolean;
     className?: string;
-    filter?: FilterDescriptor;
-    sortIconType?: SortIconType;
 } & Rendered<R, C>;
 
-type NamedColumn<R, C = CellValue> = BaseColumn<R, C> & { name: string };
+type NamedColumn<R, C = CellValue> = BaseColumn<R, C> & {
+    name: string;
+    filter?: FilterDescriptor;
+    sortable?: boolean;
+    sortIconType?: SortIconType;
+};
 type LabeledColumn<R, C = CellValue> = BaseColumn<R, C> & { label: string };
 
 type Column<R, C = CellValue> = NamedColumn<R, C> | LabeledColumn<R, C>;

--- a/apps/modernization-ui/src/design-system/table/sortable/SortableDataTable.stories.tsx
+++ b/apps/modernization-ui/src/design-system/table/sortable/SortableDataTable.stories.tsx
@@ -31,8 +31,7 @@ const columns: Column<Person>[] = [
         id: 'name',
         name: 'Name',
         sortable: true,
-        value: (value: Person) => value.name,
-        sortIconType: 'alpha'
+        value: (value: Person) => value.name
     },
     {
         id: 'email',
@@ -44,7 +43,8 @@ const columns: Column<Person>[] = [
         id: 'dob',
         name: 'DOB',
         sortable: true,
-        value: (value: Person) => value.dob
+        value: (value: Person) => value.dob,
+        sortIconType: 'numeric'
     }
 ];
 


### PR DESCRIPTION
## Description

The default sorting icons are now the alpha sorting icons.

## Tickets

* [CNFT1-4258](https://cdc-nbs.atlassian.net/browse/CNFT1-4258)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4258]: https://cdc-nbs.atlassian.net/browse/CNFT1-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ