### PR TITLE
[CNFT1-4097] Handling select values changing before options are loaded

### DIFF
--- a/apps/modernization-ui/src/design-system/select/single/Select.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.tsx
@@ -1,7 +1,9 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useCallback } from 'react';
 import classNames from 'classnames';
 import { findByValue, Selectable } from 'options';
 import { Sizing } from 'design-system/field';
+
+const hashed = (options: Selectable[]) => options.reduce((previous, next) => previous + next.value, '');
 
 type SelectProps = {
     id: string;
@@ -37,12 +39,13 @@ const Select = ({
     placeholder = '- Select -',
     ...inputProps
 }: SelectProps) => {
-    const find = findByValue(options);
-
-    const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        const selected = find(event.target.value) ?? null;
-        onChange?.(selected);
-    };
+    const handleChange = useCallback(
+        (event: ChangeEvent<HTMLSelectElement>) => {
+            const selected = findByValue(options)(event.target.value) ?? null;
+            onChange?.(selected);
+        },
+        [hashed(options), onChange]
+    );
 
     return (
         <select


### PR DESCRIPTION
## Description

There are situations where dependent options (counties of a state) are requested before the previous request has been loaded.  This results in the options of the previous request being used for the current values.

## Tickets

* [CNFT1-4097](https://cdc-nbs.atlassian.net/browse/CNFT1-4097)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
