### PR TITLE
fix: error handling for report execution library calls

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.RestClientResponseException;
 
 @ControllerAdvice(assignableTypes = {ReportController.class})
 public class ReportExceptionHandler {
@@ -39,6 +40,13 @@ public class ReportExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<String> handleFailedSerialization(HttpMessageNotReadableException ex) {
     return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  @ExceptionHandler(RestClientResponseException.class)
+  public ResponseEntity<String> handleRestClientFailure(RestClientResponseException ex) {
+    String err = ex.getResponseBodyAsString();
+    LOGGER.log(System.Logger.Level.ERROR, "Error received from rest client: %s".formatted(err), ex);
+    return new ResponseEntity<>(err, ex.getStatusCode());
   }
 
   @ExceptionHandler(Exception.class)

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
@@ -40,6 +40,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
 
 @Service
 public class ReportService {
@@ -236,6 +237,17 @@ public class ReportService {
         .contentType(MediaType.APPLICATION_JSON)
         .body(reportSpec)
         .retrieve()
+        .onStatus(
+            (status) -> status.value() >= 400,
+            (_request, response) -> {
+              throw new RestClientResponseException(
+                  "Error response from the report-execution service",
+                  response.getStatusCode(),
+                  response.getStatusText(),
+                  response.getHeaders(),
+                  response.getBody().readAllBytes(),
+                  null);
+            })
         .toEntity(ReportResult.class);
   }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
@@ -238,14 +238,14 @@ public class ReportService {
         .body(reportSpec)
         .retrieve()
         .onStatus(
-            (status) -> status.value() >= 400,
-            (_request, response) -> {
+            status -> status.value() >= 400,
+            (req, resp) -> {
               throw new RestClientResponseException(
                   "Error response from the report-execution service",
-                  response.getStatusCode(),
-                  response.getStatusText(),
-                  response.getHeaders(),
-                  response.getBody().readAllBytes(),
+                  resp.getStatusCode(),
+                  resp.getStatusText(),
+                  resp.getHeaders(),
+                  resp.getBody().readAllBytes(),
                   null);
             })
         .toEntity(ReportResult.class);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExceptionHandlerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientResponseException;
 
 class ReportExceptionHandlerTest {
 
@@ -40,5 +41,17 @@ class ReportExceptionHandlerTest {
 
     assertEquals("Illegal Argument", responseEntity.getBody());
     assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
+  }
+
+  @Test
+  void should_return_error_msg_and_status_code_for_rest_client_exceptiont() {
+    RestClientResponseException exception =
+        new RestClientResponseException(
+            "I failed", 503, "uh oh", null, "it went poorly".getBytes(), null);
+
+    ResponseEntity<String> responseEntity = handler.handleRestClientFailure(exception);
+
+    assertEquals("it went poorly", responseEntity.getBody());
+    assertEquals(HttpStatus.SERVICE_UNAVAILABLE, responseEntity.getStatusCode());
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportServiceTest.java
@@ -559,6 +559,7 @@ class ReportServiceTest {
         when(requestBodySpec.contentType(any(MediaType.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(ReportSpec.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
 
         ResponseEntity<ReportResult> expectedResponse =
             new ResponseEntity<>(getReportExecutionResponse(), HttpStatus.OK);


### PR DESCRIPTION
## Description

Add error handling for errors from the report execution library, so the status/error generally passes through

<img width="1265" height="194" alt="image" src="https://github.com/user-attachments/assets/c59ff4d7-cbc5-4082-90fd-e265fefc3dba" />

Inspired by https://skylight-hq.slack.com/archives/C09HXK6MKPE/p1780355544312889