### PR TITLE
test: temp fix - give our test patient a birthday!

### DIFF
--- a/apps/modernization-ui/src/libs/patient/demographics/sex-birth/edit/SexBirthDemographicFields.spec.tsx
+++ b/apps/modernization-ui/src/libs/patient/demographics/sex-birth/edit/SexBirthDemographicFields.spec.tsx
@@ -131,7 +131,7 @@ describe('when entering patient sex and birth demographics', () => {
 
         await user.clear(dateOfBirth).then(() => user.type(dateOfBirth, '12012012{tab}'));
 
-        expect(getByText('12 years')).toBeInTheDocument();
+        expect(getByText('13 years')).toBeInTheDocument();
     });
 
     it('should have accessibility description for the as of date field', () => {


### PR DESCRIPTION
## Description

We should mock out the current date, but I'm not sure if there are knock on effects for that, so for the quick moment to get tests passing again, change the expected age from 12 to 13.
