### PR TITLE
APP-756: Create JSON-friendly HTTP error responses

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
@@ -16,42 +16,47 @@ public class ReportExceptionHandler {
   private static final System.Logger LOGGER =
       System.getLogger(ReportExceptionHandler.class.getName());
 
+  /**
+   * JSON-friendly wrapper around 4XX/5XX HTTP error responses.
+   */
+  public record ErrorResponse(String errorMessage) {}
+
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
+  public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
     return new ResponseEntity<>(
-        ex.getBindingResult().getAllErrors().toString(), HttpStatus.UNPROCESSABLE_ENTITY);
+        new ErrorResponse(ex.getBindingResult().getAllErrors().toString()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(NotFoundException.class)
-  public ResponseEntity<String> handleNotFound(NotFoundException ex) {
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+  public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.NOT_FOUND);
   }
 
   @ExceptionHandler(NotImplementedException.class)
-  public ResponseEntity<String> handleNotImplemented(NotImplementedException ex) {
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_IMPLEMENTED);
+  public ResponseEntity<ErrorResponse> handleNotImplemented(NotImplementedException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.NOT_IMPLEMENTED);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<String> handleUnprocessableEntity(IllegalArgumentException ex) {
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+  public ResponseEntity<ErrorResponse> handleUnprocessableEntity(IllegalArgumentException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<String> handleFailedSerialization(HttpMessageNotReadableException ex) {
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+  public ResponseEntity<ErrorResponse> handleFailedSerialization(HttpMessageNotReadableException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(RestClientResponseException.class)
-  public ResponseEntity<String> handleRestClientFailure(RestClientResponseException ex) {
+  public ResponseEntity<ErrorResponse> handleRestClientFailure(RestClientResponseException ex) {
     String err = ex.getResponseBodyAsString();
     LOGGER.log(System.Logger.Level.ERROR, "Error received from rest client: %s".formatted(err), ex);
-    return new ResponseEntity<>(err, ex.getStatusCode());
+    return new ResponseEntity<>(new ErrorResponse(err), ex.getStatusCode());
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<String> handleUnexpectedError(Exception ex) {
+  public ResponseEntity<ErrorResponse> handleUnexpectedError(Exception ex) {
     LOGGER.log(System.Logger.Level.ERROR, ex.getMessage(), ex);
-    return new ResponseEntity<>("Internal Server Error", HttpStatus.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(new ErrorResponse("Internal Server Error"), HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
@@ -18,52 +18,52 @@ public class ReportExceptionHandler {
   private static final System.Logger LOGGER =
       System.getLogger(ReportExceptionHandler.class.getName());
 
-  /** JSON-friendly wrapper around 4XX/5XX HTTP error responses. */
-  public record ErrorResponse(
+  /** JSON-friendly wrapper for the response bodies of 4XX/5XX HTTP error responses. */
+  public record ErrorResponseBody(
       @Schema(requiredMode = Schema.RequiredMode.REQUIRED) @NotNull String errorMessage) {}
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleValidationExceptions(
+  public ResponseEntity<ErrorResponseBody> handleValidationExceptions(
       MethodArgumentNotValidException ex) {
     return new ResponseEntity<>(
-        new ErrorResponse(ex.getBindingResult().getAllErrors().toString()),
+        new ErrorResponseBody(ex.getBindingResult().getAllErrors().toString()),
         HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(NotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
-    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.NOT_FOUND);
+  public ResponseEntity<ErrorResponseBody> handleNotFound(NotFoundException ex) {
+    return new ResponseEntity<>(new ErrorResponseBody(ex.getMessage()), HttpStatus.NOT_FOUND);
   }
 
   @ExceptionHandler(NotImplementedException.class)
-  public ResponseEntity<ErrorResponse> handleNotImplemented(NotImplementedException ex) {
-    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.NOT_IMPLEMENTED);
+  public ResponseEntity<ErrorResponseBody> handleNotImplemented(NotImplementedException ex) {
+    return new ResponseEntity<>(new ErrorResponseBody(ex.getMessage()), HttpStatus.NOT_IMPLEMENTED);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<ErrorResponse> handleUnprocessableEntity(IllegalArgumentException ex) {
+  public ResponseEntity<ErrorResponseBody> handleUnprocessableEntity(IllegalArgumentException ex) {
     return new ResponseEntity<>(
-        new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
+        new ErrorResponseBody(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<ErrorResponse> handleFailedSerialization(
+  public ResponseEntity<ErrorResponseBody> handleFailedSerialization(
       HttpMessageNotReadableException ex) {
     return new ResponseEntity<>(
-        new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
+        new ErrorResponseBody(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(RestClientResponseException.class)
-  public ResponseEntity<ErrorResponse> handleRestClientFailure(RestClientResponseException ex) {
+  public ResponseEntity<ErrorResponseBody> handleRestClientFailure(RestClientResponseException ex) {
     String err = ex.getResponseBodyAsString();
     LOGGER.log(System.Logger.Level.ERROR, "Error received from rest client: %s".formatted(err), ex);
-    return new ResponseEntity<>(new ErrorResponse(err), ex.getStatusCode());
+    return new ResponseEntity<>(new ErrorResponseBody(err), ex.getStatusCode());
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handleUnexpectedError(Exception ex) {
+  public ResponseEntity<ErrorResponseBody> handleUnexpectedError(Exception ex) {
     LOGGER.log(System.Logger.Level.ERROR, ex.getMessage(), ex);
     return new ResponseEntity<>(
-        new ErrorResponse("Internal Server Error"), HttpStatus.INTERNAL_SERVER_ERROR);
+        new ErrorResponseBody("Internal Server Error"), HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
@@ -20,7 +20,7 @@ public class ReportExceptionHandler {
 
   /** JSON-friendly wrapper for the response bodies of 4XX/5XX HTTP error responses. */
   public record ErrorResponseBody(
-      @Schema(requiredMode = Schema.RequiredMode.REQUIRED) @NotNull String errorMessage) {}
+      @Schema(requiredMode = Schema.RequiredMode.REQUIRED) @NotNull String message) {}
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponseBody> handleValidationExceptions(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
@@ -16,15 +16,15 @@ public class ReportExceptionHandler {
   private static final System.Logger LOGGER =
       System.getLogger(ReportExceptionHandler.class.getName());
 
-  /**
-   * JSON-friendly wrapper around 4XX/5XX HTTP error responses.
-   */
+  /** JSON-friendly wrapper around 4XX/5XX HTTP error responses. */
   public record ErrorResponse(String errorMessage) {}
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+  public ResponseEntity<ErrorResponse> handleValidationExceptions(
+      MethodArgumentNotValidException ex) {
     return new ResponseEntity<>(
-        new ErrorResponse(ex.getBindingResult().getAllErrors().toString()), HttpStatus.UNPROCESSABLE_ENTITY);
+        new ErrorResponse(ex.getBindingResult().getAllErrors().toString()),
+        HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(NotFoundException.class)
@@ -39,12 +39,15 @@ public class ReportExceptionHandler {
 
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<ErrorResponse> handleUnprocessableEntity(IllegalArgumentException ex) {
-    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
+    return new ResponseEntity<>(
+        new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<ErrorResponse> handleFailedSerialization(HttpMessageNotReadableException ex) {
-    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
+  public ResponseEntity<ErrorResponse> handleFailedSerialization(
+      HttpMessageNotReadableException ex) {
+    return new ResponseEntity<>(
+        new ErrorResponse(ex.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(RestClientResponseException.class)
@@ -57,6 +60,7 @@ public class ReportExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleUnexpectedError(Exception ex) {
     LOGGER.log(System.Logger.Level.ERROR, ex.getMessage(), ex);
-    return new ResponseEntity<>(new ErrorResponse("Internal Server Error"), HttpStatus.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(
+        new ErrorResponse("Internal Server Error"), HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportExceptionHandler.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.report;
 
 import gov.cdc.nbs.exception.NotFoundException;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +19,8 @@ public class ReportExceptionHandler {
       System.getLogger(ReportExceptionHandler.class.getName());
 
   /** JSON-friendly wrapper around 4XX/5XX HTTP error responses. */
-  public record ErrorResponse(String errorMessage) {}
+  public record ErrorResponse(
+      @Schema(requiredMode = Schema.RequiredMode.REQUIRED) @NotNull String errorMessage) {}
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleValidationExceptions(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExceptionHandlerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExceptionHandlerTest.java
@@ -22,7 +22,7 @@ class ReportExceptionHandlerTest {
         handler.handleNotFound(exception);
 
     assertNotNull(responseEntity.getBody());
-    assertEquals("Not Found", responseEntity.getBody().errorMessage());
+    assertEquals("Not Found", responseEntity.getBody().message());
     assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
   }
 
@@ -34,7 +34,7 @@ class ReportExceptionHandlerTest {
         handler.handleNotImplemented(exception);
 
     assertNotNull(responseEntity.getBody());
-    assertEquals("Not Implemented", responseEntity.getBody().errorMessage());
+    assertEquals("Not Implemented", responseEntity.getBody().message());
     assertEquals(HttpStatus.NOT_IMPLEMENTED, responseEntity.getStatusCode());
   }
 
@@ -46,7 +46,7 @@ class ReportExceptionHandlerTest {
         handler.handleUnprocessableEntity(exception);
 
     assertNotNull(responseEntity.getBody());
-    assertEquals("Illegal Argument", responseEntity.getBody().errorMessage());
+    assertEquals("Illegal Argument", responseEntity.getBody().message());
     assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
   }
 
@@ -60,7 +60,7 @@ class ReportExceptionHandlerTest {
         handler.handleRestClientFailure(exception);
 
     assertNotNull(responseEntity.getBody());
-    assertEquals("it went poorly", responseEntity.getBody().errorMessage());
+    assertEquals("it went poorly", responseEntity.getBody().message());
     assertEquals(HttpStatus.SERVICE_UNAVAILABLE, responseEntity.getStatusCode());
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExceptionHandlerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.report;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import gov.cdc.nbs.exception.NotFoundException;
 import org.apache.commons.lang3.NotImplementedException;
@@ -17,9 +18,11 @@ class ReportExceptionHandlerTest {
   void should_return_error_msg_and_status_code_for_not_found() {
     NotFoundException exception = new NotFoundException("Not Found");
 
-    ResponseEntity<String> responseEntity = handler.handleNotFound(exception);
+    ResponseEntity<ReportExceptionHandler.ErrorResponseBody> responseEntity =
+        handler.handleNotFound(exception);
 
-    assertEquals("Not Found", responseEntity.getBody());
+    assertNotNull(responseEntity.getBody());
+    assertEquals("Not Found", responseEntity.getBody().errorMessage());
     assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
   }
 
@@ -27,9 +30,11 @@ class ReportExceptionHandlerTest {
   void should_return_error_msg_and_status_code_for_not_implemented() {
     NotImplementedException exception = new NotImplementedException("Not Implemented");
 
-    ResponseEntity<String> responseEntity = handler.handleNotImplemented(exception);
+    ResponseEntity<ReportExceptionHandler.ErrorResponseBody> responseEntity =
+        handler.handleNotImplemented(exception);
 
-    assertEquals("Not Implemented", responseEntity.getBody());
+    assertNotNull(responseEntity.getBody());
+    assertEquals("Not Implemented", responseEntity.getBody().errorMessage());
     assertEquals(HttpStatus.NOT_IMPLEMENTED, responseEntity.getStatusCode());
   }
 
@@ -37,21 +42,25 @@ class ReportExceptionHandlerTest {
   void should_return_error_msg_and_status_code_for_illegal_argument() {
     IllegalArgumentException exception = new IllegalArgumentException("Illegal Argument");
 
-    ResponseEntity<String> responseEntity = handler.handleUnprocessableEntity(exception);
+    ResponseEntity<ReportExceptionHandler.ErrorResponseBody> responseEntity =
+        handler.handleUnprocessableEntity(exception);
 
-    assertEquals("Illegal Argument", responseEntity.getBody());
+    assertNotNull(responseEntity.getBody());
+    assertEquals("Illegal Argument", responseEntity.getBody().errorMessage());
     assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
   }
 
   @Test
-  void should_return_error_msg_and_status_code_for_rest_client_exceptiont() {
+  void should_return_error_msg_and_status_code_for_rest_client_exception() {
     RestClientResponseException exception =
         new RestClientResponseException(
             "I failed", 503, "uh oh", null, "it went poorly".getBytes(), null);
 
-    ResponseEntity<String> responseEntity = handler.handleRestClientFailure(exception);
+    ResponseEntity<ReportExceptionHandler.ErrorResponseBody> responseEntity =
+        handler.handleRestClientFailure(exception);
 
-    assertEquals("it went poorly", responseEntity.getBody());
+    assertNotNull(responseEntity.getBody());
+    assertEquals("it went poorly", responseEntity.getBody().errorMessage());
     assertEquals(HttpStatus.SERVICE_UNAVAILABLE, responseEntity.getStatusCode());
   }
 }


### PR DESCRIPTION
## Description

Introduced an `ErrorResponseBody` record to wrap all of our HTTP error messages in, so that the reports API consistently returns JSON in the response body (rather than a string at times), regardless of success/failure.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-756)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
