### PR TITLE
[CNFT1-4418] Patient file edit perpetual loader

### DIFF
--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -29,7 +29,7 @@ testing {
             dependencies {
                 implementation(libs.spring.test)
                 implementation(libs.spring.security.test)
-                implementation "org.wiremock:wiremock-standalone:3.13.0"
+                implementation "org.wiremock:wiremock-standalone:3.13.1"
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-springBoot = '3.5.4'
-spring-security = '6.5.2'
+springBoot = '3.5.5'
+spring-security = '6.5.3'
 jackson = '2.19.0'
 queryDSL = '5.1.0'
 
 junit-jupiter = '5.13.4'
-cucumber = '7.27.0'
+cucumber = '7.27.2'
 assertj = '3.27.4'
 testcontainers = '1.21.0'
 

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/CodeValueGeneralConceptOptionFinder.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/CodeValueGeneralConceptOptionFinder.java
@@ -1,42 +1,65 @@
 package gov.cdc.nbs.option.concept;
 
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.JdbcClient;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 
 class CodeValueGeneralConceptOptionFinder implements ConceptOptionFinder {
 
-  private static final int VALUE_SET_PARAMETER = 1;
-  private static final String QUERY = """
+  private static final String ALL = """
       select
           code                as [value],
           code_short_desc_txt as [name],
           indent_level_nbr    as [order]
       from NBS_SRTE..Code_value_general
-      where code_set_nm = ?
+      where code_set_nm = :name
       order by
           indent_level_nbr,
           code_short_desc_txt
       """;
 
-  private final JdbcTemplate template;
+  private static final String EXCLUDING = """
+      select
+          code                as [value],
+          code_short_desc_txt as [name],
+          indent_level_nbr    as [order]
+      from NBS_SRTE..Code_value_general
+      where code_set_nm = :name
+          and code not in (:excluding)
+      order by
+          indent_level_nbr,
+          code_short_desc_txt
+      """;
+
+  private final JdbcClient client;
   private final RowMapper<ConceptOption> mapper;
 
-  CodeValueGeneralConceptOptionFinder(final JdbcTemplate template) {
-    this.template = template;
+  CodeValueGeneralConceptOptionFinder(final JdbcClient client) {
+    this.client = client;
     this.mapper = new ConceptOptionRowMapper();
   }
 
   @Override
-  public Collection<ConceptOption> find(final String valueSet) {
-    return this.template.query(
-        QUERY,
-        statement -> statement.setString(VALUE_SET_PARAMETER, valueSet),
-        this.mapper);
+  public Collection<ConceptOption> find(final String valueSet, final String... excluding) {
+    return excluding.length == 0 ? all(valueSet) : excluding(valueSet, excluding);
   }
 
+  private Collection<ConceptOption> all(final String valueSet) {
+    return this.client.sql(ALL)
+        .param("name", valueSet)
+        .query(this.mapper)
+        .list();
+  }
 
+  private Collection<ConceptOption> excluding(final String valueSet, final String... excluding) {
+    return this.client.sql(EXCLUDING)
+        .param("name", valueSet)
+        .param("excluding", Arrays.asList(excluding))
+        .query(this.mapper)
+        .list();
+  }
 
 }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionFinder.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionFinder.java
@@ -4,12 +4,13 @@ import java.util.Collection;
 
 public interface ConceptOptionFinder {
 
+
   /**
    * Returns all {@link ConceptOption} instances that are collected in a {@code valueSet}.
    *
-   * @param valueSet The name of the value set to retrieve concepts for.
+   * @param valueSet  The name of the value set to retrieve concepts for.
+   * @param excluding any code to exclude.
    * @return All the concepts of the value set.
    */
-  Collection<ConceptOption> find(final String valueSet);
-
+  Collection<ConceptOption> find(final String valueSet, final String... excluding);
 }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionModuleConfiguration.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionModuleConfiguration.java
@@ -3,13 +3,14 @@ package gov.cdc.nbs.option.concept;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.JdbcClient;
 
 @Configuration
 class ConceptOptionModuleConfiguration {
 
   @Bean
-  ConceptOptionFinder conceptFinder(final JdbcTemplate template) {
-    return new CodeValueGeneralConceptOptionFinder(template);
+  ConceptOptionFinder conceptFinder(final JdbcClient client) {
+    return new CodeValueGeneralConceptOptionFinder(client);
   }
 
 }

--- a/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionsController.java
+++ b/libs/options-api/src/main/java/gov/cdc/nbs/option/concept/ConceptOptionsController.java
@@ -17,6 +17,18 @@ class ConceptOptionsController {
   }
 
   @Operation(
+      operationId = "addressUses",
+      summary = "Concept Options by Value Set",
+      description = "Provides address type options from the NBS Entity Locator Use Postal for Patients value set.",
+      tags = "ConceptOptions"
+  )
+  @GetMapping("nbs/api/options/concepts/EL_USE_PST_PAT")
+  ConceptOptionsResponse addressUses() {
+    Collection<ConceptOption> found = this.finder.find("EL_USE_PST_PAT", "BIR", "DTH");
+    return ConceptOptionsResponseMapper.asResponse("EL_USE_PST_PAT", found);
+  }
+
+  @Operation(
       operationId = "concepts",
       summary = "Concept Options by Value Set",
       description = "Provides options from Concepts grouped into a value set.",

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/concept/ConceptOptionsVerificationSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/concept/ConceptOptionsVerificationSteps.java
@@ -31,7 +31,7 @@ public class ConceptOptionsVerificationSteps {
   @Then("the concept named {string} is not included")
   public void the_option_named_is_not_included(final String concept) throws Exception {
     this.response.active()
-        .andExpect(jsonPath("$.options[*].name", hasItem(not(equalToIgnoringCase(concept)))));
+        .andExpect(jsonPath("$.options[*].name", not(hasItem(equalToIgnoringCase(concept)))));
   }
 
   @Then("there are concepts available")

--- a/libs/options-api/src/test/java/gov/cdc/nbs/option/concept/ConceptsRequestSteps.java
+++ b/libs/options-api/src/test/java/gov/cdc/nbs/option/concept/ConceptsRequestSteps.java
@@ -8,15 +8,13 @@ import org.springframework.test.web.servlet.ResultActions;
 
 public class ConceptsRequestSteps {
 
-  @Autowired
-  ConceptsRequest request;
+  private final ConceptsRequest request;
 
-  @Autowired
-  Active<ResultActions> response;
+  private final Active<ResultActions> response;
 
-  @Before("@request")
-  public void reset() {
-    response.reset();
+  ConceptsRequestSteps(final ConceptsRequest request, Active<ResultActions> response) {
+    this.request = request;
+    this.response = response;
   }
 
   @When("I request all concepts for the {string} value set")

--- a/libs/options-api/src/test/resources/features/Concepts.feature
+++ b/libs/options-api/src/test/resources/features/Concepts.feature
@@ -31,3 +31,8 @@ Feature: Concept Options REST API
   Scenario: I cannot find concepts that do not exist
     When I request all concepts for the "non-existing" value set
     Then there aren't any concepts available
+
+  Scenario: The "Birth Place" and "Death Place" address uses are not returned
+    When I request all concepts for the "EL_USE_PST_PAT" value set
+    Then the concept named "Birth Place" is not included
+    And the concept named "Death Place" is not included


### PR DESCRIPTION
## Description

Resolves an issue with address data where multiple "Birth Place" or "Death Place" addresses would cause the Patient Edit Demographics tab to fail when loading.

## Tickets

* [CNFT1-4418](https://cdc-nbs.atlassian.net/browse/CNFT1-4418)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests
