### PR TITLE
feat: break out description into header, subheader, description

### DIFF
--- a/apps/report-execution/src/libraries/nbs_custom.py
+++ b/apps/report-execution/src/libraries/nbs_custom.py
@@ -18,11 +18,14 @@ def execute(
     """
     content = trx.execute(subset_query)
 
-    description = f'Custom Report For Table: {data_source_name}'
+    header = f'Custom Report For Table: {data_source_name}'
+    subheader = None
     if time_range is not None:
-        description += f'\n{time_range.start} - {time_range.end}'
+        subheader = f'{time_range.start} - {time_range.end}'
 
     # TODO: datetimes are formatted '%0m/%0d/%Y %0H:%0M:%0S' in sas. # noqa: FIX002
     # Should this be a util/post processing/sql step in python land?
 
-    return ReportResult(content_type='table', content=content, description=description)
+    return ReportResult(
+        content_type='table', content=content, header=header, subheader=subheader
+    )

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -48,4 +48,6 @@ class ReportResult(BaseModel):
 
     content_type: Literal['table']
     content: Annotated[Table, PlainSerializer(serialize_table)]
-    description: str | None
+    header: str | None = None
+    subheader: str | None = None
+    description: str | None = None

--- a/apps/report-execution/tests/execute_report.py
+++ b/apps/report-execution/tests/execute_report.py
@@ -22,7 +22,9 @@ class TestExecuteReport:
         )
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.description == 'Custom Report For Table: random_db_table_0'
+        assert result.header == 'Custom Report For Table: random_db_table_0'
+        assert result.subheader is None
+        assert result.description is None
         assert result.content.columns == ['id', 'name']
 
         assert len(result.content.data) == 4

--- a/apps/report-execution/tests/integration/execute_report.py
+++ b/apps/report-execution/tests/integration/execute_report.py
@@ -27,7 +27,7 @@ class TestIntegrationExecuteReport:
         result = execute_report(report_spec)
         assert result.content_type == 'table'
         assert (
-            result.description
+            result.header
             == 'Custom Report For Table: [NBS_ODSE].[dbo].[Filter_operator]'
         )
         assert result.content.columns == [

--- a/apps/report-execution/tests/integration/libraries/nbs_custom.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_custom.py
@@ -25,10 +25,11 @@ class TestIntegrationNbsCustomLibrary:
         )
 
         result = execute_report(report_spec)
-        assert result.description == (
-            'Custom Report For Table: [NBS_ODSE].[dbo].[Filter_operator]\n'
-            + '2024-01-01 - 2024-12-31'
+        assert result.header == (
+            'Custom Report For Table: [NBS_ODSE].[dbo].[Filter_operator]'
         )
+        assert result.subheader == '2024-01-01 - 2024-12-31'
+        assert result.description is None
         assert result.content_type == 'table'
 
         assert len(result.content.data) == 11
@@ -49,9 +50,11 @@ class TestIntegrationNbsCustomLibrary:
         )
 
         result = execute_report(report_spec)
-        assert result.description == (
+        assert result.header == (
             'Custom Report For Table: [NBS_ODSE].[dbo].[Filter_operator]'
         )
+        assert result.subheader is None
+        assert result.description is None
         assert result.content_type == 'table'
 
         assert len(result.content.data) == 11


### PR DESCRIPTION
## Description

Per discussion in standup, change report return format to have a `header`, `subheader` and `description` instead of just `description`
