### PR TITLE
fix port to be 8000

### DIFF
--- a/apps/report-execution/.gitignore
+++ b/apps/report-execution/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .ruff_cache/
 .pytest_cache/
 .venv/
+.env

--- a/apps/report-execution/.gitignore
+++ b/apps/report-execution/.gitignore
@@ -2,4 +2,3 @@ __pycache__/
 .ruff_cache/
 .pytest_cache/
 .venv/
-.env

--- a/apps/report-execution/README.md
+++ b/apps/report-execution/README.md
@@ -36,7 +36,7 @@
 1. Start the FastAPI development server with [Uvicorn](https://uvicorn.dev/) (the default ASGI server program shipped with FastAPI):
 
     ```bash
-    uv run uvicorn src.main:app
+    uv run --env-file .env uvicorn src.main:app
     ```
 
 The application will be available at:

--- a/apps/report-execution/README.md
+++ b/apps/report-execution/README.md
@@ -16,7 +16,7 @@
     uv sync --frozen
     ```
 
-1. (Optional) Create a `.env` file from the `sample.env`, if you'd like to configure the application's port or host during local development (particularly helpful if you're running outside of Docker).  _NOTE: You'll need to manually load the env (`export $(xargs <.env)`), add `--env-file .env` to `uv` commands, or install and configure [direnv](https://direnv.net/) (or an equivalent shell extension) in order to make these environment variables available to the application._
+1. Create a `.env` file from the `sample.env`, if you'd like to configure the application's port or host during local development (particularly helpful if you're running outside of Docker).  _NOTE: You'll need to manually load the env (`export $(xargs <.env)`), add `--env-file .env` to `uv` commands, or install and configure [direnv](https://direnv.net/) (or an equivalent shell extension) in order to make these environment variables available to the application._
 
     ```sh
     cp sample.env .env

--- a/apps/report-execution/README.md
+++ b/apps/report-execution/README.md
@@ -40,13 +40,13 @@
     ```
 
 The application will be available at:
-- API: http://localhost:8001
-- Interactive API docs (Swagger UI): http://localhost:8001/docs
-- Alternative API docs (ReDoc): http://localhost:8001/redoc
+- API: http://localhost:8000
+- Interactive API docs (Swagger UI): http://localhost:8000/docs
+- Alternative API docs (ReDoc): http://localhost:8000/redoc
 
 Sample curl:
 ```sh
-curl -X POST 'http://localhost:8001/report/execute' -H "accept: application/json" -H "Content-Type: application/json" -d '{
+curl -X POST 'http://localhost:8000/report/execute' -H "accept: application/json" -H "Content-Type: application/json" -d '{
             "version": 1,
             "is_export": true,
             "is_builtin": true,


### PR DESCRIPTION
## Description
I spun up this app for my own edification while reviewing [Mary's PR](https://github.com/CDCgov/NEDSS-Modernization/pull/3074) and found the port defaulted to 8000, so updating documentation. If we want to use 8001 for a reason, I think we'll need to specify in `.env` file.

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
