### PR TITLE
pin mssql-python at 1.7.1

### DIFF
--- a/apps/report-execution/pyproject.toml
+++ b/apps/report-execution/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi[standard]~=0.138",
-    "mssql-python>=1.7.1",
+    "mssql-python==1.7.1",
     "pandas>=3.0.1",
     "pydantic>=2.13.0,<3.0.0",
 ]

--- a/apps/report-execution/uv.lock
+++ b/apps/report-execution/uv.lock
@@ -952,7 +952,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.138" },
-    { name = "mssql-python", specifier = ">=1.7.1" },
+    { name = "mssql-python", specifier = "==1.7.1" },
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic", specifier = ">=2.13.0,<3.0.0" },
 ]


### PR DESCRIPTION
There are multiple versions of `mssql-python` which do not work on macOS and previously we had it set to "at least version 1.7.1" which would allow for broken versions to be installed.

This pins the version via the `mssql-python==1.7.1`.

Confirmed that:

- version `1.8.0` does not work on macOS (still has old issue)
- version `1.9.0` does not work on macOS (old issue fixed, new issue cropped up)
- version `1.10.0` does not work on macOS (new issue still present)

Latest dependabot PR for this library: https://github.com/CDCgov/NEDSS-Modernization/pull/3376