### PR TITLE
build: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,14 @@
 # This file details who the code owners are.  Code owners are automatically requested for review when a PR is created.
 # For details on the format, and condfiguration of this file see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# default for the repo
 * @CDCgov/nbs-phoenix
+
+# api + ui squad
+/apps/ @CDCgov/nbs-phoenix-app-squad
+/libs/ @CDCgov/nbs-phoenix-app-squad
+
+# library squad
+/apps/report-execution/ @CDCgov/nbs-phoenix-library-squad
+/apps/modernization-api/src/main/resources/db/ @CDCgov/nbs-phoenix-library-squad
+


### PR DESCRIPTION
## Description

Per discussion in refinement, create two sub-teams and have them take PRs for their respective parts of the codebase, while leaving broad things (ci, e2e's, dependency updates) as generally phoenix
