### PR TITLE
[CNFT1-4322]: adding support for required and aria required to each checkbox in search

### DIFF
--- a/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.spec.tsx
+++ b/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.spec.tsx
@@ -150,4 +150,19 @@ describe('CheckboxGroup', () => {
         const group = getByRole('group');
         expect(group).toBeInTheDocument();
     });
+    it('should set aria-required and required attributes when required is true', () => {
+        const { getAllByRole } = render(
+            <CheckboxGroup
+                name="test"
+                label="Testing CheckboxGroup"
+                options={options}
+                required
+            />
+        );
+        const checkboxes = getAllByRole('checkbox');
+        checkboxes.forEach(checkbox => {
+            expect(checkbox).toHaveAttribute('aria-required', 'true');
+            expect(checkbox).toHaveAttribute('required');
+        });
+    })
 });

--- a/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.tsx
+++ b/apps/modernization-ui/src/design-system/checkbox/CheckboxGroup.tsx
@@ -73,7 +73,7 @@ export const CheckboxGroup = ({
                     },
                     styles.fieldSet
                 )}
-                aria-label={`${label}${required ? ' (required)' : ''}`}>
+                aria-label={label}>
                 {items.map((item, index) => (
                     <SelectableCheckbox
                         name={name}
@@ -84,6 +84,8 @@ export const CheckboxGroup = ({
                         selected={item.selected}
                         disabled={disabled}
                         onBlur={onBlur}
+                        required={required}
+                        aria-required={required}
                     />
                 ))}
             </fieldset>


### PR DESCRIPTION
## Description

Screen reader has to announce the field is “required“ for the selectable checkbox
## Tickets

* [CNFT1-4322](https://cdc-nbs.atlassian.net/browse/CNFT1-4322)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
