### PR TITLE
[FIX] no height for non-visible Hint

### DIFF
--- a/apps/modernization-ui/src/design-system/hint/hint.module.scss
+++ b/apps/modernization-ui/src/design-system/hint/hint.module.scss
@@ -9,6 +9,8 @@
 
     visibility: hidden;
     pointer-events: none;
+    height: 0;
+    overflow: hidden;
 
     &.left {
         right: 100%;
@@ -22,5 +24,7 @@
         z-index: 10000;
         visibility: visible;
         pointer-events: all;
+        height: fit-content;
+        overflow: unset;
     }
 }

--- a/apps/modernization-ui/src/design-system/tooltip/tooltip-message.module.scss
+++ b/apps/modernization-ui/src/design-system/tooltip/tooltip-message.module.scss
@@ -5,6 +5,7 @@
 
     &::before,
     &::after {
+        height: 0;
         visibility: hidden;
         opacity: 0;
     }
@@ -12,6 +13,7 @@
     &.visible {
         &::before,
         &::after {
+            height: fit-content;
             visibility: visible;
             opacity: 1;
         }


### PR DESCRIPTION
## Description

Ensures that the `Hint`, and `Tooltip` components do not take up space when not visible.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
