### PR TITLE
[CNFT1-4112] Patient file edit > Save button state

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/edit/PatientFileEdit.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/edit/PatientFileEdit.tsx
@@ -8,6 +8,7 @@ import { useComponentSizing } from 'design-system/sizing';
 import { Button } from 'design-system/button';
 import { TabNavigation, TabNavigationEntry } from 'components/TabNavigation/TabNavigation';
 import { maybeDisplayName } from 'name';
+import { exists } from 'utils/exists';
 import {
     PatientDemographics,
     PatientDemographicsDefaults,
@@ -15,6 +16,7 @@ import {
     PatientDemographicsForm,
     usePatientDemographicDefaults
 } from 'libs/patient/demographics';
+import { usePendingFormEntry } from 'design-system/entry/pending';
 import { usePatientFileData } from '../usePatientFileData';
 import { PatientFileLayout } from '../PatientFileLayout';
 import { Patient } from '../patient';
@@ -22,7 +24,6 @@ import { evaluated } from './evaluated';
 import { useEditPatient } from './useEditPatient';
 
 import styles from './patient-file-edit.module.scss';
-import { usePendingFormEntry } from 'design-system/entry/pending';
 
 const PatientFileEdit = () => {
     const { patient, demographics, refresh } = usePatientFileData();
@@ -96,7 +97,9 @@ const Internal = ({ patient, demographics, defaults, sizing, onSuccess, onCancel
         }
     }, [interaction.status, interaction.status === 'error' && interaction.reason]);
 
-    const disabled = !form.formState.isValid || pending.pending.length > 0 || interaction.status !== 'waiting';
+    const disabled =
+        (form.formState.isValid && !exists(form.formState.dirtyFields)) ||
+        (!form.formState.isValid && exists(form.formState.dirtyFields) && interaction.status === 'waiting');
 
     const handleSave = form.handleSubmit((input) => interaction.edit(patient.id, input));
 


### PR DESCRIPTION
## Description

Adjusts the "Save" button to be disabled when there are no changes to the Patient file demographics.

## Tickets

* [CNFT1-4112](https://cdc-nbs.atlassian.net/browse/CNFT1-4112)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4112]: https://cdc-nbs.atlassian.net/browse/CNFT1-4112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ