### PR TITLE
Bug: Lined Card Preview Screen

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/shared/preview-card-lined/LinedMergePreviewCard.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-preview/components/shared/preview-card-lined/LinedMergePreviewCard.module.scss
@@ -11,7 +11,6 @@
 .content {
   display: flex;
   flex-direction: column;
-  padding-inline: 1rem;
   width: 100%;
 }
 
@@ -20,15 +19,16 @@
   flex-direction: column;
   padding-block: 0.5rem 0.5rem;
   position: relative;
+  padding-inline: 1rem;
 }
 
 .underlined::after {
   content: '';
   position: absolute;
   bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 43.5rem;
+  left: 0;
+  right: 0;
+  width: 100%;
   @extend %thin-bottom;
   pointer-events: none;
 }


### PR DESCRIPTION
## Description
This PR updates the LinedMergePreviewCard styles to ensure the thin bottom border (applied to lined items) extends completely from edge to edge of the card, with no horizontal spacing.

## Tickets
N/A

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
