### PR TITLE
use State_county_code_value for county lookup

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/mortality/PatientMortalityDemographicFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/mortality/PatientMortalityDemographicFinder.java
@@ -40,9 +40,8 @@ class PatientMortalityDemographicFinder {
           left join NBS_SRTE..State_code [state] on
                   [state].state_cd = [address].state_cd
       
-          left join NBS_SRTE..Code_value_general [county] on
-                      [county].code_set_nm = 'PHVS_COUNTY_FIPS_6-4'
-                  and [county].[code] = [address].[cnty_cd]
+          left join NBS_SRTE..State_county_code_value [county]  with (nolock) on
+                  [county].[code] = [address].[cnty_cd]
       
           left join NBS_SRTE..Country_code [country] on
                   [country].code = [address].cntry_cd

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/sex_birth/PatientSexBirthDemographicFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/sex_birth/PatientSexBirthDemographicFinder.java
@@ -52,9 +52,8 @@ class PatientSexBirthDemographicFinder {
           left join NBS_SRTE..State_code [state] on
                   [state].state_cd = [address].state_cd
       
-          left join NBS_SRTE..Code_value_general [county] on
-                      [county].code_set_nm = 'PHVS_COUNTY_FIPS_6-4'
-                  and [county].[code] = [address].[cnty_cd]
+          left join NBS_SRTE..State_county_code_value [county]  with (nolock) on
+                  [county].[code] = [address].[cnty_cd]
       
           left join NBS_SRTE..Country_code [country] on
                   [country].code = [address].cntry_cd


### PR DESCRIPTION
## Description

The Mortality and Sex and birth sections were using the `code_value_general` table for county lookups. This PR updates that to use the dedicated `State_county_code_value` table for the lookup.

## Tickets
None

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
