### PR TITLE
[CNFT1-4396] Patient file birth record add redirect

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/record/birth/redirect/SubmitBirthRecordRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/record/birth/redirect/SubmitBirthRecordRedirector.java
@@ -1,0 +1,41 @@
+package gov.cdc.nbs.patient.file.events.record.birth.redirect;
+
+import gov.cdc.nbs.patient.profile.redirect.outgoing.ClassicPatientProfileRedirector;
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Hidden
+@RestController
+class SubmitBirthRecordRedirector {
+
+    private static final String LOCATION = "/nbs/PageAction.do";
+
+    private final ClassicPatientProfileRedirector redirector;
+
+    SubmitBirthRecordRedirector(final ClassicPatientProfileRedirector redirector) {
+        this.redirector = redirector;
+    }
+
+    @PreAuthorize("hasAuthority('ADD-BIRTHRECORD')")
+    @GetMapping("/nbs/api/patients/{patient}/records/birth/redirect")
+    ResponseEntity<Void> view(
+        @PathVariable final long patient
+    ) {
+
+        URI location = UriComponentsBuilder.fromPath(LOCATION)
+            .queryParam("method", "createGenericLoad")
+            .queryParam("businessObjectType", "BIR")
+            .queryParam("Action", "DSFilePath")
+            .build()
+            .toUri();
+
+        return redirector.preparedRedirect(patient, location);
+    }
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/record/birth/PatientFileAddBirthRecordSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/record/birth/PatientFileAddBirthRecordSteps.java
@@ -1,0 +1,84 @@
+package gov.cdc.nbs.patient.file.events.record.birth;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.interaction.http.AuthenticatedMvcRequester;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class PatientFileAddBirthRecordSteps {
+
+  private final String classicUrl;
+  private final Active<PatientIdentifier> activePatient;
+  private final AuthenticatedMvcRequester authenticated;
+  private final Active<ResultActions> activeResponse;
+  private final MockRestServiceServer server;
+
+  PatientFileAddBirthRecordSteps(
+      @Value("${nbs.wildfly.url:http://wildfly:7001}") final String classicUrl,
+      final Active<PatientIdentifier> activePatient,
+      final AuthenticatedMvcRequester authenticated,
+      final Active<ResultActions> activeResponse,
+      @Qualifier("classicRestService") final MockRestServiceServer server
+  ) {
+    this.classicUrl = classicUrl;
+    this.activePatient = activePatient;
+    this.authenticated = authenticated;
+    this.activeResponse = activeResponse;
+    this.server = server;
+  }
+
+  @Before("@patient-file-birth-record-redirect")
+  public void reset() {
+    server.reset();
+  }
+
+  @When("a birth record is added from the Patient file")
+  public void added() {
+    long patient = activePatient.active().id();
+
+    server.expect(
+            requestTo(classicUrl + "/nbs/HomePage.do?method=patientSearchSubmit"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+    server.expect(requestTo(classicUrl + "/nbs/PatientSearchResults1.do?ContextAction=ViewFile&uid=" + patient))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+
+    activeResponse.active(
+        authenticated.request(
+            MockMvcRequestBuilders.get("/nbs/api/patients/{patient}/records/birth/redirect", patient)));
+  }
+
+  @Then("NBS is prepared to view a birth record")
+  @Then("NBS is prepared to add a birth record")
+  public void sessionIsPrepared() {
+    server.verify();
+  }
+
+  @Then("I am redirected to Classic NBS to add a birth record")
+  public void addRedirected() throws Exception {
+    long patient = activePatient.active().id();
+
+    String expected = "/nbs/PageAction.do?method=createGenericLoad&businessObjectType=BIR&Action=DSFilePath";
+
+    activeResponse.active()
+        .andExpect(MockMvcResultMatchers.header().string("Location", expected))
+        .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+        .andExpect(MockMvcResultMatchers.cookie().value("Return-Patient", String.valueOf(patient)));
+  }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.birth-record.redirect.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.birth-record.redirect.feature
@@ -1,0 +1,17 @@
+@patient-file-birth-record
+@patient-file-birth-record-redirect
+Feature: Patient File Birth record redirect
+
+  Background:
+    Given I have a patient
+    And I am logged in
+
+  Scenario: A birth record is added from the Patient file
+    Given I can "ADD" any "BirthRecord"
+    When a birth record is added from the Patient file
+    Then NBS is prepared to add a birth record
+    And I am redirected to Classic NBS to add a birth record
+
+  Scenario: A birth record is added from the Patient file without required permissions
+    When a birth record is added from the Patient file
+    Then I am not allowed due to insufficient permissions


### PR DESCRIPTION
## Description

Adds the `nbs/api/patient/{patient}/records/birth/add` endpoint to prepare the NBS session to accept a redirection to add a birth record.

```cucumber
  Scenario: A birth record is added from the Patient file
    Given I can "ADD" any "BirthRecord"
    When a birth record is added from the Patient file
    Then NBS is prepared to add a birth record
    And I am redirected to Classic NBS to add a birth record

  Scenario: A birth record is added from the Patient file without required permissions
    When a birth record is added from the Patient file
    Then I am not allowed due to insufficient permissions
```

## Tickets

* [CNFT1-4396](https://cdc-nbs.atlassian.net/browse/CNFT1-4396)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4396]: https://cdc-nbs.atlassian.net/browse/CNFT1-4396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ