### PR TITLE
[CNFT1-4399]-fix: adding aria description to as of date fields

### DIFF
--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.spec.tsx
@@ -69,6 +69,14 @@ describe('when entering patient address demographics', () => {
         expect(getByLabelText('Address comments')).toBeInTheDocument();
     });
 
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+
+        const dateInput = getByLabelText('Address as of');
+
+        expect(dateInput).toHaveAttribute('aria-description', 'This date defaults to today and can be changed if needed');
+    });
+
     it('should require type', async () => {
         const user = userEvent.setup();
         const { getByLabelText, getByText } = render(<Fixture />);

--- a/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/address/AddressEntryFields.tsx
@@ -49,6 +49,7 @@ export const AddressEntryFields = ({ orientation = 'horizontal', sizing = 'mediu
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This date defaults to today and can be changed if needed"
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.spec.tsx
@@ -54,6 +54,14 @@ describe('when entering patient identification demographics', () => {
         expect(await findByText('The Identification as of is required.')).toBeInTheDocument();
     });
 
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+
+        const dateInput = getByLabelText('Identification as of');
+
+        expect(dateInput).toHaveAttribute('aria-description', 'This date defaults to today and can be changed if needed');
+    });
+
     it('should require type', async () => {
         const user = userEvent.setup();
         const { getByLabelText, getByText } = render(<Fixture />);

--- a/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/identification/IdentificationEntryFields.tsx
@@ -32,6 +32,7 @@ export const IdentificationEntryFields = ({ orientation = 'horizontal', sizing =
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This date defaults to today and can be changed if needed"
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.spec.tsx
@@ -67,6 +67,14 @@ describe('when entering patient name demographics', () => {
         expect(await findByText('The Name as of is required.')).toBeInTheDocument();
     });
 
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+
+        const dateInput = getByLabelText('Name as of');
+
+        expect(dateInput).toHaveAttribute('aria-description', 'This date defaults to today and can be changed if needed');
+    });
+
     it('should require type', async () => {
         const user = userEvent.setup();
         const { getByLabelText, findByText } = render(<Fixture />);

--- a/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/name/NameEntryFields.tsx
@@ -32,6 +32,7 @@ export const NameEntryFields = ({ orientation = 'horizontal', sizing = 'medium' 
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This date defaults to today and can be changed if needed"
                     />
                 )}
             />

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.spec.tsx
@@ -78,6 +78,14 @@ describe('when entering patient phone & email demographics', () => {
         expect(await findByText('The Phone & email as of is required.')).toBeInTheDocument();
     });
 
+    it('should have accessibility description for the as of date field', () => {
+        const { getByLabelText } = render(<Fixture />);
+
+        const dateInput = getByLabelText('Phone & email as of');
+
+        expect(dateInput).toHaveAttribute('aria-description', 'This date defaults to today and can be changed if needed');
+    });
+
     it('should be valid with as of, type, and use', async () => {
         const user = userEvent.setup();
 

--- a/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
+++ b/apps/modernization-ui/src/apps/patient/data/phoneEmail/PhoneEmailEntryFields.tsx
@@ -39,6 +39,7 @@ export const PhoneEmailEntryFields = ({ orientation = 'horizontal', sizing = 'me
                         error={error?.message}
                         required
                         sizing={sizing}
+                        aria-description="This date defaults to today and can be changed if needed"
                     />
                 )}
             />


### PR DESCRIPTION
## Description

Adds aria-description attributes to all remaining "as of" date fields across patient data entry forms to improve screen reader accessibility. These fields are pre-populated with today's date, and the description helps users understand they can modify the date if the information is from a different day.
## Tickets

* [CNFT1-4399](https://cdc-nbs.atlassian.net/browse/CNFT1-4399)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4399]: https://cdc-nbs.atlassian.net/browse/CNFT1-4399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ