### PR TITLE
[APP-254] feat: add report execution feature flag

### DIFF
--- a/apps/modernization-api/src/main/resources/application-development.yml
+++ b/apps/modernization-api/src/main/resources/application-development.yml
@@ -75,4 +75,6 @@ nbs:
           enabled: true
           merge-history:
             enabled: false
-
+      report:
+        execution:
+          enabled: true

--- a/apps/modernization-api/src/main/resources/application.yml
+++ b/apps/modernization-api/src/main/resources/application.yml
@@ -16,6 +16,11 @@ nbs:
     server: ${nbs.wildfly.host}:${nbs.wildfly.port}
     port: 7001
     url: http://${nbs.wildfly.server}
+  report:
+    execution:
+      host: localhost
+      port: 8001
+      url: http://${nbs.report.execution.host}:${nbs.report.execution.port}
   datasource:
     server: localhost
     port: 1433

--- a/apps/modernization-ui/package-lock.json
+++ b/apps/modernization-ui/package-lock.json
@@ -6048,7 +6048,6 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
             "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -6088,7 +6087,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6109,7 +6107,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6130,7 +6127,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6151,7 +6147,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6172,7 +6167,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6193,7 +6187,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6214,7 +6207,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6235,7 +6227,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6256,7 +6247,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6277,7 +6267,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6298,7 +6287,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6319,7 +6307,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6340,7 +6327,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11980,7 +11966,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -19369,7 +19354,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },

--- a/apps/modernization-ui/package-lock.json
+++ b/apps/modernization-ui/package-lock.json
@@ -6048,6 +6048,7 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
             "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -6087,6 +6088,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6107,6 +6109,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6127,6 +6130,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6147,6 +6151,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6167,6 +6172,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6187,6 +6193,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6207,6 +6214,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6227,6 +6235,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6247,6 +6256,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6267,6 +6277,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6287,6 +6298,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6307,6 +6319,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6327,6 +6340,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11966,6 +11980,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -19354,6 +19369,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true
         },

--- a/apps/modernization-ui/src/configuration/configuration.ts
+++ b/apps/modernization-ui/src/configuration/configuration.ts
@@ -87,6 +87,11 @@ type Features = {
             enabled: boolean;
         };
     };
+    report: {
+        execution: {
+            enabled: boolean;
+        };
+    };
 };
 
 type Properties = {

--- a/apps/modernization-ui/src/configuration/defaults.ts
+++ b/apps/modernization-ui/src/configuration/defaults.ts
@@ -63,6 +63,11 @@ const defaultFeatures: Features = {
         management: {
             enabled: false
         }
+    },
+    report: {
+        execution: {
+            enabled: false
+        }
     }
 };
 

--- a/apps/nbs-gateway/README.md
+++ b/apps/nbs-gateway/README.md
@@ -99,6 +99,7 @@ The default profile contains the following properties configuration most likely 
 | nbs.gateway.deduplication.uri                          | `http://localhost:8083` | The full URI of the Deduplication Api                                                                                                   |
 | nbs.gateway.deduplication.merge.enabled                | `false`                 | Enables the routing for modernized System Identified merge list                                                                         |
 | nbs.gateway.system.management.enabled                  | `false`                 | Enables the routing for modernized System Management screen                                                                             |
+| nbs.gateway.report.execution.enabled                   | `false`                 | Enables the routing for modernized Report Execution                                                                                     |
 
 ### Logo
 

--- a/apps/nbs-gateway/src/main/resources/application-development.yml
+++ b/apps/nbs-gateway/src/main/resources/application-development.yml
@@ -23,3 +23,6 @@ nbs:
             enabled: true
           edit:
             enabled: true
+    report:
+      execution:
+        enabled: true

--- a/apps/nbs-gateway/src/main/resources/application.yml
+++ b/apps/nbs-gateway/src/main/resources/application.yml
@@ -42,6 +42,9 @@ nbs:
       uri: '${nbs.gateway.defaults.protocol}://${nbs.gateway.deduplication.service}'
       merge:
         enabled: false
+    report:
+      execution:
+        enabled: false
 
 logging:
   level:

--- a/cdc-sandbox/build_modernized.sh
+++ b/cdc-sandbox/build_modernized.sh
@@ -39,7 +39,7 @@ attempts=0
 until curl -sf http://localhost:9200/person/_mapping > /dev/null 2>&1; do
   attempts=$((attempts + 1))
   if [ $attempts -ge 24 ]; then
-    echo "Timed out waiting for Elasticsearch indices"
+    echo "Timed out waiting for Elasticsearch indices (is modernization-api running?)"
     exit 1
   fi
   sleep 5

--- a/libs/configuration-api/README.md
+++ b/libs/configuration-api/README.md
@@ -42,6 +42,7 @@ The `features` property in the `/nbs/api/configuration` response contains [featu
 | nbs.ui.features.patient.search.filters.enabled      | false   | Enables access to modernized Patient search filters                |
 | nbs.ui.features.patient.file.enabled                | false   | Enables access to modernized Patient file                          |
 | nbs.ui.features.patient.file.merge-history.enabled  | false   | Enables access to merge history within the modernized Patient file |
+| nbs.ui.features.report.execution.enabled            | false   | Enables access to report execution and manaement                   |
 
 ---
 

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/Features.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/Features.java
@@ -4,18 +4,15 @@ import gov.cdc.nbs.configuration.features.address.Address;
 import gov.cdc.nbs.configuration.features.deduplication.Deduplication;
 import gov.cdc.nbs.configuration.features.page_builder.PageBuilder;
 import gov.cdc.nbs.configuration.features.patient.Patient;
+import gov.cdc.nbs.configuration.features.report.Report;
 import gov.cdc.nbs.configuration.features.search.Search;
 import gov.cdc.nbs.configuration.features.system.SystemFeatures;
-import gov.cdc.nbs.configuration.features.report.Report;
-
-
 
 public record Features(
-        Search search,
-        Address address,
-        PageBuilder pageBuilder,
-        Deduplication deduplication,
-        Patient patient,
-        SystemFeatures system,
-        Report report) {
-}
+    Search search,
+    Address address,
+    PageBuilder pageBuilder,
+    Deduplication deduplication,
+    Patient patient,
+    SystemFeatures system,
+    Report report) {}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/Features.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/Features.java
@@ -6,15 +6,16 @@ import gov.cdc.nbs.configuration.features.page_builder.PageBuilder;
 import gov.cdc.nbs.configuration.features.patient.Patient;
 import gov.cdc.nbs.configuration.features.search.Search;
 import gov.cdc.nbs.configuration.features.system.SystemFeatures;
+import gov.cdc.nbs.configuration.features.report.Report;
 
 
 
 public record Features(
-    Search search,
-    Address address,
-    PageBuilder pageBuilder,
-    Deduplication deduplication,
-    Patient patient,
-    SystemFeatures system) {
-
+        Search search,
+        Address address,
+        PageBuilder pageBuilder,
+        Deduplication deduplication,
+        Patient patient,
+        SystemFeatures system,
+        Report report) {
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/FeaturesConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/FeaturesConfiguration.java
@@ -24,14 +24,6 @@ class FeaturesConfiguration {
       Patient patient,
       SystemFeatures system,
       Report report) {
-    return () -> new Features(
-        search,
-        address,
-        pageBuilder,
-        deduplication,
-        patient,
-        system,
-        report);
+    return () -> new Features(search, address, pageBuilder, deduplication, patient, system, report);
   }
-
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/FeaturesConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/FeaturesConfiguration.java
@@ -4,6 +4,7 @@ import gov.cdc.nbs.configuration.features.address.Address;
 import gov.cdc.nbs.configuration.features.deduplication.Deduplication;
 import gov.cdc.nbs.configuration.features.page_builder.PageBuilder;
 import gov.cdc.nbs.configuration.features.patient.Patient;
+import gov.cdc.nbs.configuration.features.report.Report;
 import gov.cdc.nbs.configuration.features.search.Search;
 import gov.cdc.nbs.configuration.features.system.SystemFeatures;
 import org.springframework.context.annotation.Bean;
@@ -21,14 +22,16 @@ class FeaturesConfiguration {
       PageBuilder pageBuilder,
       Deduplication deduplication,
       Patient patient,
-      SystemFeatures system) {
+      SystemFeatures system,
+      Report report) {
     return () -> new Features(
         search,
         address,
         pageBuilder,
         deduplication,
         patient,
-        system);
+        system,
+        report);
   }
 
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/Report.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/Report.java
@@ -1,0 +1,8 @@
+package gov.cdc.nbs.configuration.features.report;
+
+public record Report(
+        Execution execution) {
+
+    public record Execution(boolean enabled) {
+    }
+}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/Report.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/Report.java
@@ -1,8 +1,6 @@
 package gov.cdc.nbs.configuration.features.report;
 
-public record Report(
-        Execution execution) {
+public record Report(Execution execution) {
 
-    public record Execution(boolean enabled) {
-    }
+  public record Execution(boolean enabled) {}
 }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/ReportFeaturesConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/ReportFeaturesConfiguration.java
@@ -1,0 +1,24 @@
+package gov.cdc.nbs.configuration.features.report;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+class ReportFeaturesConfiguration {
+
+    @Bean
+    @Scope("prototype")
+    Report reportFeatures(
+            final Report.Execution execution) {
+        return new Report(execution);
+    }
+
+    @Bean
+    @Scope("prototype")
+    Report.Execution reportExecutionFeature(
+            @Value("${nbs.ui.features.report.execution.enabled:false}") final boolean enabled) {
+        return new Report.Execution(enabled);
+    }
+}

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/ReportFeaturesConfiguration.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/features/report/ReportFeaturesConfiguration.java
@@ -8,17 +8,16 @@ import org.springframework.context.annotation.Scope;
 @Configuration
 class ReportFeaturesConfiguration {
 
-    @Bean
-    @Scope("prototype")
-    Report reportFeatures(
-            final Report.Execution execution) {
-        return new Report(execution);
-    }
+  @Bean
+  @Scope("prototype")
+  Report reportFeatures(final Report.Execution execution) {
+    return new Report(execution);
+  }
 
-    @Bean
-    @Scope("prototype")
-    Report.Execution reportExecutionFeature(
-            @Value("${nbs.ui.features.report.execution.enabled:false}") final boolean enabled) {
-        return new Report.Execution(enabled);
-    }
+  @Bean
+  @Scope("prototype")
+  Report.Execution reportExecutionFeature(
+      @Value("${nbs.ui.features.report.execution.enabled:false}") final boolean enabled) {
+    return new Report.Execution(enabled);
+  }
 }

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/features/FeaturesSteps.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/features/FeaturesSteps.java
@@ -23,5 +23,4 @@ public class FeaturesSteps {
       default -> value;
     };
   }
-
 }

--- a/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/features/FeaturesSteps.java
+++ b/libs/configuration-api/src/test/java/gov/cdc/nbs/configuration/features/FeaturesSteps.java
@@ -19,6 +19,7 @@ public class FeaturesSteps {
       case "deduplication" -> "features.deduplication.enabled";
       case "deduplication merge" -> "features.deduplication.merge.enabled";
       case "system management" -> "features.system.management.enabled";
+      case "report execution" -> "features.report.execution.enabled";
       default -> value;
     };
   }

--- a/libs/configuration-api/src/test/resources/features/Features.feature
+++ b/libs/configuration-api/src/test/resources/features/Features.feature
@@ -45,3 +45,5 @@ Feature: Frontend Feature Configuration
       | patient file merge history | disabled |
       | system management          | enabled  |
       | system management          | disabled |
+      | report execution           | enabled  |
+      | report execution           | disabled |


### PR DESCRIPTION
## Description

Following existing feature flag patterns, add the `report.execution.enabled` flag to the `ui` (via `libs/configuration-api`) and `nbs-gateway` services.

<img width="685" height="994" alt="image" src="https://github.com/user-attachments/assets/ef024b3d-38b4-4b78-96c8-9f38e568042f" />


### Notes
* The `report.execution` sub-layering is futureproofing other report-related feature flags we might want to add. It might be YAGNI, but given how much we aren't touching off the bat, felt worth it (pushback welcome)
* Added the report execution service details as well since I was messing with configuration in general
* Added the hint on why waiting for elastic search indices might have timed out

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-254)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
