### PR TITLE
fix: cleanup errors when opening nbs6 saved report with 7

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
@@ -141,6 +141,12 @@ public class ReportService {
         .findById(id)
         .map(
             report -> {
+              ReportLibrary library = report.getReportLibrary();
+              if (library == null) {
+                throw new IllegalArgumentException(
+                    "No library found for this report. This can happen if a report was created or save-as'ed with NBS 6, but is trying to be opened in NBS 7. Ask your NBS administrator to sync the report and report library tables using the query in the report admin guide.");
+              }
+
               List<BasicFilterConfiguration> basicFilters =
                   report.getReportFilters().stream()
                       .filter(
@@ -194,7 +200,7 @@ public class ReportService {
 
               return new ReportConfiguration(
                   new ReportDataSource(report.getDataSource()),
-                  new Library(report.getReportLibrary()),
+                  new Library(library),
                   report.getReportTitle(),
                   report.getDescTxt(),
                   report.getOwnerUid(),
@@ -219,9 +225,9 @@ public class ReportService {
             .orElseThrow(() -> new NotFoundException(getReportNotFoundText(reportId)));
 
     ReportLibrary reportLibrary = report.getReportLibrary();
+    // If the library is null, that means this report was save-as'ed with NBS 6 from a sas report
     if (reportLibrary == null) {
-      throw new UnprocessableEntityException(
-          String.format("No report library exists for report %s", reportId));
+      return "sas";
     }
 
     return reportLibrary.getRunner();

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.*;
 import gov.cdc.nbs.authentication.NbsUserDetails;
 import gov.cdc.nbs.entity.odse.*;
 import gov.cdc.nbs.exception.NotFoundException;
-import gov.cdc.nbs.exception.UnprocessableEntityException;
 import gov.cdc.nbs.report.ReportConstants.ReportGroup;
 import gov.cdc.nbs.report.mappers.ReportMapper;
 import gov.cdc.nbs.report.models.*;
@@ -554,6 +553,19 @@ class ReportServiceTest {
           .isInstanceOf(NotFoundException.class)
           .hasMessage("Report not found for Report UID: 1 and Data Source UID: 2");
     }
+
+    @Test
+    void getReport_should_throw_when_library_not_found() {
+      Report report = mock(Report.class);
+
+      Mockito.lenient().when(report.getReportLibrary()).thenReturn(null);
+      ReportId id = new ReportId(reportUid, dataSourceUid);
+      when(reportRepository.findById(id)).thenReturn(Optional.of(report));
+
+      assertThatThrownBy(() -> service.getReport(reportUid, dataSourceUid))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("No library found for this report");
+    }
   }
 
   @Nested
@@ -579,15 +591,15 @@ class ReportServiceTest {
     }
 
     @Test
-    void getReportRunner_should_throw_when_report_has_no_library() {
+    void getReportRunner_should_return_sas_when_report_has_no_library() {
       ReportId reportId = new ReportId(reportUid, dataSourceUid);
       Report report = mockReport(reportId, "python", "nbs_ods.PHCDemographic", List.of());
 
       when(report.getReportLibrary()).thenReturn(null);
 
-      assertThatThrownBy(() -> service.getReportRunner(reportUid, dataSourceUid))
-          .isInstanceOf(UnprocessableEntityException.class)
-          .hasMessage("No report library exists for report %s", reportId);
+      String runner = service.getReportRunner(reportUid, dataSourceUid);
+
+      assertThat(runner).isEqualTo("sas");
     }
   }
 


### PR DESCRIPTION
## Description

Rage-cleanup of error state when you try to open an NBS 6 save'd report with 7. This could happen to end users (in strange scenarios) and not just in dev, so make it a user facing error with a good message. Also assume "sas" as runner if no library found