### PR TITLE
[APP-677]: filter out BAS_DAYS from where clause service

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportConstants.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportConstants.java
@@ -13,7 +13,7 @@ public final class ReportConstants {
   public static final Set<String> BAS_TYPES =
       Set.of("BAS_CON_LIST", "BAS_JUR_LIST", "BAS_CVG_LIST", "BAS_TXT", "BAS_STD_HIV_WRKR");
 
-  public static final Set<String> BAS_TYPES_NO_COLUMN = Set.of(BAS_DAYS, "J_R01", "J_R01_N");
+  public static final Set<String> BAS_CODES_NO_COLUMN = Set.of("D_01", "J_R01", "J_R01_N");
 
   public static final String SQL_AND = " AND ";
   public static final String SQL_WHERE = "WHERE ";

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportConstants.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportConstants.java
@@ -13,12 +13,14 @@ public final class ReportConstants {
   public static final Set<String> BAS_TYPES =
       Set.of("BAS_CON_LIST", "BAS_JUR_LIST", "BAS_CVG_LIST", "BAS_TXT", "BAS_STD_HIV_WRKR");
 
+  public static final Set<String> BAS_TYPES_NO_COLUMN = Set.of(BAS_DAYS, "J_R01", "J_R01_N");
+
   public static final String SQL_AND = " AND ";
   public static final String SQL_WHERE = "WHERE ";
 
   public enum SortDirection {
     ASC,
-    DESC;
+    DESC
   }
 
   public enum SelectType {
@@ -30,7 +32,7 @@ public final class ReportConstants {
     PRIVATE,
     REPORTING_FACILITY,
     PUBLIC,
-    TEMPLATE;
+    TEMPLATE
   }
 
   public static Character reportGroupToDbChar(ReportConstants.ReportGroup group) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -129,7 +129,7 @@ public class WhereClauseService {
                       new IllegalArgumentException(
                           "No basic filter configuration found for UID: "
                               + filterRequest.reportFilterUid()));
-      // BAS_DAYS is a non-column filter which is intercepted and processed
+      // BAS_TYPES_NO_COLUMN are non-column filters which are intercepted and processed
       // independently during execution spec builds.
       if (config.filterType() != null && BAS_TYPES_NO_COLUMN.contains(config.filterType().type())) {
         continue;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -1,8 +1,8 @@
 package gov.cdc.nbs.report;
 
+import static gov.cdc.nbs.report.ReportConstants.BAS_CODES_NO_COLUMN;
 import static gov.cdc.nbs.report.ReportConstants.BAS_TIME_RANGE_TYPES;
 import static gov.cdc.nbs.report.ReportConstants.BAS_TYPES;
-import static gov.cdc.nbs.report.ReportConstants.BAS_TYPES_NO_COLUMN;
 import static gov.cdc.nbs.report.ReportConstants.COMPARISON_OPERATORS;
 import static gov.cdc.nbs.report.ReportConstants.Operator;
 import static gov.cdc.nbs.report.ReportConstants.RDB_LAB_RESULT_VAL_COLS;
@@ -129,9 +129,9 @@ public class WhereClauseService {
                       new IllegalArgumentException(
                           "No basic filter configuration found for UID: "
                               + filterRequest.reportFilterUid()));
-      // BAS_TYPES_NO_COLUMN are non-column filters which are intercepted and processed
+      // BAS_CODES_NO_COLUMN are non-column filters which are intercepted and processed
       // independently during execution spec builds.
-      if (config.filterType() != null && BAS_TYPES_NO_COLUMN.contains(config.filterType().type())) {
+      if (config.filterType() != null && BAS_CODES_NO_COLUMN.contains(config.filterType().code())) {
         continue;
       }
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -128,6 +128,12 @@ public class WhereClauseService {
                       new IllegalArgumentException(
                           "No basic filter configuration found for UID: "
                               + filterRequest.reportFilterUid()));
+      // BAS_DAYS is a non-column filter which is intercepted and processed
+      // independently during execution spec builds.
+      if (config.filterType() != null
+          && ReportConstants.BAS_DAYS.equals(config.filterType().type())) {
+        continue;
+      }
 
       // Find the associated Column
       ReportColumn column =

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.report;
 
 import static gov.cdc.nbs.report.ReportConstants.BAS_TIME_RANGE_TYPES;
 import static gov.cdc.nbs.report.ReportConstants.BAS_TYPES;
+import static gov.cdc.nbs.report.ReportConstants.BAS_TYPES_NO_COLUMN;
 import static gov.cdc.nbs.report.ReportConstants.COMPARISON_OPERATORS;
 import static gov.cdc.nbs.report.ReportConstants.Operator;
 import static gov.cdc.nbs.report.ReportConstants.RDB_LAB_RESULT_VAL_COLS;
@@ -130,8 +131,7 @@ public class WhereClauseService {
                               + filterRequest.reportFilterUid()));
       // BAS_DAYS is a non-column filter which is intercepted and processed
       // independently during execution spec builds.
-      if (config.filterType() != null
-          && ReportConstants.BAS_DAYS.equals(config.filterType().type())) {
+      if (config.filterType() != null && BAS_TYPES_NO_COLUMN.contains(config.filterType().type())) {
         continue;
       }
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportSpecBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportSpecBuilderTest.java
@@ -50,9 +50,11 @@ class ReportSpecBuilderTest {
   private BasicFilterConfiguration mockBasicFilterConfiguration(
       List<String> filterDefaultValues, Long reportFilterUid, Long reportColumnUid) {
 
+    FilterType filterType = createFilterType("BAS_TXT", "");
+
     // Default to "BAS_TXT" for backwards compatibility
     return mockBasicFilterConfiguration(
-        filterDefaultValues, reportFilterUid, reportColumnUid, "BAS_TXT");
+        filterDefaultValues, reportFilterUid, reportColumnUid, filterType);
   }
 
   // For use with "BAS_DAYS" tests
@@ -60,10 +62,7 @@ class ReportSpecBuilderTest {
       List<String> filterDefaultValues,
       Long reportFilterUid,
       Long reportColumnUid,
-      String filterTypeCode) {
-
-    FilterType filterType = Mockito.mock(FilterType.class);
-    Mockito.lenient().when(filterType.type()).thenReturn(filterTypeCode);
+      FilterType filterType) {
 
     return new BasicFilterConfiguration(
         reportFilterUid, reportColumnUid, filterDefaultValues, null, null, null, filterType);
@@ -109,6 +108,14 @@ class ReportSpecBuilderTest {
     Mockito.lenient().when(request.columnUids()).thenReturn(columnUids);
 
     return request;
+  }
+
+  private FilterType createFilterType(String type, String code) {
+    FilterType filterType = Mockito.mock(FilterType.class);
+    Mockito.lenient().when(filterType.type()).thenReturn(type);
+    Mockito.lenient().when(filterType.code()).thenReturn(code);
+
+    return filterType;
   }
 
   @Test
@@ -290,9 +297,10 @@ class ReportSpecBuilderTest {
     Long filterUid = 100L;
     Long columnUid = 1L;
     List<String> filterDefaultValue = List.of("Value");
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     BasicFilterConfiguration basicFilterConfiguration =
-        mockBasicFilterConfiguration(filterDefaultValue, filterUid, columnUid);
+        mockBasicFilterConfiguration(filterDefaultValue, filterUid, columnUid, filterType);
 
     ReportColumn reportColumn1 = mockReportColumn(columnUid, "col1", "Col 1");
 
@@ -323,9 +331,10 @@ class ReportSpecBuilderTest {
     Long filterUid = 100L;
     Long columnUid = 1L;
     List<String> requestValue = List.of("11");
+    FilterType filterType = createFilterType("BAS_DAYS", "");
 
     BasicFilterConfiguration basicFilterConfiguration =
-        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, "BAS_DAYS");
+        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, filterType);
 
     ReportColumn reportColumn1 = mockReportColumn(columnUid, "col1", "Col 1");
     ReportConfiguration reportConfig =
@@ -352,9 +361,10 @@ class ReportSpecBuilderTest {
     Long filterUid = 100L;
     Long columnUid = 1L;
     List<String> requestValue = List.of("not_number");
+    FilterType filterType = createFilterType("BAS_DAYS", "");
 
     BasicFilterConfiguration basicFilterConfiguration =
-        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, "BAS_DAYS");
+        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, filterType);
 
     ReportColumn reportColumn1 = mockReportColumn(columnUid, "col1", "Col 1");
     ReportConfiguration reportConfig =
@@ -382,10 +392,11 @@ class ReportSpecBuilderTest {
     Long filterUid = 100L;
     Long columnUid = 1L;
     List<String> requestValue = List.of("11");
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     // Configured as text filter, NOT BAS_DAYS
     BasicFilterConfiguration basicFilterConfiguration =
-        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, "BAS_TXT");
+        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, filterType);
 
     ReportColumn reportColumn1 = mockReportColumn(columnUid, "col1", "Col 1");
     ReportConfiguration reportConfig =
@@ -411,9 +422,10 @@ class ReportSpecBuilderTest {
   @Test
   void build_should_return_null_days_value_when_basic_filters_are_null() {
     Long columnUid = 1L;
+    FilterType filterType = createFilterType("BAS_DAYS", "");
 
     BasicFilterConfiguration basicFilterConfiguration =
-        mockBasicFilterConfiguration(List.of(), 100L, columnUid, "BAS_DAYS");
+        mockBasicFilterConfiguration(List.of(), 100L, columnUid, filterType);
 
     ReportColumn reportColumn1 = mockReportColumn(columnUid, "col1", "Col 1");
     ReportConfiguration reportConfig =
@@ -436,9 +448,10 @@ class ReportSpecBuilderTest {
   void build_should_return_null_days_value_when_provided_value_is_blank() {
     Long filterUid = 100L;
     Long columnUid = 1L;
+    FilterType filterType = createFilterType("BAS_DAYS", "");
 
     BasicFilterConfiguration basicFilterConfiguration =
-        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, "BAS_DAYS");
+        mockBasicFilterConfiguration(List.of(), filterUid, columnUid, filterType);
 
     ReportColumn reportColumn1 = mockReportColumn(columnUid, "col1", "Col 1");
     ReportConfiguration reportConfig =

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
@@ -79,11 +79,7 @@ class WhereClauseServiceTest {
       Long reportFilterUid,
       Long reportColumnUid,
       Boolean defaultIncludeNulls,
-      String typeString) {
-
-    FilterType mockType = Mockito.mock(FilterType.class);
-    // Ensure the mock returns the string we need for the IF/ELSE logic
-    Mockito.lenient().when(mockType.type()).thenReturn(typeString);
+      FilterType fitlerType) {
 
     return new BasicFilterConfiguration(
         reportFilterUid,
@@ -92,7 +88,11 @@ class WhereClauseServiceTest {
         defaultIncludeNulls,
         null,
         null,
-        mockType);
+        fitlerType);
+  }
+
+  private FilterType createFilterType(String type, String code) {
+    return new FilterType(1L, "", "", code, "", type, "");
   }
 
   private AdvancedFilterConfiguration createAdvancedFilterConfiguration(
@@ -137,10 +137,12 @@ class WhereClauseServiceTest {
     Long columnUid = 2L;
     List<String> filterDefaultValue = List.of("condition1", "condition2");
 
+    FilterType filterType = createFilterType("BAS_TXT", "");
+
     List<BasicFilterConfiguration> basicFilterConfigs =
         List.of(
             createBasicFilterConfiguration(
-                filterDefaultValue, filterUid, columnUid, null, "BAS_TXT"));
+                filterDefaultValue, filterUid, columnUid, null, filterType));
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
 
@@ -162,12 +164,13 @@ class WhereClauseServiceTest {
     Long col1 = 1L;
     Long filter2 = 102L;
     Long col2 = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     ReportConfiguration reportConfig =
         createReportConfig(
             List.of(
-                createBasicFilterConfiguration(List.of(), filter1, col1, false, "BAS_TXT"),
-                createBasicFilterConfiguration(List.of(), filter2, col2, false, "BAS_TXT")),
+                createBasicFilterConfiguration(List.of(), filter1, col1, false, filterType),
+                createBasicFilterConfiguration(List.of(), filter2, col2, false, filterType)),
             List.of(
                 mockReportColumn(col1, "STRING", "ColumnName1"),
                 mockReportColumn(col2, "STRING", "ColumnName2")));
@@ -186,11 +189,12 @@ class WhereClauseServiceTest {
   void should_handle_allow_nulls_operator() {
     Long filterUid = 100L;
     Long columnUid = 1L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     ReportConfiguration reportConfig =
         createReportConfig(
             List.of(
-                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT")),
+                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType)),
             List.of(mockReportColumn(columnUid, "STRING", "ColumnName")));
 
     List<BasicFilterRequest> basicFilterRequest =
@@ -208,13 +212,14 @@ class WhereClauseServiceTest {
     Long columnUid = 1L;
     Long filterUid2 = 101L;
     Long columnUid2 = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     ReportConfiguration reportConfig =
         createReportConfig(
             List.of(
-                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT"),
+                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType),
                 createBasicFilterConfiguration(
-                    List.of(), filterUid2, columnUid2, false, "BAS_TXT")),
+                    List.of(), filterUid2, columnUid2, false, filterType)),
             List.of(
                 mockReportColumn(columnUid, "STRING", "ColumnName"),
                 mockReportColumn(columnUid2, "STRING", "ColumnName2")));
@@ -236,9 +241,10 @@ class WhereClauseServiceTest {
   void should_handle_only_nulls_requested() {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     List<BasicFilterConfiguration> basicFilterConfigs =
-        List.of(createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT"));
+        List.of(createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType));
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
     ReportConfiguration reportConfig =
         createReportConfig(basicFilterConfigs, List.of(reportColumn));
@@ -257,9 +263,10 @@ class WhereClauseServiceTest {
   void should_handle_time_range_logic() {
     Long filterUid = 200L;
     Long columnUid = 5L;
+    FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
 
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_TIM_RANGE");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "DATE", "date_column");
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
@@ -276,9 +283,10 @@ class WhereClauseServiceTest {
   void should_handle_time_range_with_nulls() {
     Long filterUid = 200L;
     Long columnUid = 5L;
+    FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
 
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TIM_RANGE");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "DATE", "date_column");
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
@@ -297,10 +305,11 @@ class WhereClauseServiceTest {
   void should_return_empty_string_when_no_filters_match_type() {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("UNKNOWN_TYPE", "");
 
     // Type is "UNKNOWN_TYPE", which is not in BAS_TYPES or TIME_RANGE_TYPES
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "UNKNOWN_TYPE");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
@@ -314,22 +323,23 @@ class WhereClauseServiceTest {
   }
 
   private static Stream<String> noColumnFilterTypes() {
-    return ReportConstants.BAS_TYPES_NO_COLUMN.stream();
+    return ReportConstants.BAS_CODES_NO_COLUMN.stream();
   }
 
-  // Test will loop through all values in BAS_TYPES_NO_COLUMN and run the test for each
+  // Test will loop through all values in BAS_CODES_NO_COLUMN and run the test for each
   @ParameterizedTest(
       name =
-          "Should skip processing and return empty string when filter type is in BAS_TYPES_NO_COLUMN ")
+          "Should skip processing and return empty string when filter type is in BAS_CODES_NO_COLUMN ")
   @MethodSource("noColumnFilterTypes")
   void should_return_empty_string_when_filter_type_has_no_associated_column(
-      String filterTypeNoColumn) {
+      String filterCodeNoColumn) {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("", filterCodeNoColumn);
 
     // Create configuration using the parameterized filter type string
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterTypeNoColumn);
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
 
@@ -343,23 +353,26 @@ class WhereClauseServiceTest {
     assertThat(whereFragment).isEmpty();
   }
 
-  // Test will loop through all values in BAS_TYPES_NO_COLUMN and run the test for each
+  // Test will loop through all values in BAS_CODES_NO_COLUMN and run the test for each
   @ParameterizedTest(
       name =
-          "Should skip processing and return empty string when filter type is in BAS_TYPES_NO_COLUMN ")
+          "Should skip processing and return empty string when filter type is in BAS_CODES_NO_COLUMN ")
   @MethodSource("noColumnFilterTypes")
-  void should_eliminate_BAS_DAYS_filter_but_leave_other_filters(String filterTypeNoColumn) {
+  void should_eliminate_BAS_CODES_NO_COLUMN_filters_but_leave_other_filters(
+      String filterCodeNoColumn) {
     Long filterUid = 100L;
     Long columnUid = 1L;
     Long filterUid2 = 101L;
     Long columnUid2 = 2L;
+    FilterType filterType1 = createFilterType("BAS_TXT", "");
+    FilterType filterType2 = createFilterType("", filterCodeNoColumn);
 
     ReportConfiguration reportConfig =
         createReportConfig(
             List.of(
-                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT"),
+                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType1),
                 createBasicFilterConfiguration(
-                    List.of(), filterUid2, columnUid2, false, filterTypeNoColumn)),
+                    List.of(), filterUid2, columnUid2, false, filterType2)),
             List.of(
                 mockReportColumn(columnUid, "STRING", "ColumnName"),
                 mockReportColumn(columnUid2, "STRING", "ColumnName2")));
@@ -379,10 +392,11 @@ class WhereClauseServiceTest {
   void should_escape_malicious_strings_to_prevent_in_clause_breakout() {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("BAS_CON_LIST", "");
 
     // Setup Config
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_CON_LIST");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
@@ -406,9 +420,10 @@ class WhereClauseServiceTest {
 
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     List<BasicFilterConfiguration> basicFilterConfigs =
-        List.of(createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT"));
+        List.of(createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType));
     // Column list is empty or doesn't contain 2L
     ReportConfiguration reportConfig = createReportConfig(basicFilterConfigs, List.of());
 
@@ -455,15 +470,17 @@ class WhereClauseServiceTest {
   void should_return_full_where_clause_with_prefix() {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     Long filterUid2 = 10L;
     Long columnUid2 = 3L;
+    FilterType filterType2 = createFilterType("BAS_TIM_RANGE", "");
 
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_TXT");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
 
     BasicFilterConfiguration config2 =
-        createBasicFilterConfiguration(List.of(), filterUid2, columnUid2, true, "BAS_TIM_RANGE");
+        createBasicFilterConfiguration(List.of(), filterUid2, columnUid2, true, filterType2);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
     ReportColumn reportColumn2 = mockReportColumn(columnUid2, "DATE", "TimeRangeColumn");
@@ -493,8 +510,10 @@ class WhereClauseServiceTest {
   @Test
   void should_throw_exception_when_values_mismatch_due_to_nulls() {
     Long filterUid = 100L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
+
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, 2L, false, "BAS_TXT");
+        createBasicFilterConfiguration(List.of(), filterUid, 2L, false, filterType);
     ReportColumn reportColumn = mockReportColumn(2L, "STRING", "ColumnName");
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
 
@@ -511,10 +530,11 @@ class WhereClauseServiceTest {
   void should_throw_exception_when_input_values_result_in_zero_formatted_values() {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     // Setup config and column
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_TXT");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
 
@@ -532,15 +552,17 @@ class WhereClauseServiceTest {
   void should_create_where_clause_with_all_filters_and_nested_rules() {
     Long filterUid = 100L;
     Long columnUid = 2L;
+    FilterType filterType = createFilterType("BAS_TXT", "");
 
     Long filterUid2 = 10L;
     Long columnUid2 = 3L;
+    FilterType filterType2 = createFilterType("BAS_TIM_RANGE", "");
 
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_TXT");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
 
     BasicFilterConfiguration config2 =
-        createBasicFilterConfiguration(List.of(), filterUid2, columnUid2, true, "BAS_TIM_RANGE");
+        createBasicFilterConfiguration(List.of(), filterUid2, columnUid2, true, filterType2);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
     ReportColumn reportColumn2 = mockReportColumn(columnUid2, "DATE", "TimeRangeColumn");

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
@@ -314,6 +314,53 @@ class WhereClauseServiceTest {
   }
 
   @Test
+  void should_return_empty_string_when_filter_type_is_BAS_DAYS() {
+    Long filterUid = 100L;
+    Long columnUid = 2L;
+
+    BasicFilterConfiguration config =
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_DAYS");
+
+    ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
+    ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
+
+    List<BasicFilterRequest> request =
+        List.of(new BasicFilterRequest(filterUid, List.of("val"), false));
+
+    String whereFragment = mockWhereClauseService.buildBasicWhereFragment(reportConfig, request);
+
+    assertThat(whereFragment).isEmpty();
+  }
+
+  @Test
+  void should_eliminate_BAS_DAYS_filter_but_leave_other_filters() {
+    Long filterUid = 100L;
+    Long columnUid = 1L;
+    Long filterUid2 = 101L;
+    Long columnUid2 = 2L;
+
+    ReportConfiguration reportConfig =
+        createReportConfig(
+            List.of(
+                createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT"),
+                createBasicFilterConfiguration(
+                    List.of(), filterUid2, columnUid2, false, "BAS_DAYS")),
+            List.of(
+                mockReportColumn(columnUid, "STRING", "ColumnName"),
+                mockReportColumn(columnUid2, "STRING", "ColumnName2")));
+
+    List<BasicFilterRequest> basicFilterRequest =
+        List.of(
+            new BasicFilterRequest(filterUid, List.of("condition1"), false),
+            new BasicFilterRequest(filterUid2, List.of("condition2"), false));
+
+    String whereFragment =
+        mockWhereClauseService.buildBasicWhereFragment(reportConfig, basicFilterRequest);
+
+    assertThat(whereFragment).isEqualTo("([ColumnName] IN ('condition1'))");
+  }
+
+  @Test
   void should_escape_malicious_strings_to_prevent_in_clause_breakout() {
     Long filterUid = 100L;
     Long columnUid = 2L;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
@@ -313,15 +313,26 @@ class WhereClauseServiceTest {
     assertThat(whereFragment).isEmpty();
   }
 
-  @Test
-  void should_return_empty_string_when_filter_type_is_BAS_DAYS() {
+  private static Stream<String> noColumnFilterTypes() {
+    return ReportConstants.BAS_TYPES_NO_COLUMN.stream();
+  }
+
+  // Test will loop through all values in BAS_TYPES_NO_COLUMN and run the test for each
+  @ParameterizedTest(
+      name =
+          "Should skip processing and return empty string when filter type is in BAS_TYPES_NO_COLUMN ")
+  @MethodSource("noColumnFilterTypes")
+  void should_return_empty_string_when_filter_type_has_no_associated_column(
+      String filterTypeNoColumn) {
     Long filterUid = 100L;
     Long columnUid = 2L;
 
+    // Create configuration using the parameterized filter type string
     BasicFilterConfiguration config =
-        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, "BAS_DAYS");
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterTypeNoColumn);
 
     ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "ColumnName");
+
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
 
     List<BasicFilterRequest> request =
@@ -332,8 +343,12 @@ class WhereClauseServiceTest {
     assertThat(whereFragment).isEmpty();
   }
 
-  @Test
-  void should_eliminate_BAS_DAYS_filter_but_leave_other_filters() {
+  // Test will loop through all values in BAS_TYPES_NO_COLUMN and run the test for each
+  @ParameterizedTest(
+      name =
+          "Should skip processing and return empty string when filter type is in BAS_TYPES_NO_COLUMN ")
+  @MethodSource("noColumnFilterTypes")
+  void should_eliminate_BAS_DAYS_filter_but_leave_other_filters(String filterTypeNoColumn) {
     Long filterUid = 100L;
     Long columnUid = 1L;
     Long filterUid2 = 101L;
@@ -344,7 +359,7 @@ class WhereClauseServiceTest {
             List.of(
                 createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, "BAS_TXT"),
                 createBasicFilterConfiguration(
-                    List.of(), filterUid2, columnUid2, false, "BAS_DAYS")),
+                    List.of(), filterUid2, columnUid2, false, filterTypeNoColumn)),
             List.of(
                 mockReportColumn(columnUid, "STRING", "ColumnName"),
                 mockReportColumn(columnUid2, "STRING", "ColumnName2")));


### PR DESCRIPTION
## Description

BAS_DAYS basic filter should be filtered out from processing in the where clause service

## Tickets

* [APP-677](https://cdc-nbs.atlassian.net/jira/software/c/projects/APP/boards/626?selectedIssue=APP-677)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests


[APP-677]: https://cdc-nbs.atlassian.net/browse/APP-677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ