### PR TITLE
[CNFT1-4054] Patient file Contact record empty display

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFileContactNamedByPatientFinder.java
@@ -35,9 +35,12 @@ class PatientFileContactNamedByPatientFinder extends BasePatientFIleContactFinde
               [contact_record].local_id                       as [local],
               [investigation].cd                              as [investigation_condition],
               [contact_record].contact_referral_basis_cd      as [referral_basis],
-              [processing_decision].code_desc_txt            as [processing_decision],
+              [processing_decision].code_desc_txt             as [processing_decision],
               [contact_record].[add_time]                     as [created_on],
-              [contact_record].named_On_Date                  as [named_on],
+              coalesce(
+                [contact_record].named_On_Date,
+                [contact_record].[add_time]
+              )                                               as [named_on],
               cast(
                       substring(
                               [named].local_id,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/PatientFilePatientNamedByContactFinder.java
@@ -35,9 +35,12 @@ class PatientFilePatientNamedByContactFinder extends BasePatientFIleContactFinde
               [contact_record].local_id                       as [local],
               [investigation].cd                              as [investigation_condition],
               [contact_record].contact_referral_basis_cd      as [referral_basis],
-              [processing_decision].code_desc_txt            as [processing_decision],
+              [processing_decision].code_desc_txt             as [processing_decision],
               [contact_record].[add_time]                     as [created_on],
-              [contact_record].named_On_Date                  as [named_on],
+              coalesce(
+                [contact_record].named_On_Date,
+                [contact_record].[add_time]
+              )                                               as [named_on],
               cast(
                       substring(
                               [named].local_id,

--- a/apps/modernization-ui/src/apps/patient/file/events/contacts/ContactsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/contacts/ContactsCard.tsx
@@ -142,33 +142,37 @@ const InternalCard = ({ sizing, title, data = [], onClose, titleResolver, ...rem
                     id={'patient-file-contact-named'}
                     title={title}
                     collapsible
-                    open={dataLength(data) > 0}
+                    open={data.length > 0}
                     flair={<Tag size={sizing}>{dataLength(data)}</Tag>}
                     className={styles.card}
                     actions={<ColumnPreferencesAction sizing={sizing} />}>
-                    <div className={styles.content}>
-                        {data.map((contact) => (
-                            <Section
-                                key={contact.condition}
-                                title={titleResolver(contact.condition)}
-                                id={`${contact.condition}-${title}`}
-                                sizing={sizing}
-                                className={styles.card}
-                                subtext={`${contact.contacts.length} record${contact.contacts.length > 1 ? 's' : ''}`}>
-                                <SortableDataTable
-                                    columns={apply.apply(columns(onClose))}
-                                    data={contact.contacts}
-                                    {...remaining}
+                    <Shown when={data.length > 0} fallback={<Empty />}>
+                        <div className={styles.content}>
+                            {data.map((contact) => (
+                                <Section
+                                    key={contact.condition}
+                                    title={titleResolver(contact.condition)}
+                                    id={`${contact.condition}-${title}`}
                                     sizing={sizing}
-                                />
-                            </Section>
-                        ))}
-                    </div>
+                                    className={styles.card}
+                                    subtext={`${contact.contacts.length} record${contact.contacts.length > 1 ? 's' : ''}`}>
+                                    <SortableDataTable
+                                        columns={apply.apply(columns(onClose))}
+                                        data={contact.contacts}
+                                        {...remaining}
+                                        sizing={sizing}
+                                    />
+                                </Section>
+                            ))}
+                        </div>
+                    </Shown>
                 </Card>
             )}
         </ColumnPreferenceProvider>
     );
 };
+
+const Empty = () => <div className={styles.empty}>No data has been added.</div>;
 
 type ContactsCardProps = {
     provider: MemoizedSupplier<Promise<PatientFileContacts[]>>;

--- a/apps/modernization-ui/src/apps/patient/file/events/contacts/ContactsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/contacts/ContactsCard.tsx
@@ -20,6 +20,7 @@ import { AssociatedWith } from 'libs/events/investigations/associated';
 import { PatientFileContact, PatientFileContacts } from './contacts';
 
 import styles from './contacts-card.module.scss';
+import { maybeMap } from 'utils/mapping';
 
 const EVENT_ID = { id: 'local', name: 'Event ID' };
 const DATE_CREATED = { id: 'created-on', name: 'Date created' };
@@ -37,6 +38,8 @@ const columnPreferences: ColumnPreference[] = [
     { ...ASSOCIATED_WITH, moveable: true, toggleable: true }
 ];
 
+const displayReferralBasis = maybeMap((value) => ` (${value})`);
+
 const columns = (onClose: () => void): Column<PatientFileContact>[] => [
     {
         ...EVENT_ID,
@@ -53,9 +56,11 @@ const columns = (onClose: () => void): Column<PatientFileContact>[] => [
                     onClose={onClose}>
                     {value.local}
                 </ClassicModalButton>
-                <strong>{value.processingDecision}</strong>
                 <br />
-                {value.referralBasis && `(${value.referralBasis})`}
+                <strong>
+                    {value.processingDecision}
+                    {displayReferralBasis(value.referralBasis)}
+                </strong>
             </>
         )
     },
@@ -69,7 +74,7 @@ const columns = (onClose: () => void): Column<PatientFileContact>[] => [
     },
     {
         ...DATE_NAMED,
-        className: styles['date-header'],
+        className: styles['date-time-header'],
         sortable: true,
         value: (value) => value.namedOn,
         render: (value) => internalizeDate(value.namedOn)

--- a/apps/modernization-ui/src/apps/patient/file/events/contacts/ContactsCard.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/events/contacts/ContactsCard.tsx
@@ -124,17 +124,10 @@ type InternalCardProps = {
     onClose: () => void;
 } & Omit<TableCardProps<PatientFileContacts>, 'data' | 'columns' | 'defaultColumnPreferences' | 'columnPreferencesKey'>;
 
-const dataLength = (data: PatientFileContacts[]) => {
-    let count = 0;
-    data.map((cond) => {
-        cond.contacts.map(() => {
-            count++;
-        });
-    });
-    return count;
-};
+const dataLength = (data: PatientFileContacts[]) => data.reduce((current, next) => current + next.contacts.length, 0);
 
 const InternalCard = ({ sizing, title, data = [], onClose, titleResolver, ...remaining }: InternalCardProps) => {
+    const total = dataLength(data);
     return (
         <ColumnPreferenceProvider id="key" defaults={columnPreferences}>
             {(apply) => (
@@ -143,7 +136,7 @@ const InternalCard = ({ sizing, title, data = [], onClose, titleResolver, ...rem
                     title={title}
                     collapsible
                     open={data.length > 0}
-                    flair={<Tag size={sizing}>{dataLength(data)}</Tag>}
+                    flair={<Tag size={sizing}>{total}</Tag>}
                     className={styles.card}
                     actions={<ColumnPreferencesAction sizing={sizing} />}>
                     <Shown when={data.length > 0} fallback={<Empty />}>

--- a/apps/modernization-ui/src/apps/patient/file/events/contacts/contacts-card.module.scss
+++ b/apps/modernization-ui/src/apps/patient/file/events/contacts/contacts-card.module.scss
@@ -19,6 +19,14 @@
     }
 }
 
+.empty {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+    font-size: 0.875rem;
+}
+
 .date-time-header {
     @include widths.fixed(7rem);
 }

--- a/apps/modernization-ui/src/design-system/table/data-table.module.scss
+++ b/apps/modernization-ui/src/design-system/table/data-table.module.scss
@@ -37,6 +37,7 @@
         td {
             border-style: none !important;
             white-space: pre-wrap;
+            overflow-wrap: break-word;
             vertical-align: top;
 
             &.fixed {

--- a/apps/modernization-ui/src/libs/events/investigations/associated/Associations.tsx
+++ b/apps/modernization-ui/src/libs/events/investigations/associated/Associations.tsx
@@ -1,5 +1,6 @@
 import { exists } from 'utils';
 import { Shown } from 'conditional-render';
+import { NoData } from 'design-system/data';
 import { AssociatedInvestigation } from './associated';
 
 import styles from './associations.module.scss';
@@ -10,7 +11,7 @@ type AssociationsProps = {
 };
 
 const Associations = ({ patient, children }: AssociationsProps) => (
-    <Shown when={exists(children)}>
+    <Shown when={exists(children)} fallback={<NoData />}>
         <span className={styles.associations}>
             {children?.map((association, index) => (
                 <AssociatedWith key={index} patient={patient}>

--- a/apps/modernization-ui/src/libs/patient/demographics/sections.ts
+++ b/apps/modernization-ui/src/libs/patient/demographics/sections.ts
@@ -4,13 +4,13 @@ const sections: NavSection[] = [
     { id: 'administrative', label: 'Administrative' },
     { id: 'names', label: 'Name' },
     { id: 'addresses', label: 'Address' },
-    { id: 'phoneEmails', label: 'Phone & email' },
+    { id: 'phone-emails', label: 'Phone & email' },
     { id: 'identifications', label: 'Identification' },
     { id: 'races', label: 'Race' },
     { id: 'ethnicity', label: 'Ethnicity' },
-    { id: 'sexAndBirth', label: 'Sex & birth' },
+    { id: 'sex-birth', label: 'Sex & birth' },
     { id: 'mortality', label: 'Mortality' },
-    { id: 'generalInformation', label: 'General patient information' }
+    { id: 'general-information', label: 'General patient information' }
 ];
 
 export { sections };

--- a/apps/modernization-ui/src/utils/exists.spec.ts
+++ b/apps/modernization-ui/src/utils/exists.spec.ts
@@ -25,33 +25,33 @@ describe('when evaluating that a value exists', () => {
         expect(actual).toBe(true);
     });
 
-    it('should resolve that the array value exists', () => {
-        const actual = exists([]);
-
-        expect(actual).toBe(true);
-    });
-
     it('should resolve that an empty object value does not exist', () => {
         const actual = exists({});
 
         expect(actual).toBe(false);
     });
-});
 
-it('should resolve that the undefined value does not exist', () => {
-    const actual = exists(undefined);
+    it('should resolve that the undefined value does not exist', () => {
+        const actual = exists(undefined);
 
-    expect(actual).toBe(false);
-});
+        expect(actual).toBe(false);
+    });
 
-it('should resolve that the null value does not exist', () => {
-    const actual = exists(null);
+    it('should resolve that the null value does not exist', () => {
+        const actual = exists(null);
 
-    expect(actual).toBe(false);
-});
+        expect(actual).toBe(false);
+    });
 
-it('should resolve that an empty string value does not exist', () => {
-    const actual = exists('');
+    it('should resolve that an empty string value does not exist', () => {
+        const actual = exists('');
 
-    expect(actual).toBe(false);
+        expect(actual).toBe(false);
+    });
+
+    it('should resolve that an empty array value does not exists', () => {
+        const actual = exists([]);
+
+        expect(actual).toBe(false);
+    });
 });

--- a/apps/modernization-ui/src/utils/exists.ts
+++ b/apps/modernization-ui/src/utils/exists.ts
@@ -19,6 +19,8 @@
 function exists<T>(value: T | null | undefined): value is NonNullable<T> {
     if (typeof value === 'object' && value && !Array.isArray(value)) {
         return Object.keys(value).length > 0;
+    } else if (typeof value === 'object' && Array.isArray(value)) {
+        return value.length > 0;
     } else if (typeof value === 'string') {
         return value.length > 0;
     }

--- a/apps/modernization-ui/src/utils/mapping/maybeMap.spec.ts
+++ b/apps/modernization-ui/src/utils/mapping/maybeMap.spec.ts
@@ -1,7 +1,7 @@
 import { maybeMap } from './maybeMap';
 
 describe('maybeMap', () => {
-    it.each(['value', 0, [], true, false])('should call the mapping function when %s is given', (value) => {
+    it.each(['value', 0, true, false])('should call the mapping function when %s is given', (value) => {
         const mapping = jest.fn();
 
         maybeMap(mapping)(value);
@@ -9,7 +9,7 @@ describe('maybeMap', () => {
         expect(mapping).toHaveBeenCalledWith(value);
     });
 
-    it.each([undefined, null])('should not call the mapping function when %s is given', (value) => {
+    it.each([undefined, [], null])('should not call the mapping function when %s is given', (value) => {
         const mapping = jest.fn();
 
         maybeMap(mapping)(value);


### PR DESCRIPTION
## Description

Adds handling of an empty "Contacts named by patient" or "Patient named by contact" card.

The "Date named" value will now default to the `add_time` to handle Contact Records on STI investigations.

## Tickets

* [CNFT1-4054](https://cdc-nbs.atlassian.net/browse/CNFT1-4054)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4054]: https://cdc-nbs.atlassian.net/browse/CNFT1-4054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ