### PR TITLE
Fix border in Card

### DIFF
--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -59,7 +59,9 @@ const Card = ({
             />
 
             <Shown when={collapsible} fallback={children}>
-                <Collapsible open={!collapsed}>{children}</Collapsible>
+                <Collapsible open={!collapsed}>
+                    <div className={styles.childCard}>{children}</div>
+                </Collapsible>
             </Shown>
             <Shown when={!collapsed}>
                 <footer>{footer}</footer>

--- a/apps/modernization-ui/src/design-system/card/card-header.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card-header.module.scss
@@ -6,7 +6,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    @extend %thin-bottom;
 
     .subtext {
         font-size: 0.875rem;

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -18,4 +18,8 @@
     & > footer:not(:empty) {
         padding: 0.5rem 1rem;
     }
+
+    .childCard {
+        @extend %thin-top;
+    }
 }


### PR DESCRIPTION
## Description
The border in `CardHeader` is still present when the card is in collapsed state. 
<img width="2950" height="1130" alt="image" src="https://github.com/user-attachments/assets/2e65c618-a448-4c91-a524-a493adc2bb00" />

## Tickets
* [CND-405](https://cdc-nbs.atlassian.net/browse/CND-405?atlOrigin=eyJpIjoiYTRhNTIzZjFiNzMxNDJkNjkzZmQxMDA4ZGU0MTc4MWMiLCJwIjoiaiJ9)

## Demo
<img width="643" height="359" alt="Screenshot 2025-07-31 at 9 59 28 AM" src="https://github.com/user-attachments/assets/9f62e26f-f9cd-4792-a692-8a976ef3b0f9" />

https://github.com/user-attachments/assets/de4113e6-5cc3-4901-a276-7f5215ef0c6a

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-405]: https://cdc-nbs.atlassian.net/browse/CND-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ