### PR TITLE
[Sonar] removed use of deprecated method

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/InvestigationSearchCriteriaFilterResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/investigation/InvestigationSearchCriteriaFilterResolver.java
@@ -221,8 +221,8 @@ class InvestigationSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("rpt_form_cmplt_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo())
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo())
                         )
                 )
             )
@@ -235,8 +235,8 @@ class InvestigationSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("activity_from_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo())
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo())
                         )
                 )
             )
@@ -249,8 +249,8 @@ class InvestigationSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("activity_to_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -262,8 +262,8 @@ class InvestigationSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("notification_add_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -290,8 +290,8 @@ class InvestigationSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("add_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -318,8 +318,8 @@ class InvestigationSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("public_health_case_last_chg_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaFilterResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/event/search/labreport/LabReportSearchCriteriaFilterResolver.java
@@ -159,8 +159,8 @@ class LabReportSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("activity_to_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -172,8 +172,8 @@ class LabReportSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("effective_from_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -185,8 +185,8 @@ class LabReportSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("rpt_to_state_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -213,8 +213,8 @@ class LabReportSearchCriteriaFilterResolver {
             RangeQuery.of(
                 range -> range.term(
                     term -> term.field("add_time")
-                        .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                        .to(FlexibleInstantConverter.toString(reported.getTo()))
+                        .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                        .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );
@@ -240,8 +240,8 @@ class LabReportSearchCriteriaFilterResolver {
         reported ->
             RangeQuery.of(
                 range -> range.term(term -> term.field("observation_last_chg_time")
-                    .from(FlexibleInstantConverter.toString(reported.getFrom()))
-                    .to(FlexibleInstantConverter.toString(reported.getTo()))
+                    .gte(FlexibleInstantConverter.toString(reported.getFrom()))
+                    .lte(FlexibleInstantConverter.toString(reported.getTo()))
                 )
             )
     );


### PR DESCRIPTION
## Description

Resolves 16 new code smells originating from updating the version of the `elasticsearch-java` where the `from` and `to` methods of `TermRangeQuery.Builder` were deprecated.
