### PR TITLE
Ensure Elasticsearch indices are created before starting nifi

### DIFF
--- a/cdc-sandbox/build_modernized.sh
+++ b/cdc-sandbox/build_modernized.sh
@@ -19,7 +19,15 @@ fi
 # Start ES and the proxy
 echo "Starting elasticsearch reverse-proxy"
 docker compose -f $BASE/docker-compose.yml up elasticsearch --build -d
-until curl -sf http://localhost:9200 > /dev/null 2>&1; do sleep 2; done
+attempts=0
+until curl -sf http://localhost:9200 > /dev/null 2>&1; do
+  attempts=$((attempts + 1))
+  if [ $attempts -ge 24 ]; then
+    echo "Timed out waiting for Elasticsearch"
+    exit 1
+  fi
+  sleep 5
+done
 echo "Elasticsearch is ready"
 
 # Start application services (without NiFi) to initialize Elasticsearch indices
@@ -27,7 +35,15 @@ echo "Starting modernized application services"
 docker compose -f $BASE/docker-compose.yml up modernization-api pagebuilder-api nbs-gateway keycloak --build -d
 
 echo "Waiting for Elasticsearch indices to be created..."
-until curl -sf http://localhost:9200/person/_mapping > /dev/null 2>&1; do sleep 5; done
+attempts=0
+until curl -sf http://localhost:9200/person/_mapping > /dev/null 2>&1; do
+  attempts=$((attempts + 1))
+  if [ $attempts -ge 24 ]; then
+    echo "Timed out waiting for Elasticsearch indices"
+    exit 1
+  fi
+  sleep 5
+done
 echo "Elasticsearch indices are ready"
 
 # NiFi handles synchronizing data between nbs-mssql and elasticsearch


### PR DESCRIPTION
## Description

Updates `build_modernization.sh` so that `nifi` is not started until after `modernization-api` has successfully created the Elasticsearch indices. This prevents a race condition at startup that leads to a mismatch between the index mapping on the Elasticsearch side and the expected mapping on the application side. [More context in Slack](https://skylight-hq.slack.com/archives/C09HXK6MKPE/p1770060944870259?thread_ts=1769704929.309269&cid=C09HXK6MKPE).

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CTHLU-26)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
