### PR TITLE
Fix: adding aria-description to all information as of date fields

### DIFF
--- a/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.spec.tsx
@@ -42,4 +42,12 @@ describe('when entering patient administrative information', () => {
 
         expect(queryByText('The Information as of date is required.')).toBeInTheDocument();
     });
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+        const dateInput = getByLabelText('Information as of date');
+        expect(dateInput).toHaveAttribute(
+            'aria-description',
+            "This field defaults to today's date and can be changed if needed."
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/administrative/AdministrativeEntryFields.tsx
@@ -29,6 +29,7 @@ export const AdministrativeEntryFields = ({ orientation = 'horizontal', sizing =
                         error={error?.message}
                         sizing={sizing}
                         required
+                        aria-description="This field defaults to today's date and can be changed if needed."
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/ethnicity/EthnicityEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/ethnicity/EthnicityEntryFields.spec.tsx
@@ -71,4 +71,12 @@ describe('when entering patient ethnicity demographics', () => {
 
         expect(queryByLabelText('Spanish origin')).not.toBeInTheDocument();
     });
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+        const dateInput = getByLabelText('Ethnicity information as of');
+        expect(dateInput).toHaveAttribute(
+            'aria-description',
+            "This field defaults to today's date and can be changed if needed."
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/ethnicity/EthnicityEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/ethnicity/EthnicityEntryFields.tsx
@@ -39,6 +39,7 @@ export const EthnicityEntryFields = ({ orientation = 'horizontal', sizing = 'med
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This field defaults to today's date and can be changed if needed."
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.spec.tsx
@@ -67,4 +67,12 @@ describe('when entering patient general information demographics', () => {
 
         expect(getByText('The General information as of is required.')).toBeInTheDocument();
     });
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+        const dateInput = getByLabelText('General information as of');
+        expect(dateInput).toHaveAttribute(
+            'aria-description',
+            "This field defaults to today's date and can be changed if needed."
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/general/GeneralInformationEntryFields.tsx
@@ -35,6 +35,7 @@ export const GeneralInformationEntryFields = ({ orientation = 'horizontal', sizi
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This field defaults to today's date and can be changed if needed."
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.spec.tsx
@@ -94,4 +94,12 @@ describe('when entering patient mortality demographics', () => {
         expect(getByLabelText('Death county')).toHaveValue('');
         expect(getByLabelText('Death country')).toHaveValue('');
     });
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+        const dateInput = getByLabelText('Mortality information as of');
+        expect(dateInput).toHaveAttribute(
+            'aria-description',
+            "This field defaults to today's date and can be changed if needed."
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/mortality/MortalityEntryFields.tsx
@@ -49,6 +49,7 @@ export const MortalityEntryFields = ({ orientation = 'horizontal', sizing = 'med
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This field defaults to today's date and can be changed if needed."
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.spec.tsx
@@ -183,4 +183,12 @@ describe('Race entry fields', () => {
         expect(getByText('category not valid')).toBeInTheDocument();
         expect(validator).toBeCalledWith(19, expect.objectContaining({ value: 'other' }));
     });
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+        const dateInput = getByLabelText('Race as of');
+        expect(dateInput).toHaveAttribute(
+            'aria-description',
+            "This field defaults to today's date and can be changed if needed."
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/race/RaceEntryFields.tsx
@@ -55,6 +55,7 @@ const RaceEntryFields = ({
                         orientation={orientation}
                         error={error?.message}
                         sizing={sizing}
+                        aria-description="This field defaults to today's date and can be changed if needed."
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.spec.tsx
@@ -154,4 +154,12 @@ describe('when entering patient sex and birth demographics', () => {
 
         expect(getByText('10 years')).toBeInTheDocument();
     });
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+        const dateInput = getByLabelText('Sex & birth information as of');
+        expect(dateInput).toHaveAttribute(
+            'aria-description',
+            "This field defaults to today's date and can be changed if needed."
+        );
+    });
 });

--- a/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/sexAndBirth/SexAndBirthEntryFields.tsx
@@ -65,6 +65,7 @@ export const SexAndBirthEntryFields = ({ orientation = 'horizontal', sizing = 'm
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This field defaults to today's date and can be changed if needed."
                     />
                 )}
             />


### PR DESCRIPTION
## Description

Adds aria-description attributes to all "information as of" date fields to improve accessibility. These fields are pre-populated with today's date by default, but users may need to change them if the information is from a different date.

## Tickets

* [CNFT1-4399](https://cdc-nbs.atlassian.net/browse/CNFT1-4399)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4399]: https://cdc-nbs.atlassian.net/browse/CNFT1-4399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ