### PR TITLE
[APP-414] feat: add run/export buttons to page

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportRun.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRun.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { ReportRun } from './ReportRun';
 import * as generated from 'generated';
+import userEvent from '@testing-library/user-event';
 
 vi.mock('react-router', async () => {
     const actual = await vi.importActual<typeof import('react-router')>('react-router');
@@ -16,8 +17,6 @@ vi.mock('generated');
 describe('when given valid params', () => {
     it('renders the config', async () => {
         const mockApi = vi.mocked(generated.ReportControllerService.getReportConfiguration).mockResolvedValue({
-            reportUid: 1,
-            dataSourceUid: 2,
             runner: 'python',
         });
         const { getByText, findByText } = render(<ReportRun />);
@@ -26,6 +25,38 @@ describe('when given valid params', () => {
 
         expect(mockApi).toHaveBeenCalled();
 
-        expect(await findByText(/2/)).toBeVisible();
+        expect(await findByText(/python/)).toBeVisible();
+    });
+
+    it('run button submits config', async () => {
+        const user = userEvent.setup();
+        vi.mocked(generated.ReportControllerService.getReportConfiguration).mockResolvedValue({
+            runner: 'python',
+        });
+        const mockApi = vi.mocked(generated.ReportControllerService.executeReport).mockResolvedValue('I am the result');
+
+        const { getByRole, findByText } = render(<ReportRun />);
+
+        const runButton = getByRole('button', { name: 'Run' });
+        await user.click(runButton);
+        expect(mockApi).toHaveBeenCalledWith({ requestBody: expect.objectContaining({ isExport: false }) });
+
+        expect(await findByText('"I am the result"')).toBeVisible();
+    });
+
+    it('export button submits config', async () => {
+        const user = userEvent.setup();
+        vi.mocked(generated.ReportControllerService.getReportConfiguration).mockResolvedValue({
+            runner: 'python',
+        });
+        const mockApi = vi.mocked(generated.ReportControllerService.executeReport).mockResolvedValue('I am the result');
+
+        const { getByRole, findByText } = render(<ReportRun />);
+
+        const runButton = getByRole('button', { name: 'Export' });
+        await user.click(runButton);
+        expect(mockApi).toHaveBeenCalledWith({ requestBody: expect.objectContaining({ isExport: true }) });
+
+        expect(await findByText('"I am the result"')).toBeVisible();
     });
 });

--- a/apps/modernization-ui/src/apps/report/run/ReportRun.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRun.tsx
@@ -1,3 +1,4 @@
+import { Button } from 'design-system/button';
 import { ReportConfiguration, ReportControllerService } from 'generated';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
@@ -7,15 +8,26 @@ const ReportRun = () => {
     const reportUid = parseInt(params.reportUid ?? '0');
     const dataSourceUid = parseInt(params.dataSourceUid ?? '0');
     const [config, setConfig] = useState<ReportConfiguration | null>(null);
+    const [result, setResult] = useState<string>('');
 
     useEffect(() => {
         ReportControllerService.getReportConfiguration({ reportUid, dataSourceUid }).then((value) => setConfig(value));
     }, []);
 
+    const handleSubmit = (isExport: boolean) => {
+        ReportControllerService.executeReport({ requestBody: { isExport, reportUid, dataSourceUid } }).then((res) =>
+            setResult(res)
+        );
+    };
+
     return (
         <section>
+            <Button onClick={() => handleSubmit(false)}>Run</Button>
+            <Button onClick={() => handleSubmit(true)}>Export</Button>
             <p>Config:</p>
             <p>{config ? JSON.stringify(config) : 'loading'}</p>
+            <p>Result:</p>
+            <p>{result ? JSON.stringify(result) : 'no result yet'}</p>
         </section>
     );
 };


### PR DESCRIPTION
## Description

Add `Run` and `Export` buttons to the page which make a request to the api for the report execution, display the results unformatted on the page for now

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-414

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
