### PR TITLE
[FIX] Handling of non-existant Patient administrative information

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/administrative/PatientAdministrativeInformationController.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/administrative/PatientAdministrativeInformationController.java
@@ -17,11 +17,15 @@ class PatientAdministrativeInformationController {
     this.finder = finder;
   }
 
-  @Operation(summary = "Patient File Administrative Information", description = "Provides the administrative information for a patient", tags = "PatientFile")
+  @Operation(
+      summary = "Patient File Administrative Information",
+      description = "Provides the administrative information for a patient",
+      tags = "PatientFile"
+  )
   @GetMapping("/nbs/api/patients/{patient}/demographics/administrative")
   @PreAuthorize("hasAuthority('VIEWWORKUP-PATIENT')")
   ResponseEntity<Administrative> administrative(@PathVariable("patient") long patient) {
     return this.finder.find(patient).map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+        .orElseGet(() -> ResponseEntity.ok().build());
   }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/administrative/PatientFile.administrative.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/administrative/PatientFile.administrative.feature
@@ -8,7 +8,7 @@ Feature: Viewing the administrative information of a patient
 
   Scenario:  I cannot view the administrative information of a patient that does not exist
     When I view the Administrative information for patient 1039
-    Then it was not found
+    Then no value is returned
 
   Scenario: I can view the patient's administrative information
     Given the patient has an administrative as of date of 09/13/2013


### PR DESCRIPTION
## Description

Change the patient administrative endpoint to return empty when no data is found.

