### PR TITLE
[CNFT1-4305] Adds fallback to desc values for resulted tests

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/events/tests/ResultedTestResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/events/tests/ResultedTestResolver.java
@@ -16,17 +16,23 @@ public class ResultedTestResolver {
 
   private static final String QUERY = """
       select
-              [lab_result_components].target_act_uid      as [observation],
-              [lab_test].lab_test_desc_txt                as [name],
-              [lab_result_status].[code_short_desc_txt]   as [status],
-              [coded_result].lab_result_desc_txt          as [coded],
-              [numeric].comparator_cd_1                   as [comparator],
-              [numeric].numeric_value_1                   as [numeric],
-              [numeric].numeric_scale_1                   as [scale],
-              [numeric].high_range                        as [high_range],
-              [numeric].low_range                         as [low_range],
-              [numeric].numeric_unit_cd                   as [unit],
-              [text].value_txt                            as [text]
+          [lab_result_components].target_act_uid          as [observation],
+          coalesce(
+                  [lab_test].lab_test_desc_txt,
+                  [lab_result].cd_desc_txt
+          )                                               as [name],
+          [lab_result_status].[code_short_desc_txt]       as [status],
+          coalesce(
+                  [coded_result].lab_result_desc_txt,
+                  [coded].display_name
+          )                                               as [coded],
+          [numeric].comparator_cd_1                       as [comparator],
+          [numeric].numeric_value_1                       as [numeric],
+          [numeric].numeric_scale_1                       as [scale],
+          [numeric].high_range                            as [high_range],
+          [numeric].low_range                             as [low_range],
+          [numeric].numeric_unit_cd                       as [unit],
+          [text].value_txt                                as [text]
       from  Act_relationship [lab_result_components]
               join observation [lab_result] with (nolock) on
                           [lab_result].observation_uid = [lab_result_components].[source_act_uid]

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/events/tests/ResultedTestRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/events/tests/ResultedTestRowMapper.java
@@ -40,8 +40,9 @@ class ResultedTestRowMapper implements RowMapper<ResultedTest> {
     String name = resultSet.getString(columns.name());
     String reference = maybeDisplayReferenceRange(columns, resultSet);
 
-    Optional<String> status = maybeDisplayStatus(columns, resultSet)
-        .filter(unused -> reference == null);
+    String status = maybeDisplayStatus(columns, resultSet)
+        .filter(unused -> reference == null)
+        .orElse("");
 
     String coded = resultSet.getString(columns.coded());
 
@@ -49,23 +50,17 @@ class ResultedTestRowMapper implements RowMapper<ResultedTest> {
 
     String numeric = maybeDisplayNumericResult(columns, resultSet);
 
-    String result = null;
-
-    if (coded != null) {
-      result = coded;
-    }
-
-    if (text != null) {
-      result = result == null ? text : result.concat("\n").concat(text);
-    }
-
-    if (numeric != null) {
-      result = result == null ? numeric : result.concat("\n").concat(numeric);
-    }
-
-    result = Objects.requireNonNullElse(result, "").concat(status.orElse(""));
-
-
+    String result =
+        Stream.of(
+                coded, text, numeric
+            ).filter(value -> value != null && !value.isEmpty())
+            .collect(
+                joining(
+                    "\n",
+                    "",
+                    status
+                )
+            );
 
     return new ResultedTest(
         name,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/laboratory/PatientLabReportsRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/laboratory/PatientLabReportsRowMapper.java
@@ -88,6 +88,6 @@ class PatientLabReportsRowMapper implements RowMapper<PatientLabReport> {
     String source = resultSet.getString(this.columns.specimenSource());
     String site = resultSet.getString(this.columns.specimenSite());
 
-    return (source != null || site != null) ? new PatientLabReport.Specimen(source, site) : null;
+    return (source != null || site != null) ? new PatientLabReport.Specimen(site, source) : null;
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/laboratory/PatientLabReportsRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/laboratory/PatientLabReportsRowMapper.java
@@ -18,6 +18,7 @@ class PatientLabReportsRowMapper implements RowMapper<PatientLabReport> {
       int local,
       int programArea,
       int jurisdiction,
+      int processingDecision,
       int dateReceived,
       int electronic,
       int reportingFacility,
@@ -28,9 +29,9 @@ class PatientLabReportsRowMapper implements RowMapper<PatientLabReport> {
       int specimenSource
   ) {
     Column() {
-      this(1, 2, 3, 4, 5, 6, 7, 8, 9,
-          new DisplayableSimpleNameRowMapper.Columns(10, 11,12),
-          13, 14, 15
+      this(1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+          new DisplayableSimpleNameRowMapper.Columns(11, 12, 13),
+          14, 15, 16
       );
     }
   }
@@ -55,7 +56,7 @@ class PatientLabReportsRowMapper implements RowMapper<PatientLabReport> {
     String local = resultSet.getString(this.columns.local());
     LocalDateTime dateReceived = resultSet.getObject(this.columns.dateReceived(), LocalDateTime.class);
     boolean electronic = resultSet.getBoolean(this.columns.electronic());
-    String processingDecision = resultSet.getString(this.columns.specimenSite());
+    String processingDecision = resultSet.getString(this.columns.processingDecision());
     LocalDate dateCollected = LocalDateColumnMapper.map(resultSet, this.columns.dateCollected());
     String jurisdiction = resultSet.getString(this.columns.jurisdiction());
     String programArea = resultSet.getString(this.columns.programArea());

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/LabReportMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/LabReportMother.java
@@ -365,4 +365,18 @@ public class LabReportMother {
         .update();
   }
 
+   void specimen(
+       final LabReportIdentifier report,
+       final String site
+   ) {
+     this.client.sql("""
+            update Observation set
+                target_site_cd = ?
+            where observation_uid = ?
+            """
+         )
+         .param(site)
+         .param(report.identifier())
+         .update();
+  }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/LabReportOrderedTestSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/LabReportOrderedTestSteps.java
@@ -1,0 +1,37 @@
+package gov.cdc.nbs.event.report.lab;
+
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Given;
+
+public class LabReportOrderedTestSteps {
+
+  private final Active<LabReportIdentifier> activeReport;
+  private final LabReportMother reportMother;
+  private final MaterialMother materialMother;
+
+  LabReportOrderedTestSteps(
+      final Active<LabReportIdentifier> activeReport,
+      final LabReportMother reportMother,
+      final MaterialMother materialMother
+  ) {
+    this.activeReport = activeReport;
+    this.reportMother = reportMother;
+    this.materialMother = materialMother;
+  }
+
+  @Given("the laboratory report has an ordered test with a specimen from the {specimenSite}")
+  public void specimenSite(final String site) {
+    specimen(null, site);
+  }
+
+  @Given("the laboratory report has an ordered test with a {specimenSource} specimen from the {specimenSite}")
+  public void specimen(final String source, final String site) {
+    activeReport.maybeActive()
+        .ifPresent(report -> reportMother.specimen(report, site));
+
+    if (source != null) {
+      activeReport.maybeActive()
+          .ifPresent(report -> materialMother.create(report, source));
+    }
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/MaterialMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/MaterialMother.java
@@ -1,0 +1,109 @@
+package gov.cdc.nbs.event.report.lab;
+
+import gov.cdc.nbs.identity.MotherSettings;
+import gov.cdc.nbs.testing.data.TestingDataCleaner;
+import gov.cdc.nbs.testing.identity.SequentialIdentityGenerator;
+import io.cucumber.spring.ScenarioScope;
+import jakarta.annotation.PreDestroy;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@ScenarioScope
+class MaterialMother {
+
+  private static final String CREATE = """
+      insert into Entity (entity_uid, class_cd) values (:identifier, 'MAT');
+      
+      insert into Material(
+          material_uid,
+          local_id,
+          cd,
+          version_ctrl_nbr,
+          record_status_cd,
+          record_status_time,
+          add_time,
+          add_user_id
+      ) values (
+          :identifier,
+          :local,
+          :source,
+          1,
+          'ACTIVE',
+          :addedOn,
+          :addedOn,
+          :addedBy
+      );
+      
+      insert into Participation(
+          act_uid,
+          act_class_cd,
+          type_cd,
+          record_status_cd,
+          record_status_time,
+          add_user_id,
+          add_time,
+          subject_class_cd,
+          subject_entity_uid
+      ) values (
+          :report,
+          'OBS',
+          'SPC',
+          'ACTIVE',
+          :addedOn,
+          :addedBy,
+          :addedOn,
+          'MAT',
+          :identifier
+      );
+      """;
+
+  private static final String DELETE = """
+      delete from Participation where subject_class_cd = 'MAT' and subject_entity_uid in (:identifiers);
+      
+      delete from Material where material_uid in (:identifiers);
+      
+      delete from Entity where class_cd = 'MAT' and entity_uid in (:identifiers);
+      """;
+
+  private final MotherSettings settings;
+  private final SequentialIdentityGenerator idGenerator;
+  private final JdbcClient client;
+  private final TestingDataCleaner<Long> cleaner;
+
+  MaterialMother(
+      final MotherSettings settings,
+      final SequentialIdentityGenerator idGenerator,
+      final JdbcClient client
+  ) {
+    this.settings = settings;
+    this.idGenerator = idGenerator;
+    this.client = client;
+    this.cleaner = new TestingDataCleaner<>(client, DELETE, "identifiers");
+  }
+
+  @PreDestroy
+  void reset() {
+    this.cleaner.clean();
+  }
+
+  void create(
+      final LabReportIdentifier report,
+      final String source
+  ) {
+    long identifier = idGenerator.next();
+    String local = idGenerator.nextLocal("MAT");
+
+    client.sql(CREATE)
+        .param("identifier", identifier)
+        .param("source", source)
+        .param("local", local)
+        .param("report", report.identifier())
+        .param("addedOn", this.settings.createdOn())
+        .param("addedBy", this.settings.createdBy())
+        .update();
+
+    this.cleaner.include(identifier);
+
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/SpecimenSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/report/lab/SpecimenSteps.java
@@ -1,0 +1,25 @@
+package gov.cdc.nbs.event.report.lab;
+
+import gov.cdc.nbs.testing.support.concept.ConceptParameterResolver;
+import io.cucumber.java.ParameterType;
+
+public class SpecimenSteps {
+
+  private final ConceptParameterResolver resolver;
+
+  SpecimenSteps(final ConceptParameterResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @ParameterType(name = "specimenSite", value = ".*")
+  public String specimenSite(final String value) {
+    return resolver.resolve("ANATOMIC_SITE", value)
+        .orElse(value);
+  }
+
+  @ParameterType(name = "specimenSource", value = ".*")
+  public String specimenSource(final String value) {
+    return resolver.resolve("SPECMN_SRC", value)
+        .orElse(value);
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/events/tests/ResultedTestRowMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/events/tests/ResultedTestRowMapperTest.java
@@ -64,6 +64,24 @@ class ResultedTestRowMapperTest {
   }
 
   @Test
+  void should_map_non_empty_results_with_status_from_result_set() throws SQLException {
+
+    ResultSet resultSet = mock(ResultSet.class);
+
+    when(resultSet.getString(columns.name())).thenReturn("name-value");
+    when(resultSet.getString(columns.coded())).thenReturn("coded-value");
+    when(resultSet.getString(columns.text())).thenReturn("");
+    when(resultSet.getString(columns.status())).thenReturn("status-value");
+
+    ResultedTestRowMapper mapper = new ResultedTestRowMapper(columns);
+
+    ResultedTest mapped = mapper.mapRow(resultSet, 0);
+
+    assertThat(mapped.name()).isEqualTo("name-value");
+    assertThat(mapped.result()).isEqualTo("coded-value - (status-value)");
+  }
+
+  @Test
   void should_map_coded_result_with_reference_range_from_result_set() throws SQLException {
 
     ResultSet resultSet = mock(ResultSet.class);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/reports/laboratory/PatientFileLaboratoryReportVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/reports/laboratory/PatientFileLaboratoryReportVerificationSteps.java
@@ -171,4 +171,29 @@ public class PatientFileLaboratoryReportVerificationSteps {
             ).value(hasItem(empty()))
         );
   }
+
+  @Then("the patient file has the laboratory report containing an ordered test with a specimen from the {string}")
+  public void specimenSite(final String value) throws Exception {
+    String local = this.activeReport.maybeActive().map(LabReportIdentifier::local).orElse(null);
+    this.response.active()
+        .andExpect(
+            jsonPath(
+                "$.[?(@.local=='%s' && @.specimen.site=='%s')]",
+                local, value
+            ).exists()
+        );
+  }
+
+  @Then(
+      "the patient file has the laboratory report containing an ordered test with a {string} specimen from the {string}")
+  public void specimenSource(final String source, final String site) throws Exception {
+    String local = this.activeReport.maybeActive().map(LabReportIdentifier::local).orElse(null);
+    this.response.active()
+        .andExpect(
+            jsonPath(
+                "$.[?(@.local=='%s' && @.specimen.source=='%s' && @.specimen.site=='%s')]",
+                local, source, site
+            ).exists()
+        );
+  }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.laboratory-report.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.laboratory-report.feature
@@ -56,6 +56,18 @@ Feature: Patient File Laboratory Report
     When I view the laboratory reports for the patient
     Then the patient file has the laboratory report associated with the investigation
 
+  Scenario: I can retrieve Laboratory Reports with tests ordered for a patient
+    Given the patient has a laboratory report
+    And the laboratory report has an ordered test with a specimen from the Cornea
+    When I view the laboratory reports for the patient
+    Then the patient file has the laboratory report containing an ordered test with a specimen from the "Cornea"
+
+  Scenario: I can retrieve Laboratory Reports with specimen tests ordered for a patient
+    Given the patient has a laboratory report
+    And the laboratory report has an ordered test with a Calculus (=Stone) specimen from the Right Naris
+    When I view the laboratory reports for the patient
+    Then the patient file has the laboratory report containing an ordered test with a "Calculus (=Stone)" specimen from the "Right Naris"
+
   Scenario: I cannot retrieve Laboratory Report associated investigations for a patient without permissions
     Given the patient is a subject of an investigation
     And the patient has a laboratory report


### PR DESCRIPTION
## Description

The name of a resulted test on an ELR are not likely to use the DEFAULT code system, when this happens the API will fall back to the descriptions that are populated along side the coded values.

- Feature test steps were added to allow testing of specimen source and specimen site.

## Tickets

* [CNFT1-4305](https://cdc-nbs.atlassian.net/browse/CNFT1-4305)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4305]: https://cdc-nbs.atlassian.net/browse/CNFT1-4305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ