### PR TITLE
[CNFT1-4358]adding h2 sideNav

### DIFF
--- a/apps/modernization-ui/src/design-system/side-nav/SideNavigation.tsx
+++ b/apps/modernization-ui/src/design-system/side-nav/SideNavigation.tsx
@@ -19,7 +19,7 @@ type Props = {
 export const SideNavigation = ({ title, className, children, ...remaining }: Props): ReactNode => {
     return (
         <div {...remaining} className={classNames(styles.sideNav, className)}>
-            <Heading level={1}>{title}</Heading>
+            <Heading className={styles.title} level={2}>{title}</Heading>
             <nav aria-label={title} className={styles.navEntries}>
                 <ul>{children}</ul>
             </nav>

--- a/apps/modernization-ui/src/design-system/side-nav/side-nav.module.scss
+++ b/apps/modernization-ui/src/design-system/side-nav/side-nav.module.scss
@@ -1,5 +1,6 @@
 @use 'styles/colors';
 @use 'styles/borders';
+@use 'styles/headers';
 
 .sideNav {
     display: flex;
@@ -77,5 +78,8 @@
                 }
             }
         }
+    }
+    .title {
+        @include headers.header(1);
     }
 }


### PR DESCRIPTION
## Description

Changing the structure of elements because of a reported issue that there can be only one h1 per page

## Tickets

* [CNFT1-4358](https://cdc-nbs.atlassian.net/browse/CNFT1-4358)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
