### PR TITLE
[APP-546] feat: split up basic filters into sections

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -20,7 +20,8 @@ const SECTIONS = [
         hasData: (config: ReportConfiguration) => config.basicFilters.length > 0,
         Component: ({ config, id, title }: { config: ReportConfiguration; id: string; title: string }) => (
             <CurrentStateProvider
-                stateFilter={config.basicFilters.find((f) => f.filterType.code?.startsWith(STATE_FILTER_CODE))}>
+                stateFilter={config.basicFilters.find((f) => f.filterType.code?.startsWith(STATE_FILTER_CODE))}
+            >
                 <Card id={id} title={title} collapsible={true}>
                     {config.basicFilters.map((filter, i) => (
                         <BasicFilter key={`basic_filter_${i}`} filter={filter} columns={config.columns} />
@@ -50,7 +51,8 @@ const SECTIONS = [
                 required={true}
                 subtext="Select the column variables you would like to include in this report."
                 actions={<Required />}
-                collapsible={true}>
+                collapsible={true}
+            >
                 <ColumnSelector columns={config.columns} defaultColumns={config.defaultColumnUids} />
             </Card>
         ),
@@ -78,7 +80,8 @@ const ReportConfigurationPage = ({
                         <Button onClick={(e) => handleSubmit(e, true)}>Export</Button>
                     </Permitted>
                 </>
-            }>
+            }
+        >
             <form className={layoutStyles.columnContent}>
                 {sectionData.map(({ id, title, Component }) => (
                     <Component key={id} config={config} id={id} title={title} />

--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -14,23 +14,45 @@ import layoutStyles from './layout/layout.module.scss';
 import { Required } from 'design-system/entry';
 import { InPageNavigation } from 'design-system/inPageNavigation';
 
-const SECTIONS = [
+const BASIC_SECTIONS = [
     {
-        title: 'Basic filters',
-        id: 'basic-filters',
-        hasData: (config: ReportConfiguration) => config.basicFilters.length > 0,
+        title: 'Time',
+        id: 'basic-time',
+        filterTypes: ['BAS_TIM_RANGE', 'BAS_TIM_RANGE_LIST', 'BAS_MM_YYYY_RANGE', 'BAS_TIM_RANGE_CUSTOM', 'BAS_DAYS'],
+    },
+    {
+        title: 'Condition',
+        id: 'basic-condition',
+        filterTypes: ['BAS_CON_LIST', 'BAS_CVG_LIST'],
+    },
+    {
+        title: 'Geographic area',
+        id: 'basic-geography',
+        filterTypes: ['BAS_JUR_LIST'],
+    },
+    {
+        title: 'Other filters',
+        id: 'basic-other',
+        filterTypes: ['BAS_TXT', 'BAS_STD_HIV_WRKR'],
+    },
+];
+
+const SECTIONS = [
+    ...BASIC_SECTIONS.map(({ title, id, filterTypes }) => ({
+        title,
+        id,
+        hasData: (config: ReportConfiguration) =>
+            config.basicFilters.some((f) => filterTypes.includes(f.filterType.type!)),
         Component: ({ config, id, title }: { config: ReportConfiguration; id: string; title: string }) => (
-            <CurrentStateProvider
-                stateFilter={config.basicFilters.find((f) => f.filterType.code?.startsWith(STATE_FILTER_CODE))}
-            >
-                <Card id={id} title={title} collapsible={true}>
-                    {config.basicFilters.map((filter, i) => (
+            <Card id={id} title={title} collapsible={true}>
+                {config.basicFilters
+                    .filter((filter) => filterTypes.includes(filter.filterType.type!))
+                    .map((filter, i) => (
                         <BasicFilter key={`basic_filter_${i}`} filter={filter} columns={config.columns} />
                     ))}
-                </Card>
-            </CurrentStateProvider>
+            </Card>
         ),
-    },
+    })),
     {
         title: 'Advanced filter',
         id: 'advanced-filter',
@@ -87,9 +109,13 @@ const ReportConfigurationPage = ({
                 <InPageNavigation sections={sectionData.map(({ id, title }) => ({ id, label: title }))} />
             </aside>
             <form className={layoutStyles.columnContent}>
-                {sectionData.map(({ id, title, Component }) => (
-                    <Component key={id} config={config} id={id} title={title} />
-                ))}
+                <CurrentStateProvider
+                    stateFilter={config.basicFilters.find((f) => f.filterType.code?.startsWith(STATE_FILTER_CODE))}
+                >
+                    {sectionData.map(({ id, title, Component }) => (
+                        <Component key={id} config={config} id={id} title={title} />
+                    ))}
+                </CurrentStateProvider>
             </form>
         </ReportRunLayout>
     );

--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -12,6 +12,7 @@ import { ColumnSelector } from './columns/ColumnSelector';
 
 import layoutStyles from './layout/layout.module.scss';
 import { Required } from 'design-system/entry';
+import { InPageNavigation } from 'design-system/inPageNavigation';
 
 const SECTIONS = [
     {
@@ -31,8 +32,8 @@ const SECTIONS = [
         ),
     },
     {
-        title: 'Advanced filters',
-        id: 'advanced-filters',
+        title: 'Advanced filter',
+        id: 'advanced-filter',
         hasData: (config: ReportConfiguration) => !!config.advancedFilter,
         Component: ({ config, id, title }: { config: ReportConfiguration; id: string; title: string }) => (
             <Card id={id} title={title} collapsible={true}>
@@ -82,6 +83,9 @@ const ReportConfigurationPage = ({
                 </>
             }
         >
+            <aside>
+                <InPageNavigation sections={sectionData.map(({ id, title }) => ({ id, label: title }))} />
+            </aside>
             <form className={layoutStyles.columnContent}>
                 {sectionData.map(({ id, title, Component }) => (
                     <Component key={id} config={config} id={id} title={title} />

--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -13,6 +13,50 @@ import { ColumnSelector } from './columns/ColumnSelector';
 import layoutStyles from './layout/layout.module.scss';
 import { Required } from 'design-system/entry';
 
+const SECTIONS = [
+    {
+        title: 'Basic filters',
+        id: 'basic-filters',
+        hasData: (config: ReportConfiguration) => config.basicFilters.length > 0,
+        Component: ({ config, id, title }: { config: ReportConfiguration; id: string; title: string }) => (
+            <CurrentStateProvider
+                stateFilter={config.basicFilters.find((f) => f.filterType.code?.startsWith(STATE_FILTER_CODE))}>
+                <Card id={id} title={title} collapsible={true}>
+                    {config.basicFilters.map((filter, i) => (
+                        <BasicFilter key={`basic_filter_${i}`} filter={filter} columns={config.columns} />
+                    ))}
+                </Card>
+            </CurrentStateProvider>
+        ),
+    },
+    {
+        title: 'Advanced filters',
+        id: 'advanced-filters',
+        hasData: (config: ReportConfiguration) => !!config.advancedFilter,
+        Component: ({ config, id, title }: { config: ReportConfiguration; id: string; title: string }) => (
+            <Card id={id} title={title} collapsible={true}>
+                <AdvancedFilter filter={config.advancedFilter!} columns={config.columns} />
+            </Card>
+        ),
+    },
+    {
+        title: 'Column selection',
+        id: 'column-selection',
+        hasData: (config: ReportConfiguration) => config.library.allowColumnSelection,
+        Component: ({ config, id, title }: { config: ReportConfiguration; id: string; title: string }) => (
+            <Card
+                id={id}
+                title={title}
+                required={true}
+                subtext="Select the column variables you would like to include in this report."
+                actions={<Required />}
+                collapsible={true}>
+                <ColumnSelector columns={config.columns} defaultColumns={config.defaultColumnUids} />
+            </Card>
+        ),
+    },
+];
+
 const ReportConfigurationPage = ({
     config,
     handleSubmit,
@@ -20,9 +64,7 @@ const ReportConfigurationPage = ({
     config: ReportConfiguration;
     handleSubmit: (e: React.BaseSyntheticEvent, isExport: boolean) => void;
 }) => {
-    const basicFilters = config.basicFilters;
-    // the state drives other filter options, so need to pull it out
-    const stateFilter = config.basicFilters.find((f) => f.filterType.code?.startsWith(STATE_FILTER_CODE));
+    const sectionData = SECTIONS.filter(({ hasData }) => hasData(config));
 
     return (
         <ReportRunLayout
@@ -36,41 +78,11 @@ const ReportConfigurationPage = ({
                         <Button onClick={(e) => handleSubmit(e, true)}>Export</Button>
                     </Permitted>
                 </>
-            }
-        >
+            }>
             <form className={layoutStyles.columnContent}>
-                {basicFilters.length > 0 && (
-                    <CurrentStateProvider stateFilter={stateFilter}>
-                        <Card id="basic-filters" title="Basic Filters" collapsible={true}>
-                            {basicFilters.map((filter, i) => (
-                                <BasicFilter key={`basic_filter_${i}`} filter={filter} columns={config.columns} />
-                            ))}
-                        </Card>
-                    </CurrentStateProvider>
-                )}
-                {config.advancedFilter && (
-                    <Card id="advanced-filter" title="Advanced Filter" collapsible={true}>
-                        <AdvancedFilter filter={config.advancedFilter} columns={config.columns} />
-                    </Card>
-                )}
-                {config.library.allowColumnSelection && (
-                    <Card
-                        id="column-selection"
-                        title="Column selection"
-                        required={true}
-                        subtext="Select the column variables you would like to include in this report."
-                        actions={<Required />}
-                        collapsible={true}
-                    >
-                        <ColumnSelector columns={config.columns} defaultColumns={config.defaultColumnUids} />
-                    </Card>
-                )}
-                <details>
-                    <summary>
-                        <p>Config:</p>
-                    </summary>
-                    <pre>{config ? JSON.stringify(config, null, 2) : 'loading'}</pre>
-                </details>
+                {sectionData.map(({ id, title, Component }) => (
+                    <Component key={id} config={config} id={id} title={title} />
+                ))}
             </form>
         </ReportRunLayout>
     );

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -373,11 +373,13 @@ describe('report run page', () => {
                     .mocked(generated.ReportControllerService.exportReport)
                     .mockResolvedValue(MOCK_RESULT);
 
-                const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                 expect(getByRole('status')).toHaveTextContent('Loading');
 
                 expect(mockConfigApi).toHaveBeenCalled();
+
+                expect(await findAllByText('Other filters')).toHaveLength(2);
 
                 const input = await findByLabelText('Full Name');
                 await userEvent.type(input, 'test');
@@ -488,11 +490,13 @@ describe('report run page', () => {
                         .mocked(generated.ReportControllerService.exportReport)
                         .mockResolvedValue(MOCK_RESULT);
 
-                    const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                    const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                     expect(getByRole('status')).toHaveTextContent('Loading');
 
                     expect(mockConfigApi).toHaveBeenCalled();
+
+                    expect(await findAllByText('Time')).toHaveLength(2);
 
                     expect(await findByLabelText('Full Name')).toBeVisible();
                     const fromInput = await findByLabelText('From');
@@ -615,11 +619,13 @@ describe('report run page', () => {
                     .mocked(generated.ReportControllerService.exportReport)
                     .mockResolvedValue(MOCK_RESULT);
 
-                const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                 expect(getByRole('status')).toHaveTextContent('Loading');
 
                 expect(mockConfigApi).toHaveBeenCalled();
+
+                expect(await findAllByText('Time')).toHaveLength(2);
 
                 expect(await findByLabelText('Full Name')).toBeVisible();
                 const fromInput = await findByLabelText('From');
@@ -750,11 +756,13 @@ describe('report run page', () => {
                     .mocked(generated.ReportControllerService.exportReport)
                     .mockResolvedValue(MOCK_RESULT);
 
-                const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                 expect(getByRole('status')).toHaveTextContent('Loading');
 
                 expect(mockConfigApi).toHaveBeenCalled();
+
+                expect(await findAllByText('Time')).toHaveLength(2);
 
                 expect(await findByLabelText('Full Name')).toBeVisible();
                 const fromMonthInput = await findByLabelText('From Month');
@@ -899,11 +907,13 @@ describe('report run page', () => {
                             { value: '04', name: 'Arizona' },
                         ]);
 
-                        const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                        const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                         expect(getByRole('status')).toHaveTextContent('Loading');
 
                         expect(mockConfigApi).toHaveBeenCalled();
+
+                        expect(await findAllByText('Geographic area')).toHaveLength(2);
 
                         expect(await findByRole('option', { name: 'Georgia' })).toBeVisible();
 
@@ -1214,11 +1224,13 @@ describe('report run page', () => {
                             .mockResolvedValue(MOCK_RESULT);
                         vi.mocked(options.selectableResolver).mockImplementation(mockOptionApiImpl);
 
-                        const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                        const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                         expect(getByRole('status')).toHaveTextContent('Loading');
 
                         expect(mockConfigApi).toHaveBeenCalled();
+
+                        expect(await findAllByText('Geographic area')).toHaveLength(2);
 
                         expect(await findByRole('option', { name: 'Dekalb County' })).toBeVisible();
 
@@ -1546,11 +1558,13 @@ describe('report run page', () => {
                         .mockResolvedValue(MOCK_RESULT);
                     vi.mocked(options.selectableResolver).mockImplementation(mockOptionApiImpl);
 
-                    const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                    const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                     expect(getByRole('status')).toHaveTextContent('Loading');
 
                     expect(mockConfigApi).toHaveBeenCalled();
+
+                    expect(await findAllByText('Condition')).toHaveLength(2);
 
                     expect(await findByRole('option', { name: '2019 Novel Coronavirus' })).toBeVisible();
 
@@ -1823,11 +1837,13 @@ describe('report run page', () => {
                         .mockResolvedValue(MOCK_RESULT);
                     vi.mocked(useConceptOptions).mockReturnValue(mockOptionApiImpl);
 
-                    const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                    const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                     expect(getByRole('status')).toHaveTextContent('Loading');
 
                     expect(mockConfigApi).toHaveBeenCalled();
+
+                    expect(await findAllByText('Condition')).toHaveLength(2);
 
                     expect(await findByRole('option', { name: '100 - Chancroid' })).toBeVisible();
 
@@ -2097,11 +2113,13 @@ describe('report run page', () => {
                     .mocked(generated.ReportControllerService.exportReport)
                     .mockResolvedValue(MOCK_RESULT);
 
-                const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                 expect(getByRole('status')).toHaveTextContent('Loading');
 
                 expect(mockConfigApi).toHaveBeenCalled();
+
+                expect(await findAllByText('Time')).toHaveLength(2);
 
                 const input = await findByLabelText('Duplicate Investigations Time Frame');
                 await user.type(input, '5');
@@ -2316,11 +2334,13 @@ describe('report run page', () => {
                         .mockResolvedValue(MOCK_RESULT);
                     vi.mocked(options.selectableResolver).mockImplementation(mockOptionApiImpl);
 
-                    const { getByRole, findByRole, findByLabelText, container } = renderWithRouter();
+                    const { getByRole, findByRole, findAllByText, findByLabelText, container } = renderWithRouter();
 
                     expect(getByRole('status')).toHaveTextContent('Loading');
 
                     expect(mockConfigApi).toHaveBeenCalled();
+
+                    expect(await findAllByText('Other filters')).toHaveLength(2);
 
                     expect(await findByRole('option', { name: 'Jyn Erso' })).toBeVisible();
 

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -41,6 +41,11 @@ vi.mock('configuration', () => {
     };
 });
 
+vi.mock('design-system/inPageNavigation/useInPageNavigation', () => ({
+    __esModule: true,
+    default: vi.fn(),
+}));
+
 // don't actually let the cache cache
 const localStorageMock: Storage = {
     getItem: (): string | null => null,
@@ -154,7 +159,7 @@ describe('report run page', () => {
 
             expect(mockApi).toHaveBeenCalled();
 
-            expect(await findByText(/Config/)).toBeVisible();
+            expect(await findByText('On this page')).toBeVisible();
         });
 
         it('run button submits config and opens in new tab', async () => {
@@ -221,7 +226,7 @@ describe('report run page', () => {
 
                 expect(await findByLabelText('Full Name')).toBeVisible();
                 expect(await findByText('Basic Text Filter')).toBeVisible();
-                expect(queryByText('Advanced Filter')).toBeNull();
+                expect(queryByText('Advanced filter')).toBeNull();
             });
 
             it('renders the filter name when column unavailable', async () => {
@@ -2562,14 +2567,14 @@ describe('report run page', () => {
             const mockResultApi = vi
                 .mocked(generated.ReportControllerService.exportReport)
                 .mockResolvedValue(MOCK_RESULT);
-            const { getByRole, findByText, queryByText, findByRole } = renderWithRouter();
+            const { getByRole, findAllByText, queryByText, findByRole } = renderWithRouter();
 
             expect(getByRole('status')).toHaveTextContent('Loading');
 
             expect(mockApi).toHaveBeenCalled();
 
-            expect(await findByText('Advanced Filter')).toBeVisible();
-            expect(queryByText('Basic Filters')).toBeNull();
+            expect(await findAllByText('Advanced filter')).toHaveLength(2);
+            expect(queryByText('Basic filters')).toBeNull();
 
             const fieldSelect = await findByRole('combobox', { name: 'Field' });
             expect(fieldSelect).toHaveValue('~');
@@ -2618,13 +2623,13 @@ describe('report run page', () => {
             const mockResultApi = vi
                 .mocked(generated.ReportControllerService.exportReport)
                 .mockResolvedValue(MOCK_RESULT);
-            const { getByRole, findByText, findByRole } = renderWithRouter();
+            const { getByRole, findAllByText, findByRole } = renderWithRouter();
 
             expect(getByRole('status')).toHaveTextContent('Loading');
 
             expect(mockApi).toHaveBeenCalled();
 
-            expect(await findByText('Advanced Filter')).toBeVisible();
+            expect(await findAllByText('Advanced filter')).toHaveLength(2);
 
             const exportButton = await findByRole('button', { name: 'Export' });
             const user = userEvent.setup();
@@ -2655,6 +2660,7 @@ describe('report run page', () => {
                 queryByText,
                 getByText,
                 findByText,
+                findAllByText,
                 findByLabelText,
                 findByRole,
                 findAllByRole,
@@ -2665,7 +2671,7 @@ describe('report run page', () => {
 
             expect(mockApi).toHaveBeenCalled();
 
-            expect(await findByText('Advanced Filter')).toBeVisible();
+            expect(await findAllByText('Advanced filter')).toHaveLength(2);
 
             const fieldSelect = await findByRole('combobox', { name: 'Field' });
             expect(fieldSelect).toHaveValue('~');
@@ -2834,13 +2840,13 @@ describe('report run page', () => {
                 { value: '123', name: 'Disease, terrible' },
                 { value: '456', name: 'Disease, not so bad' },
             ]);
-            const { getByRole, findByText, findByRole, findAllByRole, findAllByTitle } = renderWithRouter();
+            const { getByRole, findAllByText, findByRole, findAllByRole, findAllByTitle } = renderWithRouter();
 
             expect(getByRole('status')).toHaveTextContent('Loading');
 
             expect(mockApi).toHaveBeenCalled();
 
-            expect(await findByText('Advanced Filter')).toBeVisible();
+            expect(await findAllByText('Advanced filter')).toHaveLength(2);
 
             const combinators = await findAllByRole('combobox', { name: 'Combinator' });
             expect(combinators).toHaveLength(2);
@@ -2980,13 +2986,13 @@ describe('report run page', () => {
                 const mockResultApi = vi
                     .mocked(generated.ReportControllerService.exportReport)
                     .mockResolvedValue(MOCK_RESULT);
-                const { getByRole, findByText, findByRole, findByTestId, findAllByTestId } = renderWithRouter();
+                const { getByRole, findAllByText, findByRole, findByTestId, findAllByTestId } = renderWithRouter();
 
                 expect(getByRole('status')).toHaveTextContent('Loading');
 
                 expect(mockApi).toHaveBeenCalled();
 
-                expect(await findByText('Advanced Filter')).toBeVisible();
+                expect(await findAllByText('Advanced filter')).toHaveLength(2);
 
                 const user = userEvent.setup();
                 const ruleGroupHandle = async () => await findByTestId('drag-handle-128-128-128');
@@ -3163,13 +3169,13 @@ describe('report run page', () => {
                         },
                     },
                 });
-                const { getByRole, findByText, findAllByRole, findByTestId, findAllByTestId } = renderWithRouter();
+                const { getByRole, findAllByText, findAllByRole, findByTestId, findAllByTestId } = renderWithRouter();
 
                 expect(getByRole('status')).toHaveTextContent('Loading');
 
                 expect(mockApi).toHaveBeenCalled();
 
-                expect(await findByText('Advanced Filter')).toBeVisible();
+                expect(await findAllByText('Advanced filter')).toHaveLength(2);
 
                 const user = userEvent.setup();
                 const ruleGroupHandle = async () => await findByTestId('drag-handle-128-128-128');
@@ -3212,16 +3218,24 @@ describe('report run page', () => {
             const mockResultApi = vi
                 .mocked(generated.ReportControllerService.exportReport)
                 .mockResolvedValue(MOCK_RESULT);
-            const { container, getByRole, findByText, queryByText, findByRole, findAllByRole, findByLabelText } =
-                renderWithRouter();
+            const {
+                container,
+                getByRole,
+                findByText,
+                findAllByText,
+                queryByText,
+                findByRole,
+                findAllByRole,
+                findByLabelText,
+            } = renderWithRouter();
 
             expect(getByRole('status')).toHaveTextContent('Loading');
 
             expect(mockApi).toHaveBeenCalled();
 
-            expect(await findByText('Column selection')).toBeVisible();
-            expect(queryByText('Basic Filters')).toBeNull();
-            expect(queryByText('Advanced Filters')).toBeNull();
+            expect(await findAllByText('Column selection')).toHaveLength(2);
+            expect(queryByText('Basic filters')).toBeNull();
+            expect(queryByText('Advanced filter')).toBeNull();
 
             // starts unselected
             expect(await findByText('Select a column from "Available columns"')).toBeVisible();

--- a/apps/modernization-ui/src/apps/report/run/layout/layout.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/layout/layout.module.scss
@@ -8,6 +8,8 @@
     padding: 1rem;
 }
 
+$header-height: 6rem;
+
 .page {
     display: flex;
     flex-direction: column;
@@ -18,6 +20,24 @@
         z-index: 1000;
 
         background-color: colors.$base-white;
+    }
+
+    & > main {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-areas: 'main aside';
+
+        h2 {
+            scroll-margin-top: $header-height;
+        }
+
+        & > aside {
+            margin: 1rem;
+            grid-area: aside;
+            position: sticky;
+            align-self: start;
+            top: $header-height;
+        }
     }
 }
 

--- a/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
@@ -8,6 +8,7 @@ type NumericInputProps = {
     sizing?: Sizing;
     error?: string;
     required?: boolean;
+    helperText?: string;
 } & NumericProps;
 
 const NumericInput = ({
@@ -18,6 +19,7 @@ const NumericInput = ({
     error,
     required,
     placeholder,
+    helperText,
     ...remaining
 }: NumericInputProps) => {
     return (
@@ -28,6 +30,7 @@ const NumericInput = ({
             htmlFor={id}
             required={required}
             error={error}
+            helperText={helperText}
         >
             <Numeric id={id} placeholder={placeholder} {...remaining} />
         </EntryWrapper>


### PR DESCRIPTION
## Description

Split up the basic filters into sections per the design.

Also noticed that the numeric input tests were yelling about helperText not existing so fixed that input to use the helperText prop so it didn't get shoved on a random `<input>` element

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-546

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
