### PR TITLE
Dedupe Permissions

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
@@ -12,9 +12,7 @@ const routing = [
         path: '/deduplication/configuration',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
-                <Permitted
-                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<RedirectHome />}>
+                <Permitted permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')} fallback={<RedirectHome />}>
                     <PageTitle title="Person match configuration">
                         <MatchConfigurationLandingPage />
                     </PageTitle>
@@ -26,9 +24,7 @@ const routing = [
         path: '/deduplication/data_elements',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
-                <Permitted
-                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<RedirectHome />}>
+                <Permitted permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')} fallback={<RedirectHome />}>
                     <PageTitle title="Person match configuration">
                         <DataElementConfig />
                     </PageTitle>
@@ -40,9 +36,7 @@ const routing = [
         path: '/deduplication/merge',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
-                <Permitted
-                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<RedirectHome />}>
+                <Permitted permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')} fallback={<RedirectHome />}>
                     <PageTitle title="Patient Merge">
                         <MergeLanding />
                     </PageTitle>
@@ -54,9 +48,7 @@ const routing = [
         path: '/deduplication/merge/:matchId',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
-                <Permitted
-                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<RedirectHome />}>
+                <Permitted permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')} fallback={<RedirectHome />}>
                     <PageTitle title="Patient matches requiring review">
                         <MergeDetails />
                     </PageTitle>

--- a/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
@@ -4,15 +4,21 @@ import { MatchConfigurationLandingPage } from './configuration/MatchConfiguratio
 import { DataElementConfig } from './data-elements/DataElementConfig';
 import { MergeDetails } from './patient-merge/details/MergeDetails';
 import { MergeLanding } from './patient-merge/landing/MergeLanding';
+import { permitsAll, Permitted } from '../../libs/permission';
+import { Navigate } from 'react-router';
 
 const routing = [
     {
         path: '/deduplication/configuration',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
-                <PageTitle title="Person match configuration">
-                    <MatchConfigurationLandingPage />
-                </PageTitle>
+                <Permitted
+                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    fallback={<Navigate to="/search" replace />}>
+                    <PageTitle title="Person match configuration">
+                        <MatchConfigurationLandingPage />
+                    </PageTitle>
+                </Permitted>
             </FeatureGuard>
         )
     },
@@ -20,9 +26,13 @@ const routing = [
         path: '/deduplication/data_elements',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
-                <PageTitle title="Person match configuration">
-                    <DataElementConfig />
-                </PageTitle>
+                <Permitted
+                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    fallback={<Navigate to="/search" replace />}>
+                    <PageTitle title="Person match configuration">
+                        <DataElementConfig />
+                    </PageTitle>
+                </Permitted>
             </FeatureGuard>
         )
     },
@@ -30,9 +40,13 @@ const routing = [
         path: '/deduplication/merge',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
-                <PageTitle title="Patient Merge">
-                    <MergeLanding />
-                </PageTitle>
+                <Permitted
+                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    fallback={<Navigate to="/search" replace />}>
+                    <PageTitle title="Patient Merge">
+                        <MergeLanding />
+                    </PageTitle>
+                </Permitted>
             </FeatureGuard>
         )
     },
@@ -40,9 +54,13 @@ const routing = [
         path: '/deduplication/merge/:matchId',
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
-                <PageTitle title="Patient matches requiring review">
-                    <MergeDetails />
-                </PageTitle>
+                <Permitted
+                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    fallback={<Navigate to="/search" replace />}>
+                    <PageTitle title="Patient matches requiring review">
+                        <MergeDetails />
+                    </PageTitle>
+                </Permitted>
             </FeatureGuard>
         )
     }

--- a/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
@@ -5,7 +5,7 @@ import { DataElementConfig } from './data-elements/DataElementConfig';
 import { MergeDetails } from './patient-merge/details/MergeDetails';
 import { MergeLanding } from './patient-merge/landing/MergeLanding';
 import { permitsAll, Permitted } from '../../libs/permission';
-import { Navigate } from 'react-router';
+import { RedirectHome } from '../../routes';
 
 const routing = [
     {
@@ -14,7 +14,7 @@ const routing = [
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
                 <Permitted
                     permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<Navigate to="/search" replace />}>
+                    fallback={<RedirectHome />}>
                     <PageTitle title="Person match configuration">
                         <MatchConfigurationLandingPage />
                     </PageTitle>
@@ -28,7 +28,7 @@ const routing = [
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
                 <Permitted
                     permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<Navigate to="/search" replace />}>
+                    fallback={<RedirectHome />}>
                     <PageTitle title="Person match configuration">
                         <DataElementConfig />
                     </PageTitle>
@@ -42,7 +42,7 @@ const routing = [
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
                 <Permitted
                     permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<Navigate to="/search" replace />}>
+                    fallback={<RedirectHome />}>
                     <PageTitle title="Patient Merge">
                         <MergeLanding />
                     </PageTitle>
@@ -56,7 +56,7 @@ const routing = [
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
                 <Permitted
                     permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
-                    fallback={<Navigate to="/search" replace />}>
+                    fallback={<RedirectHome />}>
                     <PageTitle title="Patient matches requiring review">
                         <MergeDetails />
                     </PageTitle>

--- a/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/DeduplicationRouting.tsx
@@ -13,7 +13,7 @@ const routing = [
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
                 <Permitted
-                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
                     fallback={<Navigate to="/search" replace />}>
                     <PageTitle title="Person match configuration">
                         <MatchConfigurationLandingPage />
@@ -27,7 +27,7 @@ const routing = [
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.enabled}>
                 <Permitted
-                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
                     fallback={<Navigate to="/search" replace />}>
                     <PageTitle title="Person match configuration">
                         <DataElementConfig />
@@ -41,7 +41,7 @@ const routing = [
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
                 <Permitted
-                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
                     fallback={<Navigate to="/search" replace />}>
                     <PageTitle title="Patient Merge">
                         <MergeLanding />
@@ -55,7 +55,7 @@ const routing = [
         element: (
             <FeatureGuard guard={(features) => features?.deduplication?.merge.enabled}>
                 <Permitted
-                    permission={permitsAll('permissions.patient.merge', 'permissions.patient.search')}
+                    permission={permitsAll('MERGE-PATIENT', 'FIND-PATIENT')}
                     fallback={<Navigate to="/search" replace />}>
                     <PageTitle title="Patient matches requiring review">
                         <MergeDetails />

--- a/apps/modernization-ui/src/libs/permission/permissions.ts
+++ b/apps/modernization-ui/src/libs/permission/permissions.ts
@@ -30,6 +30,7 @@ export const permissions = {
         search: 'FIND-PATIENT',
         searchInactive: 'FINDINACTIVE-PATIENT',
         update: 'EDIT-PATIENT',
-        view: 'VIEW-PATIENT'
+        view: 'VIEW-PATIENT',
+        merge: 'MERGE-PATIENT'
     }
 };

--- a/apps/modernization-ui/src/routes/RedirectHome.tsx
+++ b/apps/modernization-ui/src/routes/RedirectHome.tsx
@@ -9,7 +9,7 @@ const RedirectHome = () => {
 
     const path = search.view.enabled ? '/search' : '/advanced-search';
 
-    return <Navigate to={path} />;
+    return <Navigate to={path} replace />;
 };
 
 export { RedirectHome };


### PR DESCRIPTION
## Description
If the user lacks the merge patient permission, they should not be able to access the deduplication configuration or patient merge screens.

## Tickets
* [CND-362](https://cdc-nbs.atlassian.net/browse/CND-362?atlOrigin=eyJpIjoiZDAwNTE0NmEzOWMzNDBhYWJhYzUwZjliMTUzZTNhZjAiLCJwIjoiaiJ9)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CND-362]: https://cdc-nbs.atlassian.net/browse/CND-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ