### PR TITLE
[CNFT1-4356]: adding button element and styles

### DIFF
--- a/apps/modernization-ui/src/design-system/table/header/ColumnHeader.tsx
+++ b/apps/modernization-ui/src/design-system/table/header/ColumnHeader.tsx
@@ -37,6 +37,7 @@ type BaseHeaderProps<V> = ColumnOptions & {
 
 const BaseHeader = <V,>({ className, sizing, column, children, ...remaining }: BaseHeaderProps<V>) => (
     <th
+        scope="col"
         className={classNames(
             styles.header,
             {

--- a/apps/modernization-ui/src/shared/header/NavBar.module.scss
+++ b/apps/modernization-ui/src/shared/header/NavBar.module.scss
@@ -15,6 +15,22 @@ $bumper: 0.375rem;
     --nav-bar-height: calc(#{$height} + #{$bumper});
 }
 
+@mixin nav-link {
+    color: $classic-navigation-color;
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 10pt;
+    font-family: Arial, sans-serif;
+    padding: 0.15em;
+    cursor: pointer;
+
+    &:focus {
+        background-color: $classic-active-navigation-item-background;
+        color: $classic-active-navigation-item-color;
+        outline: none;
+    }
+}
+
 .bottom {
     display: flex;
     justify-content: space-between;
@@ -90,18 +106,7 @@ $bumper: 0.375rem;
             text-align: center;
             padding: 3px;
             &.navLink a {
-                color: $classic-navigation-color;
-                text-decoration: none;
-                font-weight: bold;
-                font-size: 10pt;
-                font-family: Arial, sans-serif;
-                padding: 0.15em;
-                cursor: pointer;
-                &:focus {
-                    background-color: $classic-active-navigation-item-background;
-                    color: $classic-active-navigation-item-color;
-                    outline: none;
-                }
+                @include nav-link;
             }
             a {
                 color: $classic-navigation-color;
@@ -115,6 +120,16 @@ $bumper: 0.375rem;
                 &:focus {
                     outline: none;
                     background-color: $classic-navigation-background;
+                }
+            }
+
+            &.navLink .logoutButton {
+                @include nav-link;
+                background: transparent;
+                border: none;
+
+                &:hover {
+                    text-decoration: underline;
                 }
             }
         }

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -91,9 +91,9 @@ export const NavBar = () => {
                                             <span> | </span>
                                         </td>
                                         <td className={styles.navLink}>
-                                            <a onClick={logout} tabIndex={0}>
+                                            <button onClick={logout} tabIndex={0} className={styles.logoutButton}>
                                                 Logout
-                                            </a>
+                                            </button>
                                         </td>
                                     </tr>
                                 </tbody>


### PR DESCRIPTION
Logout button should have the space and enter keys functioning. So in this pr the prev anchor tag is now a button element.

Before changes
<img width="1506" height="201" alt="Screenshot 2025-07-24 at 2 07 52 PM" src="https://github.com/user-attachments/assets/7d679d9d-9d44-4bd2-b970-3d63166724e0" />

After changes (should be visibly the same)
<img width="1507" height="192" alt="Screenshot 2025-07-24 at 2 06 40 PM" src="https://github.com/user-attachments/assets/a47ccdd3-4235-45ec-94d5-7fde522c9620" /> Description


small demo https://github.com/user-attachments/assets/bf37d67c-c620-4228-b721-711e95ef7e29

## Tickets

* [CNFT1-4356](https://cdc-nbs.atlassian.net/browse/CNFT1-4356)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4356]: https://cdc-nbs.atlassian.net/browse/CNFT1-4356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ