### PR TITLE
build: use redhat micro as base image for report-execution

### DIFF
--- a/apps/report-execution/Dockerfile
+++ b/apps/report-execution/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM redhat/ubi10-micro:latest
 
 # Specify FastAPI application port and host, with defaults
 ENV UVICORN_PORT=8001


### PR DESCRIPTION
## Description

Per https://skylight-hq.slack.com/archives/C09FM5R0A1W/p1781787092628219
