### PR TITLE
[CNFT1-4185] Patient file contacts endpoints

### DIFF
--- a/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
+++ b/apps/modernization-api/postman/NDESS-Modernization-API.postman_collection.json
@@ -862,6 +862,49 @@
 									"response": []
 								},
 								{
+									"name": "Contacts named by patient",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{base}}/nbs/api/patients/{{patient}}/contacts",
+											"host": [
+												"{{base}}"
+											],
+											"path": [
+												"nbs",
+												"api",
+												"patients",
+												"{{patient}}",
+												"contacts"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Patient named by contacts",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{base}}/nbs/api/patients/{{patient}}/contacts/named",
+											"host": [
+												"{{base}}"
+											],
+											"path": [
+												"nbs",
+												"api",
+												"patients",
+												"{{patient}}",
+												"contacts",
+												"named"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "Laboratory Reports",
 									"request": {
 										"method": "GET",

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/BasePatientFIleContactFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/BasePatientFIleContactFinder.java
@@ -1,0 +1,58 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import com.google.common.collect.Multimap;
+import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
+import gov.cdc.nbs.patient.events.investigation.association.AssociatedInvestigationRowMapper;
+import gov.cdc.nbs.sql.MultiMapResultSetExtractor;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+class BasePatientFIleContactFinder implements PatientFileContactFinder {
+
+  private final String query;
+  private final JdbcClient client;
+  private final ResultSetExtractor<Multimap<String, PatientFileContacts.PatientFileContact>> extractor;
+
+
+  BasePatientFIleContactFinder(final String query, final JdbcClient client) {
+    this.query = query;
+    this.client = client;
+    this.extractor = new MultiMapResultSetExtractor<>(
+        (rs, rowNum) -> rs.getString(1),
+        new PatientFileContactRowMapper(
+            new PatientFileContactRowMapper.Column(2, 3, 4, 5, 6, 7, 8,
+                new NamedContactRowMapper.Columns(9, 10, 11, 12, 13),
+                14, 15,
+                new AssociatedInvestigationRowMapper.Column(16, 17, 18, 19)
+            )
+        )
+    );
+  }
+
+  @Override
+  public List<PatientFileContacts> find(final long patient, PermissionScope scope, final PermissionScope associatedScope) {
+    if (scope.allowed()) {
+      return this.client.sql(query)
+          .param("patient", patient)
+          .param("any", scope.any())
+          .param("associated", resolveAssociated(associatedScope))
+          .query(extractor)
+          .asMap()
+          .entrySet()
+          .stream()
+          .map(e -> new PatientFileContacts(e.getKey(), e.getValue()))
+          .toList();
+    }
+
+    return Collections.emptyList();
+  }
+
+  private Collection<Long> resolveAssociated(final PermissionScope scope) {
+    Collection<Long> any = scope.any();
+    return any.isEmpty() ? List.of(Long.MIN_VALUE) : any;
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/BasePatientFileContactResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/BasePatientFileContactResolver.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.authorization.permission.Permission;
+import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
+import gov.cdc.nbs.authorization.permission.scope.PermissionScopeResolver;
+
+import java.util.List;
+
+class BasePatientFileContactResolver {
+
+  private static final Permission SCOPE = new Permission("view", "ct_contact");
+  private static final Permission ASSOCIATION = new Permission("view", "Investigation");
+
+  private final PermissionScopeResolver resolver;
+  private final PatientFileContactFinder finder;
+
+  BasePatientFileContactResolver(
+      final PermissionScopeResolver resolver,
+      final PatientFileContactFinder finder
+  ) {
+    this.resolver = resolver;
+    this.finder = finder;
+  }
+
+  List<PatientFileContacts> resolve(final long patient) {
+    PermissionScope scope = resolver.resolve(SCOPE);
+    PermissionScope associatedScope = resolver.resolve(ASSOCIATION);
+
+    return finder.find(patient, scope, associatedScope);
+
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/NamedContact.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/NamedContact.java
@@ -1,0 +1,15 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+record NamedContact(
+    @JsonProperty(required = true)
+    long patientId,
+    String first,
+    String middle,
+    String last,
+    String suffix
+) {
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/NamedContactRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/NamedContactRowMapper.java
@@ -1,0 +1,35 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+class NamedContactRowMapper implements RowMapper<NamedContact> {
+
+  record Columns(int patientId, int first, int middle, int last, int suffix) {
+  }
+
+  private final Columns columns;
+
+  NamedContactRowMapper(final Columns columns) {
+    this.columns = columns;
+  }
+
+  @Override
+  public NamedContact mapRow(final ResultSet resultSet, final int row) throws SQLException {
+    long patientId = resultSet.getLong(columns.patientId());
+    String first = resultSet.getString(columns.first());
+    String middle = resultSet.getString(columns.middle());
+    String last = resultSet.getString(columns.last());
+    String suffix = resultSet.getString(columns.suffix());
+
+    return new NamedContact(
+        patientId,
+        first,
+        middle,
+        last,
+        suffix
+    );
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactFinder.java
@@ -1,0 +1,13 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
+
+import java.util.List;
+
+public interface PatientFileContactFinder {
+  List<PatientFileContacts> find(
+      long patient,
+      PermissionScope scope,
+      PermissionScope associatedScope
+  );
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientController.java
@@ -1,0 +1,31 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+class PatientFileContactNamedByPatientController {
+  private final PatientFileContactNamedByPatientResolver resolver;
+
+  PatientFileContactNamedByPatientController(final PatientFileContactNamedByPatientResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @PreAuthorize("hasAuthority('VIEW-CT_CONTACT')")
+  @Operation(
+      operationId = "contactsNamedByPatient",
+      summary = "Patient File Contacts named by patient",
+      description = "Provides contacts that were named by a patient during an investigation",
+      tags = "PatientFile"
+  )
+  @GetMapping("/nbs/api/patients/{patient}/contacts")
+  List<PatientFileContacts> find(@PathVariable final long patient) {
+    return resolver.resolve(patient);
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientFinder.java
@@ -1,0 +1,111 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+@Component
+class PatientFileContactNamedByPatientFinder extends BasePatientFIleContactFinder {
+
+  private static final String QUERY = """
+      with id_settings([prefix], [suffix],[initial]) as   (
+        select
+          [generator].UID_prefix_cd     as [prefix],
+          [generator].UID_suffix_CD     as [suffix],
+          cast([configuration].config_value as bigint)  as [initial]
+        from Local_UID_generator [generator] with (nolock),
+          NBS_configuration [configuration] with (nolock)
+        where [generator].class_name_cd = 'PERSON'
+          and [generator].type_cd = 'LOCAL'
+          and [configuration].config_key = 'SEED_VALUE'
+      ),
+      revisions (person_uid, mpr_id) as (
+          select
+              [patient].[person_uid],
+              [patient].person_parent_uid
+          from  Person [patient] with (nolock)
+          where   [patient].person_parent_uid = :patient
+              and [patient].person_parent_uid <> [patient].person_uid
+              and [patient].cd = 'PAT'
+              and [patient].record_status_cd = 'ACTIVE'
+      )
+      select
+              [condition].[condition_desc_txt]                as [condition],
+              [revisions].mpr_id                              as [patient],
+              [contact_record].CT_Contact_uid                 as [identifier],
+              [contact_record].local_id                       as [local],
+              [contact_record].contact_referral_basis_cd      as [referral_basis],
+              [processing_descision].code_desc_txt            as [processing_descision],
+              [contact_record].[add_time]                     as [created_on],
+              [contact_record].named_On_Date                  as [named_on],
+              cast(
+                      substring(
+                              [named].local_id,
+                              len(id_settings.prefix) + 1,
+                              len([named].local_id) - len(id_settings.prefix) - len(id_settings.suffix)
+                      ) as bigint
+              ) - id_settings.initial                         as [name_patient_id],
+              [named].first_nm                                as [named_first_name],
+              [named].middle_nm                               as [named_middle_name],
+              [named].last_nm                                 as [named_last_name],
+              [suffix].code_short_desc_txt                    as [named_suffix],
+              [priority].code_desc_txt                        as [priority],
+              [disposition].code_desc_txt                     as [disposition],
+              [associated].public_health_case_uid             as [associated_identifier],
+              [associated].local_id                           as [associstad_local],
+              [associated_condition].condition_short_nm       as [associated_condition],
+              [follow_up_status].code_desc_txt                as [associated_status]
+      from id_settings, revisions
+              join CT_contact [contact_record] with (nolock) on
+                          [contact_record].SUBJECT_ENTITY_UID = [revisions].person_uid
+                      and [contact_record].record_status_cd = 'ACTIVE'
+                      and [contact_record].program_jurisdiction_oid in (:any)
+      
+              join public_health_case [investigation] with (nolock) on
+                      [investigation].public_health_case_uid = [contact_record].subject_entity_phc_uid
+      
+              join nbs_srte..Condition_code [condition] with (nolock) on
+                      [condition].condition_cd = [investigation].cd
+      
+              join Person [named] with (nolock) on
+                          [named].person_uid = [contact_record].CONTACT_ENTITY_UID
+      
+              left join NBS_SRTE..Code_value_general [suffix] with (nolock) on
+                          [suffix].[code_set_nm] = 'P_NM_SFX'
+                      and [suffix].[code] = [named].nm_suffix
+      
+              left join NBS_SRTE..Code_value_general [processing_descision] with (nolock) on
+                          [processing_descision].[code] = [contact_record].[processing_decision_cd]
+                      and [processing_descision].code_set_nm = 'STD_CONTACT_RCD_PROCESSING_DECISION'
+      
+              left join NBS_SRTE..Code_value_general [priority] with (nolock) on
+                          [priority].code = [contact_record].priority_cd
+                      and [priority].code_set_nm = 'NBS_PRIORITY'
+      
+              left join NBS_SRTE..Code_value_general [disposition] with (nolock) on
+                          [disposition].code = [contact_record].disposition_cd
+                      and [disposition].code_set_nm = 'NBS_DISPO'
+      
+              --  Associated investigations
+              left join public_health_case [associated] with (nolock) on
+                          [associated].public_health_case_uid  = [contact_record].contact_entity_phc_uid
+                      and [associated].program_jurisdiction_oid in (:associated)
+      
+              left join nbs_srte..Condition_code [associated_condition] with (nolock) on
+                              [associated_condition].condition_cd = [associated].cd
+      
+              left join case_management [management] with (nolock) on
+                      [management].public_health_case_uid = [associated].public_health_case_uid
+      
+              left join NBS_SRTE..Code_value_general [follow_up_status] with (nolock) on
+                          [follow_up_status].code = [management].init_foll_up
+                      and [follow_up_status].code_set_nm = 'STD_NBS_PROCESSING_DECISION_ALL'
+      
+      order by
+              [contact_record].local_id desc
+      """;
+
+  PatientFileContactNamedByPatientFinder(final JdbcClient client) {
+    super(QUERY, client);
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientResolver.java
@@ -1,0 +1,18 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.authorization.permission.scope.PermissionScopeResolver;
+import org.springframework.stereotype.Component;
+
+@Component
+class PatientFileContactNamedByPatientResolver extends BasePatientFileContactResolver {
+
+
+  PatientFileContactNamedByPatientResolver(
+      final PermissionScopeResolver resolver,
+      final PatientFileContactNamedByPatientFinder finder
+  ) {
+    super(resolver, finder);
+  }
+
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactRowMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactRowMapper.java
@@ -1,0 +1,71 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.data.time.LocalDateColumnMapper;
+import gov.cdc.nbs.patient.events.investigation.association.AssociatedInvestigation;
+import gov.cdc.nbs.patient.events.investigation.association.AssociatedInvestigationRowMapper;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+class PatientFileContactRowMapper implements RowMapper<PatientFileContacts.PatientFileContact> {
+
+  record Column(
+      int patient,
+      int identifier,
+      int local,
+      int referralBasis,
+      int processingDecision,
+      int createdOn,
+      int namedOn,
+      NamedContactRowMapper.Columns named,
+      int priority,
+      int disposition,
+      AssociatedInvestigationRowMapper.Column associated
+  ) {
+  }
+
+  private final Column columns;
+  private final RowMapper<NamedContact> namedContactRowMapper;
+  private final RowMapper<AssociatedInvestigation> associatedRowMapper;
+
+  PatientFileContactRowMapper(final Column columns) {
+    this.columns = columns;
+    this.namedContactRowMapper = new NamedContactRowMapper(columns.named);
+    this.associatedRowMapper = new AssociatedInvestigationRowMapper(columns.associated);
+  }
+
+  @Override
+  public PatientFileContacts.PatientFileContact mapRow(
+      final ResultSet resultSet,
+      final int rowNum
+  ) throws SQLException {
+    long patient = resultSet.getLong(this.columns.patient());
+    long identifier = resultSet.getLong(this.columns.identifier());
+    String local = resultSet.getString(this.columns.local());
+    String processingDecision = resultSet.getString(this.columns.processingDecision());
+    String referralBasis = resultSet.getString(this.columns.referralBasis());
+    LocalDateTime createdOn = resultSet.getObject(this.columns.createdOn, LocalDateTime.class);
+    LocalDate namedOn = LocalDateColumnMapper.map(resultSet, this.columns.namedOn());
+    NamedContact named = namedContactRowMapper.mapRow(resultSet, rowNum);
+    String priority = resultSet.getString(this.columns.priority());
+    String disposition = resultSet.getString(this.columns.disposition());
+    AssociatedInvestigation associated = associatedRowMapper.mapRow(resultSet, rowNum);
+
+    return new PatientFileContacts.PatientFileContact(
+        patient,
+        identifier,
+        local,
+        processingDecision,
+        referralBasis,
+        createdOn,
+        namedOn,
+        named,
+        priority,
+        disposition,
+        associated
+    );
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContacts.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContacts.java
@@ -1,0 +1,35 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.cdc.nbs.patient.events.investigation.association.AssociatedInvestigation;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+record PatientFileContacts(
+    @JsonProperty(required = true) String condition,
+    @JsonProperty(required = true) Collection<PatientFileContact> contacts
+) {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record PatientFileContact(
+      @JsonProperty(required = true) long patient,
+      @JsonProperty(required = true) long identifier,
+      @JsonProperty(required = true) String local,
+      String processingDecision,
+      String referralBasis,
+      @JsonProperty(required = true)
+      LocalDateTime createdOn,
+      LocalDate namedOn,
+      @JsonProperty(required = true)
+      NamedContact named,
+      String priority,
+      String disposition,
+      AssociatedInvestigation associated
+  ) {
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactController.java
@@ -1,0 +1,31 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+class PatientFilePatientNamedByContactController {
+  private final PatientFilePatientNamedByContactResolver resolver;
+
+  PatientFilePatientNamedByContactController(final PatientFilePatientNamedByContactResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @PreAuthorize("hasAuthority('VIEW-CT_CONTACT')")
+  @Operation(
+      operationId = "patientNamedByContact",
+      summary = "Patient File Contacts that named patient",
+      description = "Provides contacts that named the patient during their investigation",
+      tags = "PatientFile"
+  )
+  @GetMapping("/nbs/api/patients/{patient}/contacts/named")
+  List<PatientFileContacts> find(@PathVariable final long patient) {
+    return resolver.resolve(patient);
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactFinder.java
@@ -1,0 +1,113 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+@Component
+class PatientFilePatientNamedByContactFinder extends BasePatientFIleContactFinder {
+
+  private static final String QUERY = """
+      with id_settings([prefix], [suffix],[initial]) as   (
+          select
+            [generator].UID_prefix_cd     as [prefix],
+            [generator].UID_suffix_CD     as [suffix],
+            cast([configuration].config_value as bigint)  as [initial]
+          from Local_UID_generator [generator] WITH (NOLOCK),
+            NBS_configuration [configuration] WITH (NOLOCK)
+          where [generator].class_name_cd = 'PERSON'
+            and [generator].type_cd = 'LOCAL'
+            and [configuration].config_key = 'SEED_VALUE'
+        ),
+        revisions (person_uid, mpr_id) as (
+            select
+                [patient].[person_uid],
+                [patient].person_parent_uid
+            from  Person [patient] with (nolock)
+            where   [patient].person_parent_uid = :patient
+                and [patient].person_parent_uid <> [patient].person_uid
+                and [patient].cd = 'PAT'
+                and [patient].record_status_cd = 'ACTIVE'
+      )
+      select
+              [condition].[condition_desc_txt]                as [condition],
+              [revisions].mpr_id                              as [patient],
+              [contact_record].[CT_Contact_uid]               as [identifier],
+              [contact_record].local_id                       as [local],
+              [contact_record].contact_referral_basis_cd      as [referral_basis],
+              [processing_descision].code_desc_txt            as [processing_descision],
+              [contact_record].[add_time]                     as [created_on],
+              [contact_record].named_On_Date                  as [named_on],
+              cast(
+                      substring(
+                              [named].local_id,
+                              len(id_settings.prefix) + 1,
+                              len([named].local_id) - len(id_settings.prefix) - len(id_settings.suffix)
+                      ) as bigint
+              ) - id_settings.initial                         as [name_patient_id],
+              [named].first_nm                                as [named_first_name],
+              [named].middle_nm                               as [named_middle_name],
+              [named].last_nm                                 as [named_last_name],
+              [suffix].code_short_desc_txt                    as [named_suffix],
+              [priority].code_desc_txt                        as [priority],
+              [disposition].code_desc_txt                     as [disposition],
+              [associated].public_health_case_uid             as [associated_identifier],
+              [associated].local_id                           as [associstad_local],
+              [associated_condition].condition_short_nm       as [associated_condition],
+              [follow_up_status].code_desc_txt                as [associated_status]
+      from id_settings, revisions
+              join CT_contact [contact_record] with (nolock) on
+                          [contact_record].contact_entity_uid = [revisions].person_uid
+                      and [contact_record].record_status_cd = 'ACTIVE'
+                      and [contact_record].program_jurisdiction_oid in (:any)
+      
+              join public_health_case [investigation] with (nolock) on
+                      [investigation].public_health_case_uid = [contact_record].subject_entity_phc_uid
+      
+              join nbs_srte..Condition_code [condition] on
+                      [condition].condition_cd = [investigation].cd
+      
+              join Person [named] with (nolock) on
+                          [named].person_uid = [contact_record].subject_entity_uid
+      
+              left join NBS_SRTE..Code_value_general [suffix] on
+                          [suffix].[code_set_nm] = 'P_NM_SFX'
+                      and [suffix].[code] = [named].nm_suffix
+      
+              left join NBS_SRTE..Code_value_general [processing_descision] with (nolock) on
+                          [processing_descision].[code] = [contact_record].[processing_decision_cd]
+                      and [processing_descision].code_set_nm = 'STD_CONTACT_RCD_PROCESSING_DECISION'
+      
+              left join NBS_SRTE..Code_value_general [priority] on
+                          [priority].code = [contact_record].priority_cd
+                      and [priority].code_set_nm = 'NBS_PRIORITY'
+      
+              left join NBS_SRTE..Code_value_general [disposition] with (nolock) on
+                          [disposition].code = [contact_record].disposition_cd
+                      and [disposition].code_set_nm = 'NBS_DISPO'
+      
+              --  Associated investigations
+              left join public_health_case [associated] with (nolock) on
+                          [associated].PUBLIC_HEALTH_CASE_UID  = [contact_record].SUBJECT_ENTITY_PHC_UID
+                      and [associated].program_jurisdiction_oid in (:associated)
+      
+              left join nbs_srte..Condition_code [associated_condition] with (nolock) on
+                              [associated_condition].condition_cd = [associated].cd
+      
+              left join case_management [management] with (nolock) on
+                      [management].public_health_case_uid = [associated].public_health_case_uid
+      
+              left join NBS_SRTE..Code_value_general [follow_up_status] with (nolock) on
+                          [follow_up_status].code = [management].init_foll_up
+                      and [follow_up_status].code_set_nm = 'STD_NBS_PROCESSING_DECISION_ALL'
+      
+      order by
+          [contact_record].local_id desc
+      """;
+
+
+
+  PatientFilePatientNamedByContactFinder(final JdbcClient client) {
+    super(QUERY, client);
+  }
+
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactResolver.java
@@ -1,0 +1,17 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.authorization.permission.scope.PermissionScopeResolver;
+import org.springframework.stereotype.Component;
+
+@Component
+class PatientFilePatientNamedByContactResolver extends BasePatientFileContactResolver {
+
+  PatientFilePatientNamedByContactResolver(
+      final PermissionScopeResolver resolver,
+      final PatientFilePatientNamedByContactFinder finder
+  ) {
+    super(resolver, finder);
+  }
+
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/event/investigation/InvestigationSteps.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.testing.authorization.ActiveUser;
 import gov.cdc.nbs.testing.authorization.jurisdiction.JurisdictionIdentifier;
 import gov.cdc.nbs.testing.authorization.programarea.ProgramAreaIdentifier;
 import gov.cdc.nbs.testing.support.Active;
+import gov.cdc.nbs.testing.support.Available;
 import gov.cdc.nbs.testing.support.concept.ConceptParameterResolver;
 import io.cucumber.java.ParameterType;
 import io.cucumber.java.en.Given;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 @Transactional
 public class InvestigationSteps {
 
+  private final Available<PatientIdentifier> availablePatients;
   private final Active<PatientIdentifier> activePatient;
   private final Active<JurisdictionIdentifier> activeJurisdiction;
   private final Active<ProgramAreaIdentifier> activeProgramArea;
@@ -26,6 +28,7 @@ public class InvestigationSteps {
   private final ConceptParameterResolver resolver;
 
   public InvestigationSteps(
+      final Available<PatientIdentifier> availablePatients,
       final Active<PatientIdentifier> activePatient,
       final Active<JurisdictionIdentifier> activeJurisdiction,
       final Active<ProgramAreaIdentifier> activeProgramArea,
@@ -34,6 +37,7 @@ public class InvestigationSteps {
       final InvestigationMother mother,
       final ConceptParameterResolver resolver
   ) {
+    this.availablePatients = availablePatients;
     this.activePatient = activePatient;
     this.activeJurisdiction = activeJurisdiction;
     this.activeProgramArea = activeProgramArea;
@@ -64,6 +68,21 @@ public class InvestigationSteps {
         )
     );
   }
+
+  @Given("the previous patient is a subject of an investigation for {programArea} within {jurisdiction}")
+  public void previousSubject(
+      final ProgramAreaIdentifier programArea,
+      final JurisdictionIdentifier jurisdiction
+  ) {
+    availablePatients.maybePrevious().ifPresent(
+        patient -> mother.create(
+            patient,
+            jurisdiction,
+            programArea
+        )
+    );
+  }
+
 
   @Given("the patient is a subject of {int} investigations")
   public void the_patient_is_a_subject_N_investigation(final int n) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientRequester.java
@@ -1,0 +1,22 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.interaction.http.AuthenticatedMvcRequester;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@Component
+class PatientFileContactNamedByPatientRequester {
+
+  private final AuthenticatedMvcRequester authenticated;
+
+  PatientFileContactNamedByPatientRequester(final AuthenticatedMvcRequester authenticated) {
+    this.authenticated = authenticated;
+  }
+
+  ResultActions request(final PatientIdentifier patient) {
+    return authenticated.request(get("/nbs/api/patients/{patient}/contacts", patient.id()));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientSteps.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class PatientFileContactNamedByPatientSteps {
+
+  private final Active<PatientIdentifier> activePatient;
+  private final PatientFileContactNamedByPatientRequester requester;
+  private final Active<ResultActions> response;
+
+  PatientFileContactNamedByPatientSteps(
+      final Active<PatientIdentifier> activePatient,
+      final PatientFileContactNamedByPatientRequester requester,
+      final Active<ResultActions> response
+  ) {
+    this.activePatient = activePatient;
+    this.requester = requester;
+    this.response = response;
+  }
+
+  @When("I view the contacts named by the patient")
+  public void view() {
+    this.activePatient.maybeActive()
+        .map(requester::request)
+        .ifPresent(response::active);
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactRecordVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactRecordVerificationSteps.java
@@ -1,0 +1,122 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.event.investigation.InvestigationIdentifier;
+import gov.cdc.nbs.testing.event.contact.ContactRecordIdentifier;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Then;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+public class PatientFileContactRecordVerificationSteps {
+
+  private final Active<ContactRecordIdentifier> activeContact;
+  private final Active<InvestigationIdentifier> activeInvestigation;
+  private final Active<ResultActions> response;
+
+  PatientFileContactRecordVerificationSteps(
+      final Active<ContactRecordIdentifier> activeContact,
+      final Active<InvestigationIdentifier> activeInvestigation,
+      final Active<ResultActions> response
+  ) {
+    this.activeContact = activeContact;
+    this.activeInvestigation = activeInvestigation;
+    this.response = response;
+  }
+
+  private String local() {
+    return this.activeContact.maybeActive().map(ContactRecordIdentifier::local).orElse(null);
+  }
+
+  @Then("the patient file has the patient named by the contact")
+  @Then("the patient file has the contact named by the patient")
+  public void found() throws Exception {
+    this.response.active().andExpect(jsonPath("$.[*].contacts[?(@.local=='%s')]", local()).exists());
+  }
+
+  @Then("the patient file has the patient named by the contact {string} {string}")
+  @Then("the patient file has the contact {string} {string} named by the patient")
+  public void named(final String first, final String last) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.named.first=='%s' && @.named.last=='%s')]",
+                local(), first, last
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record created on {localDate} at {time}")
+  public void createdOn(final LocalDate on, final LocalTime at) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.createdOn=='%s')]",
+                local(), LocalDateTime.of(on, at), at
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record named on {localDate}")
+  public void namedOn(final LocalDate on) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.namedOn=='%s')]",
+                local(), on
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record with a {string} priority")
+  public void priority(final String value) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.priority=='%s')]",
+                local(), value
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record with a {string} disposition")
+  public void disposition(final String value) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.disposition=='%s')]",
+                local(), value
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record with a {referralBasis} referral basis")
+  public void referralBasis(final String value) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.referralBasis=='%s')]",
+                local(), value
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record with a {string} processing decision")
+  public void processingDecision(final String value) throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.processingDecision=='%s')]",
+                local(), value
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record associated with the investigation")
+  public void associated() throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.associated.local=='%s')]",
+                local(), this.activeInvestigation.active().local()
+            ).exists()
+        );
+  }
+
+  @Then("the patient file has the contact record not associated with the investigation")
+  public void notAssociated() throws Exception {
+    this.response.active()
+        .andExpect(jsonPath("$.[*].contacts[?(@.local=='%s' && @.associated.local=='%s')]",
+                local(), this.activeInvestigation.active().local()
+            ).doesNotExist()
+        );
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactRequester.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactRequester.java
@@ -1,0 +1,22 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.interaction.http.AuthenticatedMvcRequester;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@Component
+class PatientFilePatientNamedByContactRequester {
+
+  private final AuthenticatedMvcRequester authenticated;
+
+  PatientFilePatientNamedByContactRequester(final AuthenticatedMvcRequester authenticated) {
+    this.authenticated = authenticated;
+  }
+
+  ResultActions request(final PatientIdentifier patient) {
+    return authenticated.request(get("/nbs/api/patients/{patient}/contacts/named", patient.id()));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactSteps.java
@@ -1,0 +1,30 @@
+package gov.cdc.nbs.patient.file.events.contact;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.When;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class PatientFilePatientNamedByContactSteps {
+
+  private final Active<PatientIdentifier> activePatient;
+  private final PatientFilePatientNamedByContactRequester requester;
+  private final Active<ResultActions> response;
+
+  PatientFilePatientNamedByContactSteps(
+      final Active<PatientIdentifier> activePatient,
+      final PatientFilePatientNamedByContactRequester requester,
+      final Active<ResultActions> response
+  ) {
+    this.activePatient = activePatient;
+    this.requester = requester;
+    this.response = response;
+  }
+
+  @When("I view the contacts that named the patient")
+  public void view() {
+    this.activePatient.maybeActive()
+        .map(requester::request)
+        .ifPresent(response::active);
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/EventConceptSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/EventConceptSteps.java
@@ -1,0 +1,43 @@
+package gov.cdc.nbs.testing.event;
+
+import gov.cdc.nbs.testing.support.concept.ConceptParameterResolver;
+import io.cucumber.java.ParameterType;
+
+public class EventConceptSteps {
+
+  private final ConceptParameterResolver resolver;
+
+  EventConceptSteps(final ConceptParameterResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @ParameterType(name = "priority", value = ".*")
+  public String priority(final String value) {
+    return resolver.resolve("NBS_PRIORITY", value)
+        .orElse(value);
+  }
+
+  @ParameterType(name = "disposition", value = ".*")
+  public String disposition(final String value) {
+    return resolver.resolve("NBS_DISPO", value)
+        .orElse(value);
+  }
+
+  @ParameterType(name = "processingDecision", value = ".*")
+  public String processingDecision(final String value) {
+    return resolver.resolve("NBS_NO_ACTION_RSN", value)
+        .orElse(value);
+  }
+
+  @ParameterType(name = "stdProcessingDecision", value = ".*")
+  public String stdProcessingDecision(final String value) {
+    return resolver.resolve("STD_NBS_PROCESSING_DECISION_ALL", value)
+        .orElse(value);
+  }
+
+  @ParameterType(name = "referralBasis", value = ".*")
+  public String referralBasis(final String value) {
+    return resolver.resolve("REFERRAL_BASIS", value)
+        .orElse(value);
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordIdentifier.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordIdentifier.java
@@ -1,0 +1,4 @@
+package gov.cdc.nbs.testing.event.contact;
+
+public record ContactRecordIdentifier(long identifier, String local) {
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordMother.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordMother.java
@@ -1,0 +1,168 @@
+package gov.cdc.nbs.testing.event.contact;
+
+import gov.cdc.nbs.event.investigation.InvestigationIdentifier;
+import gov.cdc.nbs.identity.MotherSettings;
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.authorization.jurisdiction.JurisdictionIdentifier;
+import gov.cdc.nbs.testing.authorization.programarea.ProgramAreaIdentifier;
+import gov.cdc.nbs.testing.data.TestingDataCleaner;
+import gov.cdc.nbs.testing.identity.SequentialIdentityGenerator;
+import gov.cdc.nbs.testing.support.Active;
+import jakarta.annotation.PreDestroy;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+class ContactRecordMother {
+
+  private static final String CREATE = """
+      insert into Act(act_uid, class_cd, mood_cd) values (:identifier, 'CT','EVN');
+      
+      insert into CT_contact (
+          ct_contact_uid,
+          local_id,
+          subject_entity_uid,
+          contact_entity_uid,
+          subject_entity_phc_uid,
+          prog_area_cd,
+          jurisdiction_cd,
+          program_jurisdiction_oid,
+          version_ctrl_nbr,
+          add_time,
+          add_user_id,
+          last_chg_time,
+          last_chg_user_id,
+          record_status_cd,
+          record_status_time
+      ) values (
+          :identifier,
+          :local,
+          :patient,
+          :named,
+          :investigation,
+          :programArea,
+          :jurisdiction,
+          :oid,
+          1,
+          :addedOn,
+          :addedBy,
+          :addedOn,
+          :addedBy,
+          'ACTIVE',
+          :addedOn
+      )
+      """;
+
+  private static final String DELETE_IN = """
+      delete from CT_contact where CT_Contact_uid in (:identifiers);
+      delete from Act where class_cd = 'CT' and act_uid in (:identifiers);
+      """;
+
+  private final JdbcClient client;
+  private final Active<ContactRecordIdentifier> active;
+  private final MotherSettings settings;
+  private final SequentialIdentityGenerator idGenerator;
+  private final TestingDataCleaner<Long> cleaner;
+
+  ContactRecordMother(
+      final JdbcClient client,
+      final Active<ContactRecordIdentifier> active,
+      final MotherSettings settings,
+      final SequentialIdentityGenerator idGenerator
+  ) {
+    this.client = client;
+    this.active = active;
+    this.settings = settings;
+    this.idGenerator = idGenerator;
+    this.cleaner = new TestingDataCleaner<>(client, DELETE_IN, "identifiers");
+  }
+
+  @PreDestroy
+  void cleanup() {
+    this.cleaner.clean();
+  }
+
+  void create(
+      final PatientIdentifier named,
+      final InvestigationIdentifier investigation
+  ) {
+
+    long identifier = idGenerator.next();
+    String local = idGenerator.nextLocal("CON");
+
+    ProgramAreaIdentifier programArea = investigation.programArea();
+    JurisdictionIdentifier jurisdiction = investigation.jurisdiction();
+
+    this.client.sql(CREATE)
+        .param("identifier", identifier)
+        .param("local", local)
+        .param("addedOn", settings.createdOn())
+        .param("addedBy", settings.createdBy())
+        .param("programArea", programArea.code())
+        .param("jurisdiction", jurisdiction.code())
+        .param("oid", programArea.oid(jurisdiction))
+        .param("patient", investigation.revision())
+        .param("named", named.id())
+        .param("investigation", investigation.identifier())
+        .update();
+
+    include(new ContactRecordIdentifier(identifier, local));
+  }
+
+  private void include(final ContactRecordIdentifier identifier) {
+    this.active.active(identifier);
+    this.cleaner.include(identifier.identifier());
+  }
+
+  void createdOn(final ContactRecordIdentifier contact, final LocalDateTime on) {
+    this.client.sql("update ct_contact set add_time = ? where ct_contact_uid = ?")
+        .param(on)
+        .param(contact.identifier())
+        .update();
+  }
+
+  void namedOn(final ContactRecordIdentifier contact, final LocalDate on) {
+    this.client.sql("update ct_contact set named_On_Date = ? where ct_contact_uid = ?")
+        .param(on)
+        .param(contact.identifier())
+        .update();
+  }
+
+  void priority(final ContactRecordIdentifier contact, final String value) {
+    this.client.sql("update ct_contact set priority_cd = ? where ct_contact_uid = ?")
+        .param(value)
+        .param(contact.identifier())
+        .update();
+  }
+
+  void disposition(final ContactRecordIdentifier contact, final String value) {
+    this.client.sql("update ct_contact set disposition_cd = ? where ct_contact_uid = ?")
+        .param(value)
+        .param(contact.identifier())
+        .update();
+  }
+
+  void referralBasis(final ContactRecordIdentifier contact, final String value) {
+    this.client.sql("update ct_contact set contact_referral_basis_cd = ? where ct_contact_uid = ?")
+        .param(value)
+        .param(contact.identifier())
+        .update();
+  }
+
+  void processingDecision(final ContactRecordIdentifier contact, final String value) {
+    this.client.sql("update ct_contact set processing_decision_cd = ? where ct_contact_uid = ?")
+        .param(value)
+        .param(contact.identifier())
+        .update();
+  }
+
+  public void associated(final ContactRecordIdentifier contact, final InvestigationIdentifier investigation) {
+    this.client.sql("update ct_contact set contact_entity_phc_uid = ? where ct_contact_uid = ?")
+        .param(investigation.identifier())
+        .param(contact.identifier())
+        .update();
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordSteps.java
@@ -1,0 +1,102 @@
+package gov.cdc.nbs.testing.event.contact;
+
+import gov.cdc.nbs.event.investigation.InvestigationIdentifier;
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.patient.RevisionMother;
+import gov.cdc.nbs.testing.support.Active;
+import gov.cdc.nbs.testing.support.Available;
+import io.cucumber.java.en.Given;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class ContactRecordSteps {
+
+  private final Active<InvestigationIdentifier> activeInvestigation;
+  private final Active<PatientIdentifier> activePatient;
+  private final Available<PatientIdentifier> availablePatients;
+  private final Active<ContactRecordIdentifier> activeContactRecord;
+  private final RevisionMother revisionMother;
+  private final ContactRecordMother mother;
+
+  ContactRecordSteps(
+      final Active<InvestigationIdentifier> activeInvestigation,
+      final Active<PatientIdentifier> activePatient,
+      final Available<PatientIdentifier> availablePatients,
+      final Active<ContactRecordIdentifier> activeContactRecord,
+      final RevisionMother revisionMother,
+      final ContactRecordMother mother
+  ) {
+    this.activeInvestigation = activeInvestigation;
+    this.activePatient = activePatient;
+    this.availablePatients = availablePatients;
+    this.activeContactRecord = activeContactRecord;
+    this.revisionMother = revisionMother;
+    this.mother = mother;
+  }
+
+
+  @Given("the patient names the previous patient as a contact on the investigation")
+  public void namesPrevious() {
+    this.activeInvestigation.maybeActive()
+        .ifPresent(investigation -> mother.create(
+                revisionMother.revise(availablePatients.previous()),
+                investigation
+            )
+        );
+  }
+
+  @Given("the patient was named as a contact in the investigation")
+  public void named() {
+    this.activeInvestigation.maybeActive()
+        .ifPresent(investigation -> mother.create(
+                revisionMother.revise(activePatient.active()),
+                investigation
+            )
+        );
+  }
+
+  @Given("the contact record was created on {localDate} at {time}")
+  public void createdOn(final LocalDate on, final LocalTime at) {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.createdOn(contact, LocalDateTime.of(on, at)));
+  }
+
+  @Given("the contact record was named on {localDate}")
+  public void namedOn(final LocalDate value) {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.namedOn(contact, value));
+  }
+
+  @Given("the contact record has a {priority} priority")
+  public void priority(final String value) {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.priority(contact, value));
+  }
+
+  @Given("the contact record has a {disposition} disposition")
+  public void disposition(final String value) {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.disposition(contact, value));
+  }
+
+  @Given("the contact record has a {referralBasis} referral basis")
+  public void referralBasis(final String value) {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.referralBasis(contact, value));
+  }
+
+  @Given("the contact record has a {stdProcessingDecision} processing decision")
+  public void processingDecision(final String value) {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.processingDecision(contact, value));
+  }
+
+
+  @Given("the contact record is associated with the investigation")
+  public void associated() {
+    this.activeContactRecord.maybeActive()
+        .ifPresent(contact -> mother.associated(contact, activeInvestigation.active()));
+  }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordSupportConfiguration.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/event/contact/ContactRecordSupportConfiguration.java
@@ -1,0 +1,24 @@
+package gov.cdc.nbs.testing.event.contact;
+
+import gov.cdc.nbs.testing.support.Active;
+import gov.cdc.nbs.testing.support.Available;
+import io.cucumber.spring.ScenarioScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+class ContactRecordSupportConfiguration {
+
+  @Bean
+  @ScenarioScope
+  Active<ContactRecordIdentifier> activeContactRecord() {
+    return new Active<>();
+  }
+
+  @Bean
+  @ScenarioScope
+  Available<ContactRecordIdentifier> availableContactRecords() {
+    return new Available<>();
+  }
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/patient/RevisionPatientCreator.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/testing/patient/RevisionPatientCreator.java
@@ -10,68 +10,19 @@ import org.springframework.stereotype.Component;
 class RevisionPatientCreator {
 
   private static final String QUERY = """
-      insert into Entity(entity_uid, class_cd) values (:identifier, 'PSN');
-      insert into Person (
-        person_parent_uid,
-        person_uid,
-        local_id,
-        version_ctrl_nbr,
-        cd,
-        birth_time,
-        curr_sex_cd,
-        add_user_id,
-        add_time,
-        last_chg_user_id,
-        last_chg_time,
-        record_status_cd,
-        record_status_time
-      )
-      select
-        [mpr].person_uid,
-        :identifier,
-        [mpr].local_id,
-        1,
-        [mpr].cd,
-        [mpr].birth_time,
-        [mpr].curr_sex_cd,
-        :by,
-        getDate(),
-        :by,
-        getDate(),
-        'ACTIVE',
-        getDate()
-      from Person [mpr]
-      where [mpr].person_uid = :mpr;
+      declare @legal table (patient bigint not null, first_nm varchar(50), middle_nm varchar(50), last_nm varchar(50));
       
-      insert into Person_name (
-          person_uid,
-          person_name_seq,
-          nm_use_cd,
+      insert into @legal (
+          patient,
           first_nm,
-          last_nm,
-          add_user_id,
-          add_time,
-          last_chg_user_id,
-          last_chg_time,
-          record_status_cd,
-          record_status_time,
-          status_cd,
-          status_time
+          middle_nm,
+          last_nm
       )
       select
-          :identifier,
-          1,
-          [name].nm_use_cd,
+          [name].person_uid,
           [name].first_nm,
-          [name].last_nm,
-          [name].add_user_id,
-          [name].add_time,
-          [name].last_chg_user_id,
-          [name].last_chg_time,
-          [name].record_status_cd,
-          [name].record_status_time,
-          [name].status_cd,
-          [name].status_time
+          [name].middle_nm,
+          [name].last_nm
       from Person_name [name]
       where   [name].person_uid = :mpr
           and [name].nm_use_cd = 'L'
@@ -95,6 +46,80 @@ class RevisionPatientCreator {
                   and [seq_name].[as_of_date] = [name].as_of_date
           )
       ;
+      
+      insert into Entity(entity_uid, class_cd) values (:identifier, 'PSN');
+      
+      insert into Person (
+        person_parent_uid,
+        person_uid,
+        local_id,
+        version_ctrl_nbr,
+        cd,
+        birth_time,
+        curr_sex_cd,
+        first_nm,
+        middle_nm,
+        last_nm,
+        add_user_id,
+        add_time,
+        last_chg_user_id,
+        last_chg_time,
+        record_status_cd,
+        record_status_time
+      )
+      select
+        [mpr].person_uid,
+        :identifier,
+        [mpr].local_id,
+        1,
+        [mpr].cd,
+        [mpr].birth_time,
+        [mpr].curr_sex_cd,
+        [legal].first_nm,
+        [legal].middle_nm,
+        [legal].last_nm,
+        :by,
+        getDate(),
+        :by,
+        getDate(),
+        'ACTIVE',
+        getDate()
+      from Person [mpr]
+          left join @legal [legal] on
+                  [legal].patient = [mpr].person_uid
+      
+      where [mpr].person_uid = :mpr;
+      
+      insert into Person_name (
+          person_uid,
+          person_name_seq,
+          nm_use_cd,
+          first_nm,
+          last_nm,
+          add_user_id,
+          add_time,
+          last_chg_user_id,
+          last_chg_time,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time
+      )
+      select
+          :identifier,
+          1,
+          'L',
+          [name].first_nm,
+          [name].last_nm,
+          :by,
+          getDate(),
+          :by,
+          getDate(),
+          'ACTIVE',
+          getDate(),
+          'A',
+          :by
+      from @legal [name];
       """;
 
   private final JdbcClient client;

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.contacts-named-by-patient.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.contacts-named-by-patient.feature
@@ -1,0 +1,53 @@
+@patient-file-contact-named-by-patient
+Feature: Patient File Contacts named by Patient
+
+  Background:
+    Given there is a program area named "Tyrant Virus"
+    And there is a jurisdiction named "Racoon City"
+    And I am logged into NBS
+    And I can "View" any "ct_contact" for Tyrant Virus in Racoon City
+    And I have a patient
+    And the patient has the Legal name "Claire" "Redfield"
+    And I have another patient
+    And the patient has the Legal name "Jill" "Valentine"
+    And the patient is a subject of an investigation for Tyrant Virus within Racoon City
+    And the patient names the previous patient as a contact on the investigation
+
+  Scenario: I can view Contacts named by a patient
+    Given the contact record has a High priority
+    And the contact record was created on 04/01/2018 at 19:23:29
+    And the contact record has a T1 - Positive Test referral basis
+    And the contact record was named on 02/05/2014
+    And the contact record has a Confirmed Case disposition
+    And the contact record has a Insufficient Info processing decision
+    When I view the contacts named by the patient
+    Then the patient file has the contact "Claire" "Redfield" named by the patient
+    And the patient file has the contact record with a T1 - Positive Test referral basis
+    And the patient file has the contact record with a "High" priority
+    And the patient file has the contact record created on 04/01/2018 at 19:23:29
+    And the patient file has the contact record named on 02/05/2014
+    And the patient file has the contact record with a "Confirmed Case" disposition
+    And the patient file has the contact record with a "Insufficient Info" processing decision
+
+  Scenario: I can view Contacts named by a patient with associated investigations for a patient
+    Given there is a program area named "T-JCCC203"
+    And there is a jurisdiction named "Arklay Mountains"
+    And the previous patient is a subject of an investigation for T-JCCC203 within Arklay Mountains
+    And the contact record is associated with the investigation
+    And I can "view" any "investigation" for T-JCCC203 in Arklay Mountains
+    When I view the contacts named by the patient
+    Then the patient file has the contact record associated with the investigation
+
+  Scenario: I cannot retrieve Contacts named by a patient associated investigations for a patient without permissions
+    Given there is a program area named "T-JCCC203"
+    And there is a jurisdiction named "Arklay Mountains"
+    And the previous patient is a subject of an investigation for T-JCCC203 within Arklay Mountains
+    And the contact record is associated with the investigation
+    When I view the contacts named by the patient
+    Then the patient file has the contact record not associated with the investigation
+
+
+  Scenario: I cannot retrieve Contact records named by a patient that haven't been named
+    Given I have another patient
+    When I view the contacts named by the patient
+    Then no values are returned

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.contacts-named-by-patient.permission.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.contacts-named-by-patient.permission.feature
@@ -1,0 +1,46 @@
+@patient-file-contact-named-by-patient
+Feature: Patient File Contacts named by patient permission
+
+  Background:
+    Given I am logged in
+    And I can "find" any "patient"
+    And there is a program area named "Gray Brittle Death"
+    And there is a jurisdiction named "Arkham"
+    And there is a program area named "Spattergroit"
+    And there is a jurisdiction named "Wizarding World"
+    And I have a patient
+    And I have another patient
+
+
+  Scenario: I cannot retrieve Contacts named by a patient without proper permission
+    When I view the contacts named by the patient
+    Then I am not allowed due to insufficient permissions
+
+  Scenario: I can only view Contacts named by a patient a patient within Program areas that I have access to
+    Given I can "view" any "ct_contact" for Spattergroit in Wizarding World
+    And the patient is a subject of an investigation for Spattergroit within Wizarding World
+    And the patient names the previous patient as a contact on the investigation
+    When I view the contacts named by the patient
+    Then the patient file has the contact named by the patient
+
+  Scenario: I can not view Contacts named by a patient a patient for Program areas that I have access to
+    Given I can "view" any "ct_contact" for Spattergroit in Wizarding World
+    And the patient is a subject of an investigation for Gray Brittle Death within Wizarding World
+    And the patient names the previous patient as a contact on the investigation
+    When I view the contacts named by the patient
+    Then no values are returned
+
+  Scenario: I can only view Contacts named by a patient a patient for Jurisdictions that I have access to
+    Given I can "view" any "ct_contact" for Gray Brittle Death in Arkham
+    And the patient is a subject of an investigation for Gray Brittle Death within Arkham
+    And the patient names the previous patient as a contact on the investigation
+    When I view the contacts named by the patient
+    Then the patient file has the contact named by the patient
+
+  Scenario: I can not view Contacts named by a patient a patient for Jurisdictions that I have access to
+    Given I can "view" any "ct_contact" for Gray Brittle Death in Arkham
+    And the patient is a subject of an investigation for Spattergroit within Arkham
+    And the patient names the previous patient as a contact on the investigation
+    When I view the contacts named by the patient
+    Then no values are returned
+

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.patient-named-by-contact.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.patient-named-by-contact.feature
@@ -1,0 +1,45 @@
+@patient-file-patient-named-by-contact
+Feature: Patient File Patient named by contact
+
+  Background:
+    Given there is a program area named "Tyrant Virus"
+    And there is a jurisdiction named "Racoon City"
+    And I am logged into NBS
+    And I can "View" any "ct_contact" for Tyrant Virus in Racoon City
+    And I have a patient
+    And the patient has the Legal name "Claire" "Redfield"
+    And the patient is a subject of an investigation for Tyrant Virus within Racoon City
+    And I have another patient
+    And the patient has the Legal name "Jill" "Valentine"
+    And the patient was named as a contact in the investigation
+
+  Scenario: I can view Contacts named by a patient
+    Given the contact record has a High priority
+    And the contact record was created on 04/01/2018 at 19:23:29
+    And the contact record has a T1 - Positive Test referral basis
+    And the contact record was named on 02/05/2014
+    And the contact record has a Confirmed Case disposition
+    And the contact record has a Insufficient Info processing decision
+    When I view the contacts that named the patient
+    Then the patient file has the contact "Claire" "Redfield" named by the patient
+    And the patient file has the contact record with a T1 - Positive Test referral basis
+    And the patient file has the contact record with a "High" priority
+    And the patient file has the contact record created on 04/01/2018 at 19:23:29
+    And the patient file has the contact record named on 02/05/2014
+    And the patient file has the contact record with a "Confirmed Case" disposition
+    And the patient file has the contact record with a "Insufficient Info" processing decision
+
+  Scenario: I can view Contacts named by a patient with associated investigations for a patient
+    Given I can "view" any "investigation" for Tyrant Virus in Racoon City
+    When I view the contacts that named the patient
+    Then the patient file has the contact record associated with the investigation
+
+  Scenario: I cannot retrieve Contacts named by a patient associated investigations for a patient without permissions
+    When I view the contacts that named the patient
+    Then the patient file has the contact record not associated with the investigation
+
+
+  Scenario: I cannot retrieve Contact records named by a patient that haven't been named
+    Given I have another patient
+    When I view the contacts that named the patient
+    Then no values are returned

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.patient-named-by-contacts.permissions.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.patient-named-by-contacts.permissions.feature
@@ -1,0 +1,47 @@
+@patient-file-patient-named-by-contact
+Feature: Patient File Patient named by contact permission
+
+  Background:
+    Given I am logged in
+    And I can "find" any "patient"
+    And there is a program area named "Gray Brittle Death"
+    And there is a jurisdiction named "Arkham"
+    And there is a program area named "Spattergroit"
+    And there is a jurisdiction named "Wizarding World"
+    And I have a patient
+
+  Scenario: I cannot retrieve Contacts named by a patient without proper permission
+    When I view the contacts that named the patient
+    Then I am not allowed due to insufficient permissions
+
+  Scenario: I can only view Contacts named by a patient a patient within Program areas that I have access to
+    Given I can "view" any "ct_contact" for Spattergroit in Wizarding World
+    And the patient is a subject of an investigation for Spattergroit within Wizarding World
+    And I have another patient
+    And the patient was named as a contact in the investigation
+    When I view the contacts that named the patient
+    Then the patient file has the patient named by the contact
+
+  Scenario: I can not view Contacts named by a patient a patient for Program areas that I have access to
+    Given I can "view" any "ct_contact" for Spattergroit in Wizarding World
+    And the patient is a subject of an investigation for Gray Brittle Death within Wizarding World
+    And I have another patient
+    And the patient was named as a contact in the investigation
+    When I view the contacts that named the patient
+    Then no values are returned
+
+  Scenario: I can only view Contacts named by a patient a patient for Jurisdictions that I have access to
+    Given I can "view" any "ct_contact" for Gray Brittle Death in Arkham
+    And the patient is a subject of an investigation for Gray Brittle Death within Arkham
+    And I have another patient
+    And the patient was named as a contact in the investigation
+    When I view the contacts that named the patient
+    Then the patient file has the patient named by the contact
+
+  Scenario: I can not view Contacts named by a patient a patient for Jurisdictions that I have access to
+    Given I can "view" any "ct_contact" for Gray Brittle Death in Arkham
+    And the patient is a subject of an investigation for Spattergroit within Arkham
+    And I have another patient
+    And the patient was named as a contact in the investigation
+    When I view the contacts that named the patient
+    Then no values are returned

--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -36,6 +36,7 @@ export type { LoginResponse } from './models/LoginResponse';
 export type { Me } from './models/Me';
 export type { MortalityDemographic } from './models/MortalityDemographic';
 export type { Name } from './models/Name';
+export type { NamedContact } from './models/NamedContact';
 export type { NameDemographic } from './models/NameDemographic';
 export type { NewPatient } from './models/NewPatient';
 export type { NotificationStatus } from './models/NotificationStatus';
@@ -44,6 +45,8 @@ export type { PatientAddressDemographic } from './models/PatientAddressDemograph
 export type { PatientDemographicsSummary } from './models/PatientDemographicsSummary';
 export type { PatientEthnicityDemographic } from './models/PatientEthnicityDemographic';
 export { PatientFile } from './models/PatientFile';
+export type { PatientFileContact } from './models/PatientFileContact';
+export type { PatientFileContacts } from './models/PatientFileContacts';
 export type { PatientFileTreatment } from './models/PatientFileTreatment';
 export type { PatientGeneralInformationDemographic } from './models/PatientGeneralInformationDemographic';
 export type { PatientIdentificationDemographic } from './models/PatientIdentificationDemographic';

--- a/apps/modernization-ui/src/generated/models/NamedContact.ts
+++ b/apps/modernization-ui/src/generated/models/NamedContact.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type NamedContact = {
+    patientId: number;
+    first?: string;
+    middle?: string;
+    last?: string;
+    suffix?: string;
+};
+

--- a/apps/modernization-ui/src/generated/models/PatientFileContact.ts
+++ b/apps/modernization-ui/src/generated/models/PatientFileContact.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AssociatedInvestigation } from './AssociatedInvestigation';
+import type { NamedContact } from './NamedContact';
+export type PatientFileContact = {
+    patient: number;
+    identifier: number;
+    local: string;
+    processingDecision?: string;
+    referralBasis?: string;
+    createdOn: string;
+    namedOn?: string;
+    named: NamedContact;
+    priority?: string;
+    disposition?: string;
+    associated?: AssociatedInvestigation;
+};
+

--- a/apps/modernization-ui/src/generated/models/PatientFileContacts.ts
+++ b/apps/modernization-ui/src/generated/models/PatientFileContacts.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PatientFileContact } from './PatientFileContact';
+export type PatientFileContacts = {
+    condition: string;
+    contacts: Array<PatientFileContact>;
+};
+

--- a/apps/modernization-ui/src/generated/services/PatientFileService.ts
+++ b/apps/modernization-ui/src/generated/services/PatientFileService.ts
@@ -12,6 +12,7 @@ import type { PatientAddressDemographic } from '../models/PatientAddressDemograp
 import type { PatientDemographicsSummary } from '../models/PatientDemographicsSummary';
 import type { PatientEthnicityDemographic } from '../models/PatientEthnicityDemographic';
 import type { PatientFile } from '../models/PatientFile';
+import type { PatientFileContacts } from '../models/PatientFileContacts';
 import type { PatientFileTreatment } from '../models/PatientFileTreatment';
 import type { PatientGeneralInformationDemographic } from '../models/PatientGeneralInformationDemographic';
 import type { PatientIdentificationDemographic } from '../models/PatientIdentificationDemographic';
@@ -415,6 +416,44 @@ export class PatientFileService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/nbs/api/patients/{patient}/demographics/addresses',
+            path: {
+                'patient': patient,
+            },
+        });
+    }
+    /**
+     * Patient File Contacts named by patient
+     * Provides contacts that were named by a patient during an investigation
+     * @returns PatientFileContacts OK
+     * @throws ApiError
+     */
+    public static contactsNamedByPatient({
+        patient,
+    }: {
+        patient: number,
+    }): CancelablePromise<Array<PatientFileContacts>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/patients/{patient}/contacts',
+            path: {
+                'patient': patient,
+            },
+        });
+    }
+    /**
+     * Patient File Contacts that named patient
+     * Provides contacts that named the patient during their investigation
+     * @returns PatientFileContacts OK
+     * @throws ApiError
+     */
+    public static patientNamedByContact({
+        patient,
+    }: {
+        patient: number,
+    }): CancelablePromise<Array<PatientFileContacts>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/nbs/api/patients/{patient}/contacts/named',
             path: {
                 'patient': patient,
             },

--- a/libs/testing/auth-cucumber/src/main/java/gov/cdc/nbs/testing/authorization/programarea/ProgramAreaSteps.java
+++ b/libs/testing/auth-cucumber/src/main/java/gov/cdc/nbs/testing/authorization/programarea/ProgramAreaSteps.java
@@ -21,7 +21,7 @@ public class ProgramAreaSteps {
     this.mother.create(name);
   }
 
-  @ParameterType(name = "programArea", value = "\"?([\\w ]*)\"?")
+  @ParameterType(name = "programArea", value = "\"?([\\w\\d- ]*)\"?")
   public ProgramAreaIdentifier programArea(final String value) {
     return resolver.resolve(value).orElse(null);
   }

--- a/libs/testing/support/src/main/java/gov/cdc/nbs/testing/support/Available.java
+++ b/libs/testing/support/src/main/java/gov/cdc/nbs/testing/support/Available.java
@@ -50,11 +50,21 @@ public class Available<V> {
 
   public V one() {
     return maybeOne()
-        .orElseThrow(() -> new IllegalStateException("there are none available"));
+        .orElseThrow(() -> new NoSuchElementException("there are none available"));
   }
 
   public Stream<V> all() {
     return this.items.stream();
+  }
+
+  public Optional<V> maybePrevious() {
+    return (this.items.size() > 1)
+        ? Optional.ofNullable(this.items.get(this.items.size() - 2))
+        : Optional.empty();
+  }
+
+  public V previous() {
+    return maybePrevious().orElseThrow(() -> new NoSuchElementException("there is no previous available"));
   }
 
   public Stream<Indexed<V>> indexed() {

--- a/libs/testing/support/src/test/java/gov/cdc/nbs/testing/support/AvailableTest.java
+++ b/libs/testing/support/src/test/java/gov/cdc/nbs/testing/support/AvailableTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.testing.support;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.NoSuchElementException;
 import java.util.function.UnaryOperator;
 
 import static org.assertj.core.api.Assertions.*;
@@ -107,8 +108,8 @@ class AvailableTest {
   void should_require_initializer() {
     Available<Object> available = new Available<>();
 
-   assertThatThrownBy(() -> available.selected(current -> fail(), null))
-       .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> available.selected(current -> fail(), null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
@@ -275,5 +276,41 @@ class AvailableTest {
 
     assertThat(available.random()).isNotPresent();
 
+  }
+
+  @Test
+  void should_return_the_previous_item() {
+    Available<Object> available = new Available<>();
+
+    Object one = new Object();
+    Object two = new Object();
+    Object three = new Object();
+
+    available.available(one);
+    available.available(two);
+    available.available(three);
+
+    assertThat(available.maybePrevious()).hasValueSatisfying(item -> assertThat(item).isSameAs(two));
+
+    assertThat(available.previous()).isSameAs(two);
+  }
+
+  @Test
+  void should_not_return_the_previous_when_there_are_no_elements() {
+    Available<Object> available = new Available<>();
+
+    assertThat(available.maybePrevious()).isEmpty();
+
+    assertThatThrownBy(available::previous).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  void should_not_return_the_previous_when_there_is_only_one_element() {
+    Available<Object> available = new Available<>();
+    available.available(new Object());
+
+    assertThat(available.maybePrevious()).isEmpty();
+
+    assertThatThrownBy(available::previous).isInstanceOf(NoSuchElementException.class);
   }
 }


### PR DESCRIPTION
## Description

Adds the `/nbs/api/patients/{{patient}}/contacts` endpoint to return the contacts named by a patient in an investigation.
Adds the `/nbs/api/patients/{{patient}}/contacts/named` endpoint to return the contacts that named a patient in an investigation

## Tickets

* [CNFT1-4185](https://cdc-nbs.atlassian.net/browse/CNFT1-4185)
* [CNFT1-4055](https://cdc-nbs.atlassian.net/browse/CNFT1-4055)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
