### PR TITLE
CNFT1-4307:adding required asterisk for screen reader accessibility

### DIFF
--- a/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.tsx
+++ b/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.tsx
@@ -74,7 +74,7 @@ export const CheckboxGroup = ({
                     styles.fieldSet
                 )}
                 aria-required={required}
-                aria-label={label}>
+                aria-label={`${label} ${required ? '*' : ''}`}>
                 {items.map((item, index) => (
                     <SelectableCheckbox
                         name={name}


### PR DESCRIPTION
## Description

Add required indicator (*) to CheckboxGroup aria-label for screen reader accessibility

- Include asterisk in fieldset aria-label when required=true
- Ensures screen readers announce required status since checkboxes don't have direct label relationship
- Maintains parity between visual and screen reader experience
## Tickets

* [CNFT1-4307](https://cdc-nbs.atlassian.net/browse/CNFT1-4307)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4307]: https://cdc-nbs.atlassian.net/browse/CNFT1-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ