### PR TITLE
[CNFT1-4342] Adds birth record redirect

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/record/birth/redirect/SubmitBirthRecordRedirector.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/record/birth/redirect/SubmitBirthRecordRedirector.java
@@ -31,8 +31,9 @@ class SubmitBirthRecordRedirector {
 
         URI location = UriComponentsBuilder.fromPath(LOCATION)
             .queryParam("method", "createGenericLoad")
-            .queryParam("businessObjectType", "BIR")
+            .queryParam("mode", "Create")
             .queryParam("Action", "DSFilePath")
+            .queryParam("businessObjectType", "BIR")
             .build()
             .toUri();
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/record/birth/PatientFileAddBirthRecordSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/events/record/birth/PatientFileAddBirthRecordSteps.java
@@ -14,6 +14,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -74,10 +76,17 @@ public class PatientFileAddBirthRecordSteps {
   public void addRedirected() throws Exception {
     long patient = activePatient.active().id();
 
-    String expected = "/nbs/PageAction.do?method=createGenericLoad&businessObjectType=BIR&Action=DSFilePath";
-
     activeResponse.active()
-        .andExpect(MockMvcResultMatchers.header().string("Location", expected))
+        .andExpect(MockMvcResultMatchers.header().string(
+                "Location",
+                allOf(
+                    containsString("method=createGenericLoad"),
+                    containsString("mode=Create"),
+                    containsString("Action=DSFilePath"),
+                    containsString("businessObjectType=BIR")
+                )
+            )
+        )
         .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
         .andExpect(MockMvcResultMatchers.cookie().value("Return-Patient", String.valueOf(patient)));
   }


### PR DESCRIPTION
## Description

Adds the `mode=Create` request parameter to the Add birth record redirect so that the session is properly configured to save the Birth Record when clicking submit.

## Tickets

* [CNFT1-4342](https://cdc-nbs.atlassian.net/browse/CNFT1-4342)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4342]: https://cdc-nbs.atlassian.net/browse/CNFT1-4342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ