### PR TITLE
Allow Icon variants in SearchBar

### DIFF
--- a/apps/modernization-ui/src/apps/system-management/layout/SystemManagementPage.tsx
+++ b/apps/modernization-ui/src/apps/system-management/layout/SystemManagementPage.tsx
@@ -68,6 +68,7 @@ const SystemManagementPage = () => {
                         aria-label="Search"
                         value={filter}
                         onChange={setFilter}
+                        iconName={'filter_alt'}
                     />
                 </div>
             </header>

--- a/apps/modernization-ui/src/design-system/search/SearchBar.tsx
+++ b/apps/modernization-ui/src/design-system/search/SearchBar.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { Button } from 'design-system/button/Button';
 import { Sizing } from 'design-system/field';
 import styles from './SearchBar.module.scss';
+import { Icons } from '../icon';
 
 type SearchBarProps = {
     size?: Sizing;
@@ -11,6 +12,7 @@ type SearchBarProps = {
     value?: string;
     onChange?: (value: string) => void;
     onSearch?: (value: string) => void;
+    iconName?: Icons;
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'value' | 'onChange'>;
 
 export const SearchBar = ({
@@ -20,6 +22,7 @@ export const SearchBar = ({
     value: controlledValue,
     onChange: controlledOnChange,
     onSearch,
+    iconName = 'search',
     ...props
 }: SearchBarProps) => {
     // Internal state only if no controlledValue provided
@@ -79,7 +82,7 @@ export const SearchBar = ({
                     <Button
                         type="button"
                         sizing={size}
-                        icon="close"
+                        icon={'close'}
                         onClick={handleClear}
                         className={classNames(styles.clearButton, styles[`size-${size}`])}
                         aria-label="Clear"
@@ -89,7 +92,7 @@ export const SearchBar = ({
             <div>
                 <Button
                     sizing={size}
-                    icon="search"
+                    icon={iconName}
                     className={classNames(styles.searchButton, styles[`size-${size}`], { [styles.tall]: tall })}
                     onClick={() => onSearch?.(value)}
                     aria-label="Search"


### PR DESCRIPTION
## Description
1. Allow icon variants in `SearchBar`.
2. Bug 🐞: Update the `Icon` in `Button` in `system/management`

## Tickets
* [CND-367](https://cdc-nbs.atlassian.net/browse/CND-367?atlOrigin=eyJpIjoiMDc3NDVjMTExMWZhNDU3MGE5N2M2ODNiNTkzOWU2YjUiLCJwIjoiaiJ9)

## Demo
<img width="1512" height="298" alt="image" src="https://github.com/user-attachments/assets/6067590c-fa64-4a4f-9028-0477632ecdc6" />

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CND-367]: https://cdc-nbs.atlassian.net/browse/CND-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ