### PR TITLE
Remove Guarded, replace w/ FeatureToggle

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/summary/PatientFileSummary.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/summary/PatientFileSummary.tsx
@@ -4,8 +4,7 @@ import { PatientFileDemographicsSummaryCard } from '../demographics/summary';
 import { PatientFileOpenInvestigationsCard } from './openInvestigations';
 import { PatientDocumentRequiringReviewCard } from './documentRequiringReview';
 import { PatientMergeHistoryCard } from './mergeHistory/PatientMergeHistoryCard';
-import { Guarded } from '../../../../libs/guard';
-import { permissions } from '../../../../libs/permission';
+import { FeatureToggle } from '../../../../feature';
 
 const PatientFileSummary = () => {
     const { summary, demographics, patient } = usePatientFileData();
@@ -28,11 +27,9 @@ const PatientFileSummary = () => {
                 provider={summary.get().drr}
                 sizing={sizing}
             />
-            <Guarded
-                feature={(features) => features.patient.file.mergeHistory?.enabled}
-                permission={permissions.patient.file}>
+            <FeatureToggle guard={(features) => features.patient.file.mergeHistory?.enabled}>
                 <PatientMergeHistoryCard id="merge-history" provider={summary.get().mergeHistory} patient={patient} />
-            </Guarded>
+            </FeatureToggle>
         </>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/file/summary/mergeHistory/PatientMergeHistory.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/summary/mergeHistory/PatientMergeHistory.module.scss
@@ -19,8 +19,8 @@
     }
     th:first-child,
     td:first-child {
-      width: 5rem;
-      min-width: 5rem;
+      width: 6rem;
+      min-width: 6rem;
       max-width: 9rem;
       white-space: nowrap;
     }


### PR DESCRIPTION
## Description
The usage of `Guarded` redirected the Patient File page to Home. 

Another bug: Merge History first column was too small
