### PR TITLE
Update state - county handling in address repeating block

### DIFF
--- a/apps/modernization-ui/src/libs/patient/demographics/address/edit/AddressDemographicFields.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/address/edit/AddressDemographicFields.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { maxLengthRule, validateRequiredRule } from 'validation/entry';
 import {
@@ -14,6 +14,7 @@ import { TextAreaField } from 'design-system/input/text/TextAreaField';
 import { SingleSelect } from 'design-system/select';
 import { AddressOptions } from './useAddressOptions';
 import { AddressDemographic, labels } from '../address';
+import { Selectable } from 'options';
 
 type AddressDemographicFieldsProps = { options: AddressOptions; entry?: AddressDemographic } & EntryFieldsProps;
 
@@ -25,14 +26,16 @@ const AddressDemographicFields = ({
 }: AddressDemographicFieldsProps) => {
     const { control, setValue } = useFormContext<AddressDemographic>();
 
-    const selectedState = useWatch({ control, name: 'state', defaultValue: entry?.state });
-
     useEffect(() => {
-        if (selectedState?.value !== entry?.state?.value) {
-            setValue('county', null);
-        }
-        options.location.state(selectedState);
-    }, [selectedState?.value, options.location.state]);
+        // on form initialization, load counties for selected state
+        options.location.state(entry?.state);
+    }, [entry?.state]);
+
+    const handleStateChange = (state: Selectable | null) => {
+        // when user selects a different state, clear selected county and load new county list
+        setValue('county', null);
+        options.location.state(state);
+    };
 
     return (
         <>
@@ -160,7 +163,10 @@ const AddressDemographicFields = ({
                         label={labels.state}
                         orientation={orientation}
                         value={value}
-                        onChange={onChange}
+                        onChange={(v) => {
+                            handleStateChange(v);
+                            onChange(v);
+                        }}
                         onBlur={onBlur}
                         id={name}
                         name={name}

--- a/apps/modernization-ui/src/libs/patient/demographics/mortality/edit/MortalityDemographicFields.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/mortality/edit/MortalityDemographicFields.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Controller, UseFormReturn, useWatch } from 'react-hook-form';
-import { isEqual } from 'options';
+import { isEqual, Selectable } from 'options';
 import { indicators } from 'options/indicator';
 import { Shown } from 'conditional-render';
 import { maxLengthRule, validateRequiredRule } from 'validation/entry';
@@ -26,19 +26,21 @@ const MortalityDemographicFields = ({
     options,
     entry
 }: MortalityDemographicFieldsProps) => {
-    const selectedState = useWatch({ control: form.control, name: 'mortality.state', defaultValue: entry?.state });
-
     const selectedDeceased = useWatch({
         control: form.control,
         name: 'mortality.deceased'
     });
 
     useEffect(() => {
-        if (selectedState?.value !== entry?.state?.value) {
-            form.setValue('mortality.county', null);
-        }
-        options.location.state(selectedState);
-    }, [selectedState?.value, options.location.state, form.setValue]);
+        // load counties for initial state
+        options.location.state(entry?.state);
+    }, [entry?.state]);
+
+    const handleStateChange = (state: Selectable | null) => {
+        // when user selects a different state, clear selected county and load new county list
+        form.setValue('mortality.county', null);
+        options.location.state(state);
+    };
 
     return (
         <>
@@ -125,7 +127,10 @@ const MortalityDemographicFields = ({
                             label={labels.state}
                             orientation={orientation}
                             value={value}
-                            onChange={onChange}
+                            onChange={(v) => {
+                                handleStateChange(v);
+                                onChange(v);
+                            }}
                             onBlur={onBlur}
                             id={name}
                             name={name}

--- a/apps/modernization-ui/src/libs/patient/demographics/sex-birth/edit/SexBirthDemographicFields.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/sex-birth/edit/SexBirthDemographicFields.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Controller, UseFormReturn, useWatch } from 'react-hook-form';
 import { AgeResolver } from 'date';
-import { isEqual } from 'options';
+import { isEqual, Selectable } from 'options';
 import { Shown } from 'conditional-render';
 import { DatePickerInput, validDateRule } from 'design-system/date';
 import { SingleSelect } from 'design-system/select';
@@ -33,7 +33,7 @@ const SexBirthDemographicFields = ({
         name: 'sexBirth.current',
         defaultValue: entry?.current
     });
-    const selectedState = useWatch({ control: form.control, name: 'sexBirth.state', defaultValue: entry?.state });
+
     const selectedMultipleBirth = useWatch({
         control: form.control,
         name: 'sexBirth.multiple',
@@ -46,11 +46,15 @@ const SexBirthDemographicFields = ({
     const isUnknownGender = isEqual(options.genders.unknown);
 
     useEffect(() => {
-        if (selectedState?.value !== entry?.state?.value) {
-            form.setValue('sexBirth.county', null);
-        }
-        options.location.state(selectedState);
-    }, [selectedState?.value, options.location.state, form.setValue]);
+        // load counties for initial state
+        options.location.state(entry?.state);
+    }, [entry?.state]);
+
+    const handleStateChange = (state: Selectable | null) => {
+        // when user selects a different state, clear selected county and load new county list
+        form.setValue('sexBirth.county', null);
+        options.location.state(state);
+    };
 
     useEffect(() => {
         if (!isUnknownGender(selectedCurrentGender)) {
@@ -255,7 +259,10 @@ const SexBirthDemographicFields = ({
                         label={labels.state}
                         orientation={orientation}
                         value={value}
-                        onChange={onChange}
+                        onChange={(v) => {
+                            handleStateChange(v);
+                            onChange(v);
+                        }}
                         onBlur={onBlur}
                         id={name}
                         name={name}


### PR DESCRIPTION
## Description

Fixes the county selection in the Edit patient Address repeating block. 

## Tickets

- [CNFT1-4097](https://cdc-nbs.atlassian.net/browse/CNFT1-4097)

## Demo
### Before the fix (note the blank county when moving from view -> edit)
![countyBroken](https://github.com/user-attachments/assets/aa825427-695c-4f50-a024-965ffc6282e9)

### After the fix
![countyFixed](https://github.com/user-attachments/assets/0a2cc44f-e433-44b5-bcfb-de2c11eacdf8)


## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4097]: https://cdc-nbs.atlassian.net/browse/CNFT1-4097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ