### PR TITLE
[CNFT1-4096] Adds overflow wrapping to the value field value

### DIFF
--- a/apps/modernization-ui/src/design-system/field/value/value-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/value/value-field.module.scss
@@ -3,7 +3,8 @@
 @use 'styles/components';
 
 .view {
-    display: flex;
+    display: grid;
+    grid-template-columns: var(--label-area-width, 13rem) 1fr;
     gap: 1rem;
 
     color: colors.$base-darkest;
@@ -22,14 +23,14 @@
         align-items: center;
         height: var(--component-height);
         font-weight: 700;
-        width: 13rem;
     }
 
     .value {
         display: flex;
         align-items: center;
         height: var(--component-height);
-        width: 20rem;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
     }
 
     &:not(:last-child) {
@@ -37,13 +38,9 @@
     }
 
     &.small {
-        @extend %small;
+        --label-area-width: 12rem;
 
-        .content {
-            .label {
-                width: 12rem;
-            }
-        }
+        @extend %small;
     }
 
     &.large {


### PR DESCRIPTION
## Description

Adds overflow handling to `ValueField` to prevent clipping of long values.

<img width="735" height="71" alt="image" src="https://github.com/user-attachments/assets/8cc65aa7-1936-4300-908b-fdef4b842bf3" />

## Tickets

* [CNFT1-4096](https://cdc-nbs.atlassian.net/browse/CNFT1-4096)
* [CNFT1-4097](https://cdc-nbs.atlassian.net/browse/CNFT1-4097)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4096]: https://cdc-nbs.atlassian.net/browse/CNFT1-4096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CNFT1-4097]: https://cdc-nbs.atlassian.net/browse/CNFT1-4097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ