### PR TITLE
[APP-310] build: incrementally enforce formatting via spotless

### DIFF
--- a/.github/workflows/verify-formatting.yaml
+++ b/.github/workflows/verify-formatting.yaml
@@ -17,8 +17,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/.github/workflows/verify-formatting.yaml
+++ b/.github/workflows/verify-formatting.yaml
@@ -17,6 +17,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+            # need all of the branches to do the diff
+            fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/.github/workflows/verify-formatting.yaml
+++ b/.github/workflows/verify-formatting.yaml
@@ -1,0 +1,38 @@
+name: Check Style
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  pipeline:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: "zulu" # Alternative distribution options are available
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+          
+      - name: Check formatting
+        working-directory: ./
+        run: ./gradlew clean spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'java-library'
     id 'jacoco'
     id 'org.sonarqube' version '6.2.0.5505'
-    id "com.diffplug.spotless"  version "8.2.1"
+    id 'com.diffplug.spotless'  version '8.2.1'
 }
 
 version = '1.0.1-SNAPSHOT'  // The plugin will assign the root project version to all its subprojects.

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ plugins {
     id 'java-library'
     id 'jacoco'
     id 'org.sonarqube' version '6.2.0.5505'
+    id "com.diffplug.spotless"  version "8.2.1"
 }
 
 version = '1.0.1-SNAPSHOT'  // The plugin will assign the root project version to all its subprojects.
@@ -35,6 +36,24 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'jvm-test-suite'
     apply plugin: 'jacoco'
+    apply plugin: 'com.diffplug.spotless'
+
+    spotless {
+        // limit format enforcement to just the files changed by this feature branch
+        ratchetFrom 'origin/main'
+
+        java {
+            targetExclude '**/generated/**/*.java'
+            googleJavaFormat()
+            formatAnnotations()
+            trimTrailingWhitespace()
+            endWithNewline()
+        }
+    }
+
+    tasks.named('compileJava') {
+        dependsOn tasks.named('spotlessApply')
+    }
 
     java {
         toolchain {

--- a/documentation/Code-Formatting.md
+++ b/documentation/Code-Formatting.md
@@ -24,4 +24,4 @@ To fix the code formatting (also runs on build):
 
 ### Editor Setup
 
-While the spotless formatting is the source of truth for what is correct. You can set up your editor to directly use the [google-java-format](https://github.com/google/google-java-format?tab=readme-ov-file) so functions like format on save are available.
+While the spotless formatting is the source of truth for what is correct. You can set up your editor to directly use the [google-java-format](https://github.com/google/google-java-format?tab=readme-ov-file#third-party-integrations) so functions like format on save are available.

--- a/documentation/Code-Formatting.md
+++ b/documentation/Code-Formatting.md
@@ -2,59 +2,26 @@
 
 ## Java Formatting
 
-Java Code is formatted using the Google Java Style Guide with minimal customizations.
+Java Code is formatted using the Google Java Style Guide. We use spotless to check and fix formatting on files changed by the branch. It will run on build and CI will check that it's been run. 
 
-### IntelliJ
+We recommend adding the [pre-push hook](spotlessInstallGitPrePushHook) to check formatting before pushing to GitHub.
 
-1. Open settings -> Editor -> Code Style
-1. Click the Gear icon next to the Scheme name
-1. Select Import Scheme -> Eclipse XML Profile
-1. Select the [eclipse-java-google-style.xml](../eclipse-java-google-style.xml) file in the root of the repository
+```sh
+./gradlew spotlessInstallGitPrePushHook
+```
 
-### VS-Code
+### Running Formatting
 
-1. Add the following to your `settings.json`.
+To check if the code is formatted correctly:
+```sh
+./gradlew spotlessCheck
+```
 
-   ```json
-   "java.format.settings.profile": "GoogleStyle",
-   "java.format.settings.url": "eclipse-java-google-style.xml"
-   ```
+To fix the code formatting (also runs on build):
+```sh
+./gradlew spotlessApply
+```
 
-### Customizations
+### Editor Setup
 
-1. Allow method parameters to be on new lines
-
-   ```xml
-   <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
-   ```
-
-   Example:
-
-   ```java
-   return new PatientCommand.AddPatient(
-               request.patient(),
-               request.patientLocalId(),
-               request.ssn(),
-               request.dateOfBirth(),
-               request.birthGender(),
-               request.currentGender(),
-               request.deceased(),
-               request.deceasedTime(),
-               request.maritalStatus(),
-               request.ethnicity(),
-               request.asOf(),
-               request.comments(),
-               request.createdBy(),
-               request.createdAt());
-   ```
-
-1. Increase max line length to 120
-
-   ```xml
-   <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
-
-   ```
-
-## Typescript Formatting
-
-Typescript formatting is handled by the [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) plugin.
+While the spotless formatting is the source of truth for what is correct. You can set up your editor to directly use the [google-java-format](https://github.com/google/google-java-format?tab=readme-ov-file) so functions like format on save are available.

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/EntityId.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/EntityId.java
@@ -6,10 +6,8 @@ import gov.cdc.nbs.audit.Status;
 import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.PatientIdentificationHistoryListener;
 import jakarta.persistence.*;
-
 import java.time.LocalDate;
 import java.util.function.Predicate;
-
 
 @Entity
 @Table(name = "Entity_id")
@@ -20,22 +18,18 @@ public class EntityId implements Identifiable<EntityIdId> {
     return input -> input.recordStatus.isActive();
   }
 
-  @EmbeddedId
-  private EntityIdId id;
+  @EmbeddedId private EntityIdId id;
 
   @MapsId("entityUid")
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "entity_uid", nullable = false)
   @SuppressWarnings(
       //  Bidirectional mappings require knowledge of each other
-      "javaarchitecture:S7027"
-  )
+      "javaarchitecture:S7027")
   private NBSEntity nbsEntityUid;
 
-
-
   @Column(name = "assigning_authority_cd", length = 199)
-      private String assigningAuthorityCd;
+  private String assigningAuthorityCd;
 
   @Column(name = "root_extension_txt", length = 100)
   private String rootExtensionTxt;
@@ -46,24 +40,18 @@ public class EntityId implements Identifiable<EntityIdId> {
   @Column(name = "as_of_date")
   private LocalDate asOfDate;
 
-  @Embedded
-  private Audit audit;
+  @Embedded private Audit audit;
 
-  @Embedded
-  private RecordStatus recordStatus;
+  @Embedded private RecordStatus recordStatus;
 
-  @Embedded
-  private Status status;
+  @Embedded private Status status;
 
-  protected EntityId() {
-
-  }
+  protected EntityId() {}
 
   public EntityId(
       final NBSEntity nbs,
       final EntityIdId identifier,
-      final PatientCommand.AddIdentification added
-  ) {
+      final PatientCommand.AddIdentification added) {
     this.nbsEntityUid = nbs;
     this.id = identifier;
 

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/EntityId.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/EntityId.java
@@ -32,8 +32,10 @@ public class EntityId implements Identifiable<EntityIdId> {
   )
   private NBSEntity nbsEntityUid;
 
+
+
   @Column(name = "assigning_authority_cd", length = 199)
-  private String assigningAuthorityCd;
+      private String assigningAuthorityCd;
 
   @Column(name = "root_extension_txt", length = 100)
   private String rootExtensionTxt;


### PR DESCRIPTION
## Description

Use spotless to enforce that files we newly touch in branches must be formatted according to Google Java Style (no more customizations). This is also enforced via CI.

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-310

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
