### PR TITLE
[CNFT1-4326] Patient file > Demographics > Address census tract

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/address/PatientAddressDemographicFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/address/PatientAddressDemographicFinder.java
@@ -27,7 +27,7 @@ class PatientAddressDemographicFinder {
           [address].zip_cd                as [zip_code],
           [address].[cntry_cd]            as [country_value],
           [country].code_desc_txt         as [country_name],
-          [address].census_track_cd       as [census_tract],
+          [address].census_tract          as [census_tract],
           [locators].locator_desc_txt     as [comment]
       from Entity_locator_participation [locators]
       
@@ -51,7 +51,6 @@ class PatientAddressDemographicFinder {
       
           left join NBS_SRTE..Country_code [country] with (nolock) on
                   [country].code = [address].cntry_cd
-      
       
       where   [locators].entity_uid = ?
           and [locators].[class_cd] = 'PST'


### PR DESCRIPTION
## Description

The value for "Census tract" was being pulled from the incorrect field `census_track_cd`, it has been changed to `census_tract`

## Tickets

* [CNFT1-4326](https://cdc-nbs.atlassian.net/browse/CNFT1-4326)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4326]: https://cdc-nbs.atlassian.net/browse/CNFT1-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ