### PR TITLE
Fix incorrect join in Merge History API causing mergedByUser to be null

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/history/PatientMergeHistoryFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/history/PatientMergeHistoryFinder.java
@@ -16,7 +16,7 @@ public class PatientMergeHistoryFinder {
         FROM
             person_merge pm
         LEFT JOIN
-            auth_user u ON pm.merge_user_id = u.auth_user_uid
+            auth_user u ON pm.merge_user_id = u.nedss_entry_id
         WHERE
             pm.surviving_person_uid = ?
         ORDER BY

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/history/PatientMergeHistorySteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/history/PatientMergeHistorySteps.java
@@ -44,7 +44,7 @@ public class PatientMergeHistorySteps {
     patientMergeMother.createMerge(
         survivingId, 1, survivingId,
         supersededId, 1, supersededId,
-        user.id(),
+        user.nedssEntry(),
         LocalDateTime.now()
     );
   }


### PR DESCRIPTION
## Description

Modified the SQL query to update the join condition between the person_merge table and the auth_user table.


## Tickets
https://cdc-nbs.atlassian.net/browse/CND-413