### PR TITLE
APP-769: filter unmapped race codes from demographics summary card

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryRaceFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryRaceFinder.java
@@ -10,10 +10,10 @@ class PatientDemographicsSummaryRaceFinder {
   private static final String QUERY =
       """
       select
-          coalesce([race].code_short_desc_txt, [patient].race_category_cd, '')
+          [race].code_short_desc_txt
       from person_race [patient]
 
-              left join NBS_SRTE..Code_value_general [race] on
+              join NBS_SRTE..Code_value_general [race] on
                   [race].code_set_nm = 'RACE_CALCULATED'
               and [race].[code] = [patient].race_category_cd
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/race/PatientRaceDemographicsSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/race/PatientRaceDemographicsSteps.java
@@ -32,6 +32,11 @@ public class PatientRaceDemographicsSteps {
     patient.maybeActive().ifPresent(current -> applier.withRace(current, asOf, category));
   }
 
+  @Given("the patient has a race with the unmapped category code {string} as of {localDate}")
+  public void unmappedCategory(final String code, final LocalDate asOf) {
+    patient.maybeActive().ifPresent(current -> applier.withRace(current, asOf, code));
+  }
+
   @Given("the patient race of {raceCategory} includes {raceDetail}")
   public void detailed(final String category, final String detail) {
     patient.maybeActive().ifPresent(current -> applier.withRace(current, category, detail));

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryVerificationSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/file/demographics/summary/PatientDemographicsSummaryVerificationSteps.java
@@ -1,6 +1,8 @@
 package gov.cdc.nbs.patient.file.demographics.summary;
 
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -112,5 +114,10 @@ public class PatientDemographicsSummaryVerificationSteps {
   public void summary_have_an_nth_race_of(final int nth, final String value) throws Exception {
     int position = nth - 1;
     this.results.active().andDo(print()).andExpect(jsonPath("$.races[%d]", position).value(value));
+  }
+
+  @Then("the demographics summary of the patient does not include the race {string}")
+  public void summary_does_not_include_the_race(final String value) throws Exception {
+    this.results.active().andExpect(jsonPath("$.races", not(hasItem(value))));
   }
 }

--- a/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/file/demographics/PatientFile.demographics-summary.feature
@@ -73,3 +73,10 @@ Feature: Summarizing the demographics of a patient
     Then the 1st race in the demographics summary of the patient is "Asian"
     And the 2nd race in the demographics summary of the patient is "Other"
     And the 3rd race in the demographics summary of the patient is "Unknown"
+
+  Scenario: Race categories without a matching code are not shown in the summarized demographics
+    Given the patient's race is Asian as of 11/05/2022
+    And the patient has a race with the unmapped category code "ZTEST" as of 07/24/1974
+    When I view the demographics summary of the patient
+    Then the 1st race in the demographics summary of the patient is "Asian"
+    And the demographics summary of the patient does not include the race "ZTEST"


### PR DESCRIPTION
## Summary
The patient demographics **Summary** card showed raw `race_category_cd` values (e.g. "UNK", "1") for race codes with no `NBS_SRTE..Code_value_general` RACE_CALCULATED match, while the **Demographics** card correctly showed only matched values. Reported by Montana (SEER #18435).

Root cause: the two cards use different finders.
- `PatientDemographicsSummaryRaceFinder` LEFT JOINed the SRTE code table and fell back to the raw code via `coalesce(..., race_category_cd, '')`, so an unmatched code rendered raw.
- `PatientRaceDemographicFinder` (Demographics) INNER JOINs and drops unmatched codes.

## Change
Switch the Summary race finder to an INNER JOIN, matching the Demographics finder, so unmapped category codes are filtered out instead of shown raw. Drops the now-dead `coalesce` fallbacks.

## Testing
Added a `demographics-summary` Cucumber scenario with a race category code that has no SRTE match. Verified red→green against the `nedssdb` Testcontainer: before the fix `$.races` was `["Asian","ZTEST"]`; after, `["Asian"]`. Full `@patient-demographics-summary` and `@patient-race-demographics` suites pass with no regression.