### PR TITLE
[CNFT1-4175] Patient FIle: Morbidity Report card

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/events/PatientFileEvents.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/PatientFileEvents.tsx
@@ -2,6 +2,7 @@ import { useComponentSizing } from 'design-system/sizing';
 import { usePatientFileData } from '../usePatientFileData';
 import { PatientFileInvestigationsCard } from './investigations';
 import { PatientFileLaboratoryReportsCard } from './reports/laboratory';
+import { PatientFileMorbidityReportsCard } from './reports/morbidity';
 
 const PatientFileEvents = () => {
     const { id, events } = usePatientFileData();
@@ -19,6 +20,12 @@ const PatientFileEvents = () => {
                 id="laboratory-reports"
                 patient={id}
                 provider={events.get().reports.laboratory}
+                sizing={sizing}
+            />
+            <PatientFileMorbidityReportsCard
+                id="morbidity-reports"
+                patient={id}
+                provider={events.get().reports.morbidity}
                 sizing={sizing}
             />
         </>

--- a/apps/modernization-ui/src/apps/patient/file/events/events.ts
+++ b/apps/modernization-ui/src/apps/patient/file/events/events.ts
@@ -1,9 +1,11 @@
 import { MemoizedSupplier } from 'libs/supplying';
 import { PatientFileInvestigation, patientInvestigations } from './investigations';
 import { PatientFileLaboratoryReport, patientLaboratoryReports } from './reports/laboratory';
+import { PatientFileMorbidityReport, patientMorbidityReports } from './reports/morbidity';
 
 type Reports = {
     laboratory: MemoizedSupplier<Promise<PatientFileLaboratoryReport[]>>;
+    morbidity: MemoizedSupplier<Promise<PatientFileMorbidityReport[]>>;
 };
 
 type PatientFileEventData = {
@@ -16,7 +18,8 @@ export type { PatientFileEventData };
 const events = (patient: number): PatientFileEventData => ({
     investigations: new MemoizedSupplier(() => patientInvestigations(patient)),
     reports: {
-        laboratory: new MemoizedSupplier(() => patientLaboratoryReports(patient))
+        laboratory: new MemoizedSupplier(() => patientLaboratoryReports(patient)),
+        morbidity: new MemoizedSupplier(() => patientMorbidityReports(patient))
     }
 });
 

--- a/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/PatientFileMorbidityReportsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/PatientFileMorbidityReportsCard.tsx
@@ -1,0 +1,170 @@
+import { Suspense } from 'react';
+import { Await } from 'react-router';
+import { LoadingOverlay } from 'libs/loading';
+import { MemoizedSupplier } from 'libs/supplying';
+import { Column } from 'design-system/table';
+import { ColumnPreference } from 'design-system/table/preferences';
+import { TableCard, TableCardProps } from 'design-system/card';
+import { PatientFileMorbidityReport } from './morbidity-report';
+import { internalizeDateTime } from 'date';
+import { displayProvider } from 'libs/provider';
+import { MaybeLabeledValue } from 'design-system/value';
+import { Associations } from 'libs/events/investigations/associated';
+import { ResultedTests } from 'libs/events/tests';
+import { permissions, Permitted } from 'libs/permission';
+import { LinkButton } from 'design-system/button';
+import { TreatmentList } from 'libs/events/reports/morbidity';
+
+import styles from './morbidity-reports.module.scss';
+
+const EVENT_ID = { id: 'local', name: 'Event ID' };
+const DATE_RECEIVED = { id: 'received-on', name: 'Date received' };
+const DATE_ADDED = { id: 'added-on', name: 'Date added' };
+const FACILITY_PROVIDER = { id: 'facility-provider', name: 'Facility/provider' };
+const REPORT_DATE = { id: 'reported-on', name: 'Report date' };
+const CONDITION = { id: 'condition', name: 'Condition' };
+const TREATMENT_INFO = { id: 'treatment-info', name: 'Treatment info' };
+const ASSOCIATED_WITH = { id: 'associated-with', name: 'Associated with' };
+const JURISDICTION = { id: 'jurisdiction', name: 'Jurisdiction' };
+
+const columnPreferences: ColumnPreference[] = [
+    { ...EVENT_ID },
+    { ...DATE_RECEIVED, moveable: true, toggleable: true },
+    { ...DATE_ADDED, moveable: true, toggleable: true, hidden: true },
+    { ...FACILITY_PROVIDER, moveable: true, toggleable: true },
+    { ...REPORT_DATE, moveable: true, toggleable: true },
+    { ...CONDITION, moveable: true, toggleable: true },
+    { ...TREATMENT_INFO, moveable: true, toggleable: true },
+    { ...ASSOCIATED_WITH, moveable: true, toggleable: true },
+    { ...JURISDICTION, moveable: true, toggleable: true }
+];
+
+const columns: Column<PatientFileMorbidityReport>[] = [
+    {
+        ...EVENT_ID,
+        className: styles['local-header'],
+        sortable: true,
+        value: (value) => value.local,
+        render: (value) => <a href={`/nbs/api/profile/${value.patient}/report/morbidity/${value.id}`}>{value.local}</a>
+    },
+    {
+        ...DATE_RECEIVED,
+        className: styles['date-time-header'],
+        sortable: true,
+        value: (value) => value.receivedOn,
+        render: (value) => internalizeDateTime(value.receivedOn),
+        sortIconType: 'numeric'
+    },
+    {
+        ...DATE_ADDED,
+        className: styles['date-header'],
+        sortable: true,
+        value: (value) => value.addedOn,
+        render: (value) => internalizeDateTime(value.addedOn),
+        sortIconType: 'numeric'
+    },
+    {
+        ...FACILITY_PROVIDER,
+        className: styles['text-header'],
+        sortable: true,
+        value: (value) => value.reportingFacility,
+        render: (value) => (
+            <>
+                <MaybeLabeledValue orientation="vertical" label="Reporting facility:">
+                    {value.reportingFacility}
+                </MaybeLabeledValue>
+                <MaybeLabeledValue orientation="vertical" label="Ordering provider:">
+                    {displayProvider(value.orderingProvider)}
+                </MaybeLabeledValue>
+                <MaybeLabeledValue orientation="vertical" label="Reporting provider:">
+                    {displayProvider(value.reportingProvider)}
+                </MaybeLabeledValue>
+            </>
+        )
+    },
+    {
+        ...REPORT_DATE,
+        className: styles['date-time-header'],
+        sortable: true,
+        value: (value) => value.reportedOn,
+        sortIconType: 'numeric'
+    },
+    {
+        ...CONDITION,
+        sortable: true,
+        value: (value) => value.condition,
+        render: (value) => (
+            <>
+                <strong>{value.condition}</strong>
+                <ResultedTests>{value.resultedTests}</ResultedTests>
+            </>
+        )
+    },
+    {
+        ...TREATMENT_INFO,
+        sortable: true,
+        value: (value) => value.treatments?.join(),
+        render: (value) => <TreatmentList>{value.treatments}</TreatmentList>
+    },
+    {
+        ...JURISDICTION,
+        sortable: true,
+        className: styles['long-coded-header'],
+        value: (value) => value.jurisdiction
+    },
+    {
+        ...ASSOCIATED_WITH,
+        className: styles['local-header'],
+        sortable: true,
+        value: (value) => value.associations?.[0]?.local,
+        render: (value) => <Associations patient={value.patient}>{value.associations}</Associations>
+    }
+];
+
+type InternalCardProps = {
+    patient: number;
+    data?: PatientFileMorbidityReport[];
+} & Omit<
+    TableCardProps<PatientFileMorbidityReport>,
+    'columnPreferencesKey' | 'defaultColumnPreferences' | 'columns' | 'data' | 'title'
+>;
+
+const InternalCard = ({ patient, sizing, data = [], ...remaining }: InternalCardProps) => (
+    <TableCard
+        title="Morbidity reports"
+        sizing={sizing}
+        data={data}
+        columns={columns}
+        columnPreferencesKey="patient.file.morbidity-report.preferences"
+        defaultColumnPreferences={columnPreferences}
+        actions={
+            <Permitted permission={permissions.morbidityReport.add}>
+                <LinkButton
+                    secondary
+                    sizing={sizing}
+                    icon="add_circle"
+                    href={`/nbs/api/profile/${patient}/report/morbidity`}>
+                    Add morbidity report
+                </LinkButton>
+            </Permitted>
+        }
+        {...remaining}
+    />
+);
+
+type PatientFileMorbidityReportsCardProps = {
+    provider: MemoizedSupplier<Promise<PatientFileMorbidityReport[]>>;
+} & Omit<InternalCardProps, 'data'>;
+
+const PatientFileMorbidityReportsCard = ({ provider, ...remaining }: PatientFileMorbidityReportsCardProps) => (
+    <Suspense
+        fallback={
+            <LoadingOverlay>
+                <InternalCard {...remaining} />
+            </LoadingOverlay>
+        }>
+        <Await resolve={provider.get()}>{(data) => <InternalCard data={data} {...remaining} />}</Await>
+    </Suspense>
+);
+
+export { PatientFileMorbidityReportsCard };

--- a/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/index.ts
+++ b/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/index.ts
@@ -1,0 +1,4 @@
+export { PatientFileMorbidityReportsCard } from './PatientFileMorbidityReportsCard';
+
+export type { PatientFileMorbidityReport } from './morbidity-report';
+export { patientMorbidityReports } from './patientMorbidityReports';

--- a/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/morbidity-report.ts
+++ b/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/morbidity-report.ts
@@ -1,0 +1,22 @@
+import { AssociatedInvestigation } from 'libs/events/investigations/associated';
+import { ResultedTest } from 'libs/events/tests';
+import { Provider } from 'libs/provider';
+
+type PatientFileMorbidityReport = {
+    patient: number;
+    id: number;
+    local: string;
+    jurisdiction: string;
+    addedOn: Date;
+    receivedOn?: Date;
+    reportedOn?: Date;
+    condition?: string;
+    reportingFacility?: string;
+    orderingProvider?: Provider;
+    reportingProvider?: Provider;
+    treatments?: string[];
+    resultedTests?: ResultedTest[];
+    associations?: AssociatedInvestigation[];
+};
+
+export type { PatientFileMorbidityReport };

--- a/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/morbidity-reports.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/morbidity-reports.module.scss
@@ -1,0 +1,5 @@
+@use 'design-system/table/header/widths';
+
+.date-time-header {
+    @include widths.fixed(7rem);
+}

--- a/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/patientMorbidityReports.ts
+++ b/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/patientMorbidityReports.ts
@@ -1,0 +1,12 @@
+import { maybeJson } from 'libs/api';
+import { mapOr } from 'utils/mapping';
+import { PatientFileMorbidityReport } from './morbidity-report';
+import { transformer } from './transformer';
+
+const patientMorbidityReports = (patient: number): Promise<PatientFileMorbidityReport[]> =>
+    fetch(`/nbs/api/patients/${patient}/reports/morbidity`, { credentials: 'same-origin' })
+        .then(maybeJson)
+        .then(mapOr((response) => response.map(transformer), []))
+        .catch(() => []);
+
+export { patientMorbidityReports };

--- a/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/transformer.ts
+++ b/apps/modernization-ui/src/apps/patient/file/events/reports/morbidity/transformer.ts
@@ -1,0 +1,12 @@
+import { PatientMorbidityReport } from 'generated';
+import { PatientFileMorbidityReport } from './morbidity-report';
+import { maybeDate } from 'date';
+
+const transformer = (response: PatientMorbidityReport): PatientFileMorbidityReport => ({
+    ...response,
+    addedOn: new Date(response.addedOn),
+    receivedOn: maybeDate(response.receivedOn),
+    reportedOn: maybeDate(response.reportedOn)
+});
+
+export { transformer };

--- a/apps/modernization-ui/src/libs/api/index.ts
+++ b/apps/modernization-ui/src/libs/api/index.ts
@@ -1,2 +1,4 @@
+export { maybeJson } from './maybeJson';
+
 export { useApi } from './useApi';
 export type { ApiInteraction } from './useApi';

--- a/apps/modernization-ui/src/libs/api/maybeJson.ts
+++ b/apps/modernization-ui/src/libs/api/maybeJson.ts
@@ -1,0 +1,16 @@
+/**
+ * Attempts to extract a JSON payload from a {@link Response}.  If the response is not successful
+ * the resulting {@link Promise} contains the rejected {@link Response}.
+ *
+ * @param {Response} response
+ * @return {Promise}
+ */
+const maybeJson = (response: Response) => {
+    if (response.ok) {
+        return response.status !== 204 ? response.json() : Promise.resolve();
+    } else {
+        return Promise.reject(response);
+    }
+};
+
+export { maybeJson };

--- a/apps/modernization-ui/src/libs/events/reports/morbidity/TreatmentList.spec.tsx
+++ b/apps/modernization-ui/src/libs/events/reports/morbidity/TreatmentList.spec.tsx
@@ -1,0 +1,27 @@
+import { render, screen, within } from '@testing-library/react';
+import { TreatmentList } from './TreatmentList';
+
+describe('TreatmentList', () => {
+    it('should display each treatment', () => {
+        render(<TreatmentList>{['one', 'two', 'five', 'other']}</TreatmentList>);
+
+        const list = screen.queryByRole('list');
+
+        expect(within(list!).getByText('one'));
+        expect(within(list!).getByText('two'));
+        expect(within(list!).getByText('five'));
+        expect(within(list!).getByText('other'));
+    });
+
+    it('should not display a list when treatments are not given', () => {
+        render(<TreatmentList />);
+
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('should not display a list when there are no treatments', () => {
+        render(<TreatmentList>{[]}</TreatmentList>);
+
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+});

--- a/apps/modernization-ui/src/libs/events/reports/morbidity/TreatmentList.tsx
+++ b/apps/modernization-ui/src/libs/events/reports/morbidity/TreatmentList.tsx
@@ -1,13 +1,12 @@
 import { Shown } from 'conditional-render';
 import styles from './treatment-list.module.scss';
-import { exists } from 'utils/exists';
 
 type TreatmentListProps = {
     children?: string[];
 };
 
 const TreatmentList = ({ children }: TreatmentListProps) => (
-    <Shown when={exists(children)}>
+    <Shown when={Boolean(children?.length)}>
         <ul className={styles.treatments}>{children?.map((treatment, index) => <li key={index}>{treatment}</li>)}</ul>
     </Shown>
 );

--- a/apps/modernization-ui/src/libs/events/reports/morbidity/TreatmentList.tsx
+++ b/apps/modernization-ui/src/libs/events/reports/morbidity/TreatmentList.tsx
@@ -1,0 +1,15 @@
+import { Shown } from 'conditional-render';
+import styles from './treatment-list.module.scss';
+import { exists } from 'utils/exists';
+
+type TreatmentListProps = {
+    children?: string[];
+};
+
+const TreatmentList = ({ children }: TreatmentListProps) => (
+    <Shown when={exists(children)}>
+        <ul className={styles.treatments}>{children?.map((treatment, index) => <li key={index}>{treatment}</li>)}</ul>
+    </Shown>
+);
+
+export { TreatmentList };

--- a/apps/modernization-ui/src/libs/events/reports/morbidity/index.ts
+++ b/apps/modernization-ui/src/libs/events/reports/morbidity/index.ts
@@ -1,0 +1,1 @@
+export { TreatmentList } from './TreatmentList';

--- a/apps/modernization-ui/src/libs/events/reports/morbidity/treatment-list.module.scss
+++ b/apps/modernization-ui/src/libs/events/reports/morbidity/treatment-list.module.scss
@@ -1,0 +1,4 @@
+.treatments {
+    margin: 0;
+    padding: 0;
+}

--- a/apps/modernization-ui/src/libs/events/reports/morbidity/treatment-list.module.scss
+++ b/apps/modernization-ui/src/libs/events/reports/morbidity/treatment-list.module.scss
@@ -1,4 +1,5 @@
 .treatments {
     margin: 0;
     padding: 0;
+    list-style-position: inside;
 }


### PR DESCRIPTION
## Description

Adds the "Morbidity reports" card to the Patient file.

<img width="1365" height="219" alt="image" src="https://github.com/user-attachments/assets/bfc47d56-db57-4e29-89df-d23eecb37917" />


## Tickets

* [CNFT1-4175](https://cdc-nbs.atlassian.net/browse/CNFT1-4175)
* [CNFT1-4181](https://cdc-nbs.atlassian.net/browse/CNFT1-4181)
* [CNFT1-4046](https://cdc-nbs.atlassian.net/browse/CNFT1-4046)
* 
## Checklist before requesting a review
- [ ] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4175]: https://cdc-nbs.atlassian.net/browse/CNFT1-4175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-4181]: https://cdc-nbs.atlassian.net/browse/CNFT1-4181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-4046]: https://cdc-nbs.atlassian.net/browse/CNFT1-4046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ