### PR TITLE
[CNFT1-4425] Only active patients should have edit and delete options

### DIFF
--- a/apps/modernization-ui/src/apps/patient/file/PatientFileHeader.spec.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileHeader.spec.tsx
@@ -33,7 +33,7 @@ describe('when displaying the demographics summary of a patient', () => {
             id: 17,
             patientId: 397,
             local: 'local-id-value',
-            status: 'status value',
+            status: 'ACTIVE',
             deletability: 'Deletable'
         };
 
@@ -47,7 +47,7 @@ describe('when displaying the demographics summary of a patient', () => {
             id: 17,
             patientId: 397,
             local: 'local-id-value',
-            status: 'status value',
+            status: 'ACTIVE',
             deletability: 'Deletable',
             sex: 'gender-value'
         };
@@ -62,7 +62,7 @@ describe('when displaying the demographics summary of a patient', () => {
             id: 17,
             patientId: 397,
             local: 'local-id-value',
-            status: 'status value',
+            status: 'ACTIVE',
             deletability: 'Deletable'
         };
 
@@ -91,7 +91,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 name: {
                     first: 'first-name-value',
@@ -115,7 +115,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 name: {
                     first: 'first-name-value'
@@ -136,7 +136,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 name: {
                     middle: 'middle-name-value'
@@ -157,7 +157,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 name: {
                     last: 'last-name-value'
@@ -178,7 +178,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 name: {
                     suffix: 'suffix-value'
@@ -203,7 +203,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 birthday: '08/09/1979'
             };
@@ -220,7 +220,7 @@ describe('when displaying the demographics summary of a patient', () => {
                 id: 17,
                 patientId: 397,
                 local: 'local-id-value',
-                status: 'status value',
+                status: 'ACTIVE',
                 deletability: 'Deletable',
                 birthday: '08/09/1979',
                 deceasedOn: '11/18/2010'

--- a/apps/modernization-ui/src/apps/patient/file/PatientFileView.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/PatientFileView.tsx
@@ -10,6 +10,7 @@ import { DeleteAction } from './delete';
 import styles from './patient-file-view.module.scss';
 import { useLocation } from 'react-router';
 import { TabNavigation, TabNavigationEntry } from 'components/TabNavigation/TabNavigation';
+import { Shown } from 'conditional-render';
 
 type PatientFileViewProps = {
     patient: Patient;
@@ -30,7 +31,11 @@ const ViewActions = (patient: Patient) => {
     const { pathname } = useLocation();
     return (
         <>
-            <DeleteAction patient={patient} />
+            <Shown when={patient.status === 'ACTIVE'}>
+                <Permitted permission={permissions.patient.delete}>
+                    <DeleteAction patient={patient} />
+                </Permitted>
+            </Shown>
             <Button
                 onClick={openPrintableView(patient.id)}
                 aria-label="Print"
@@ -40,11 +45,14 @@ const ViewActions = (patient: Patient) => {
                 sizing="medium"
                 secondary
             />
-            <Permitted permission={permissions.patient.update}>
-                <NavLinkButton icon="edit" secondary sizing="medium" to="../edit" state={{ return: pathname }}>
-                    Edit
-                </NavLinkButton>
-            </Permitted>
+
+            <Shown when={patient.status === 'ACTIVE'}>
+                <Permitted permission={permissions.patient.update}>
+                    <NavLinkButton icon="edit" secondary sizing="medium" to="../edit" state={{ return: pathname }}>
+                        Edit
+                    </NavLinkButton>
+                </Permitted>
+            </Shown>
         </>
     );
 };

--- a/apps/modernization-ui/src/apps/patient/file/edit/GuardedPatientFileEdit.tsx
+++ b/apps/modernization-ui/src/apps/patient/file/edit/GuardedPatientFileEdit.tsx
@@ -2,14 +2,22 @@ import { RedirectHome } from 'routes';
 import { permissions } from 'libs/permission';
 import { Guarded } from 'libs/guard';
 import { PatientFileEdit } from './PatientFileEdit';
+import { usePatientFileData } from '../usePatientFileData';
+import { Shown } from 'conditional-render';
 
-const GuardedPatientFileEdit = () => (
-    <Guarded
-        feature={(features) => features.patient.file.enabled}
-        permission={permissions.patient.update}
-        fallback={<RedirectHome />}>
-        <PatientFileEdit />
-    </Guarded>
-);
+const GuardedPatientFileEdit = () => {
+    const { patient } = usePatientFileData();
+
+    return (
+        <Shown when={patient.status === 'ACTIVE'} fallback={<RedirectHome />}>
+            <Guarded
+                feature={(features) => features.patient.file.enabled}
+                permission={permissions.patient.update}
+                fallback={<RedirectHome />}>
+                <PatientFileEdit />
+            </Guarded>
+        </Shown>
+    );
+};
 
 export { GuardedPatientFileEdit };

--- a/apps/modernization-ui/src/apps/patient/file/patient.ts
+++ b/apps/modernization-ui/src/apps/patient/file/patient.ts
@@ -6,7 +6,7 @@ type Patient = {
     id: number;
     patientId: number;
     local: string;
-    status: string;
+    status: 'ACTIVE' | 'INACTIVE' | 'SUPERSEDED';
     deletability: Deletability;
     sex?: string;
     birthday?: string;


### PR DESCRIPTION
## Description

Ensures that the "Edit" and "Delete" buttons on Patient file are only displayed for `ACTIVE` patients.

## Tickets

* [CNFT1-4425](https://cdc-nbs.atlassian.net/browse/CNFT1-4425)

## Checklist before requesting a review
- [X] PR focuses on a single story
- [X] Code has been fully tested to meet acceptance criteria
- [X] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [X] All new functions/classes/components reasonably small
- [X] Functions/classes/components focused on one responsibility
- [X] Code easy to understand and modify (clarity over concise/clever)
- [X] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [X] PR does not contain hardcoded values (Uses constants)
- [X] All code is covered by unit or feature tests


[CNFT1-4425]: https://cdc-nbs.atlassian.net/browse/CNFT1-4425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ