### PR TITLE
[FIX] use ubi9 for now

### DIFF
--- a/apps/nbs-gateway/Dockerfile
+++ b/apps/nbs-gateway/Dockerfile
@@ -28,7 +28,7 @@ RUN jlink \
   --no-man-pages \
   --output gateway/runtime
 
-FROM redhat/ubi10-micro:latest
+FROM redhat/ubi9-micro:latest
 
 COPY --from=builder /usr/src/nbs/gateway/runtime /deployment/runtime
 


### PR DESCRIPTION
## Description

Changes the base image of the `nbs-gateway` to `ubi9-micro` until the trivy step is updated
