### PR TITLE
[CNFT1-4288] Column preferences sizing

### DIFF
--- a/apps/modernization-ui/src/apps/search/layout/result/header/options/table/SearchResultsTableOptions.tsx
+++ b/apps/modernization-ui/src/apps/search/layout/result/header/options/table/SearchResultsTableOptions.tsx
@@ -1,6 +1,5 @@
-import { OverlayPanel } from 'overlay';
 import { Sizing } from 'design-system/field';
-import { ColumnPreferencesPanel } from 'design-system/table/preferences';
+import { ColumnPreferencesAction } from 'design-system/table/preferences';
 import { useFilter } from 'design-system/filter';
 import { Button } from 'components/button';
 import { FeatureToggle } from 'feature';
@@ -44,23 +43,7 @@ const SearchResultsTableOptions = ({ disabled = false, sizing }: Props) => {
                     />
                 </div>
             </FeatureToggle>
-            <OverlayPanel
-                className={styles.overlay}
-                position="right"
-                toggle={({ toggle }) => (
-                    <Button
-                        aria-label="Settings"
-                        data-tooltip-position="top"
-                        data-tooltip-offset="center"
-                        secondary
-                        disabled={disabled}
-                        icon="settings"
-                        onClick={toggle}
-                        sizing={sizing}
-                    />
-                )}
-                render={(close) => <ColumnPreferencesPanel close={close} />}
-            />
+            <ColumnPreferencesAction sizing={sizing} />
         </>
     );
 };

--- a/apps/modernization-ui/src/design-system/card/table/TableCard.tsx
+++ b/apps/modernization-ui/src/design-system/card/table/TableCard.tsx
@@ -48,7 +48,6 @@ const TableCard = <V,>({
             id={id}
             title={title}
             className={className}
-            sizing={sizing}
             collapsible={collapsible}
             open={collapsible && props.data.length > 0}
             flair={<Tag size={sizing}>{props.data.length}</Tag>}
@@ -58,7 +57,7 @@ const TableCard = <V,>({
                     <ColumnPreferencesAction sizing={sizing} />
                 </>
             }>
-            <ManagedDataTable {...props} id={`${id}-table`} columns={columns} />
+            <ManagedDataTable {...props} id={`${id}-table`} sizing={sizing} columns={columns} />
         </ColumnPreferencesCard>
     );
 };

--- a/apps/modernization-ui/src/design-system/card/table/TableCard.tsx
+++ b/apps/modernization-ui/src/design-system/card/table/TableCard.tsx
@@ -35,6 +35,7 @@ const TableCard = <V,>({
     columns,
     columnPreferencesKey,
     defaultColumnPreferences,
+    sizing,
     ...props
 }: TableCardProps<V>) => {
     const ColumnPreferencesCard = withColumnPreferences(Card, {
@@ -47,13 +48,14 @@ const TableCard = <V,>({
             id={id}
             title={title}
             className={className}
+            sizing={sizing}
             collapsible={collapsible}
             open={collapsible && props.data.length > 0}
-            flair={<Tag size={props.sizing}>{props.data.length}</Tag>}
+            flair={<Tag size={sizing}>{props.data.length}</Tag>}
             actions={
                 <>
                     {actions}
-                    <ColumnPreferencesAction sizing="small" />
+                    <ColumnPreferencesAction sizing={sizing} />
                 </>
             }>
             <ManagedDataTable {...props} id={`${id}-table`} columns={columns} />

--- a/apps/modernization-ui/src/design-system/checkbox/checkbox.module.scss
+++ b/apps/modernization-ui/src/design-system/checkbox/checkbox.module.scss
@@ -1,9 +1,7 @@
 @use 'styles/colors';
 @use 'styles/components';
 
-$checkbox-small: 1rem;
-$checkbox-medium: 1.125rem;
-$checkbox-large: 1.25rem;
+$border-size: 2px;
 
 .checkbox {
     --checkbox-size: 1.125rem;
@@ -19,12 +17,12 @@ $checkbox-large: 1.25rem;
         position: relative;
 
         height: var(--checkbox-size);
-        line-height: var(--checkbox-size);
+        line-height: 125%;
 
         display: inline-block;
 
         &.labeled {
-            padding-left: calc(var(--checkbox-size) + 0.5rem);
+            padding-left: calc(var(--checkbox-size) - $border-size + 0.75rem);
         }
 
         &.disabled {
@@ -32,12 +30,12 @@ $checkbox-large: 1.25rem;
             cursor: not-allowed;
 
             &::before {
-                box-shadow: 0 0 0 2px colors.$disabled-darker;
+                box-shadow: 0 0 0 $border-size colors.$disabled-darker;
             }
 
             &:has(input:checked)::before {
                 background-color: colors.$disabled-darker;
-                box-shadow: 0 0 0 2px colors.$disabled-darker;
+                box-shadow: 0 0 0 $border-size colors.$disabled-darker;
             }
         }
 
@@ -45,26 +43,25 @@ $checkbox-large: 1.25rem;
             content: '';
             display: block;
             left: 0;
-            // top: 2px;
             position: absolute;
-            height: var(--checkbox-size);
-            width: var(--checkbox-size);
+            height: calc(var(--checkbox-size) - $border-size);
+            width: calc(var(--checkbox-size) - $border-size);
             border-radius: 1px;
 
             background: colors.$base-white;
             background-position: center center;
             background-size: 0.75rem auto;
             background-repeat: no-repeat;
-            box-shadow: 0 0 0 2px colors.$base-darkest;
+            box-shadow: 0 0 0 $border-size colors.$base-darkest;
         }
 
         &:has(input:focus)::before {
-            outline: 0.25rem solid colors.$focused;
+            outline: 2px solid colors.$focused;
             outline-offset: 2px;
         }
 
         &:has(input:checked)::before {
-            box-shadow: 0 0 0 2px colors.$primary;
+            box-shadow: 0 0 0 $border-size colors.$primary;
             background-color: colors.$primary;
             background-image:
                 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='65' height='50' viewBox='0 0 65 50'%3E%3Ctitle%3Ecorrect8%3C/title%3E%3Cpath fill='%23FFF' fill-rule='evenodd' d='M63.268 7.063l-5.616-5.61C56.882.685 55.946.3 54.845.3s-2.038.385-2.808 1.155L24.951 28.552 12.81 16.385c-.77-.77-1.707-1.155-2.808-1.155-1.1 0-2.037.385-2.807 1.154l-5.616 5.61C.81 22.764.425 23.7.425 24.8s.385 2.035 1.155 2.805l14.947 14.93 5.616 5.61c.77.77 1.706 1.154 2.807 1.154s2.038-.384 2.808-1.154l5.616-5.61 29.894-29.86c.77-.77 1.157-1.707 1.157-2.805 0-1.101-.385-2.036-1.156-2.805l-.001-.002z'/%3E%3C/svg%3E"),
@@ -80,9 +77,11 @@ $checkbox-large: 1.25rem;
 
     &.small {
         --checkbox-size: 1rem;
+        @extend %small;
     }
 
     &.large {
         --checkbox-size: 1.25rem;
+        @extend %large;
     }
 }

--- a/apps/modernization-ui/src/design-system/panel/closable/ClosablePanel.tsx
+++ b/apps/modernization-ui/src/design-system/panel/closable/ClosablePanel.tsx
@@ -12,14 +12,15 @@ type Closable = {
 
 type FooterRenderer = (closeable: Closable) => ReactNode;
 
-type Props = {
+type ClosablePanelProps = {
     title: string;
     headingLevel?: HeadingLevel;
     children: ReactNode;
     footer?: FooterRenderer;
-} & Closable;
+} & Closable &
+    JSX.IntrinsicElements['div'];
 
-const ClosablePanel = ({ title, headingLevel = 2, children, footer, onClose }: Props) => {
+const ClosablePanel = ({ title, headingLevel = 2, children, footer, onClose }: ClosablePanelProps) => {
     return (
         <div className={styles.panel}>
             <header>

--- a/apps/modernization-ui/src/design-system/panel/closable/closable-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/panel/closable/closable-panel.module.scss
@@ -15,10 +15,6 @@
         padding-right: 0.5rem;
 
         @extend %thin-bottom;
-
-        h2 {
-            margin: 0;
-        }
     }
 
     .closer {

--- a/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
+++ b/apps/modernization-ui/src/design-system/table/preferences/ColumnPreferencesPanel.tsx
@@ -103,6 +103,7 @@ const ColumnPreferencesPanel = ({ close, sizing = 'small' }: Props) => {
                                         <div ref={draggable.innerRef} {...draggable.draggableProps}>
                                             {isNamed(preference) && (
                                                 <PreferenceOption
+                                                    sizing={sizing}
                                                     draggable={draggable}
                                                     onVisibilityChange={handleVisibilityChange(preference)}>
                                                     {preference}
@@ -138,13 +139,15 @@ const PreferencePlaceholder = ({ draggable, children }: PreferencePlaceholderPro
 type PreferenceOptionProps = {
     draggable: DraggableProvided;
     onVisibilityChange: (value: boolean) => void;
+    sizing?: Sizing;
     children: NamedColumnPreference;
-};
+} & Omit<JSX.IntrinsicElements['span'], 'draggable' | 'children'>;
 
-const PreferenceOption = ({ draggable, onVisibilityChange, children }: PreferenceOptionProps) => (
-    <span className={styles.preference}>
+const PreferenceOption = ({ draggable, onVisibilityChange, sizing, children, ...remaining }: PreferenceOptionProps) => (
+    <span className={styles.preference} {...remaining}>
         <Checkbox
             id={`${children.id}_visible`}
+            sizing={sizing}
             name={children.id}
             label={children.name}
             disabled={!children.toggleable}

--- a/apps/modernization-ui/src/design-system/table/preferences/column-preference-action.module.scss
+++ b/apps/modernization-ui/src/design-system/table/preferences/column-preference-action.module.scss
@@ -1,3 +1,3 @@
 .preferences {
-    --modal-min-width: 17.1875rem;
+    --modal-min-width: 15.5625rem;
 }

--- a/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
@@ -9,6 +9,12 @@
     @extend %thin-top;
 }
 
+.preferences {
+    & > :not(:last-child) {
+        @extend %thin-bottom;
+    }
+}
+
 .preference {
     display: flex;
     flex: 1 0 0;
@@ -18,8 +24,7 @@
     padding-right: 0.5rem;
     background-color: colors.$base-white;
 
-    height: 2.75rem;
-    border-bottom: 1px solid colors.$base-lighter;
+    height: 2rem;
 
     .handle {
         cursor: pointer;

--- a/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
+++ b/apps/modernization-ui/src/design-system/table/preferences/column-preference-panel.module.scss
@@ -32,5 +32,9 @@
         justify-content: center;
         align-items: center;
         flex-shrink: 0;
+
+        svg {
+            height: 16px;
+        }
     }
 }

--- a/apps/modernization-ui/src/styles/_tooltip.scss
+++ b/apps/modernization-ui/src/styles/_tooltip.scss
@@ -49,7 +49,6 @@ $bubbleWidth: calc($arrowWidth + 100%);
 
 @mixin tooltip($messageProperty: 'aria-label') {
     position: relative;
-    z-index: 10000;
 
     &::before {
         content: attr(#{$messageProperty});
@@ -79,6 +78,7 @@ $bubbleWidth: calc($arrowWidth + 100%);
 
     &::before,
     &::after {
+        z-index: 10000;
         transition-property: opacity;
         transition-duration: 0.2s;
         transition-timing-function: ease-in-out;


### PR DESCRIPTION
## Description

Updates the sizing of the Column Preferences to match the newer designs.

<img width="272" height="440" alt="image" src="https://github.com/user-attachments/assets/59157894-44cd-43c6-9eff-22f19e816b42" />


## Tickets

* [CNFT1-4288](https://cdc-nbs.atlassian.net/browse/CNFT1-4288)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4288]: https://cdc-nbs.atlassian.net/browse/CNFT1-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ