### PR TITLE
Use the standard col widths

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/shared/merge-data-table/MergeDataTable.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/shared/merge-data-table/MergeDataTable.tsx
@@ -59,6 +59,7 @@ export const MergeDataTable = <V,>({
         {
             id: 'view-icon',
             name: '',
+            className: styles['selection-header'],
             render: (v) => (
                 <div className={styles.action}>
                     <Button

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/shared/merge-data-table/merge-data-table.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/shared/merge-data-table/merge-data-table.module.scss
@@ -4,7 +4,7 @@
 
 .dataTable {
     border-collapse: collapse !important;
-    height: 100%;
+
     & > thead tr th {
         &:nth-of-type(1) {
             width: 3rem;

--- a/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/shared/merge-data-table/merge-data-table.module.scss
+++ b/apps/modernization-ui/src/apps/deduplication/patient-merge/details/merge-review/patient-form/shared/merge-data-table/merge-data-table.module.scss
@@ -1,13 +1,13 @@
 @use 'styles/colors';
 @use 'styles/borders';
+@use 'design-system/table/header/widths';
 
 .dataTable {
     border-collapse: collapse !important;
-    table-layout: auto !important;
     height: 100%;
     & > thead tr th {
         &:nth-of-type(1) {
-            width: 50px;
+            width: 3rem;
         }
 
         &:nth-of-type(5) {
@@ -17,6 +17,7 @@
     & > tbody {
         & > tr {
             @extend %thin-bottom;
+            word-wrap: break-word;
 
             & > td {
                 &:nth-child(5) {


### PR DESCRIPTION
## Description

Use standard column widths instead of auto. Add break word to prevent overlap

## Tickets
N/A

## Demo
### Before
<img width="941" height="779" alt="image" src="https://github.com/user-attachments/assets/acd450b7-129b-4299-a7a6-10aacd46f045" />


### After
<img width="937" height="801" alt="image" src="https://github.com/user-attachments/assets/73083b89-1a24-449a-a06e-8b3ee5a78a5c" />


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
