### PR TITLE
[FIX] Handling deletes from classic modal

### DIFF
--- a/apps/modernization-ui/src/libs/api/index.ts
+++ b/apps/modernization-ui/src/libs/api/index.ts
@@ -7,5 +7,4 @@ export { isFailure } from './response';
 export type { StandardResponse, SuccessResponse, FailureResponse } from './response';
 
 export { RequestError } from './RequestError';
-export { get } from './request';
-export { put } from './request';
+export { get, post, put } from './request';

--- a/apps/modernization-ui/src/libs/api/request.ts
+++ b/apps/modernization-ui/src/libs/api/request.ts
@@ -1,6 +1,9 @@
 import { maybeMap } from 'utils/mapping';
 
-const maybeAsJson = maybeMap((body: object | string | number) => JSON.stringify(body));
+const maybeAsJsonPayload = maybeMap((body: object | string | number) => ({
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+}));
 
 /**
  * Creates a standard GET request to the API.
@@ -17,6 +20,22 @@ const get = (url: string) => {
 };
 
 /**
+ * Creates a standard POST request to the API with an optional request `body`.  If a body is provided it is converted to JSON.
+ *
+ * @param {string} url The URL of the request.
+ * @param {object} body The body of the request.
+ * @return {Request} The resulting Request
+ */
+const post = (url: string, body?: object) => {
+    const payload = maybeAsJsonPayload(body);
+    return new Request(url, {
+        method: 'POST',
+        credentials: 'same-origin',
+        ...payload
+    });
+};
+
+/**
  * Creates a standard PUT request to the API with an optional request `body`.  If a body is provided it is converted to JSON.
  *
  * @param {string} url The URL of the request.
@@ -24,12 +43,11 @@ const get = (url: string) => {
  * @return {Request} The resulting Request
  */
 const put = (url: string, body?: object) => {
+    const payload = maybeAsJsonPayload(body);
     return new Request(url, {
         method: 'PUT',
-        body: maybeAsJson(body),
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin'
+        ...payload
     });
 };
 
-export { get, put };
+export { get, post, put };

--- a/apps/modernization-ui/src/libs/classic/ClassicModalButton.tsx
+++ b/apps/modernization-ui/src/libs/classic/ClassicModalButton.tsx
@@ -1,6 +1,9 @@
 import { useEffect } from 'react';
+import { post } from 'libs/api';
 import { Button, ButtonProps } from 'design-system/button';
 import { Status, useClassicModal } from './useClassicModal';
+
+const performAction = (action?: string) => (action ? fetch(post(action)) : Promise.resolve());
 
 type ClassicModalButtonProps = {
     url: string;
@@ -12,10 +15,12 @@ const ClassicModalButton = ({ url, onClose, ...remaining }: ClassicModalButtonPr
 
     useEffect(() => {
         if (state.status === Status.Closed) {
-            reset();
-            onClose?.();
+            performAction(state.action).finally(() => {
+                reset();
+                onClose?.();
+            });
         }
-    }, [state.status]);
+    }, [state.status, state.action]);
 
     return <Button {...remaining} onClick={() => open(url)} />;
 };


### PR DESCRIPTION
## Description

Adds support for delete actions within a `ClassicModal`.  NBS relies on a form action being performed in order to execute the delete for events displayed within a `ClassicModal`.  The `action` is now invoked if specified by the page being displayed.
