### PR TITLE
Add Permissions for NavBar

### DIFF
--- a/apps/modernization-ui/src/libs/permission/permissions.ts
+++ b/apps/modernization-ui/src/libs/permission/permissions.ts
@@ -24,6 +24,12 @@ export const permissions = {
         edit: 'EDIT-OBSERVATIONMORBIDITYREPORT',
         view: 'VIEW-OBSERVATIONMORBIDITYREPORT'
     },
+    viewReports: {
+        template: 'VIEWREPORTTEMPLATE-REPORTING',
+        public: 'VIEWREPORTPUBLIC-REPORTING',
+        private: 'VIEWREPORTPRIVATE-REPORTING',
+        reportingFacility: 'VIEWREPORTREPORTINGFACILITY-REPORTING'
+    },
     vaccination: {
         add: 'ADD-INTERVENTIONVACCINERECORD',
         view: 'VIEW-INTERVENTIONVACCINERECORD'

--- a/apps/modernization-ui/src/libs/permission/permissions.ts
+++ b/apps/modernization-ui/src/libs/permission/permissions.ts
@@ -24,11 +24,23 @@ export const permissions = {
         edit: 'EDIT-OBSERVATIONMORBIDITYREPORT',
         view: 'VIEW-OBSERVATIONMORBIDITYREPORT'
     },
-    viewReports: {
-        template: 'VIEWREPORTTEMPLATE-REPORTING',
-        public: 'VIEWREPORTPUBLIC-REPORTING',
-        private: 'VIEWREPORTPRIVATE-REPORTING',
-        reportingFacility: 'VIEWREPORTREPORTINGFACILITY-REPORTING'
+    reports: {
+        template: {
+            view: 'VIEWREPORTTEMPLATE-REPORTING'
+        },
+        public: {
+            view: 'VIEWREPORTPUBLIC-REPORTING'
+        },
+        private: {
+            view: 'VIEWREPORTPRIVATE-REPORTING'
+        },
+        reportingFacility: {
+            view: 'VIEWREPORTREPORTINGFACILITY-REPORTING'
+        }
+    },
+    summaryReports: {
+        view: 'VIEW-SUMMARYREPORT',
+        delete: 'DELETE-SUMMARYREPORT'
     },
     vaccination: {
         add: 'ADD-INTERVENTIONVACCINERECORD',

--- a/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
@@ -40,6 +40,20 @@ describe('NavBar component tests', () => {
         });
     });
 
+    describe('Merge Patients Section', ()=> {
+        it.each([
+            [permissions.patient.merge]
+        ])('should show Merge Patients with permission: %s', (permission) => {
+            const { getByText } = renderNavBarWithPermissions([permission]);
+            expect(getByText('Merge Patients')).toBeInTheDocument();
+        });
+
+        it('should NOT show Merge Patients without merge permissions', () => {
+            const { queryByText } = renderNavBarWithPermissions(['ADMINISTRATE-SYSTEM']);
+            expect(queryByText('Merge Patients')).not.toBeInTheDocument();
+        });
+    });
+
     describe('Reports section', () => {
         it.each([
             [permissions.viewReports.template],

--- a/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
@@ -40,6 +40,23 @@ describe('NavBar component tests', () => {
         });
     });
 
+    describe('Data Entry section', ()=>{
+        it.each([
+            [permissions.morbidityReport.add],
+            [permissions.labReport.add],
+            [permissions.summaryReports.view],
+            [permissions.patient.search]
+        ])('should show Data Entry with permission: %s', (permission) => {
+            const { getByText } = renderNavBarWithPermissions([permission]);
+            expect(getByText('Data Entry')).toBeInTheDocument();
+        });
+
+        it('should NOT show Data Entry without permissions', () => {
+            const { queryByText } = renderNavBarWithPermissions(['ADMINISTRATE-SYSTEM']);
+            expect(queryByText('Data Entry')).not.toBeInTheDocument();
+        });
+    });
+
     describe('Merge Patients Section', ()=> {
         it.each([
             [permissions.patient.merge]

--- a/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
@@ -73,10 +73,10 @@ describe('NavBar component tests', () => {
 
     describe('Reports section', () => {
         it.each([
-            [permissions.viewReports.template],
-            [permissions.viewReports.public],
-            [permissions.viewReports.private],
-            [permissions.viewReports.reportingFacility],
+            [permissions.reports.template.view],
+            [permissions.reports.public.view],
+            [permissions.reports.private.view],
+            [permissions.reports.reportingFacility.view],
         ])('should show Reports with permission: %s', (permission) => {
             const { getByText } = renderNavBarWithPermissions([permission]);
             expect(getByText('Reports')).toBeInTheDocument();
@@ -84,8 +84,8 @@ describe('NavBar component tests', () => {
 
         it('should show Reports with multiple report permissions', () => {
             const { getByText } = renderNavBarWithPermissions([
-                permissions.viewReports.template,
-                permissions.viewReports.private,
+                permissions.reports.template.view,
+                permissions.reports.private.view,
             ]);
             expect(getByText('Reports')).toBeInTheDocument();
         });

--- a/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
@@ -1,10 +1,10 @@
 import { usePage } from 'page';
 import { NavBar } from './NavBar';
 import { render } from '@testing-library/react';
+import { permissions} from 'libs/permission';
 
-const mockPermissions = ['ADMINISTRATE-SYSTEM', 'ADMINISTRATE-SECURITY'];
-const mockAllows = (permission: string) => mockPermissions.includes(permission);
-const mockAllowFn = jest.fn(mockAllows);
+let mockPermissions: string[] = [];
+const mockAllowFn = jest.fn((permission: string) => mockPermissions.includes(permission));
 
 jest.mock('../../libs/permission/usePermissions', () => ({
     usePermissions: () => ({
@@ -14,22 +14,54 @@ jest.mock('../../libs/permission/usePermissions', () => ({
 }));
 
 jest.mock('page', () => ({
-    usePage: jest.fn()
+    usePage: jest.fn(),
 }));
+
+const renderNavBarWithPermissions = (permissions: string[]) => {
+    mockPermissions = permissions;
+    return render(<NavBar />);
+};
 
 describe('NavBar component tests', () => {
     beforeEach(() => {
-        mockAllowFn.mockImplementation(mockAllows);
+        mockAllowFn.mockClear();
         (usePage as jest.Mock).mockReturnValue({ title: 'Test page' });
     });
 
     it('should render navigation bar', () => {
-        const { getByText } = render(<NavBar />);
+        const { getByText } = renderNavBarWithPermissions([]);
         expect(getByText('Test page')).toBeInTheDocument();
     });
 
-    it('should display System Management for users with Permissions', () => {
-        const { getByText } = render(<NavBar />);
-        expect(getByText('System Management')).toBeInTheDocument();
+    describe('System Management section', () => {
+        it('should display System Management with appropriate permission', () => {
+            const { getByText } = renderNavBarWithPermissions(['ADMINISTRATE-SYSTEM']);
+            expect(getByText('System Management')).toBeInTheDocument();
+        });
+    });
+
+    describe('Reports section', () => {
+        it.each([
+            [permissions.viewReports.template],
+            [permissions.viewReports.public],
+            [permissions.viewReports.private],
+            [permissions.viewReports.reportingFacility],
+        ])('should show Reports with permission: %s', (permission) => {
+            const { getByText } = renderNavBarWithPermissions([permission]);
+            expect(getByText('Reports')).toBeInTheDocument();
+        });
+
+        it('should show Reports with multiple report permissions', () => {
+            const { getByText } = renderNavBarWithPermissions([
+                permissions.viewReports.template,
+                permissions.viewReports.private,
+            ]);
+            expect(getByText('Reports')).toBeInTheDocument();
+        });
+
+        it('should NOT show Reports without report permissions', () => {
+            const { queryByText } = renderNavBarWithPermissions(['ADMINISTRATE-SYSTEM']);
+            expect(queryByText('Reports')).not.toBeInTheDocument();
+        });
     });
 });

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -24,18 +24,25 @@ export const NavBar = () => {
                                         <td className={styles.navLink}>
                                             <a href={`/nbs/HomePage.do?method=loadHomePage`}>Home</a>
                                         </td>
-                                        <td>
-                                            <span> | </span>
-                                        </td>
 
-                                        <td className={styles.navLink}>
-                                            <a href={`/nbs/LoadNavbar.do?ContextAction=DataEntry`}>Data Entry</a>
-                                        </td>
-                                        <td>
-                                            <span> | </span>
-                                        </td>
-
+                                        <Permitted
+                                            permission={permitsAny(
+                                                permissions.morbidityReport.add,
+                                                permissions.labReport.add,
+                                                permissions.summaryReports.view,
+                                                permissions.patient.search
+                                            )}>
+                                            <td>
+                                                <span> | </span>
+                                            </td>
+                                            <td className={styles.navLink}>
+                                                <a href={`/nbs/LoadNavbar.do?ContextAction=DataEntry`}>Data Entry</a>
+                                            </td>
+                                        </Permitted>
                                         <Permitted permission={permitsAll(permissions.patient.merge)}>
+                                            <td>
+                                                <span> | </span>
+                                            </td>
                                             <td className={styles.navLink}>
                                                 <a href={`/nbs/LoadNavbar1.do?ContextAction=MergePerson`}>
                                                     Merge Patients
@@ -43,27 +50,28 @@ export const NavBar = () => {
                                             </td>
                                         </Permitted>
 
-                                        <td>
-                                            <span> | </span>
-                                        </td>
-
-                                        <td className={styles.navLink}>
-                                            <a
-                                                href={`/nbs/LoadNavbar.do?ContextAction=GlobalInvestigations&initLoad=true`}>
-                                                Open Investigations
-                                            </a>
-                                        </td>
-                                        <td>
-                                            <span> | </span>
-                                        </td>
+                                        <Permitted permission={permitsAll(permissions.investigation.view)}>
+                                            <td>
+                                                <span> | </span>
+                                            </td>
+                                            <td className={styles.navLink}>
+                                                <a
+                                                    href={`/nbs/LoadNavbar.do?ContextAction=GlobalInvestigations&initLoad=true`}>
+                                                    Open Investigations
+                                                </a>
+                                            </td>
+                                        </Permitted>
 
                                         <Permitted
                                             permission={permitsAny(
-                                                permissions.viewReports.template,
-                                                permissions.viewReports.public,
-                                                permissions.viewReports.private,
-                                                permissions.viewReports.reportingFacility
+                                                permissions.reports.template.view,
+                                                permissions.reports.public.view,
+                                                permissions.reports.private.view,
+                                                permissions.reports.reportingFacility.view
                                             )}>
+                                            <td>
+                                                <span> | </span>
+                                            </td>
                                             <td className={styles.navLink}>
                                                 <a href={`/nbs/nfc?ObjectType=7&amp;OperationType=116`}>Reports</a>
                                             </td>

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -1,4 +1,4 @@
-import { permitsAny, Permitted, permissions } from 'libs/permission';
+import { permitsAny, Permitted, permissions, permitsAll } from 'libs/permission';
 import { usePage } from 'page';
 import { useUser } from 'user';
 
@@ -35,9 +35,14 @@ export const NavBar = () => {
                                             <span> | </span>
                                         </td>
 
-                                        <td className={styles.navLink}>
-                                            <a href={`/nbs/LoadNavbar1.do?ContextAction=MergePerson`}>Merge Patients</a>
-                                        </td>
+                                        <Permitted permission={permitsAll(permissions.patient.merge)}>
+                                            <td className={styles.navLink}>
+                                                <a href={`/nbs/LoadNavbar1.do?ContextAction=MergePerson`}>
+                                                    Merge Patients
+                                                </a>
+                                            </td>
+                                        </Permitted>
+
                                         <td>
                                             <span> | </span>
                                         </td>

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -1,4 +1,4 @@
-import { permitsAny, Permitted } from 'libs/permission';
+import { permitsAny, Permitted, permissions } from 'libs/permission';
 import { usePage } from 'page';
 import { useUser } from 'user';
 
@@ -52,9 +52,17 @@ export const NavBar = () => {
                                             <span> | </span>
                                         </td>
 
-                                        <td className={styles.navLink}>
-                                            <a href={`/nbs/nfc?ObjectType=7&amp;OperationType=116`}>Reports</a>
-                                        </td>
+                                        <Permitted
+                                            permission={permitsAny(
+                                                permissions.viewReports.template,
+                                                permissions.viewReports.public,
+                                                permissions.viewReports.private,
+                                                permissions.viewReports.reportingFacility
+                                            )}>
+                                            <td className={styles.navLink}>
+                                                <a href={`/nbs/nfc?ObjectType=7&amp;OperationType=116`}>Reports</a>
+                                            </td>
+                                        </Permitted>
 
                                         <Permitted
                                             permission={permitsAny(
@@ -66,7 +74,8 @@ export const NavBar = () => {
                                                 'REPORTADMIN-SYSTEM',
                                                 'ALERTADMIN-SYSTEM',
                                                 'ADMINISTRATE-SYSTEM',
-                                                'ADMINISTRATE-SECURITY'
+                                                'ADMINISTRATE-SECURITY',
+                                                'MERGE-PATIENT'
                                             )}>
                                             <td className={styles.navLink}>
                                                 <span> | </span>


### PR DESCRIPTION
## Description
Bug 🐞: When viewing the modernized page, the NavBar shows links to pages that the user does not have permissions to. 
This fix is a part of a [bug](https://cdc-nbs.atlassian.net/browse/CND-378?atlOrigin=eyJpIjoiMDE3NDkyNzk3NTFlNDI0Y2I1YjhkYTkyZTNjMjY0OGQiLCJwIjoiaiJ9) found while viewing System Management page through an MSA user. 

## Tickets
* [CND-378](https://cdc-nbs.atlassian.net/browse/CND-378?atlOrigin=eyJpIjoiMDE3NDkyNzk3NTFlNDI0Y2I1YjhkYTkyZTNjMjY0OGQiLCJwIjoiaiJ9)

## Demo
MSA user system management screen with the right NavBar:
<img width="1464" height="381" alt="image" src="https://github.com/user-attachments/assets/fec72aa6-0ef7-4de4-b0c2-42b0eb9e652f" />

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CND-378]: https://cdc-nbs.atlassian.net/browse/CND-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ