### PR TITLE
[FIX] modal width

### DIFF
--- a/apps/modernization-ui/src/design-system/modal/modal.module.scss
+++ b/apps/modernization-ui/src/design-system/modal/modal.module.scss
@@ -8,15 +8,13 @@
     z-index: 1000;
 }
 
-.modal {
+dialog.modal {
     left: auto;
     right: auto;
 
     border: none;
 
     background-color: colors.$base-white !important;
-
-    min-width: unset;
 
     &.small {
         width: 30rem;
@@ -26,10 +24,7 @@
         width: 55rem;
     }
 
-    &.unbounded {
-        height: clamp(15rem, 55rem, 90dvh);
-        width: clamp(30rem, 55rem, 90dvw);
-    }
+    max-width: clamp(30rem, 55rem, 90dvw);
 
     header.header {
         display: flex;


### PR DESCRIPTION
## Description

Ensures that the `Modal` component width does not come from the `usa-modal` styles.


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
