### PR TITLE
fix: cleanup types and other small issues

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -67,7 +67,7 @@ const SECTIONS = [
                 Use AND to require all connected rules or groups to match, or OR to require
                 only one to match. Your advanced filter combines with your basic filters
                 using AND logic. The WHERE clause preview shows your advanced filter as you build it."
-                contentWidth="widescreen"
+                contentMaxWidth="widescreen"
             >
                 <AdvancedFilter filter={config.advancedFilter!} columns={config.columns} />
             </Card>

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
@@ -36,7 +36,11 @@ const ResultDataPage = ({
     dataSourceName: string;
 }) => {
     const id = useId();
-    const { data, errors, meta } = Papa.parse<Record<string, string>>(content, { header: true, skipEmptyLines: true });
+    const { data, errors, meta } = Papa.parse<Record<string, string>>(content, {
+        header: true,
+        skipEmptyLines: true,
+        delimiter: ',',
+    });
 
     const formattedTime = formatTimestamp(timestamp);
     const descriptionHtml = description ? DOMPurify.sanitize(marked.parse(description.trim()) as string) : '';
@@ -52,8 +56,8 @@ const ResultDataPage = ({
                 {(errors?.length ?? 0) > 0 && (
                     <AlertMessage type="error" title="There were errors parsing the result:">
                         <ul>
-                            {errors.map((e) => (
-                                <li>{e.message}</li>
+                            {errors.map((e, i) => (
+                                <li key={`error-${i}`}>{e.message}</li>
                             ))}
                         </ul>
                     </AlertMessage>

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
@@ -1,18 +1,19 @@
-import React, { useId, useEffect } from 'react';
+import { useId, useEffect } from 'react';
 import { FullField, ValueEditorProps } from 'react-querybuilder';
-import { NumericInput, TextInputField } from '../../../../../design-system/input';
-import { DatePickerInput } from '../../../../../design-system/date';
-import { DatePickerRange } from '../../../../../design-system/date/range/DatePickerRange.tsx';
-import { DateBetweenCriteria } from '../../../../../design-system/date/criteria';
-import { NumberBetweenCriteria } from '../../../../../design-system/input/range/NumberRangeField.tsx';
+import { NumericInput, NumericRangeInput, TextInputField } from 'design-system/input';
+import { DatePickerInput } from 'design-system/date';
+import { DatePickerRange } from 'design-system/date/range/DatePickerRange.tsx';
+import { DateBetweenCriteria } from 'design-system/date/criteria';
+import { NumberBetweenCriteria } from 'design-system/input/range/NumberRangeField.tsx';
 import { BETWEEN_OPERATOR } from './operators.ts';
+import { ReactComponentLike } from 'prop-types';
 
-const RANGE_COMPONENTS = {
+const RANGE_COMPONENTS: Record<string, ReactComponentLike> = {
     date: DatePickerRange,
-    number: NumericInput,
+    number: NumericRangeInput,
 } as const;
 
-const SINGLE_COMPONENTS = {
+const SINGLE_COMPONENTS: Record<string, ReactComponentLike> = {
     date: DatePickerInput,
     number: NumericInput,
     text: TextInputField,
@@ -20,7 +21,7 @@ const SINGLE_COMPONENTS = {
 
 const BETWEEN_OPERATOR_NAME = BETWEEN_OPERATOR.name;
 
-const getConvertedRange = (props): DateBetweenCriteria | NumberBetweenCriteria => {
+const getConvertedRange = (props: ValueEditorProps<FullField>): DateBetweenCriteria | NumberBetweenCriteria => {
     if (props.operator === BETWEEN_OPERATOR_NAME && typeof props.value === 'string' && props.value) {
         const [from = '', to = ''] = props.value.split(',');
         return { between: { from, to } };
@@ -33,7 +34,7 @@ const ValueInput = (props: ValueEditorProps<FullField>) => {
     const { handleOnChange, inputType, operator, title, value } = props;
     const labelName = title ?? '';
     const isBetween = operator === BETWEEN_OPERATOR_NAME;
-    const InputComponent = isBetween ? RANGE_COMPONENTS[inputType] : SINGLE_COMPONENTS[inputType];
+    const InputComponent = isBetween ? RANGE_COMPONENTS[inputType!] : SINGLE_COMPONENTS[inputType!];
 
     let convertedValue = isBetween ? getConvertedRange(props) : (value ?? '');
 
@@ -73,7 +74,6 @@ const ValueInput = (props: ValueEditorProps<FullField>) => {
                 value={convertedValue}
                 name={labelName}
                 onChange={isBetween ? handleBetweenOnChange : handleSingleOnChange}
-                {...(isBetween && inputType === 'number' ? { isRange: true } : {})}
                 required
             />
         </div>

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueSingleSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueSingleSelector.tsx
@@ -1,16 +1,16 @@
-import React, { useId } from 'react';
-import { FullField, ValueEditorProps } from 'react-querybuilder';
-import { SingleSelect } from '../../../../../design-system/select';
-import { Selectable } from '../../../../../options';
+import { useId } from 'react';
+import { FullOption, ValueSelectorProps } from 'react-querybuilder';
+import { SingleSelect } from 'design-system/select';
+import { Selectable } from 'options';
 
-const ValueSingleSelector = (props: ValueEditorProps<FullField>) => {
+const ValueSingleSelector = (props: ValueSelectorProps<FullOption>) => {
     const id = useId();
     const title = props.title ?? '';
-    const options = props.options ?? [];
+    const options: FullOption[] = (props.options as FullOption[]) ?? [];
 
     // adjust the name to the label so it displays the easy-to-read name
     // (e.g. "Investigation ID" instead of "public_health_case_uid" in dropdown)
-    const availableOptions = options.map((opt) => ({
+    const availableOptions: Selectable[] = options.map((opt) => ({
         ...opt,
         name: opt.label,
     }));
@@ -29,9 +29,9 @@ const ValueSingleSelector = (props: ValueEditorProps<FullField>) => {
                 label={title}
                 value={currentSelection}
                 onChange={handleOnChange}
-                orientation={'vertical'}
+                orientation="vertical"
                 required
-                placeholder={''}
+                placeholder=""
                 name={title}
                 options={availableOptions}
             />

--- a/apps/modernization-ui/src/apps/report/run/modals/SaveReportModal.tsx
+++ b/apps/modernization-ui/src/apps/report/run/modals/SaveReportModal.tsx
@@ -1,8 +1,8 @@
 import { ModalRef, ModalToggleButton } from '@trussworks/react-uswds';
-import React, { RefObject } from 'react';
-import { ModalComponent } from '../../../../components/ModalComponent/ModalComponent.tsx';
+import { RefObject } from 'react';
+import { ModalComponent } from 'components/ModalComponent/ModalComponent.tsx';
 import styles from './save-report-modal.module.scss';
-import { ButtonGroup } from '../../../../design-system/button';
+import { ButtonGroup } from 'design-system/button';
 
 type SaveReportModalProps = {
     saveReportModalRef: RefObject<ModalRef>;

--- a/apps/modernization-ui/src/design-system/card/Card.tsx
+++ b/apps/modernization-ui/src/design-system/card/Card.tsx
@@ -16,7 +16,7 @@ type CardProps = {
     footer?: ReactNode;
     required?: boolean;
     disabled?: boolean;
-    contentWidth?: string;
+    contentMaxWidth?: string;
 } & Omit<CardHeaderProps, 'control'> &
     JSX.IntrinsicElements['section'];
 
@@ -35,7 +35,7 @@ const Card = ({
     required = false,
     disabled = false,
     children,
-    contentWidth,
+    contentMaxWidth,
     ...remaining
 }: CardProps) => {
     const [collapsed, setCollapsed] = useState<boolean>(!open);
@@ -48,7 +48,7 @@ const Card = ({
             id={cardId}
             role="group"
             aria-labelledby={id}
-            className={classNames(styles.card, className, contentWidth ? styles[`card--${contentWidth}`] : '', {
+            className={classNames(styles.card, className, contentMaxWidth ? styles[`card--${contentMaxWidth}`] : '', {
                 [styles.disabled]: disabled,
             })}
             {...remaining}

--- a/apps/modernization-ui/src/design-system/card/card.module.scss
+++ b/apps/modernization-ui/src/design-system/card/card.module.scss
@@ -2,7 +2,7 @@
 @use 'styles/borders';
 @use 'styles/components';
 
-$content-width: (
+$content-max-width: (
     'widescreen': 90rem,
 );
 
@@ -38,7 +38,7 @@ section.card {
         @include components.required();
     }
 
-    @each $name, $value in $content-width {
+    @each $name, $value in $content-max-width {
         &--#{$name} {
             header {
                 div {
@@ -49,7 +49,7 @@ section.card {
 
                 // target the content div
                 + div {
-                    width: $value;
+                    max-width: $value;
                 }
             }
         }

--- a/apps/modernization-ui/src/design-system/input/index.ts
+++ b/apps/modernization-ui/src/design-system/input/index.ts
@@ -1,2 +1,2 @@
-export { NumericInput } from './numeric';
+export { NumericInput, NumericRangeInput } from './numeric';
 export { TextInputField } from './text/TextInputField';

--- a/apps/modernization-ui/src/design-system/input/numeric/NumericInput.spec.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/NumericInput.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import { NumericInput } from './NumericInput';
+import { NumericInput, NumericRangeInput } from './NumericInput';
 
 describe('when entering numeric values for a field', () => {
     it('should render with no accessibility violations on single input', async () => {
@@ -11,7 +11,11 @@ describe('when entering numeric values for a field', () => {
 
     it('should render with no accessibility violations on range input', async () => {
         const { container } = render(
-            <NumericInput isRange={true} id="testing-date-range-accessibility" onChange={vi.fn()} />
+            <NumericRangeInput
+                id="testing-date-range-accessibility"
+                label="Numeric Range Input test"
+                onChange={vi.fn()}
+            />
         );
 
         expect(await axe(container)).toHaveNoViolations();

--- a/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
@@ -13,15 +13,13 @@ type BaseNumericInputProps = {
 } & NumericProps;
 
 type RangeInputProps = BaseNumericInputProps & {
-    isRange: true;
-    value: NumberBetweenCriteria;
+    value?: NumberBetweenCriteria;
+    onChange?: (val?: NumberBetweenCriteria) => void;
 };
 
 type SingleInputProps = BaseNumericInputProps & {
-    value: number;
+    value?: number;
 };
-
-type NumericInputProps = RangeInputProps | SingleInputProps;
 
 const NumericInput = ({
     id,
@@ -32,9 +30,8 @@ const NumericInput = ({
     required,
     placeholder,
     helperText,
-    isRange = false,
     ...remaining
-}: NumericInputProps) => {
+}: SingleInputProps) => {
     return (
         <EntryWrapper
             orientation={orientation}
@@ -43,15 +40,34 @@ const NumericInput = ({
             htmlFor={id}
             required={required}
             error={error}
-            helperText={helperText}
-        >
-            {isRange ? (
-                <NumberRangeField id={id} sizing={sizing} required={required} {...remaining} />
-            ) : (
-                <Numeric id={id} placeholder={placeholder} {...remaining} />
-            )}
+            helperText={helperText}>
+            <Numeric id={id} placeholder={placeholder} {...remaining} />
         </EntryWrapper>
     );
 };
 
-export { NumericInput };
+const NumericRangeInput = ({
+    id,
+    label,
+    orientation,
+    sizing,
+    error,
+    required,
+    helperText,
+    ...remaining
+}: Omit<RangeInputProps, 'placeholder'>) => {
+    return (
+        <EntryWrapper
+            orientation={orientation}
+            sizing={sizing}
+            label={label}
+            htmlFor={id}
+            required={required}
+            error={error}
+            helperText={helperText}>
+            <NumberRangeField id={id} sizing={sizing} required={required} {...remaining} />
+        </EntryWrapper>
+    );
+};
+
+export { NumericInput, NumericRangeInput };

--- a/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
+++ b/apps/modernization-ui/src/design-system/input/numeric/NumericInput.tsx
@@ -40,7 +40,8 @@ const NumericInput = ({
             htmlFor={id}
             required={required}
             error={error}
-            helperText={helperText}>
+            helperText={helperText}
+        >
             <Numeric id={id} placeholder={placeholder} {...remaining} />
         </EntryWrapper>
     );
@@ -64,7 +65,8 @@ const NumericRangeInput = ({
             htmlFor={id}
             required={required}
             error={error}
-            helperText={helperText}>
+            helperText={helperText}
+        >
             <NumberRangeField id={id} sizing={sizing} required={required} {...remaining} />
         </EntryWrapper>
     );

--- a/apps/modernization-ui/src/design-system/input/numeric/index.ts
+++ b/apps/modernization-ui/src/design-system/input/numeric/index.ts
@@ -1,2 +1,2 @@
-export { NumericInput } from './NumericInput';
+export { NumericInput, NumericRangeInput } from './NumericInput';
 export { onlyNumericKeys } from './onlyNumericKeys';

--- a/apps/modernization-ui/src/design-system/input/range/NumberRangeField.tsx
+++ b/apps/modernization-ui/src/design-system/input/range/NumberRangeField.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Field, Orientation, Sizing } from 'design-system/field';
 
 import styles from './number-range-field.module.scss';
@@ -18,8 +17,9 @@ export type NumberRangeFieldProps = {
     id: string;
     value?: NumberBetweenCriteria;
     sizing?: Sizing;
-    onChange: (value?: NumberBetweenCriteria) => void;
+    onChange?: (value?: NumberBetweenCriteria) => void;
     onBlur?: () => void;
+    label?: string;
     required?: boolean;
     orientation?: Orientation;
     helperText?: string;
@@ -27,7 +27,7 @@ export type NumberRangeFieldProps = {
 };
 
 const parseValue = (value: number | undefined | null) => {
-    if (value === undefined || value === null) return '';
+    if (value === undefined || value === null) return undefined;
     return value;
 };
 
@@ -43,13 +43,13 @@ const NumberRangeField = ({
     helperText,
     error,
 }: NumberRangeFieldProps) => {
-    const handleFieldOnChange = (v, type) => {
+    const handleFieldOnChange = (v: number | null | undefined, type: 'to' | 'from') => {
         if (type === 'to') {
-            onChange({ between: { from: parseValue(value?.between.from), to: parseValue(v) } });
+            onChange?.({ between: { from: parseValue(value?.between.from), to: parseValue(v) } });
         }
 
         if (type === 'from') {
-            onChange({ between: { from: parseValue(v), to: parseValue(value?.between.to) } });
+            onChange?.({ between: { from: parseValue(v), to: parseValue(value?.between.to) } });
         }
     };
 


### PR DESCRIPTION
## Description

* Appease typescript in `src` (splitting NumericInput into two components, one for range and one for plain makes this easier (and is how things work for dates))
* Fix width content limiting in card
* Provide delimiter to result data's csv parser so if there's a one column, header-only result, that doesn't display an error
