### PR TITLE
[CNFT1-4418] Prevent error when evaluating administrative

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/edit/evaluated.spec.ts
+++ b/apps/modernization-ui/src/apps/patient/file/edit/evaluated.spec.ts
@@ -1,0 +1,73 @@
+import {
+    evaluateAdministrative,
+    evaluateEthnicity,
+    evaluateGeneralInformation,
+    evaluateMortality,
+    evaluateSexBirth
+} from './evaluated';
+
+jest.mock('design-system/date/clock', () => ({
+    now: () => '2013-09-17T00:00:00'
+}));
+
+describe('when evaluating PatientDemographicEntry', () => {
+    it('should initialize administrative when not present', () => {
+        const actual = evaluateAdministrative(undefined);
+
+        expect(actual).toEqual(expect.objectContaining({ administrative: { asOf: '09/17/2013' } }));
+    });
+
+    it('should use values from administrative', () => {
+        const actual = evaluateAdministrative({ asOf: '11/19/2023' });
+
+        expect(actual).toEqual(expect.objectContaining({ administrative: { asOf: '11/19/2023' } }));
+    });
+
+    it('should initialize ethnicity when not present', () => {
+        const actual = evaluateEthnicity(undefined);
+
+        expect(actual).toEqual(expect.objectContaining({ ethnicity: expect.objectContaining({ asOf: '09/17/2013' }) }));
+    });
+
+    it('should use values from ethnicity', () => {
+        const actual = evaluateEthnicity({ asOf: '11/19/2023' });
+
+        expect(actual).toEqual(expect.objectContaining({ ethnicity: expect.objectContaining({ asOf: '11/19/2023' }) }));
+    });
+
+    it('should initialize sex and birth when not present', () => {
+        const actual = evaluateSexBirth(undefined);
+
+        expect(actual).toEqual(expect.objectContaining({ sexBirth: expect.objectContaining({ asOf: '09/17/2013' }) }));
+    });
+
+    it('should use values from sex and birth', () => {
+        const actual = evaluateSexBirth({ asOf: '11/19/2023' });
+
+        expect(actual).toEqual(expect.objectContaining({ sexBirth: expect.objectContaining({ asOf: '11/19/2023' }) }));
+    });
+
+    it('should initialize mortality when not present', () => {
+        const actual = evaluateMortality(undefined);
+
+        expect(actual).toEqual(expect.objectContaining({ mortality: expect.objectContaining({ asOf: '09/17/2013' }) }));
+    });
+
+    it('should use values from mortality', () => {
+        const actual = evaluateMortality({ asOf: '11/19/2023' });
+
+        expect(actual).toEqual(expect.objectContaining({ mortality: expect.objectContaining({ asOf: '11/19/2023' }) }));
+    });
+
+    it('should initialize general when not present', () => {
+        const actual = evaluateGeneralInformation(undefined);
+
+        expect(actual).toEqual(expect.objectContaining({ general: expect.objectContaining({ asOf: '09/17/2013' }) }));
+    });
+
+    it('should use values from general', () => {
+        const actual = evaluateGeneralInformation({ asOf: '11/19/2023' });
+
+        expect(actual).toEqual(expect.objectContaining({ general: expect.objectContaining({ asOf: '11/19/2023' }) }));
+    });
+});

--- a/apps/modernization-ui/src/apps/patient/file/edit/evaluated.ts
+++ b/apps/modernization-ui/src/apps/patient/file/edit/evaluated.ts
@@ -1,4 +1,5 @@
-import { AdministrativeInformation, PatientDemographics } from 'libs/patient/demographics';
+import { PatientDemographics, PatientDemographicsEntry } from 'libs/patient/demographics';
+import { AdministrativeInformation, initial as initialAdministrative } from 'libs/patient/demographics/administrative';
 import { EthnicityDemographic, initial as initialEthnicity } from 'libs/patient/demographics/ethnicity';
 import { MortalityDemographic, initial as initialMortality } from 'libs/patient/demographics/mortality';
 import { SexBirthDemographic, initial as initialSexBirth } from 'libs/patient/demographics/sex-birth';
@@ -33,20 +34,18 @@ const initial = () => ({
  * @param {PatientDemographicsData} data The demographics data for a patient.
  * @return {Promise} A Promise containing the `PatientDemographics`
  */
-const evaluated = (data: PatientDemographicsData): Promise<Required<PatientDemographics>> =>
+const evaluated = (data: PatientDemographicsData): Promise<PatientDemographicsEntry> =>
     Promise.all([
-        data.administrative.get().then(asAdministrative),
+        data.administrative.get().then(evaluateAdministrative),
         data.names.get().then(into('names', copyAll)),
         data.addresses.get().then(into('addresses', copyAll)),
         data.phoneEmail.get().then(into('phoneEmails', copyAll)),
         data.identifications.get().then(into('identifications', copyAll)),
         data.race.get().then(into('races', copyAll)),
-        data.ethnicity.get().then(into('ethnicity', mapOr(asEthnicity, initialEthnicity))),
-        data.sexBirth
-            .get()
-            .then((resolved) => into('sexBirth', mapOr(asSexBirth, initialSexBirth))(resolved.demographic)),
-        data.mortality.get().then(into('mortality', mapOr(asMortality, initialMortality))),
-        data.general.get().then(into('general', mapOr(asGeneralInformation, initialGeneral)))
+        data.ethnicity.get().then(evaluateEthnicity),
+        data.sexBirth.get().then((resolved) => evaluateSexBirth(resolved.demographic)),
+        data.mortality.get().then(evaluateMortality),
+        data.general.get().then(evaluateGeneralInformation)
     ]).then(
         (resolved) =>
             resolved.reduce((current, next) => ({ ...current, ...next }), initial()) as Required<PatientDemographics>
@@ -55,13 +54,18 @@ const evaluated = (data: PatientDemographicsData): Promise<Required<PatientDemog
 export { evaluated };
 
 const asAdministrative = (demographic: AdministrativeInformation) => ({
-    administrative: { ...demographic, asOf: orElseToday(demographic.asOf) }
+    ...demographic,
+    asOf: orElseToday(demographic.asOf)
 });
+
+const evaluateAdministrative = into('administrative', mapOr(asAdministrative, initialAdministrative));
 
 const asEthnicity = (demographic: EthnicityDemographic) => ({
     ...demographic,
     asOf: orElseToday(demographic.asOf)
 });
+
+const evaluateEthnicity = into('ethnicity', mapOr(asEthnicity, initialEthnicity));
 
 const asSexBirth = (demographic: SexBirthDemographic) => ({
     ...demographic,
@@ -69,13 +73,21 @@ const asSexBirth = (demographic: SexBirthDemographic) => ({
     bornOn: internalizeDate(demographic.bornOn)
 });
 
+const evaluateSexBirth = into('sexBirth', mapOr(asSexBirth, initialSexBirth));
+
 const asMortality = (demographic: MortalityDemographic) => ({
     ...demographic,
     asOf: orElseToday(demographic.asOf),
     deceasedOn: internalizeDate(demographic.deceasedOn)
 });
 
+const evaluateMortality = into('mortality', mapOr(asMortality, initialMortality));
+
 const asGeneralInformation = (demographic: GeneralInformationDemographic) => ({
     ...demographic,
     asOf: internalizeDate(demographic.asOf)
 });
+
+const evaluateGeneralInformation = into('general', mapOr(asGeneralInformation, initialGeneral));
+
+export { evaluateAdministrative, evaluateEthnicity, evaluateSexBirth, evaluateMortality, evaluateGeneralInformation };


### PR DESCRIPTION
## Description

There was an assumption that "Administrative Information" would always be present for a patient.  The `evaluated` function now does not assume that `administrative` exists.

## Tickets

* [CNFT1-4418](https://cdc-nbs.atlassian.net/browse/CNFT1-4418)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[CNFT1-4418]: https://cdc-nbs.atlassian.net/browse/CNFT1-4418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ