### PR TITLE
fix: adding no comments available text to the amdin panel in patient file

### DIFF
--- a/apps/modernization-ui/src/libs/patient/demographics/administrative/view/AdministrativeInformationCard.spec.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/administrative/view/AdministrativeInformationCard.spec.tsx
@@ -16,4 +16,11 @@ describe('when displaying administrative comments for a patient', () => {
         expect(screen.getByText('random comments')).toBeInTheDocument();
         expect(screen.getByText('As of 01/25/2025')).toBeInTheDocument();
     });
+
+    it('should display No comments available when no comments are present', () => {
+        const data = { comment: '' };
+        render(<AdministrativeInformationCard data={data} collapsible id={'test'} title={'test'} />);
+
+        expect(screen.getByText('No comments available.')).toBeInTheDocument();
+    });
 });

--- a/apps/modernization-ui/src/libs/patient/demographics/administrative/view/AdministrativeInformationCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/administrative/view/AdministrativeInformationCard.tsx
@@ -1,10 +1,13 @@
 import classNames from 'classnames';
 import { internalizeDate } from 'date';
 import { Card, CardProps } from 'design-system/card';
-import { OrElseNoData } from 'design-system/data';
 import { AdministrativeInformation } from '../administrative';
+import { defaultTo } from 'libs/supplying';
 
 import styles from './administrative-information-card.module.scss';
+
+
+const orElseNoData = defaultTo('No comments available.') 
 
 type AdministrativeInformationCardProps = {
     title?: string;
@@ -28,7 +31,7 @@ const AdministrativeInformationCard = ({
                     [styles.medium]: sizing === 'medium',
                     [styles.large]: sizing === 'large'
                 })}>
-                <OrElseNoData>{data?.comment}</OrElseNoData>
+               {orElseNoData(data?.comment)}
             </div>
         </Card>
     );

--- a/apps/modernization-ui/src/libs/patient/demographics/administrative/view/AdministrativeInformationCard.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/administrative/view/AdministrativeInformationCard.tsx
@@ -6,8 +6,7 @@ import { defaultTo } from 'libs/supplying';
 
 import styles from './administrative-information-card.module.scss';
 
-
-const orElseNoData = defaultTo('No comments available.') 
+const orElseNoData = defaultTo('No comments available.');
 
 type AdministrativeInformationCardProps = {
     title?: string;
@@ -31,7 +30,7 @@ const AdministrativeInformationCard = ({
                     [styles.medium]: sizing === 'medium',
                     [styles.large]: sizing === 'large'
                 })}>
-               {orElseNoData(data?.comment)}
+                {orElseNoData(data?.comment)}
             </div>
         </Card>
     );


### PR DESCRIPTION


## Description
 Adding no data indication for admin panel in patient file 
<img width="742" height="199" alt="Screenshot 2025-09-12 at 3 29 50 PM" src="https://github.com/user-attachments/assets/d58c46b4-62cf-4916-9e57-8a926a9fbc28" />


## Tickets

* [CNFT1-4433](https://cdc-nbs.atlassian.net/browse/CNFT1-4433)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[CNFT1-4433]: https://cdc-nbs.atlassian.net/browse/CNFT1-4433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ