### PR TITLE
[FIX] ValueField padding

### DIFF
--- a/apps/modernization-ui/src/design-system/field/value/value-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/value/value-field.module.scss
@@ -5,7 +5,7 @@
 .view {
     display: grid;
     grid-template-columns: var(--label-area-width, 13rem) 1fr;
-    gap: 1rem;
+    gap: 2rem;
 
     color: colors.$base-darkest;
     line-height: normal;


### PR DESCRIPTION
## Description

Restores the padding between the label and displayed value in a `ValueField` to ensure that it matches the designs of `HorizontalField`
