### PR TITLE
APP-379, Take Four - Suppress remaining Sonar code smells

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/data/pagination/DirectionCoercing.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/data/pagination/DirectionCoercing.java
@@ -32,6 +32,13 @@ class DirectionCoercing implements Coercing<Sort.Direction, String> {
     return (input instanceof String value) ? FlexibleDirectionConverter.from(value) : null;
   }
 
+  //  Suppressing java:2637 ("@NonNull" values should not be set to null) because there is a known
+  //  issue regarding that Sonar rule throwing false positives in certain situations, which seems
+  //  to be the case here.  The `value.getValue() != null` check prior to invoking `parseValue`
+  //  guarantees the first parameter will never be null, and yet the issue is still triggered.
+  //
+  //  https://sonarsource.atlassian.net/browse/JAVASE-91
+  @SuppressWarnings("java:S2637")
   @Override
   public Sort.Direction parseLiteral(
       @Nonnull final Value<?> input,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/data/pagination/DirectionCoercing.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/data/pagination/DirectionCoercing.java
@@ -32,7 +32,7 @@ class DirectionCoercing implements Coercing<Sort.Direction, String> {
     return (input instanceof String value) ? FlexibleDirectionConverter.from(value) : null;
   }
 
-  //  Suppressing java:2637 ("@NonNull" values should not be set to null) because there is a known
+  //  Suppressing java:S2637 ("@NonNull" values should not be set to null) because there is a known
   //  issue regarding that Sonar rule throwing false positives in certain situations, which seems
   //  to be the case here.  The `value.getValue() != null` check prior to invoking `parseValue`
   //  guarantees the first parameter will never be null, and yet the issue is still triggered.

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/AccumulatingResultSetExtractor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/AccumulatingResultSetExtractor.java
@@ -6,8 +6,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BinaryOperator;
-
-import jakarta.validation.constraints.Null;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
@@ -49,8 +47,7 @@ public class AccumulatingResultSetExtractor<K, V> implements ResultSetExtractor<
   //  incompatibility is stemming from.
   @SuppressWarnings("java:S2638")
   @Override
-  @Nullable
-  public Collection<V> extractData(final ResultSet resultSet)
+  @Nullable public Collection<V> extractData(final ResultSet resultSet)
       throws SQLException, DataAccessException {
 
     Map<K, V> map = new LinkedHashMap<>();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/AccumulatingResultSetExtractor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/AccumulatingResultSetExtractor.java
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BinaryOperator;
+
+import jakarta.validation.constraints.Null;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
@@ -40,8 +42,15 @@ public class AccumulatingResultSetExtractor<K, V> implements ResultSetExtractor<
     this.merger = merger;
   }
 
+  //  Suppressing java:S2638 (Method overrides should not change contracts), which was being
+  //  thrown because of "the incompatibility of the annotation @Nullable to honor @NonNullApi
+  //  at package level of the overridden method".  The parent method on `ResultSetExtractor` is
+  //  annotated with `@Nullable` just like this method, so it's unclear where the purported
+  //  incompatibility is stemming from.
+  @SuppressWarnings("java:S2638")
   @Override
-  public @Nullable Collection<V> extractData(final ResultSet resultSet)
+  @Nullable
+  public Collection<V> extractData(final ResultSet resultSet)
       throws SQLException, DataAccessException {
 
     Map<K, V> map = new LinkedHashMap<>();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/MultiMapResultSetExtractor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/MultiMapResultSetExtractor.java
@@ -19,8 +19,15 @@ public class MultiMapResultSetExtractor<K, V> implements ResultSetExtractor<Mult
     this.valueMapper = valueMapper;
   }
 
+  //  Suppressing java:S2638 (Method overrides should not change contracts), which was being
+  //  thrown because of "the incompatibility of the annotation @Nullable to honor @NonNullApi
+  //  at package level of the overridden method".  The parent method on `ResultSetExtractor` is
+  //  annotated with `@Nullable` just like this method, so it's unclear where the purported
+  //  incompatibility is stemming from.
+  @SuppressWarnings("java:S2638")
   @Override
-  public @Nullable Multimap<K, V> extractData(final ResultSet resultSet)
+  @Nullable
+  public Multimap<K, V> extractData(final ResultSet resultSet)
       throws SQLException, DataAccessException {
 
     ArrayListMultimap<K, V> multimap = ArrayListMultimap.create();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/MultiMapResultSetExtractor.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/MultiMapResultSetExtractor.java
@@ -26,8 +26,7 @@ public class MultiMapResultSetExtractor<K, V> implements ResultSetExtractor<Mult
   //  incompatibility is stemming from.
   @SuppressWarnings("java:S2638")
   @Override
-  @Nullable
-  public Multimap<K, V> extractData(final ResultSet resultSet)
+  @Nullable public Multimap<K, V> extractData(final ResultSet resultSet)
       throws SQLException, DataAccessException {
 
     ArrayListMultimap<K, V> multimap = ArrayListMultimap.create();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/DateCoercing.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/DateCoercing.java
@@ -48,6 +48,13 @@ public class DateCoercing implements Coercing<LocalDate, String> {
     }
   }
 
+  //  Suppressing java:2637 ("@NonNull" values should not be set to null) because there is a known
+  //  issue regarding that Sonar rule throwing false positives in certain situations, which seems
+  //  to be the case here.  The `value.getValue() != null` check prior to invoking `parseValue`
+  //  guarantees the first parameter will never be null, and yet the issue is still triggered.
+  //
+  //  https://sonarsource.atlassian.net/browse/JAVASE-91
+  @SuppressWarnings("java:S2637")
   @Nonnull
   @Override
   public LocalDate parseLiteral(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/DateCoercing.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/DateCoercing.java
@@ -48,7 +48,7 @@ public class DateCoercing implements Coercing<LocalDate, String> {
     }
   }
 
-  //  Suppressing java:2637 ("@NonNull" values should not be set to null) because there is a known
+  //  Suppressing java:S2637 ("@NonNull" values should not be set to null) because there is a known
   //  issue regarding that Sonar rule throwing false positives in certain situations, which seems
   //  to be the case here.  The `value.getValue() != null` check prior to invoking `parseValue`
   //  guarantees the first parameter will never be null, and yet the issue is still triggered.

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/ISO8601InstantCoercing.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/ISO8601InstantCoercing.java
@@ -47,7 +47,7 @@ public class ISO8601InstantCoercing implements Coercing<Instant, String> {
     }
   }
 
-  //  Suppressing java:2637 ("@NonNull" values should not be set to null) because there is a known
+  //  Suppressing java:S2637 ("@NonNull" values should not be set to null) because there is a known
   //  issue regarding that Sonar rule throwing false positives in certain situations, which seems
   //  to be the case here.  The `value.getValue() != null` check prior to invoking `parseValue`
   //  guarantees the first parameter will never be null, and yet the issue is still triggered.

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/ISO8601InstantCoercing.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/time/graphql/ISO8601InstantCoercing.java
@@ -47,6 +47,13 @@ public class ISO8601InstantCoercing implements Coercing<Instant, String> {
     }
   }
 
+  //  Suppressing java:2637 ("@NonNull" values should not be set to null) because there is a known
+  //  issue regarding that Sonar rule throwing false positives in certain situations, which seems
+  //  to be the case here.  The `value.getValue() != null` check prior to invoking `parseValue`
+  //  guarantees the first parameter will never be null, and yet the issue is still triggered.
+  //
+  //  https://sonarsource.atlassian.net/browse/JAVASE-91
+  @SuppressWarnings("java:S2637")
   @Override
   @Nonnull
   public Instant parseLiteral(

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/NbsPropertiesFinder.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/NbsPropertiesFinder.java
@@ -56,8 +56,15 @@ public class NbsPropertiesFinder {
 
   private RowMapper<AbstractMap.SimpleEntry<String, String>> mapper() {
     return new RowMapper<AbstractMap.SimpleEntry<String, String>>() {
+      //  Suppressing java:S2638 (Method overrides should not change contracts), which was being
+      //  thrown because of "the incompatibility of the annotation @Nullable to honor @NonNullApi
+      //  at package level of the overridden method".  The parent method on `RowMapper` is
+      //  annotated with `@Nullable` just like this method, so it's unclear where the purported
+      //  incompatibility is stemming from.
+      @SuppressWarnings("java:S2638")
       @Override
-      public @Nullable AbstractMap.SimpleEntry<String, String> mapRow(ResultSet rs, int rowNum)
+      @Nullable
+      public AbstractMap.SimpleEntry<String, String> mapRow(ResultSet rs, int rowNum)
           throws SQLException {
         return new AbstractMap.SimpleEntry<>(rs.getString(1), rs.getString(2));
       }

--- a/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/NbsPropertiesFinder.java
+++ b/libs/configuration-api/src/main/java/gov/cdc/nbs/configuration/nbs/NbsPropertiesFinder.java
@@ -63,8 +63,7 @@ public class NbsPropertiesFinder {
       //  incompatibility is stemming from.
       @SuppressWarnings("java:S2638")
       @Override
-      @Nullable
-      public AbstractMap.SimpleEntry<String, String> mapRow(ResultSet rs, int rowNum)
+      @Nullable public AbstractMap.SimpleEntry<String, String> mapRow(ResultSet rs, int rowNum)
           throws SQLException {
         return new AbstractMap.SimpleEntry<>(rs.getString(1), rs.getString(2));
       }


### PR DESCRIPTION
## Description

[My previous PR](https://github.com/CDCgov/NEDSS-Modernization/pull/3152) attempting to remediate the outstanding Sonar issues didn't take, so this PR simply suppresses the remaining issues across the board.  The two types of issues being suppressed here are as follows:

### 1. Parameter 1 to this call is marked "@Nonnull" but null could be passed.
There are 3 instances of this issue still being thrown.  I decided to suppress these because it's hard for me to see these as anything other than false positives at this point - all three instances of this error are contained within an explicit `!= null` check for the parameter being described as possibly `null`.  That, combined with the presence of [an outstanding Sonar issue](https://sonarsource.atlassian.net/browse/JAVASE-72) regarding false positives for this very rule, has me pretty confident this is a Sonar bug.
<img width="925" height="300" alt="Screenshot 2026-04-13 at 3 21 48 PM" src="https://github.com/user-attachments/assets/b282d254-66cd-4244-b4c4-1148b22f12bb" />



### 2. Fix the incompatibility of the annotation @Nullable to honor @NonNullApi at package level of the overridden method.
This issue also exists in 3 different spots within the repo.  In all 3 cases, there is a class implementing a `@Nullable`-annotated method of a third-party interface with an equivalent `@Nullable`-annotated method.  I'm wondering if there is a `@NonNullApi` annotation specified on the parent third-party packages that Sonar is getting tripped up on, but I decided to suppress them because I'm not sure what more can be done to demonstrate compatibility.
<img width="796" height="305" alt="Screenshot 2026-04-13 at 3 51 17 PM" src="https://github.com/user-attachments/assets/2b7aebcc-1370-4f97-9a96-2a325efff09d" />


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-379)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
