### PR TITLE
build: ignore formatting in blame, remove ratchet

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Formatting commits to ignore in git blame
+
+# apply formatting
+eba96a9de6862bcfacb365c087c91c74e9f4dc55
+03465e5dd6de6bf8e9638f4a151582215b1ccbd0
+c20f51da432961c33c0988b8f60888a4c1f990fc
+c99502fb0962c11bc9341163f641d7c6bec3f096
+b6422bb85fa0bad2de5787662473b6a2802a4090

--- a/build.gradle
+++ b/build.gradle
@@ -36,28 +36,20 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'jvm-test-suite'
     apply plugin: 'jacoco'
+    apply plugin: 'com.diffplug.spotless'
 
-    // run spotless on build if git present (not in a docker container)
-    def gitDirectory = new File('.git')
-    if (gitDirectory.exists()) {
-        apply plugin: 'com.diffplug.spotless'
-
-        spotless {
-            // limit format enforcement to just the files changed by this feature branch
-            ratchetFrom 'origin/main'
-
-            java {
-                targetExclude '**/generated/**/*.java'
-                googleJavaFormat()
-                formatAnnotations()
-                trimTrailingWhitespace()
-                endWithNewline()
-            }
+    spotless {
+        java {
+            targetExclude '**/generated/**/*.java'
+            googleJavaFormat()
+            formatAnnotations()
+            trimTrailingWhitespace()
+            endWithNewline()
         }
+    }
 
-        tasks.named('compileJava') {
-            dependsOn tasks.named('spotlessApply')
-        }
+    tasks.named('compileJava') {
+        dependsOn tasks.named('spotlessApply')
     }
 
     java {


### PR DESCRIPTION
## Description

Follow on PR to ignore the styling commits in the git blame and remove the ratchetting/git special logic
