### PR TITLE
[CNFT1-4346]added handleKey down test case for select component and functionality …

### DIFF
--- a/apps/modernization-ui/src/design-system/select/single/Select.spec.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.spec.tsx
@@ -10,19 +10,19 @@ describe('Select Component', () => {
         { name: 'name-four', value: 'value-four', label: 'label-four' }
     ];
 
-    test('renders with placeholder', () => {
+    it('renders with placeholder', () => {
         const { getByText } = render(<Select id="test-select" options={options} placeholder="Select an option" />);
         expect(getByText('Select an option')).toBeInTheDocument();
     });
 
-    test('renders options', () => {
+    it('renders options', () => {
         const { getByText } = render(<Select id="test-select" options={options} />);
         options.forEach((option) => {
             expect(getByText(option.name)).toBeInTheDocument();
         });
     });
 
-    test('calls onChange with selected option', () => {
+    it('calls onChange with selected option', () => {
         const handleChange = jest.fn();
         const { getByRole } = render(
             <Select
@@ -39,13 +39,28 @@ describe('Select Component', () => {
         expect(checked).toHaveTextContent('name-four');
     });
 
-    test('applies className', () => {
+    it('applies className', () => {
         const { getByRole } = render(<Select id="test-select" options={options} className="custom-class" />);
         expect(getByRole('combobox')).toHaveClass('custom-class');
     });
 
-    test('sets default value', () => {
+    it('sets default value', () => {
         const { getByRole } = render(<Select id="test-select" options={options} value={options[1]} />);
         expect(getByRole('combobox')).toHaveValue('value-two');
+    });
+
+    it('calls showPicker and stops propagation on Enter key press', async () => {
+        const user = userEvent.setup();
+        const { getByRole } = render(<Select id="test-select" options={options} />);
+        const select = getByRole('combobox') as HTMLSelectElement;
+
+        const mockShowPicker = jest.fn();
+        select.showPicker = mockShowPicker;
+
+        select.focus();
+
+        await user.keyboard('{Enter}');
+
+        expect(mockShowPicker).toHaveBeenCalled();
     });
 });

--- a/apps/modernization-ui/src/design-system/select/single/Select.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, type KeyboardEvent } from 'react';
 import classNames from 'classnames';
 import { findByValue, Selectable } from 'options';
 import { Sizing } from 'design-system/field';
@@ -46,6 +46,14 @@ const Select = ({
         }
     };
 
+    const handleKeyDown = (event: KeyboardEvent<HTMLSelectElement>) => {
+        if (event.key === 'Enter') {
+            event.stopPropagation();
+            const selectElement = event.currentTarget;
+            selectElement.showPicker();
+        }
+    };
+
     return (
         <select
             id={id}
@@ -53,6 +61,7 @@ const Select = ({
             name={inputProps.name ?? id}
             value={value?.value ?? ''}
             onChange={handleChange}
+            onKeyDown={handleKeyDown}
             {...inputProps}>
             {renderOptions(options, placeholder)}
         </select>


### PR DESCRIPTION
…meeting accesibility requirements

## Description

Problem: Users could not open the Select dropdown using the Enter key, which is a common accessibility pattern and expected behavior for keyboard navigation.

Native HTML select limitations on the standard HTML select element does not natively respond to the Enter key for opening dropdowns - they typically only respond to:
Space key to open dropdown
Arrow keys to navigate options
Mouse clicks

therefore a showPicker() API (which opens the dropdown programmatically) was available but not being utilized for keyboard interactions

## Tickets

* [CNFT1-4346](https://cdc-nbs.atlassian.net/browse/CNFT1-4346)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
