### PR TITLE
Cnft1 4289 shortcut search

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.spec.tsx
@@ -48,9 +48,10 @@ type FixtureProps = {
     criteria?: () => ReactNode;
     searchEnabled?: boolean;
     onSearch?: () => void;
+    actions?: (buttonRef?: React.RefObject<HTMLButtonElement>) => ReactNode;
 };
 
-const Fixture = ({ criteria, searchEnabled, onSearch }: FixtureProps) => (
+const Fixture = ({ criteria, searchEnabled, onSearch, actions }: FixtureProps) => (
     <MemoryRouter>
         <SkipLinkProvider>
             <SearchResultDisplayProvider>
@@ -62,6 +63,7 @@ const Fixture = ({ criteria, searchEnabled, onSearch }: FixtureProps) => (
                         onSearch={onSearch ?? jest.fn()}
                         onClear={jest.fn()}
                         searchEnabled={searchEnabled}
+                        actions={actions}
                     />
                 </FilterProvider>
             </SearchResultDisplayProvider>
@@ -108,5 +110,25 @@ describe('SearchLayout', () => {
         button.focus();
         await user.keyboard('{Enter}');
         expect(onSearch).not.toHaveBeenCalled();
+    });
+
+    it('clicks action button when Alt+A is pressed', async () => {
+        const user = userEvent.setup();
+        const mockClick = jest.fn();
+
+        const actions = (buttonRef?: React.RefObject<HTMLButtonElement>) => (
+            <button ref={buttonRef} onClick={mockClick}>
+                Action
+            </button>
+        );
+
+        const { getByRole } = render(<Fixture criteria={() => <input type="text" />} actions={actions} />);
+
+        const input = getByRole('textbox');
+        input.focus();
+
+        await user.keyboard('{Alt>}a{/Alt}');
+
+        expect(mockClick).toHaveBeenCalled();
     });
 });

--- a/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/SearchLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, KeyboardEvent as ReactKeyboardEvent } from 'react';
+import React, { ReactNode, KeyboardEvent as ReactKeyboardEvent, useRef } from 'react';
 import { Button } from 'components/button';
 import { Loading } from 'components/Spinner';
 import { Sizing } from 'design-system/field';
@@ -15,7 +15,7 @@ import { FeatureToggle } from 'feature';
 
 import styles from './search-layout.module.scss';
 
-type Renderer = () => ReactNode;
+type Renderer = (actionButtonRef?: React.RefObject<HTMLButtonElement>) => ReactNode;
 
 type Props = {
     sizing?: Sizing;
@@ -42,6 +42,7 @@ const SearchLayout = <R,>({
     noInput = () => <NoInput />,
     noResults = () => <NoResults />
 }: Props) => {
+    const actionButtonRef = useRef<HTMLButtonElement>(null);
     const {
         status,
         results: { total, terms }
@@ -52,6 +53,9 @@ const SearchLayout = <R,>({
     const handleKey = (event: ReactKeyboardEvent<HTMLElement>) => {
         if (event.key === 'Enter' && searchEnabled && !(event.target instanceof HTMLButtonElement)) {
             onSearch();
+        }
+        if (event.key === 'a' && event.altKey) {
+            actionButtonRef?.current?.click();
         }
     };
 
@@ -106,7 +110,7 @@ const SearchLayout = <R,>({
                 </div>
             </div>
             <Shown when={!!actions}>
-                <div className={styles.actions}>{actions?.()}</div>
+                <div className={styles.actions}>{actions?.(actionButtonRef)}</div>
             </Shown>
         </section>
     );

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.spec.tsx
@@ -68,13 +68,13 @@ describe('SearchTerms', () => {
 
     it('has correct aria-label', () => {
         const { getByLabelText } = render(<SearchTerms total={2} terms={terms} />);
-        const resultsCountDiv = getByLabelText('2 Results have been found');
+        const resultsCountDiv = getByLabelText('2 Results have been found, press Alt + A to add a new patient');
         expect(resultsCountDiv).toBeInTheDocument();
     });
 
     it('has correct aria-label singular form when total is 1', () => {
         const { getByLabelText } = render(<SearchTerms total={1} terms={terms} />);
-        const resultsCountDiv = getByLabelText('1 Result has been found');
+        const resultsCountDiv = getByLabelText('1 Result has been found, press Alt + A to add a new patient');
         expect(resultsCountDiv).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/terms/SearchTerms.tsx
@@ -14,7 +14,7 @@ type Props = {
 const SearchTerms = ({ total, terms }: Props) => {
     const resultsText = pluralize('Result', total);
     const verbText = pluralize('has', total, 'have');
-    const ariaLabel = `${total} ${resultsText} ${verbText} been found`;
+    const ariaLabel = `${total} ${resultsText} ${verbText} been found, press Alt + A to add a new patient`;
 
     const { without } = useSearchInteraction();
 

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearch.tsx
@@ -40,7 +40,12 @@ const PatientSearch = () => {
                         <FormProvider {...form}>
                             <SearchLayout
                                 sizing={sizing}
-                                actions={() => <PatientSearchActions disabled={interaction.status !== 'completed'} />}
+                                actions={(buttonRef) => (
+                                    <PatientSearchActions
+                                        disabled={interaction.status !== 'completed'}
+                                        buttonRef={buttonRef}
+                                    />
+                                )}
                                 criteria={() => <PatientCriteria sizing={sizing} />}
                                 resultsAsList={() => (
                                     <SearchResultList<PatientSearchResult>

--- a/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/PatientSearchActions.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Button } from 'components/button';
 import { useAddPatientFromSearch } from './add/useAddPatientFromSearch';
 import { permissions, Permitted } from 'libs/permission';
@@ -5,14 +6,20 @@ import { Icon } from 'design-system/icon';
 
 type Props = {
     disabled: boolean;
+    buttonRef?: React.RefObject<HTMLButtonElement>;
 };
 
-const PatientSearchActions = ({ disabled }: Props) => {
+const PatientSearchActions = ({ disabled, buttonRef }: Props) => {
     const { add } = useAddPatientFromSearch();
 
     return (
         <Permitted permission={permissions.patient.add}>
-            <Button type="button" onClick={add} disabled={disabled} icon={<Icon name="add_circle" />}>
+            <Button
+                buttonRef={buttonRef}
+                type="button"
+                onClick={add}
+                disabled={disabled}
+                icon={<Icon name="add_circle" />}>
                 Add new patient
             </Button>
         </Permitted>

--- a/apps/modernization-ui/src/design-system/button/Button.tsx
+++ b/apps/modernization-ui/src/design-system/button/Button.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { Sizing } from 'design-system/field';
 import { buttonClassnames } from './buttonClassNames';
 
@@ -13,6 +13,7 @@ type StandardButtonProps = {
     sizing?: Sizing;
     tertiary?: boolean;
     labelPosition?: 'left' | 'right';
+    buttonRef?: React.RefObject<HTMLButtonElement>;
 };
 
 type ButtonProps = {
@@ -37,6 +38,7 @@ const Button = ({
     outline,
     unstyled,
     children,
+    buttonRef,
     ...defaultProps
 }: ButtonProps) => {
     const classes = buttonClassnames({
@@ -52,7 +54,7 @@ const Button = ({
     });
 
     return (
-        <button className={classes} {...defaultProps} type={type} disabled={disabled}>
+        <button ref={buttonRef} className={classes} {...defaultProps} type={type} disabled={disabled}>
             {icon}
             {children}
         </button>


### PR DESCRIPTION
## Description
Added a Alt + A keyboard shortcut to quickly add a new patient from search results, with screen reader support

-Added keyboard event handler to trigger add patient action when Alt + A is pressed after a search is made and the button is enabled.

## Tickets

* [CNFT1-4289](https://cdc-nbs.atlassian.net/browse/CNFT1-4289)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
