### PR TITLE
[CNFT1-4338]:Adding global uswds styles to avoid overwriting of skip link styles in the future

### DIFF
--- a/apps/modernization-ui/src/styles/_uswds.scss
+++ b/apps/modernization-ui/src/styles/_uswds.scss
@@ -182,3 +182,7 @@ input.usa-input--error:focus {
 .usa-date-picker__calendar__date {
     padding: var(--calendar-date-padding, 10px) 0;
 }
+
+.usa-skipnav {
+    z-index: 10000;
+}


### PR DESCRIPTION
## Description

The navbar component had z-index used for the navbar styles of z-index: 100;, and since skip link is rendering on top of the navbar and it has no z index the styles of the button were overwritten and therefore the skip link is not visible.. so to solve this I added the skip link styles gloabbly on the uswds stylesheet

## Tickets

* [CNFT1-4338](https://cdc-nbs.atlassian.net/browse/CNFT1-4338)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4338]: https://cdc-nbs.atlassian.net/browse/CNFT1-4338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ