### PR TITLE
[CNFT1-4112] Patient file edit > page level validations

### DIFF
--- a/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.scss
+++ b/apps/modernization-ui/src/components/selection/multi/MultiSelectInput.scss
@@ -10,6 +10,12 @@
     background-size: 1.25rem;
 }
 
+.select-indicator {
+    background-image:
+        url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTEyIDUuODNMMTUuMTcgOWwxLjQxLTEuNDFMMTIgMyA3LjQxIDcuNTkgOC44MyA5IDEyIDUuODN6bTAgMTIuMzRMOC44MyAxNWwtMS40MSAxLjQxTDEyIDIxbDQuNTktNC41OUwxNS4xNyAxNSAxMiAxOC4xN3oiLz48L3N2Zz4=),
+        linear-gradient(transparent, transparent);
+}
+
 .multi-select {
     max-width: 20rem;
     .multi-select__control {

--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -34,17 +34,18 @@ const Card = ({
 }: CardProps) => {
     const [collapsed, setCollapsed] = useState<boolean>(!open);
 
+    const cardId = useId();
     const collapsibleId = useId();
 
     return (
         <section
-            id={id}
+            id={cardId}
             role="group"
-            aria-labelledby={`${id}-title`}
+            aria-labelledby={id}
             className={classNames(styles.card, className)}
             {...remaining}>
             <CardHeader
-                id={`${id}-title`}
+                id={id}
                 title={title}
                 level={level}
                 flair={flair}
@@ -55,7 +56,7 @@ const Card = ({
                     <Shown when={collapsible}>
                         <Button
                             className={classNames(styles.toggle, { [styles.collapsed]: collapsed })}
-                            sizing="small"
+                            sizing={remaining.sizing}
                             tertiary
                             icon="expand_less"
                             aria-label={collapsed ? `Show ${title} content` : `Hide ${title} content`}

--- a/apps/modernization-ui/src/design-system/card/table/TableCard.spec.tsx
+++ b/apps/modernization-ui/src/design-system/card/table/TableCard.spec.tsx
@@ -77,7 +77,7 @@ describe('TableCard', () => {
 
     it('renders without crashing', () => {
         const { container } = render(<Fixture />);
-        expect(container.querySelector('section#tablecard')).toBeInTheDocument();
+        expect(container.querySelector('#tablecard')).toBeInTheDocument();
     });
 
     it('should render with no accessibility violations', async () => {

--- a/apps/modernization-ui/src/design-system/entry/pending/PendingEntryAlert.tsx
+++ b/apps/modernization-ui/src/design-system/entry/pending/PendingEntryAlert.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react';
+import { Shown } from 'conditional-render';
+import { PendingEntry } from './pending';
+import { AlertMessage } from 'design-system/message';
+
+type PendingMessageRendererProps = { entry: PendingEntry };
+
+type PendingMessageRenderer = ({ entry }: PendingMessageRendererProps) => ReactNode;
+
+type PendingEntryAlertProps = {
+    pending: PendingEntry[];
+    title: string;
+    renderer: PendingMessageRenderer;
+};
+
+const PendingEntryAlert = ({ pending, title, renderer }: PendingEntryAlertProps) => {
+    return (
+        <Shown when={pending.length > 0}>
+            <div ref={scrollTo}>
+                <AlertMessage title={title} type="error">
+                    <ul>
+                        {pending.map((entry, index) => (
+                            <li key={index}>{renderer({ entry })}</li>
+                        ))}
+                    </ul>
+                </AlertMessage>
+            </div>
+        </Shown>
+    );
+};
+
+const scrollTo = (element: HTMLElement | null) => {
+    if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+};
+
+export { PendingEntryAlert };
+export type { PendingMessageRendererProps, PendingMessageRenderer };

--- a/apps/modernization-ui/src/design-system/entry/pending/index.ts
+++ b/apps/modernization-ui/src/design-system/entry/pending/index.ts
@@ -1,0 +1,7 @@
+export type { PendingEntry, HasPendingEntry } from './pending';
+
+export { usePendingFormEntry } from './usePendingFormEntry';
+export type { PendingFormEntryInteraction } from './usePendingFormEntry';
+
+export { PendingEntryAlert } from './PendingEntryAlert';
+export type { PendingMessageRendererProps, PendingMessageRenderer } from './PendingEntryAlert';

--- a/apps/modernization-ui/src/design-system/entry/pending/pending.ts
+++ b/apps/modernization-ui/src/design-system/entry/pending/pending.ts
@@ -1,0 +1,11 @@
+type PendingEntry = {
+    id: string;
+    name: string;
+    valid: boolean;
+};
+
+type HasPendingEntry = {
+    pending?: PendingEntry[];
+};
+
+export type { PendingEntry, HasPendingEntry };

--- a/apps/modernization-ui/src/design-system/entry/pending/usePendingFormEntry.ts
+++ b/apps/modernization-ui/src/design-system/entry/pending/usePendingFormEntry.ts
@@ -1,0 +1,85 @@
+import { useCallback, useRef, useState } from 'react';
+import { useController, UseFormReturn } from 'react-hook-form';
+import { HasPendingEntry, PendingEntry } from './pending';
+
+type EntryIdentifier = Pick<PendingEntry, 'id' | 'name'>;
+
+type PendingFormEntrySettings = {
+    form: UseFormReturn<HasPendingEntry>;
+};
+
+type OnEntry = (entry: EntryIdentifier) => (isPending: boolean) => void;
+type OnValid = (entry: EntryIdentifier) => (isValid: boolean) => void;
+
+type PendingFormEntryInteraction = {
+    pending: PendingEntry[];
+    onEntry: OnEntry;
+    onValid: OnValid;
+    check: (values: HasPendingEntry) => boolean;
+};
+
+const usePendingFormEntry = ({ form }: PendingFormEntrySettings): PendingFormEntryInteraction => {
+    const [pending, setPending] = useState<PendingEntry[]>([]);
+    const entries = useRef(new Map<string, PendingEntry>());
+
+    const { field } = useController({
+        name: 'pending',
+        control: form.control,
+        defaultValue: [],
+        rules: { validate }
+    });
+
+    const evaluate = useCallback(() => {
+        const values = Array.from(entries.current.values());
+        field.onChange(values);
+        field.onBlur();
+
+        // if there are pending entries from a check, update the pending list when changes have been made
+        setPending((current) => (current.length > 0 ? values : current));
+    }, [entries.current, field.onChange, field.onBlur]);
+
+    const onEntry = useCallback(
+        (entry: EntryIdentifier) => (isPending: boolean) => {
+            if (isPending) {
+                entries.current.set(entry.id, { ...entry, valid: true });
+            } else {
+                entries.current.delete(entry.id);
+            }
+
+            evaluate();
+        },
+        [entries.current, evaluate]
+    );
+
+    const onValid = useCallback(
+        (entry: EntryIdentifier) => (valid: boolean) => {
+            if (entries.current.has(entry.id)) {
+                entries.current.set(entry.id, { ...entry, valid });
+            }
+
+            evaluate();
+        },
+        [entries.current, evaluate]
+    );
+
+    const check = (values: HasPendingEntry) => {
+        const current = values.pending ?? [];
+
+        setPending(current);
+
+        return current.length === 0;
+    };
+
+    return { pending, onEntry, onValid, check };
+};
+
+const validate = (values?: PendingEntry[]) => {
+    if (values) {
+        return !values.some((entry) => !entry.valid);
+    }
+
+    return true;
+};
+
+export { usePendingFormEntry };
+export type { PendingFormEntryInteraction };

--- a/apps/modernization-ui/src/libs/patient/demographics/PatientDemographicsForm.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/PatientDemographicsForm.tsx
@@ -1,10 +1,16 @@
 import { useCallback, useRef } from 'react';
 import { UseFormReturn, useWatch } from 'react-hook-form';
+import classNames from 'classnames';
 import { Sizing } from 'design-system/field';
 import { InPageNavigation } from 'design-system/inPageNavigation';
 import { sections } from './sections';
 import { BackToTop } from 'libs/page/back-to-top';
-import { PatientDemographics, PatientDemographicsDefaults } from './demographics';
+import {
+    PendingEntryAlert,
+    PendingFormEntryInteraction,
+    PendingMessageRendererProps
+} from 'design-system/entry/pending';
+import { PatientDemographicsDefaults, PatientDemographicsEntry } from './demographics';
 import { EditAdministrativeInformationCard } from './administrative';
 import { EditGeneralInformationDemographicCard } from './general';
 import { EditEthnicityDemographicCard } from './ethnicity';
@@ -18,15 +24,29 @@ import { EditIdentificationDemographicsCard } from './identification';
 import { EditRaceDemographicsCard } from './race';
 
 import styles from './patient-demographics-form.module.scss';
-import classNames from 'classnames';
+import { SkipLink } from 'SkipLink';
+
+const NAME_ENTRY = { id: 'names', name: 'Name' };
+const ADDRESS_ENTRY = { id: 'addresses', name: 'Address' };
+const PHONE_EMAIL_ENTRY = { id: 'phone-emails', name: 'Phone & email' };
+const IDENTIFICATION_ENTRY = { id: 'identifications', name: 'Identification' };
+const RACE_ENTRY = { id: 'races', name: 'Race' };
 
 type PatientDemographicsFormProps = {
-    form: UseFormReturn<PatientDemographics>;
+    form: UseFormReturn<PatientDemographicsEntry>;
     defaults: PatientDemographicsDefaults;
+    pending: PendingFormEntryInteraction;
     sizing?: Sizing;
 } & JSX.IntrinsicElements['div'];
 
-const PatientDemographicsForm = ({ form, defaults, sizing, className, ...remaining }: PatientDemographicsFormProps) => {
+const PatientDemographicsForm = ({
+    form,
+    defaults,
+    pending,
+    sizing,
+    className,
+    ...remaining
+}: PatientDemographicsFormProps) => {
     const content = useRef<HTMLDivElement>(null);
 
     const deceasedOn = useWatch({ control: form.control, name: 'mortality.deceasedOn' });
@@ -35,16 +55,62 @@ const PatientDemographicsForm = ({ form, defaults, sizing, className, ...remaini
 
     return (
         <div {...remaining} className={classNames(styles.demographics, className)}>
+            <SkipLink id="administrative.asOf" />
             <aside>
                 <InPageNavigation sections={sections} />
             </aside>
             <div ref={content} className={styles.content}>
+                <PendingEntryAlert
+                    pending={pending.pending}
+                    title="Please fix the following errors:"
+                    renderer={PendingEntryMessage}
+                />
                 <EditAdministrativeInformationCard id="administrative" form={form} sizing={sizing} />
-                <EditNameDemographicsCard form={form} defaults={defaults} sizing={sizing} />
-                <EditAddressDemographicsCard form={form} defaults={defaults} sizing={sizing} />
-                <EditPhoneEmailDemographicsCard form={form} defaults={defaults} sizing={sizing} />
-                <EditIdentificationDemographicsCard form={form} defaults={defaults} sizing={sizing} />
-                <EditRaceDemographicsCard form={form} defaults={defaults} sizing={sizing} />
+                <EditNameDemographicsCard
+                    form={form}
+                    defaults={defaults}
+                    sizing={sizing}
+                    id={NAME_ENTRY.id}
+                    title={NAME_ENTRY.name}
+                    isDirty={pending.onEntry(NAME_ENTRY)}
+                    isValid={pending.onValid(NAME_ENTRY)}
+                />
+                <EditAddressDemographicsCard
+                    form={form}
+                    defaults={defaults}
+                    sizing={sizing}
+                    id={ADDRESS_ENTRY.id}
+                    title={ADDRESS_ENTRY.name}
+                    isDirty={pending.onEntry(ADDRESS_ENTRY)}
+                    isValid={pending.onValid(ADDRESS_ENTRY)}
+                />
+                <EditPhoneEmailDemographicsCard
+                    form={form}
+                    defaults={defaults}
+                    sizing={sizing}
+                    id={PHONE_EMAIL_ENTRY.id}
+                    title={PHONE_EMAIL_ENTRY.name}
+                    isDirty={pending.onEntry(PHONE_EMAIL_ENTRY)}
+                    isValid={pending.onValid(PHONE_EMAIL_ENTRY)}
+                />
+                <EditIdentificationDemographicsCard
+                    form={form}
+                    defaults={defaults}
+                    sizing={sizing}
+                    id={IDENTIFICATION_ENTRY.id}
+                    title={IDENTIFICATION_ENTRY.name}
+                    isDirty={pending.onEntry(IDENTIFICATION_ENTRY)}
+                    isValid={pending.onValid(IDENTIFICATION_ENTRY)}
+                />
+                <EditRaceDemographicsCard
+                    form={form}
+                    defaults={defaults}
+                    sizing={sizing}
+                    id={RACE_ENTRY.id}
+                    title={RACE_ENTRY.name}
+                    isDirty={pending.onEntry(RACE_ENTRY)}
+                    isValid={pending.onValid(RACE_ENTRY)}
+                />
                 <EditEthnicityDemographicCard id="ethnicity" form={form} sizing={sizing} />
                 <EditSexBirthDemographicCard id="sex-birth" form={form} sizing={sizing} ageResolver={ageResolver} />
                 <EditMortalityDemographicCard id="mortality" form={form} sizing={sizing} />
@@ -54,6 +120,13 @@ const PatientDemographicsForm = ({ form, defaults, sizing, className, ...remaini
         </div>
     );
 };
+
+const PendingEntryMessage = ({ entry }: PendingMessageRendererProps) => (
+    <>
+        Data has been entered in the <a href={`#${entry.id}`}>{entry.name}</a> section. Please press Add or clear the
+        data and submit again.
+    </>
+);
 
 export { PatientDemographicsForm };
 export type { PatientDemographicsFormProps };

--- a/apps/modernization-ui/src/libs/patient/demographics/address/AddressDemographicCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/address/AddressDemographicCard.tsx
@@ -9,7 +9,7 @@ import {
 
 const sortResolver = columnSortResolver(columns);
 
-type AddressDemographicCardProps = Omit<
+type AddressDemographicCardProps = { title?: string } & Omit<
     AddressDemographicRepeatingBlockProps,
     'columns' | 'formRenderer' | 'viewRenderer' | 'defaultValues'
 >;

--- a/apps/modernization-ui/src/libs/patient/demographics/address/edit/EditAddressDemographicsCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/address/edit/EditAddressDemographicsCard.tsx
@@ -12,7 +12,7 @@ import { useAddressOptions } from './useAddressOptions';
 type EditAddressDemographicsCardProps = {
     form: UseFormReturn<HasAddressDemographics>;
     defaults: PatientDemographicsDefaults;
-} & Omit<AddressDemographicRepeatingBlockProps, 'id' | 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
+} & Omit<AddressDemographicRepeatingBlockProps, 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
 
 const EditAddressDemographicsCard = ({ form, defaults, ...remaining }: EditAddressDemographicsCardProps) => {
     const options = useAddressOptions();
@@ -22,10 +22,9 @@ const EditAddressDemographicsCard = ({ form, defaults, ...remaining }: EditAddre
         <Controller
             control={form.control}
             name="addresses"
-            render={({ field: { onChange, value, name } }) => (
+            render={({ field: { onChange, value } }) => (
                 <AddressDemographicRepeatingBlock
                     {...remaining}
-                    id={name}
                     collapsible={false}
                     data={value}
                     viewable

--- a/apps/modernization-ui/src/libs/patient/demographics/demographics.ts
+++ b/apps/modernization-ui/src/libs/patient/demographics/demographics.ts
@@ -1,4 +1,4 @@
-import { today } from 'date';
+import { HasPendingEntry } from 'design-system/entry/pending';
 import { HasAdministrativeInformation, initial as initialAdministrative } from './administrative';
 import { HasAddressDemographics } from './address';
 import { HasNameDemographics } from './name';
@@ -25,24 +25,31 @@ type PatientDemographics = HasAdministrativeInformation &
 
 export type { PatientDemographics };
 
+type PatientDemographicsEntry = PatientDemographics & HasPendingEntry;
+
 type PatientDemographicsDefaults = {
     asOf: Supplier<string>;
     address?: AddressDemographicDefaults;
 };
 
-export type { PatientDemographicsDefaults };
+export type { PatientDemographicsEntry, PatientDemographicsDefaults };
 
-const initial = (asOf: string = today()) => ({
-    administrative: initialAdministrative(asOf),
-    ethnicity: initialEthnicity(asOf),
-    sexBirth: initialSexBirth(asOf),
-    mortality: initialMortality(asOf),
-    general: initialGeneral(asOf),
-    names: [],
-    addresses: [],
-    phoneEmails: [],
-    identifications: [],
-    races: []
-});
+const initial = (defaults: PatientDemographicsDefaults): PatientDemographicsEntry => {
+    const asOf = defaults.asOf();
+
+    return {
+        pending: [],
+        administrative: initialAdministrative(asOf),
+        ethnicity: initialEthnicity(asOf),
+        sexBirth: initialSexBirth(asOf),
+        mortality: initialMortality(asOf),
+        general: initialGeneral(asOf),
+        names: [],
+        addresses: [],
+        phoneEmails: [],
+        identifications: [],
+        races: []
+    };
+};
 
 export { initial };

--- a/apps/modernization-ui/src/libs/patient/demographics/identification/edit/EditIdentificationDemographicsCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/identification/edit/EditIdentificationDemographicsCard.tsx
@@ -12,10 +12,7 @@ import { useIdentificationOptions } from './useIdentificationOptions';
 type EditIdentificationDemographicsCardProps = {
     form: UseFormReturn<HasIdentificationDemographics>;
     defaults: PatientDemographicsDefaults;
-} & Omit<
-    IdentificationDemographicRepeatingBlockProps,
-    'id' | 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'
->;
+} & Omit<IdentificationDemographicRepeatingBlockProps, 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
 
 const EditIdentificationDemographicsCard = ({
     form,
@@ -28,10 +25,9 @@ const EditIdentificationDemographicsCard = ({
         <Controller
             control={form.control}
             name="identifications"
-            render={({ field: { onChange, value, name } }) => (
+            render={({ field: { onChange, value } }) => (
                 <IdentificationDemographicRepeatingBlock
                     {...remaining}
-                    id={name}
                     collapsible={false}
                     data={value}
                     onChange={onChange}

--- a/apps/modernization-ui/src/libs/patient/demographics/index.ts
+++ b/apps/modernization-ui/src/libs/patient/demographics/index.ts
@@ -10,7 +10,7 @@ export type { RaceDemographic } from './race';
 export type { SexBirthDemographic } from './sex-birth';
 
 export { initial } from './demographics';
-export type { PatientDemographics, PatientDemographicsDefaults } from './demographics';
+export type { PatientDemographics, PatientDemographicsDefaults, PatientDemographicsEntry } from './demographics';
 
 export { PatientDemographicsForm } from './PatientDemographicsForm';
 export { usePatientDemographicDefaults } from './usePatientDemographicDefaults';

--- a/apps/modernization-ui/src/libs/patient/demographics/name/edit/EditNameDemographicsCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/name/edit/EditNameDemographicsCard.tsx
@@ -2,15 +2,14 @@ import { Controller, UseFormReturn } from 'react-hook-form';
 import { Sizing } from 'design-system/field';
 import { PatientDemographicsDefaults } from '../../demographics';
 import { HasNameDemographics, initial, NameDemographic } from '../names';
-import { NameDemographicCardProps } from '../NameDemographicCard';
-import { NameDemographicRepeatingBlock } from '../NameDemographicRepeatingBlock';
+import { NameDemographicRepeatingBlock, NameDemographicRepeatingBlockProps } from '../NameDemographicRepeatingBlock';
 import { NameDemographicFields } from './NameDemographicFields';
 import { useNameOptions } from './useNameOptions';
 
 type EditNameDemographicsCardProps = {
     form: UseFormReturn<HasNameDemographics>;
     defaults: PatientDemographicsDefaults;
-} & Omit<NameDemographicCardProps, 'id' | 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
+} & Omit<NameDemographicRepeatingBlockProps, 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
 
 const EditNameDemographicsCard = ({ form, defaults, ...remaining }: EditNameDemographicsCardProps) => {
     const options = useNameOptions();
@@ -19,10 +18,9 @@ const EditNameDemographicsCard = ({ form, defaults, ...remaining }: EditNameDemo
         <Controller
             control={form.control}
             name="names"
-            render={({ field: { onChange, value, name } }) => (
+            render={({ field: { onChange, value } }) => (
                 <NameDemographicRepeatingBlock
                     {...remaining}
-                    id={name}
                     collapsible={false}
                     data={value}
                     onChange={onChange}

--- a/apps/modernization-ui/src/libs/patient/demographics/phoneEmail/edit/EditPhoneEmailDemographicsCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/phoneEmail/edit/EditPhoneEmailDemographicsCard.tsx
@@ -10,7 +10,7 @@ import { usePhoneEmailOptions } from './usePhoneEmailOptions';
 type EditPhoneEmailDemographicsCardProps = {
     form: UseFormReturn<HasPhoneEmailDemographics>;
     defaults: PatientDemographicsDefaults;
-} & Omit<PhoneEmailDemographicCardProps, 'id' | 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
+} & Omit<PhoneEmailDemographicCardProps, 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
 
 const EditPhoneEmailDemographicsCard = ({ form, defaults, ...remaining }: EditPhoneEmailDemographicsCardProps) => {
     const options = usePhoneEmailOptions();
@@ -19,10 +19,9 @@ const EditPhoneEmailDemographicsCard = ({ form, defaults, ...remaining }: EditPh
         <Controller
             control={form.control}
             name="phoneEmails"
-            render={({ field: { onChange, value, name } }) => (
+            render={({ field: { onChange, value } }) => (
                 <PhoneEmailDemographicRepeatingBlock
                     {...remaining}
-                    id={name}
                     collapsible={false}
                     data={value}
                     viewable

--- a/apps/modernization-ui/src/libs/patient/demographics/race/RaceDemographicCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/race/RaceDemographicCard.tsx
@@ -6,7 +6,7 @@ import {
     columns
 } from './RaceDemographicRepeatingBlock';
 
-type RaceDemographicCardProps = Omit<
+type RaceDemographicCardProps = { title?: string } & Omit<
     RaceDemographicRepeatingBlockProps,
     'columns' | 'formRenderer' | 'viewRenderer' | 'defaultValues'
 >;

--- a/apps/modernization-ui/src/libs/patient/demographics/race/RaceDemographicRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/race/RaceDemographicRepeatingBlock.tsx
@@ -33,7 +33,7 @@ const columns: Column<RaceDemographic>[] = [
 
 type RaceDemographicRepeatingBlockProps = {
     title?: string;
-} & Omit<RepeatingBlockProps<RaceDemographic>, 'columns' | 'viewRenderer' | 'title'>;
+} & Omit<RepeatingBlockProps<RaceDemographic>, 'columns' | 'viewRenderer'>;
 
 const RaceDemographicRepeatingBlock = ({
     title = 'Race',

--- a/apps/modernization-ui/src/libs/patient/demographics/race/edit/EditRaceDemographicsCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/race/edit/EditRaceDemographicsCard.tsx
@@ -10,7 +10,7 @@ import { useRaceOptions } from './useRaceOptions';
 type EditRaceDemographicsCardProps = {
     form: UseFormReturn<HasRaceDemographics>;
     defaults: PatientDemographicsDefaults;
-} & Omit<RaceDemographicRepeatingBlockProps, 'id' | 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
+} & Omit<RaceDemographicRepeatingBlockProps, 'collapsible' | 'formRenderer' | 'editable' | 'defaultValues'>;
 
 const EditRaceDemographicsCard = ({ form, defaults, ...remaining }: EditRaceDemographicsCardProps) => {
     const options = useRaceOptions();
@@ -19,10 +19,9 @@ const EditRaceDemographicsCard = ({ form, defaults, ...remaining }: EditRaceDemo
         <Controller
             control={form.control}
             name="races"
-            render={({ field: { onChange, value, name } }) => (
+            render={({ field: { onChange, value } }) => (
                 <RaceDemographicRepeatingBlock
                     {...remaining}
-                    id={name}
                     collapsible={false}
                     data={value}
                     viewable

--- a/apps/modernization-ui/src/libs/patient/demographics/transformer.spec.ts
+++ b/apps/modernization-ui/src/libs/patient/demographics/transformer.spec.ts
@@ -3,7 +3,7 @@ import { transformer } from './transformer';
 
 describe('when transforming entered extended patient data', () => {
     it('should transform administrative to a format accepted by the API', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017', comment: 'entered-value' }
         };
 
@@ -15,7 +15,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform names', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             names: [
                 {
@@ -35,7 +35,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform addresses', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             addresses: [
                 {
@@ -58,7 +58,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform phone and emails', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             phoneEmails: [
                 {
@@ -80,8 +80,8 @@ describe('when transforming entered extended patient data', () => {
         );
     });
 
-    it('should transform identifictions', () => {
-        const entry: PatientDemographics = {
+    it('should transform identifications', () => {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             identifications: [
                 {
@@ -104,7 +104,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform races', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             races: [
                 {
@@ -126,7 +126,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform ethnicity', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             ethnicity: {
                 asOf: '04/13/2017',
@@ -145,7 +145,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform sex', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             sexBirth: {
                 asOf: '04/13/2017',
@@ -163,7 +163,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform birth', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             sexBirth: {
                 asOf: '04/13/2017',
@@ -181,7 +181,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform mortality', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             mortality: {
                 asOf: '04/13/2017',
@@ -199,7 +199,7 @@ describe('when transforming entered extended patient data', () => {
     });
 
     it('should transform general information', () => {
-        const entry: PatientDemographics = {
+        const entry = {
             administrative: { asOf: '04/13/2017' },
             general: {
                 asOf: '04/13/2017',

--- a/apps/modernization-ui/src/libs/patient/demographics/transformer.ts
+++ b/apps/modernization-ui/src/libs/patient/demographics/transformer.ts
@@ -1,5 +1,5 @@
 import { maybeMap, maybeMapAll } from 'utils/mapping';
-import { PatientDemographics } from './demographics';
+import { PatientDemographicsEntry } from './demographics';
 import { PatientDemographicsRequest } from './request';
 import { asAdministrative } from './administrative';
 import { asName } from './name';
@@ -25,7 +25,7 @@ const maybeBirth = maybeMap(asBirth);
 const maybeMortality = maybeMap(asMortality);
 const maybeGeneral = maybeMap(asGeneral);
 
-const transformer = (demographics: PatientDemographics): PatientDemographicsRequest => {
+const transformer = (demographics: PatientDemographicsEntry): PatientDemographicsRequest => {
     const administrative = maybeAsAdministrative(demographics.administrative);
     const names = asNames(demographics.names);
     const addresses = asAddresses(demographics.addresses);

--- a/apps/modernization-ui/src/styles/global.scss
+++ b/apps/modernization-ui/src/styles/global.scss
@@ -10,51 +10,14 @@
 body {
     height: 100vh;
     background-color: colors.$background;
-    scroll-behavior: smooth;
 }
 
 #root {
     height: 100%;
 }
 
-.select-indicator {
-    background-image:
-        url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTEyIDUuODNMMTUuMTcgOWwxLjQxLTEuNDFMMTIgMyA3LjQxIDcuNTkgOC44MyA5IDEyIDUuODN6bTAgMTIuMzRMOC44MyAxNWwtMS40MSAxLjQxTDEyIDIxbDQuNTktNC41OUwxNS4xNyAxNSAxMiAxOC4xN3oiLz48L3N2Zz4=),
-        linear-gradient(transparent, transparent);
-}
-
-.common-card {
-    background: colors.$base-white;
-    border: 1px solid colors.$border;
-    border-radius: 5px;
-    min-height: 147px;
-    height: auto;
-}
-
-.font-sans-xl {
-    font-size: 32px !important;
-    font-family: sans-serif !important;
-}
-
-td span {
-    word-break: break-word;
-}
-
-.required {
-    @include components.required();
-}
-.required-before {
-    &::before {
-        content: '* ';
-        color: colors.$mandatory;
-    }
-}
-
-.text-red {
-    color: colors.$mandatory !important;
-}
-
 a {
+    scroll-behavior: smooth;
     color: colors.$primary;
     font-weight: 600;
     text-decoration: none;
@@ -62,26 +25,4 @@ a {
     &:hover {
         text-decoration: underline;
     }
-}
-
-.page-title-bar {
-    min-height: 78px;
-    font-family: sans-serif;
-    padding: 0 23px;
-    border-bottom: 1px solid #e7e9e9;
-    .add-patient-button {
-        height: fit-content;
-        margin: 0 !important;
-    }
-    .hide-button {
-        display: none;
-    }
-}
-
-.text-uppercase {
-    text-transform: uppercase;
-}
-
-.display-inline-flex {
-    display: inline-flex;
 }


### PR DESCRIPTION
## Description

Adds page level validations to Patient file edit to alert a user to any pending entry within repeating blocks.

- Adds the `usePendingFormEntry` hook for tracking the state of entry within one or more `RepeatingBlock` components.
- Adds the `PendingEntryAlert` component to display validation messages for pending entry.

## Tickets

* [CNFT1-4112](https://cdc-nbs.atlassian.net/browse/CNFT1-4112)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4112]: https://cdc-nbs.atlassian.net/browse/CNFT1-4112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ