### PR TITLE
[CNFT1-4314] OrElseNoData now uses exists

### DIFF
--- a/apps/modernization-ui/src/design-system/data/OrElseNoData.spec.tsx
+++ b/apps/modernization-ui/src/design-system/data/OrElseNoData.spec.tsx
@@ -1,16 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { OrElseNoData } from './OrElseNoData';
 
-describe('NoData Component', () => {
-    it('should display "---" ', () => {
-        render(<OrElseNoData>{undefined}</OrElseNoData>);
+describe('OrElseNoData', () => {
+    it.each([undefined, null])('should display "---" when %s', (value) => {
+        render(<OrElseNoData>{value}</OrElseNoData>);
 
         expect(screen.getByText('---')).toBeInTheDocument();
     });
 
-    it('should display content', () => {
-        render(<OrElseNoData>{'testing'}</OrElseNoData>);
+    it.each(['testing', 0])('should display content: %s', (value) => {
+        render(<OrElseNoData>{value}</OrElseNoData>);
 
-        expect(screen.getByText('testing')).toBeInTheDocument();
+        expect(screen.getByText(`${value}`)).toBeInTheDocument();
     });
 });

--- a/apps/modernization-ui/src/design-system/data/OrElseNoData.tsx
+++ b/apps/modernization-ui/src/design-system/data/OrElseNoData.tsx
@@ -1,10 +1,17 @@
 import { ReactNode } from 'react';
+import { exists } from 'utils/exists';
 import { NoData } from './NoData';
 
 type OrElseNoDataProps = {
     children: ReactNode;
 };
 
-const OrElseNoData = ({ children }: OrElseNoDataProps) => (children ? children : <NoData />);
+/**
+ * Renders the children component or the "no data" placeholder of "---" if it does not {@link exists}.
+ *
+ * @param {OrElseNoDataProps}
+ * @return {ReactNode}
+ */
+const OrElseNoData = ({ children }: OrElseNoDataProps) => (exists(children) ? children : <NoData />);
 
 export { OrElseNoData };

--- a/apps/modernization-ui/src/utils/exists.ts
+++ b/apps/modernization-ui/src/utils/exists.ts
@@ -19,8 +19,10 @@
 function exists<T>(value: T | null | undefined): value is NonNullable<T> {
     if (typeof value === 'object' && value && !Array.isArray(value)) {
         return Object.keys(value).length > 0;
+    } else if (typeof value === 'string') {
+        return value.length > 0;
     }
-    return typeof value === 'boolean' || value ? true : false;
+    return typeof value !== 'undefined' && value !== null;
 }
 
 export { exists };


### PR DESCRIPTION
## Description

The `OrElseNoData` component was changed to use the `exists` function to be able to handle falsy values.

## Tickets

* [CNFT1-4314](https://cdc-nbs.atlassian.net/browse/CNFT1-4314)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
