### PR TITLE
[CNFT1-4319] Patient file permissions using VIEWWORKUP-PATIENT

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/PatientFileController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/PatientFileController.java
@@ -23,12 +23,8 @@ class PatientFileController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "file",
-      summary = "Patient File Header",
-      tags = "PatientFile"
-  )
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @Operation(operationId = "file", summary = "Patient File Header", tags = "PatientFile")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   @GetMapping("/nbs/api/patients/{patientId}/file")
   ResponseEntity<PatientFile> find(@PathVariable final long patientId) {
     return finder.resolve(patientId, LocalDate.now(clock))

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/address/PatientAddressDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/address/PatientAddressDemographicController.java
@@ -17,13 +17,9 @@ class PatientAddressDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      summary = "Patient File Address Demographics",
-      description = "Provides the address demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(summary = "Patient File Address Demographics", description = "Provides the address demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/addresses")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   List<PatientAddressDemographic> addresses(@PathVariable("patient") long patient) {
     return this.finder.find(patient);
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/administrative/PatientAdministrativeInformationController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/administrative/PatientAdministrativeInformationController.java
@@ -17,13 +17,9 @@ class PatientAdministrativeInformationController {
     this.finder = finder;
   }
 
-  @Operation(
-      summary = "Patient File Administrative Information",
-      description = "Provides the administrative information for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(summary = "Patient File Administrative Information", description = "Provides the administrative information for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/administrative")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<Administrative> administrative(@PathVariable("patient") long patient) {
     return this.finder.find(patient).map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/ethnicity/PatientEthnicityDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/ethnicity/PatientEthnicityDemographicController.java
@@ -16,14 +16,9 @@ class PatientEthnicityDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "ethnicityDemographics",
-      summary = "Patient file ethnicity demographics",
-      description = "Provides the ethnicity demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(operationId = "ethnicityDemographics", summary = "Patient file ethnicity demographics", description = "Provides the ethnicity demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/ethnicity")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<PatientEthnicityDemographic> ethnicity(@PathVariable("patient") long patient) {
     return this.finder.find(patient)
         .map(ResponseEntity::ok)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/general/PatientGeneralInformationDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/general/PatientGeneralInformationDemographicController.java
@@ -16,14 +16,9 @@ class PatientGeneralInformationDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "generalInformationDemographics",
-      summary = "Patient File General Information Demographics",
-      description = "Provides the General Information demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(operationId = "generalInformationDemographics", summary = "Patient File General Information Demographics", description = "Provides the General Information demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/general")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<PatientGeneralInformationDemographic> generalInformation(@PathVariable("patient") long patient) {
     return this.finder.find(patient).map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.ok().build());

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/identification/PatientIdentificationDemographicController.java
@@ -17,13 +17,9 @@ class PatientIdentificationDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      summary = "Patient File Identification Demographics",
-      description = "Provides the identification demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(summary = "Patient File Identification Demographics", description = "Provides the identification demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/identifications")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   List<PatientIdentificationDemographic> identifications(@PathVariable("patient") long patient) {
     return this.finder.find(patient);
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/mortality/PatientMortalityDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/mortality/PatientMortalityDemographicController.java
@@ -16,14 +16,9 @@ class PatientMortalityDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "mortalityDemographics",
-      summary = "Patient File Mortality Demographics",
-      description = "Provides the Mortality demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(operationId = "mortalityDemographics", summary = "Patient File Mortality Demographics", description = "Provides the Mortality demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/mortality")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<PatientMortalityDemographic> mortality(@PathVariable("patient") long patient) {
     return this.finder.find(patient).map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.ok().build());

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/name/PatientNameDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/name/PatientNameDemographicController.java
@@ -17,12 +17,8 @@ class PatientNameDemographicController {
     this.finder = finder;
   }
 
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
-  @Operation(
-      summary = "Patient File Name Demographics",
-      description = "Provides the name demographics for a patient",
-      tags = "PatientFile"
-  )
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
+  @Operation(summary = "Patient File Name Demographics", description = "Provides the name demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/names")
   public List<PatientNameDemographic> names(@PathVariable final long patient) {
     return finder.find(patient);

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/phone/PatientPhoneDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/phone/PatientPhoneDemographicController.java
@@ -17,13 +17,9 @@ class PatientPhoneDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      summary = "Patient File Phone Demographics",
-      description = "Provides the phone demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(summary = "Patient File Phone Demographics", description = "Provides the phone demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/phones")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   List<PatientPhoneDemographic> phones(@PathVariable("patient") long patient) {
     return this.finder.find(patient);
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/race/PatientRaceDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/race/PatientRaceDemographicController.java
@@ -17,14 +17,9 @@ class PatientRaceDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "raceDemographics",
-      summary = "Patient file race demographics",
-      description = "Provides the race demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(operationId = "raceDemographics", summary = "Patient file race demographics", description = "Provides the race demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/races")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   Collection<PatientRaceDemographic> races(@PathVariable("patient") long patient) {
     return this.finder.find(patient);
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/race/validation/PatientRaceCategoryValidationController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/race/validation/PatientRaceCategoryValidationController.java
@@ -22,30 +22,17 @@ class PatientRaceCategoryValidationController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "validateRace",
-      summary = "Validates that a patient can accept a race demographic for the given category.",
-      tags = "PatientFile",
-      responses = {
-          @ApiResponse(responseCode = "200", description = "Allowable race category for the patient"),
-          @ApiResponse(
-              responseCode = "400",
-              description = "The race category is already present on the patient",
-              content = {
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ExistingRaceCategory.class)
-                  )
-              }
-          )
-      }
-  )
+  @Operation(operationId = "validateRace", summary = "Validates that a patient can accept a race demographic for the given category.", tags = "PatientFile", responses = {
+      @ApiResponse(responseCode = "200", description = "Allowable race category for the patient"),
+      @ApiResponse(responseCode = "400", description = "The race category is already present on the patient", content = {
+          @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExistingRaceCategory.class))
+      })
+  })
   @PostMapping("validate")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<ExistingRaceCategoryResponse> validate(
       @PathVariable final long patient,
-      @PathVariable final String category
-  ) {
+      @PathVariable final String category) {
     return this.finder.find(patient, category)
         .map(this::invalid)
         .orElseGet(this::valid);

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/sex_birth/PatientSexBirthDemographicController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/sex_birth/PatientSexBirthDemographicController.java
@@ -16,14 +16,9 @@ class PatientSexBirthDemographicController {
     this.finder = finder;
   }
 
-  @Operation(
-      operationId = "sexBirthDemographics",
-      summary = "Patient File Sex & Birth Demographics",
-      description = "Provides the Sex & Birth demographics for a patient",
-      tags = "PatientFile"
-  )
+  @Operation(operationId = "sexBirthDemographics", summary = "Patient File Sex & Birth Demographics", description = "Provides the Sex & Birth demographics for a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics/sex-birth")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<PatientSexBirthDemographic> sexBirth(@PathVariable("patient") long patient) {
     return this.finder.find(patient).map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.ok().build());

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryController.java
@@ -18,19 +18,14 @@ class PatientDemographicsSummaryController {
 
   PatientDemographicsSummaryController(
       final Clock clock,
-      final PatientDemographicsSummaryResolver resolver
-  ) {
+      final PatientDemographicsSummaryResolver resolver) {
     this.clock = clock;
     this.resolver = resolver;
   }
 
-  @Operation(
-      summary = "Patient File Demographics Summary",
-      description = "Provides summarized demographics of a patient",
-      tags = "PatientFile"
-  )
+  @Operation(summary = "Patient File Demographics Summary", description = "Provides summarized demographics of a patient", tags = "PatientFile")
   @GetMapping("/nbs/api/patients/{patient}/demographics")
-  @PreAuthorize("hasAuthority('VIEW-PATIENT')")
+  @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<PatientDemographicsSummary> summary(@PathVariable("patient") long patient) {
     return resolver.resolve(patient, LocalDate.now(clock))
         .map(ResponseEntity::ok)

--- a/apps/modernization-api/src/test/resources/features/patient/PatientDelete.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/PatientDelete.feature
@@ -3,7 +3,7 @@ Feature: Patient Delete
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I can "delete" any "patient"
     And I have a patient
 

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.address.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.address.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with address demographics
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with an address demographic
     Given I am entering the House - Home address at "1640 Riverside Drive" "Hill Valley" "33266" as of 11/01/1955

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.administrative.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.administrative.feature
@@ -4,7 +4,7 @@
     Background:
       Given I am logged into NBS
       And I can "add" any "patient"
-      And I can "view" any "patient"
+      And I can "viewworkup" any "patient"
 
     Scenario: I can create a patient with administrative demographics information
       Given I enter the patient administrative as of date 05/29/2023

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.birth.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.birth.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with birth demographics
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with birth demographics information
     Given I enter the birth demographics as of date 07/03/1990

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.ethnicity.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.ethnicity.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with extended ethnicity data
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with ethnicity information
     Given I am entering the ethnicity as of date 05/29/2023

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.gender.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.gender.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with gender demographics
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with gender demographics information
     Given I enter the gender demographics as of date 07/03/1990

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.general.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.general.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with extended General Information data
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with general information demographics
     Given I enter the general information as of date 05/29/2023

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.identification.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.identification.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with identification demographics
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with an identification demographic
     Given I am entering a Driver's license number identification of "00123" as of 05/13/1997

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.mortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.mortality.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with mortality data
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with mortality information
     Given I am entering the mortality as of date 06/29/2023

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.names.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.names.feature
@@ -4,7 +4,7 @@
     Background:
       Given I am logged into NBS
       And I can "add" any "patient"
-      And I can "view" any "patient"
+      And I can "viewworkup" any "patient"
 
     Scenario: I can create a patient with a legal name
       Given I am entering a legal name as of 07/19/2017

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.phones.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.phones.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with phone demographics
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with a phone demographic with a phone number
     Given I am entering the Email Address - Home number of "555-555-5555" as of 11/07/2023

--- a/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.race.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/create/NewPatient.race.feature
@@ -4,7 +4,7 @@ Feature: Creation of Patients with race demographics
   Background:
     Given I am logged into NBS
     And I can "add" any "patient"
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can create a patient with a race
     Given I am entering the Other race as of 04/11/2019

--- a/apps/modernization-api/src/test/resources/features/patient/file/PatientFile.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/PatientFile.feature
@@ -3,7 +3,7 @@ Feature: Patient File
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I cannot view Patient file of the patient that does not exist

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
@@ -3,7 +3,7 @@ Feature: Summarizing the demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario:  I cannot view the demographics summary of the patient that does not exist

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/address/PatientFile.address.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/address/PatientFile.address.feature
@@ -3,7 +3,7 @@ Feature: Viewing the address demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view the patient's address demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/administrative/PatientFile.administrative.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/administrative/PatientFile.administrative.feature
@@ -3,7 +3,7 @@ Feature: Viewing the administrative information of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario:  I cannot view the administrative information of a patient that does not exist

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/birth/PatientFile.birth.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/birth/PatientFile.birth.feature
@@ -3,7 +3,7 @@ Feature: Viewing the birth demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's birth demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/ethnicity/PatientFile.ethnicity.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/ethnicity/PatientFile.ethnicity.feature
@@ -3,7 +3,7 @@ Feature: Viewing the ethnicity demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's ethnicity demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/gender/PatientFile.gender.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/gender/PatientFile.gender.feature
@@ -3,7 +3,7 @@ Feature: Viewing the gender demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's gender demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/general/PatientFile.general.HIV-access.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/general/PatientFile.general.HIV-access.feature
@@ -3,7 +3,7 @@ Feature: Viewing the sensitive general demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's state HIV case when I have access to HIV Fields

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/general/PatientFile.general.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/general/PatientFile.general.feature
@@ -3,7 +3,7 @@ Feature: Viewing the general demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's general demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/identification/PatientFile.identification.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/identification/PatientFile.identification.feature
@@ -3,7 +3,7 @@ Feature: Viewing the identification demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view the patient's identification demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/mortality/PatientFile.mortality.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/mortality/PatientFile.mortality.feature
@@ -3,7 +3,7 @@ Feature: Viewing the mortality demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's mortality demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/name/PatientFile.name.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/name/PatientFile.name.feature
@@ -4,7 +4,7 @@ Feature: Viewing the name demographics of a patient
   Background: I am logged in and can find patient
     Given I am logged into NBS
     And I have a patient
-    And I can "View" any "Patient"
+    And I can "viewworkup" any "patient"
 
   Scenario: I can find patient names
     Given the patient has the legal name "Joe" "Jacob" "Smith", Jr. as of 01/01/2000

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/phone/PatientFile.phone.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/phone/PatientFile.phone.feature
@@ -3,7 +3,7 @@ Feature: Viewing the phone demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view the patient's phone demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/race/PatientFile.race.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/race/PatientFile.race.feature
@@ -3,7 +3,7 @@ Feature: Viewing the race demographics of a patient
 
   Background:
     Given I am logged into NBS
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: I can view a Patient's race demographics

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/race/PatientFile.race.validation.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/race/PatientFile.race.validation.feature
@@ -3,7 +3,7 @@ Feature: Patient File Race Validation
 
   Background:
     Given I am logged in
-    And I can "view" any "patient"
+    And I can "viewworkup" any "patient"
     And I have a patient
 
   Scenario: A patient file should allow at least one entry for a Race Category

--- a/apps/modernization-ui/src/apps/patient/file/PatientFileRouting.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileRouting.tsx
@@ -1,10 +1,9 @@
 import { lazy, Suspense } from 'react';
 import { Navigate } from 'react-router';
-import { permissions, Permitted } from 'libs/permission';
+import { permissions } from 'libs/permission';
 import { PageTitle } from 'page';
-
+import { Guarded } from 'libs/guard';
 import { loader } from './loader';
-import { FeatureGuard } from 'feature';
 
 const LazyPatientFile = lazy(() => import('./PatientFile').then((module) => ({ default: module.PatientFile })));
 const LazyPatientFileSummary = lazy(() =>
@@ -19,15 +18,13 @@ const routing = [
     {
         path: '/patient/:id',
         element: (
-            <FeatureGuard guard={(features) => features.patient.file.enabled}>
-                <Permitted permission={permissions.patient.view}>
-                    <PageTitle title="Patient file">
-                        <Suspense>
-                            <LazyPatientFile />
-                        </Suspense>
-                    </PageTitle>
-                </Permitted>
-            </FeatureGuard>
+            <Guarded feature={(features) => features.patient.file.enabled} permission={permissions.patient.file}>
+                <PageTitle title="Patient file">
+                    <Suspense>
+                        <LazyPatientFile />
+                    </Suspense>
+                </PageTitle>
+            </Guarded>
         ),
         loader,
         children: [

--- a/apps/modernization-ui/src/feature/FeatureGuard.tsx
+++ b/apps/modernization-ui/src/feature/FeatureGuard.tsx
@@ -1,10 +1,9 @@
+import { FeatureToggle, FeatureToggleProps } from 'feature';
 import { ReactNode } from 'react';
 import { RedirectHome } from 'routes';
-import { FeatureToggle } from './FeatureToggle';
-import { Guard } from './guard';
 
 type FeatureGuardProps = {
-    guard: Guard;
+    guard: FeatureToggleProps['guard'];
     children: ReactNode;
 };
 

--- a/apps/modernization-ui/src/feature/FeatureToggle.tsx
+++ b/apps/modernization-ui/src/feature/FeatureToggle.tsx
@@ -4,13 +4,13 @@ import { useConfiguration } from 'configuration';
 import { ReactNode } from 'react';
 import { Guard } from './guard';
 
-type Props = {
+type FeatureToggleProps = {
     guard: Guard;
     children: ReactNode;
     fallback?: ReactNode;
 };
 
-const FeatureToggle = ({ guard, children, fallback }: Props) => {
+const FeatureToggle = ({ guard, children, fallback }: FeatureToggleProps) => {
     const { features } = useConfiguration();
 
     return (
@@ -21,3 +21,4 @@ const FeatureToggle = ({ guard, children, fallback }: Props) => {
 };
 
 export { FeatureToggle };
+export type { FeatureToggleProps };

--- a/apps/modernization-ui/src/feature/index.ts
+++ b/apps/modernization-ui/src/feature/index.ts
@@ -1,3 +1,6 @@
 export { FeatureToggle } from './FeatureToggle';
-export { FeatureGuard } from './FeatureGuard';
+export type { FeatureToggleProps } from './FeatureToggle';
+
 export { FeatureLayout } from './FeatureLayout';
+
+export { FeatureGuard } from './FeatureGuard';

--- a/apps/modernization-ui/src/libs/guard/Guarded.tsx
+++ b/apps/modernization-ui/src/libs/guard/Guarded.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { RedirectHome } from 'routes';
+import { FeatureToggle, FeatureToggleProps } from 'feature';
+import { Permitted, PermittedProps } from 'libs/permission';
+
+type GuardedProps = {
+    feature: FeatureToggleProps['guard'];
+    permission: PermittedProps['permission'];
+    children: ReactNode;
+};
+
+/**
+ * A composition of {@link Permitted} and {@link FeatureToggle} where features are resolved first, then permissions.
+ *
+ * @param {GuardedProps} props
+ * @return {ReactNode} The component displayed when the feature and permission evaluation passes.
+ */
+const Guarded = ({ permission, feature, children }: GuardedProps) => (
+    <FeatureToggle guard={feature} fallback={<RedirectHome />}>
+        <Permitted permission={permission} fallback={<RedirectHome />}>
+            {children}
+        </Permitted>
+    </FeatureToggle>
+);
+
+export { Guarded };
+export type { GuardedProps };

--- a/apps/modernization-ui/src/libs/guard/GuardedLayout.tsx
+++ b/apps/modernization-ui/src/libs/guard/GuardedLayout.tsx
@@ -1,0 +1,18 @@
+import { Outlet } from 'react-router';
+import { Guarded, GuardedProps } from './Guarded';
+
+type GuardedLayoutProps = Omit<GuardedProps, 'children'>;
+
+/**
+ * A specialized {@link Guarded} with {@link Outlet} as a child used to restrict a path using permissions and features.
+ *
+ * @param {GuardedLayoutProps} props
+ * @return {ReactNode} The component displayed when the feature and permission evaluation passes.
+ */
+const GuardedLayout = (props: GuardedLayoutProps) => (
+    <Guarded {...props}>
+        <Outlet />
+    </Guarded>
+);
+
+export { GuardedLayout };

--- a/apps/modernization-ui/src/libs/guard/index.ts
+++ b/apps/modernization-ui/src/libs/guard/index.ts
@@ -1,0 +1,1 @@
+export { Guarded } from './Guarded';

--- a/apps/modernization-ui/src/libs/permission/Permitted.tsx
+++ b/apps/modernization-ui/src/libs/permission/Permitted.tsx
@@ -43,3 +43,4 @@ const Permitted = ({ permission, children, fallback }: PermittedProps) => {
 };
 
 export { Permitted };
+export type { PermittedProps };

--- a/apps/modernization-ui/src/libs/permission/index.ts
+++ b/apps/modernization-ui/src/libs/permission/index.ts
@@ -1,4 +1,6 @@
 export { Permitted } from './Permitted';
+export type { PermittedProps } from './Permitted';
+
 export { permissions } from './permissions';
 export { permits } from './permits';
 export { permitsAll } from './permitsAll';

--- a/apps/modernization-ui/src/libs/permission/permissions.ts
+++ b/apps/modernization-ui/src/libs/permission/permissions.ts
@@ -31,6 +31,7 @@ export const permissions = {
         searchInactive: 'FINDINACTIVE-PATIENT',
         update: 'EDIT-PATIENT',
         view: 'VIEW-PATIENT',
+        file: 'VIEWWORKUP-PATIENT',
         merge: 'MERGE-PATIENT'
     },
     system: {


### PR DESCRIPTION
## Description

Changes the Patient file API's and the Patient file UI to use the `VIEWWORKUP-PATIENT` permission over the `VIEW-PATIENT` permission.

## Tickets

* [CNFT1-4319](https://cdc-nbs.atlassian.net/browse/CNFT1-4319)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4319]: https://cdc-nbs.atlassian.net/browse/CNFT1-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ