### PR TITLE
[Refactor] defaultTo

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/edit/PatientFileEdit.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/edit/PatientFileEdit.tsx
@@ -24,12 +24,14 @@ import { useEditPatient } from './useEditPatient';
 
 import styles from './patient-file-edit.module.scss';
 
+const resolveBackPath = defaultTo('..');
+
 const PatientFileEdit = () => {
     const { state } = useLocation();
     const navigate = useNavigate();
 
     const goBack = useCallback(() => {
-        const path = defaultTo('..', state?.return);
+        const path = resolveBackPath(state?.return);
         navigate(path);
     }, [navigate, state?.return]);
 

--- a/apps/modernization-ui/src/apps/search/patient/result/displayProfileLegalName.tsx
+++ b/apps/modernization-ui/src/apps/search/patient/result/displayProfileLegalName.tsx
@@ -1,13 +1,12 @@
 import { PatientSearchResult } from 'generated/graphql/schema';
 import { displayName } from 'name';
-import { maybeMap } from 'utils/mapping';
+import { mapOr } from 'utils/mapping';
 import { PatientFileLink } from './PatientFileLink';
-import { defaultTo } from 'libs/supplying';
 
-const maybeDisplayName = maybeMap(displayName('fullLastFirst'));
+const maybeDisplayName = mapOr(displayName('fullLastFirst'), 'No Data');
 
 const displayProfileLegalName = (result: PatientSearchResult) => {
-    const display = defaultTo('No Data', maybeDisplayName(result.legalName));
+    const display = maybeDisplayName(result.legalName);
 
     return (
         <PatientFileLink identifier={result.patient} patientId={result.shortId}>

--- a/apps/modernization-ui/src/date/age/ageResolver.ts
+++ b/apps/modernization-ui/src/date/age/ageResolver.ts
@@ -1,13 +1,15 @@
 import { displayAgeAsOf, today } from 'date';
 import { defaultTo } from 'libs/supplying';
 
+const orElseToday = defaultTo(today);
+
 type AgeResolver = (birthday?: string) => string | undefined;
 
 const asOfAgeResolver =
     (asOf?: string): AgeResolver =>
     (birthday?: string) => {
         if (birthday) {
-            return displayAgeAsOf(birthday, defaultTo(today, asOf));
+            return displayAgeAsOf(birthday, orElseToday(asOf));
         }
     };
 

--- a/apps/modernization-ui/src/libs/patient/PatientDescriptor.tsx
+++ b/apps/modernization-ui/src/libs/patient/PatientDescriptor.tsx
@@ -9,13 +9,15 @@ import { displayAgeAsOf, today } from 'date';
 import { NoData } from 'design-system/data';
 import { Heading, HeadingLevel } from 'components/heading';
 
+const orElseToday = defaultTo(today);
+
 import styles from './patient-descriptor.module.scss';
 
 const maybeDisplayName = mapOr(displayName('fullLastFirst'), '---');
 
 const maybeDisplayBirthday = (birthday?: string, asOf?: string) => {
     if (birthday) {
-        return `${birthday} (${displayAgeAsOf(birthday, defaultTo(today, asOf))})`;
+        return `${birthday} (${displayAgeAsOf(birthday, orElseToday(asOf))})`;
     }
 };
 

--- a/apps/modernization-ui/src/libs/supplying/defaultTo.spec.ts
+++ b/apps/modernization-ui/src/libs/supplying/defaultTo.spec.ts
@@ -2,7 +2,7 @@ import { defaultTo } from './defaultTo';
 
 describe('defaultTo', () => {
     it('should return the provided value when present', () => {
-        const actual = defaultTo('fallback-value', 'actual-value');
+        const actual = defaultTo('fallback-value')('actual-value');
 
         expect(actual).toBe('actual-value');
     });
@@ -10,7 +10,7 @@ describe('defaultTo', () => {
     it('should return the provided value when present without resolving the fallback', () => {
         const fallback = jest.fn();
 
-        const actual = defaultTo(fallback, 'actual-value');
+        const actual = defaultTo(fallback)('actual-value');
 
         expect(actual).toBe('actual-value');
 
@@ -18,25 +18,25 @@ describe('defaultTo', () => {
     });
 
     it('should return the fallback value when no value is provided', () => {
-        const actual = defaultTo('fallback-value');
+        const actual = defaultTo('fallback-value')();
 
         expect(actual).toBe('fallback-value');
     });
 
     it('should return the fallback value when an undefined value is provided', () => {
-        const actual = defaultTo('fallback-value', undefined);
+        const actual = defaultTo('fallback-value')(undefined);
 
         expect(actual).toBe('fallback-value');
     });
 
     it('should return the resolved fallback value when no value is provided', () => {
-        const actual = defaultTo(() => 'fallback-value');
+        const actual = defaultTo(() => 'fallback-value')();
 
         expect(actual).toBe('fallback-value');
     });
 
     it('should return the resolved fallback value when an undefined value is provided', () => {
-        const actual = defaultTo(() => 'fallback-value', undefined);
+        const actual = defaultTo(() => 'fallback-value')(undefined);
 
         expect(actual).toBe('fallback-value');
     });

--- a/apps/modernization-ui/src/libs/supplying/defaultTo.ts
+++ b/apps/modernization-ui/src/libs/supplying/defaultTo.ts
@@ -1,10 +1,12 @@
 import { Supplier } from './supplier';
 
-const defaultTo = <T>(fallback?: T | Supplier<T>, value?: T) => {
-    if (value) {
-        return value;
-    }
-    return fallback instanceof Function ? fallback() : fallback;
-};
+const defaultTo =
+    <T>(fallback: T | Supplier<T>) =>
+    (value?: T) => {
+        if (value) {
+            return value;
+        }
+        return fallback instanceof Function ? fallback() : fallback;
+    };
 
 export { defaultTo };


### PR DESCRIPTION
## Description

Refactors the `defaultTo` method from a `<T>(fallback?: T | Supplier<T>, value?: T)` signature to `<T>(fallback: T | Supplier<T>) =>  (value?: T) => ` to allow more expressive uses of the function.  This means that `defaultTo(today, asOf)` can now be expressed as `const orElseToday = defaultTo(today)` making it easier to understand the intention.
