### PR TITLE
test: ensure csv escapes things well

### DIFF
--- a/apps/report-execution/tests/models.py
+++ b/apps/report-execution/tests/models.py
@@ -81,11 +81,13 @@ class TestModels:
         assert example_large_int == '1000000000000001'
 
     def test_newline_comma_formatting(self):
-        data = [(
-            'a comment with\na new line',
-            'a comment with\r\na carriage return',
-            'a comment with " a quote',
-            'a comment with , a comma')
+        data = [
+            (
+                'a comment with\na new line',
+                'a comment with\r\na carriage return',
+                'a comment with " a quote',
+                'a comment with , a comma',
+            )
         ]
         columns = ['new line', 'carriage return', 'quote', 'comma']
 

--- a/apps/report-execution/tests/models.py
+++ b/apps/report-execution/tests/models.py
@@ -87,9 +87,10 @@ class TestModels:
                 'a comment with\r\na carriage return',
                 'a comment with " a quote',
                 'a comment with , a comma',
+                'a comment with\r\nall, the " things',
             )
         ]
-        columns = ['new line', 'carriage return', 'quote', 'comma']
+        columns = ['new line', 'carriage return', 'quote', 'comma', 'all the things']
 
         t = models.Table(data=data, columns=columns)
         csv_str = models.serialize_table(t)
@@ -100,3 +101,4 @@ class TestModels:
         assert df['carriage return'][0] == 'a comment with\r\na carriage return'
         assert df['quote'][0] == 'a comment with " a quote'
         assert df['comma'][0] == 'a comment with , a comma'
+        assert df['all the things'][0] == 'a comment with\r\nall, the " things'

--- a/apps/report-execution/tests/models.py
+++ b/apps/report-execution/tests/models.py
@@ -1,6 +1,8 @@
 import datetime
+import io
 import re
 
+import pandas as pd
 from faker import Faker
 
 from src import models
@@ -77,3 +79,22 @@ class TestModels:
         assert example_large_float == '123456789.23'
         assert example_small_int == '1'
         assert example_large_int == '1000000000000001'
+
+    def test_newline_comma_formatting(self):
+        data = [(
+            'a comment with\na new line',
+            'a comment with\r\na carriage return',
+            'a comment with " a quote',
+            'a comment with , a comma')
+        ]
+        columns = ['new line', 'carriage return', 'quote', 'comma']
+
+        t = models.Table(data=data, columns=columns)
+        csv_str = models.serialize_table(t)
+        str_io = io.StringIO(csv_str)
+        df = pd.read_csv(str_io)
+
+        assert df['new line'][0] == 'a comment with\na new line'
+        assert df['carriage return'][0] == 'a comment with\r\na carriage return'
+        assert df['quote'][0] == 'a comment with " a quote'
+        assert df['comma'][0] == 'a comment with , a comma'


### PR DESCRIPTION
## Description

To ensure/prevent backsliding on the issue reported in https://nbscentral.cdc.gov/issues/18295
