### PR TITLE
build: configure asset dir to `static` to match prior behavior

### DIFF
--- a/apps/modernization-ui/vite.config.mts
+++ b/apps/modernization-ui/vite.config.mts
@@ -34,6 +34,6 @@ export default defineConfig(({ mode }) => {
                 '/login': { target: `http://localhost:${NBS_API_PORT}`, changeOrigin: true },
             },
         },
-        build: { outDir: 'build' },
+        build: { outDir: 'build', assetsDir: 'static' },
     };
 });


### PR DESCRIPTION
## Description

Found in bug bash, there were strange mime type errors, but at least some of these seem to stem from things trying to authenticate when they did not need it. `vite` has a different default asset directory than `CRA`. This PR changes the default to instead use `static` as CRA did
