### PR TITLE
Nis 64 patient search dob field accepting zero

### DIFF
--- a/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/exact/ExactDateField.tsx
@@ -10,7 +10,7 @@ import styles from './exact-date-field.module.scss';
 type Field = keyof DateEntry;
 
 const next = (field: Field, value: number | undefined) =>
-    value ? withProperty<DateEntry, number>(field, value) : withoutProperty<DateEntry>(field);
+    value !== undefined ? withProperty<DateEntry, number>(field, value) : withoutProperty<DateEntry>(field);
 
 type ExactDateFieldProps = {
     id: string;

--- a/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
+++ b/apps/modernization-ui/src/design-system/date/validateDateEntry.ts
@@ -4,7 +4,7 @@ import { occursInThePast } from './occursInThePast';
 import { now } from './clock';
 
 const validateYear = (name: string) => (value: DateEntry) => {
-    if (value.year) {
+    if (value.year !== undefined) {
         if (value.year < 1875) {
             return `The ${name} should occur after 12/31/1874.`;
         } else if (value.year > now().getFullYear()) {


### PR DESCRIPTION
## Description

Fixes issues with DOB field accepting 0 & 00 value without any error message after clicking Enter. The zero value was being coerced into falsey when checking the dates, now we explicitly check for undefined. 

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/NIS-64)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
