### PR TITLE
[FIX] TextArea null handling

### DIFF
--- a/apps/modernization-ui/src/design-system/input/text/TextArea.spec.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextArea.spec.tsx
@@ -32,18 +32,22 @@ describe('text area', () => {
 
         expect(onChange).toHaveBeenCalledWith('s');
     });
+
     it('should allow pasting of text values', async () => {
+        const onChange = jest.fn();
         const user = userEvent.setup();
-        const { getByRole } = render(<Fixture />);
+        const { getByRole } = render(<Fixture onChange={onChange} />);
 
         const input = getByRole('textbox', { name: 'Text area test' });
 
-        await user.click(input);
-        await user.paste('pasted value');
-        await user.tab();
+        await user
+            .click(input)
+            .then(() => user.paste('pasted value'))
+            .then(() => user.tab());
 
-        expect(input).toHaveValue('pasted value');
+        expect(onChange).toHaveBeenCalledWith('pasted value');
     });
+
     it('should display given value', () => {
         const { getByRole } = render(<Fixture value={'given value'} />);
 

--- a/apps/modernization-ui/src/design-system/input/text/TextArea.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextArea.tsx
@@ -46,8 +46,6 @@ const TextArea = ({
                 onBlur={onBlur}
                 placeholder={placeholder}
                 value={current}
-                required={props.required}
-                aria-required={props.required}
                 {...props}
             />
             <div className={styles.counter}>

--- a/apps/modernization-ui/src/design-system/input/text/TextArea.tsx
+++ b/apps/modernization-ui/src/design-system/input/text/TextArea.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent } from 'react';
 import styles from './textarea.module.scss';
 
 type TextOnChange = (value?: string) => void;
@@ -27,21 +27,11 @@ const TextArea = ({
     className,
     ...props
 }: TextAreaProps) => {
-    const [current, setCurrent] = useState<string>(value ?? '');
-
-    useEffect(() => {
-        setCurrent(value ?? '');
-    }, [value]);
+    const current = value ?? '';
 
     const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-        const next = event.target.value;
-        if (next) {
-            setCurrent(next);
-            onChange?.(next);
-        } else {
-            setCurrent('');
-            onChange?.();
-        }
+        const next = event.target.value ?? null;
+        onChange?.(next);
     };
 
     return (

--- a/apps/modernization-ui/src/design-system/input/text/index.ts
+++ b/apps/modernization-ui/src/design-system/input/text/index.ts
@@ -6,3 +6,5 @@ export type { TextInputFieldProps } from './TextInputField';
 
 export { MaskedTextInputField } from './MaskedTextInputField';
 export type { MaskedTextInputFieldProps } from './MaskedTextInputField';
+
+export { TextAreaField, type TextAreaFieldProps } from './TextAreaField';

--- a/apps/modernization-ui/src/libs/patient/demographics/administrative/edit/AdministrativeInformationFields.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/administrative/edit/AdministrativeInformationFields.tsx
@@ -1,7 +1,7 @@
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { EntryFieldsProps } from 'design-system/entry';
 import { DatePickerInput, validDateRule } from 'design-system/date';
-import { TextAreaField } from 'design-system/input/text/TextAreaField';
+import { TextAreaField } from 'design-system/input/text';
 import { maxLengthRule, validateRequiredRule } from 'validation/entry';
 import { HasAdministrativeInformation, labels } from '../administrative';
 


### PR DESCRIPTION
## Description

Resolves an issue where pressing backspace on the last character of a `TextArea` would revert to the previous value.  The state value was removed to work more like `TextInput`.