### PR TITLE
[APP-671] ci: add build-and-push for report-execution

### DIFF
--- a/.github/workflows/Build-and-deploy-report-execution.yaml
+++ b/.github/workflows/Build-and-deploy-report-execution.yaml
@@ -1,6 +1,5 @@
 name: Build and Push report execution image to ECR
 on:
-  pull_request: # temp for PR
   push:
     branches:
       - main

--- a/.github/workflows/Build-and-deploy-report-execution.yaml
+++ b/.github/workflows/Build-and-deploy-report-execution.yaml
@@ -1,0 +1,23 @@
+name: Build and Push report execution image to ECR
+on:
+  pull_request: # temp for PR
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/report-execution/**"
+      - ".github/workflows/Build-and-deploy-report-execution.yaml"
+
+jobs:
+  call-build-microservice-container-workflow:
+    permissions:
+      id-token: write
+      contents: read
+      security-events: write
+    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-other-microservice-container.yaml@main
+    with:
+      microservice_name: nbs7-report-execution
+      dockerfile_relative_path: ./apps/report-execution
+      environment_classifier: SNAPSHOT
+    secrets:
+      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}


### PR DESCRIPTION
## Description

Add standard CI workflow to build and push the report execution container to ECR

Sample run: https://github.com/CDCgov/NEDSS-Modernization/actions/runs/27384317426/job/80927945028

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-671

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
