### PR TITLE
fix: trim column names and titles for safety

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/mappers/ReportColumnMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/mappers/ReportColumnMapper.java
@@ -22,8 +22,8 @@ public class ReportColumnMapper {
     return new ReportColumn(
         dataSourceColumn.getId(),
         dataSourceColumn.getColumnMaxLength(),
-        dataSourceColumn.getColumnName(),
-        dataSourceColumn.getColumnTitle(),
+        dataSourceColumn.getColumnName().trim(),
+        dataSourceColumn.getColumnTitle().trim(),
         dataSourceColumn.getColumnSourceTypeCode(),
         dataSourceColumn.getDescTxt(),
         isDisplayable,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/ReportColumnMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/ReportColumnMapperTest.java
@@ -18,8 +18,8 @@ class ReportColumnMapperTest {
         DataSourceColumn.builder()
             .id(1L)
             .columnMaxLength(255)
-            .columnName("column_name")
-            .columnTitle("Column Title")
+            .columnName(" column_name")
+            .columnTitle(" Column Title ")
             .columnSourceTypeCode("VARCHAR")
             .dataSource(dataSource)
             .descTxt("Some description")
@@ -35,8 +35,8 @@ class ReportColumnMapperTest {
 
     assertThat(mapped.id()).isEqualTo(dbColumn.getId());
     assertThat(mapped.maxLength()).isEqualTo(dbColumn.getColumnMaxLength());
-    assertThat(mapped.name()).isEqualTo(dbColumn.getColumnName());
-    assertThat(mapped.title()).isEqualTo(dbColumn.getColumnTitle());
+    assertThat(mapped.name()).isEqualTo(dbColumn.getColumnName().trim());
+    assertThat(mapped.title()).isEqualTo(dbColumn.getColumnTitle().trim());
     assertThat(mapped.sourceTypeCode()).isEqualTo(dbColumn.getColumnSourceTypeCode());
     assertThat(mapped.descTxt()).isEqualTo(dbColumn.getDescTxt());
     assertThat(mapped.isDisplayable()).isTrue();


### PR DESCRIPTION
## Description


Trim column names and titles to make sure whitespace doesn't cause problems when formatting/using them
