### PR TITLE
Merge Preview: Font size fix

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/shared/preview-card-table/MergePreviewTableCard.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/shared/preview-card-table/MergePreviewTableCard.module.scss
@@ -5,6 +5,7 @@
   border-bottom-left-radius: 0.3125rem;
   border-bottom-right-radius: 0.3125rem;
   border-bottom: none !important;
+  font-size: 0.75rem !important;
 }
 
 .card {

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/shared/preview-card-table/MergePreviewTableCard.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/shared/preview-card-table/MergePreviewTableCard.tsx
@@ -24,7 +24,13 @@ export function MergePreviewTableCard<T>({ id, title, columns, data }: SortableT
                     {data.length}
                 </Tag>
             }>
-            <SortableDataTable id={`${id}-table`} columns={columns} data={data} className={styles.dataTable} />
+            <SortableDataTable
+                id={`${id}-table`}
+                columns={columns}
+                data={data}
+                sizing={'small'}
+                className={styles.dataTable}
+            />
             <div className={styles.footer} />
         </Card>
     );


### PR DESCRIPTION
## Description
Merge preview screen fonts different between repeating block and non repeating block fields

Fixed:
<img width="1464" height="610" alt="image" src="https://github.com/user-attachments/assets/75eedea5-efae-47a2-aa13-d04c036d506b" />

## Tickets
* [CND-403](https://cdc-nbs.atlassian.net/browse/CND-403?atlOrigin=eyJpIjoiMGY0MmJjZmNlYTBlNDQ1YWExMjBkMTdmZmE3Zjc2MTAiLCJwIjoiaiJ9)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
