### PR TITLE
[FIX] Mocks now for date sensitive test

### DIFF
--- a/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/list/PatientSearchResultListItem.spec.tsx
@@ -3,7 +3,17 @@ import { MemoryRouter } from 'react-router';
 import { PatientSearchResultListItem } from './PatientSearchResultListItem';
 import { PatientSearchResult } from 'generated/graphql/schema';
 
+const mockNow = jest.fn();
+
+jest.mock('design-system/date/clock', () => ({
+    now: () => mockNow()
+}));
+
 describe('PatientSearchResultListItem', () => {
+    beforeEach(() => {
+        mockNow.mockReturnValue(new Date('2025-01-25T00:00:00'));
+    });
+
     it('should render the patient name', () => {
         const patient: PatientSearchResult = {
             patient: 829,


### PR DESCRIPTION
## Description

Fixes a fragile test that performed a date calculation without mocking `now()`.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
