### PR TITLE
fix: ensuring footer is displayed only if exists and adding unique aria label to navigation inline nav element

### DIFF
--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -73,7 +73,7 @@ const Card = ({
                     {children}
                 </Collapsible>
             </Shown>
-            <Shown when={!collapsed}>
+            <Shown when={!collapsed && !!footer}>
                 <footer>{footer}</footer>
             </Shown>
         </section>

--- a/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
+++ b/apps/modernization-ui/src/design-system/inPageNavigation/InPageNavigation.tsx
@@ -30,7 +30,7 @@ export const InPageNavigation: React.FC<InPageNavigationProps> = ({ sections, ti
     }, [location.hash]);
 
     return (
-        <nav>
+        <nav aria-label={title}>
             <div className={styles.navTitle}>{title}</div>
             <div className={styles.navOptions}>
                 {sections.map((section) => (


### PR DESCRIPTION
## Description

ensuring footer is displayed only if exists
adding unique aria label to navigation inline nav element
## Tickets

*[CNFT1-4430](https://cdc-nbs.atlassian.net/browse/CNFT1-4430)
*[CNFT1-4431](https://cdc-nbs.atlassian.net/browse/CNFT1-4431)


## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4430]: https://cdc-nbs.atlassian.net/browse/CNFT1-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNFT1-4431]: https://cdc-nbs.atlassian.net/browse/CNFT1-4431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ