### PR TITLE
[CNFT1-4323] Handling displaying of longer text fields

### DIFF
--- a/apps/modernization-ui/src/design-system/entry/multi-value/view/DetailView.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/view/DetailView.tsx
@@ -1,6 +1,7 @@
 import { Fragment, ReactElement, useId } from 'react';
 import classNames from 'classnames';
-import { NoData } from 'design-system/data';
+import { Orientation } from 'design-system/field';
+import { OrElseNoData } from 'design-system/data';
 import styles from './detail-view.module.scss';
 
 type Children = ReactElement<DetailValueProps>;
@@ -22,16 +23,23 @@ const DetailView = ({ className, children }: DetailViewProps) => {
 
 type DetailValueProps = {
     label: string;
+    orientation?: Orientation;
     children?: number | string | null;
 };
 
-const DetailValue = ({ label, children }: DetailValueProps) => {
+const DetailValue = ({ label, orientation, children }: DetailValueProps) => {
     const id = useId();
+
+    const longText = typeof children === 'string' && children.length > 75;
 
     return (
         <>
             <dt id={id}>{label}</dt>
-            <dd aria-labelledby={id}>{children ?? <NoData />}</dd>
+            <dd
+                aria-labelledby={id}
+                className={classNames({ [styles.vertical]: longText || orientation === 'vertical' })}>
+                <OrElseNoData>{children}</OrElseNoData>
+            </dd>
         </>
     );
 };

--- a/apps/modernization-ui/src/design-system/entry/multi-value/view/detail-view.module.scss
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/view/detail-view.module.scss
@@ -3,10 +3,11 @@
 
 .details {
     display: grid;
-    grid-template-columns: max-content max-content;
+    grid-template-columns: 33% [label] 12rem [value] 1fr;
     column-gap: 2rem;
     row-gap: 0.5rem;
-    justify-content: center;
+
+    padding: 0 1rem;
 
     color: colors.$base-darkest;
     line-height: normal;
@@ -18,13 +19,20 @@
     @extend %small;
 
     dt {
-        grid-column-start: 1;
+        grid-column: label;
         font-weight: 700;
         margin: 0;
     }
 
     dd {
-        grid-column-start: 2;
+        grid-column: value;
         margin: 0;
+        white-space: pre-line;
+        word-wrap: normal;
+        max-width: 75ch;
+
+        &.vertical {
+            grid-column: label / span 2;
+        }
     }
 }

--- a/apps/modernization-ui/src/libs/patient/demographics/address/AddressDemographicView.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/address/AddressDemographicView.tsx
@@ -1,6 +1,6 @@
+import { internalizeDate } from 'date';
 import { DetailValue, DetailView } from 'design-system/entry/multi-value';
 import { AddressDemographic } from './address';
-import { internalizeDate } from 'date';
 
 type AddressDemographicViewProps = {
     entry: AddressDemographic;

--- a/apps/modernization-ui/src/libs/patient/demographics/administrative/AdministrativeInformationCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/administrative/AdministrativeInformationCard.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { internalizeDate } from 'date';
 import { Card, CardProps } from 'design-system/card';
 import { OrElseNoData } from 'design-system/data';
@@ -14,13 +15,19 @@ const AdministrativeInformationCard = ({
     title = 'Administrative',
     collapsible = true,
     data,
+    sizing,
     ...remaining
 }: AdministrativeInformationCardProps) => {
     const subtext = data?.comment ? `As of ${internalizeDate(data?.asOf)}` : undefined;
 
     return (
         <Card title={title} subtext={subtext} collapsible={collapsible} open={Boolean(data?.comment)} {...remaining}>
-            <div className={styles.content}>
+            <div
+                className={classNames(styles.content, {
+                    [styles.small]: sizing === 'small',
+                    [styles.medium]: sizing === 'medium',
+                    [styles.large]: sizing === 'large'
+                })}>
                 <OrElseNoData>{data?.comment}</OrElseNoData>
             </div>
         </Card>

--- a/apps/modernization-ui/src/libs/patient/demographics/administrative/administrative-information-card.module.scss
+++ b/apps/modernization-ui/src/libs/patient/demographics/administrative/administrative-information-card.module.scss
@@ -1,7 +1,21 @@
 @use 'styles/components';
-.content {
-    font-size: #{components.$small-font-size};
 
+.content {
     padding: 1rem;
     white-space: pre-line;
+    word-wrap: normal;
+    max-width: 75ch;
+    line-height: 140%;
+
+    &.small {
+        @extend %small;
+    }
+
+    &.medium {
+        @extend %medium;
+    }
+
+    &.large {
+        @extend %large;
+    }
 }


### PR DESCRIPTION
## Description

Restricts comment fields to have a max character length of around 75 characters.  In detail views the comments are displayed under the label when it reaches the max character per line threshold.

<img width="1426" height="531" alt="image" src="https://github.com/user-attachments/assets/f8ec180e-eb0b-41aa-bbdc-3faf94d30ab6" />

<img width="1422" height="316" alt="image" src="https://github.com/user-attachments/assets/ee02c910-50f9-4995-9d87-23aa183c730c" />

<img width="1425" height="369" alt="image" src="https://github.com/user-attachments/assets/d25176fe-7496-4f31-95b3-3ca3c3cd93cf" />


## Tickets

* [CNFT1-4323](https://cdc-nbs.atlassian.net/browse/CNFT1-4323)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4323]: https://cdc-nbs.atlassian.net/browse/CNFT1-4323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ