### PR TITLE
[CNFT1-4395] Patient file view Birth record redirect

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/record/birth/redirect/ViewBirthRecordRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/record/birth/redirect/ViewBirthRecordRedirector.java
@@ -1,0 +1,44 @@
+package gov.cdc.nbs.patient.file.events.record.birth.redirect;
+
+import gov.cdc.nbs.patient.profile.redirect.outgoing.ClassicPatientProfileRedirector;
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Hidden
+@RestController
+class ViewBirthRecordRedirector {
+
+  private static final String LOCATION = "/nbs/PageAction.do";
+
+  private final ClassicPatientProfileRedirector redirector;
+
+  ViewBirthRecordRedirector(final ClassicPatientProfileRedirector redirector) {
+    this.redirector = redirector;
+  }
+
+  @PreAuthorize("hasAuthority('VIEW-BIRTHRECORD')")
+  @GetMapping("/nbs/api/patients/{patient}/records/birth/{identifier}")
+  ResponseEntity<Void> view(
+      @PathVariable final long patient,
+      @PathVariable final long identifier
+  ) {
+
+    URI location = UriComponentsBuilder.fromPath(LOCATION)
+        .queryParam("method", "viewGenericLoad")
+        .queryParam("businessObjectType", "BIR")
+        .queryParam("actUid", identifier)
+        .build()
+        .toUri();
+
+    return redirector.preparedRedirect(patient, location);
+  }
+
+
+}

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/record/birth/PatientFileViewBirthRecordSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/record/birth/PatientFileViewBirthRecordSteps.java
@@ -1,0 +1,78 @@
+package gov.cdc.nbs.patient.file.events.record.birth;
+
+import gov.cdc.nbs.patient.identifier.PatientIdentifier;
+import gov.cdc.nbs.testing.event.record.birth.BirthRecordIdentifier;
+import gov.cdc.nbs.testing.interaction.http.AuthenticatedMvcRequester;
+import gov.cdc.nbs.testing.support.Active;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class PatientFileViewBirthRecordSteps {
+
+  private final String classicUrl;
+  private final Active<PatientIdentifier> activePatient;
+  private final Active<BirthRecordIdentifier> activeBirthRecord;
+  private final AuthenticatedMvcRequester authenticated;
+  private final Active<ResultActions> activeResponse;
+  private final MockRestServiceServer server;
+
+  PatientFileViewBirthRecordSteps(
+      @Value("${nbs.wildfly.url:http://wildfly:7001}") final String classicUrl,
+      final Active<PatientIdentifier> activePatient,
+      final Active<BirthRecordIdentifier> activeBirthRecord,
+      final AuthenticatedMvcRequester authenticated,
+      final Active<ResultActions> activeResponse,
+      @Qualifier("classicRestService") final MockRestServiceServer server
+  ) {
+    this.classicUrl = classicUrl;
+    this.activePatient = activePatient;
+    this.activeBirthRecord = activeBirthRecord;
+    this.authenticated = authenticated;
+    this.activeResponse = activeResponse;
+    this.server = server;
+  }
+
+  @When("the birth record is viewed from the Patient file")
+  public void viewed() {
+    long patient = activePatient.active().id();
+
+    server.expect(
+            requestTo(classicUrl + "/nbs/HomePage.do?method=patientSearchSubmit"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+    server.expect(requestTo(classicUrl + "/nbs/PatientSearchResults1.do?ContextAction=ViewFile&uid=" + patient))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess());
+
+    long identifier = activeBirthRecord.active().identifier();
+
+    activeResponse.active(
+        authenticated.request(
+            MockMvcRequestBuilders.get("/nbs/api/patients/{patient}/records/birth/{identifier}", patient, identifier)));
+  }
+
+  @Then("I am redirected to Classic NBS to view a birth record")
+  public void redirected() throws Exception {
+    long patient = activePatient.active().id();
+    long identifier = activeBirthRecord.active().identifier();
+
+    String expected = "/nbs/PageAction.do?method=viewGenericLoad&businessObjectType=BIR&actUid=" + identifier;
+
+    activeResponse.active()
+        .andExpect(MockMvcResultMatchers.header().string("Location", expected))
+        .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+        .andExpect(MockMvcResultMatchers.cookie().value("Return-Patient", String.valueOf(patient)));
+  }
+}

--- a/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.birth-record.redirect.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/events/PatientFile.birth-record.redirect.feature
@@ -3,15 +3,26 @@
 Feature: Patient File Birth record redirect
 
   Background:
-    Given I have a patient
-    And I am logged in
+    Given I am logged in
+    And I have a patient
+    And the patient has a birth record
 
-  Scenario: A birth record is added from the Patient file
+  Scenario: A Birth record is added from the Patient file
     Given I can "ADD" any "BirthRecord"
     When a birth record is added from the Patient file
     Then NBS is prepared to add a birth record
     And I am redirected to Classic NBS to add a birth record
 
-  Scenario: A birth record is added from the Patient file without required permissions
+  Scenario: A Birth record is added from the Patient file without required permissions
     When a birth record is added from the Patient file
+    Then I am not allowed due to insufficient permissions
+
+  Scenario: A Birth record is viewed from the Patient file
+    Given I can "VIEW" any "BirthRecord"
+    When the birth record is viewed from the Patient file
+    Then NBS is prepared to view a birth record
+    And I am redirected to Classic NBS to view a birth record
+
+  Scenario: A Birth record is viewed from the Patient Profile without required permissions
+    When the birth record is viewed from the Patient file
     Then I am not allowed due to insufficient permissions


### PR DESCRIPTION
## Description

Adds the `nbs/api/patient/{patient}/records/birth/{identifier}` endpoint to prepare the NBS session to accept a redirection to view a birth record.

```cucumber
Scenario: A Birth record is viewed from the Patient file
    Given I can "VIEW" any "BirthRecord"
    When the birth record is viewed from the Patient file
    Then NBS is prepared to view a birth record
    And I am redirected to Classic NBS to view a birth record

Scenario: A Birth record is viewed from the Patient Profile without required permissions
  When the birth record is viewed from the Patient file
  Then I am not allowed due to insufficient permissions
```

## Tickets

* [CNFT1-4395](https://cdc-nbs.atlassian.net/browse/CNFT1-4395)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
