### PR TITLE
fix: handle switch to null operators in advanced filter

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -2824,6 +2824,8 @@ describe('report run page', () => {
             await user.type(numHigh, '1');
             expect(numHigh).toHaveValue(201);
 
+            await user.selectOptions(operators[0], 'null');
+
             const exportButton = await findByRole('button', { name: 'Export' });
             await user.click(exportButton);
 
@@ -2839,8 +2841,8 @@ describe('report run page', () => {
                                 {
                                     id: '124-124-124',
                                     columnId: 2001,
-                                    operator: 'SW',
-                                    value: 'prefix',
+                                    operator: 'IN',
+                                    value: '',
                                 },
                                 {
                                     id: '125-125-125',

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
@@ -30,7 +30,7 @@ import { RemoveButton } from '././RemoveButton.tsx';
 import styles from './advanced-filter.module.scss';
 import { validateRule } from './validator.ts';
 import { AddButton } from './AddButton.tsx';
-import { ALL_OPERATORS, LIST_OPERATORS, OPERATOR_MAP } from './operators.ts';
+import { ALL_OPERATORS, LIST_OPERATORS, NULL_OPERATORS, OPERATOR_MAP } from './operators.ts';
 import { Heading } from '../../../../../components/heading';
 import { AlertMessage } from 'design-system/message/index.ts';
 
@@ -114,7 +114,11 @@ const queryToAdvancedFilterRequest = (query: QbRuleGroup, columns: ReportColumn[
             id,
             operator: mapToNbsOp(operator)!,
             columnId: columns.find(({ name }) => field === name)!.id,
-            value: LIST_OPERATORS.find(({ name }) => name === operator) ? joinWith(value, '|') : value.toString(),
+            value: LIST_OPERATORS.find(({ name }) => name === operator)
+                ? joinWith(value, '|')
+                : NULL_OPERATORS.find(({ name }) => name === operator)
+                  ? ''
+                  : value.toString(),
         };
     }) as RuleGroup;
 };

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
@@ -47,11 +47,6 @@ const ValueInput = (props: ValueEditorProps<FullField>) => {
         }
     }, [handleOnChange, operator, value]);
 
-    // clear value on un-mount
-    useEffect(() => {
-        return () => handleOnChange('');
-    }, []);
-
     const handleSingleOnChange = (newValue: number | string | undefined) => {
         if (newValue !== undefined) {
             props.handleOnChange(newValue.toString());

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
@@ -47,6 +47,11 @@ const ValueInput = (props: ValueEditorProps<FullField>) => {
         }
     }, [handleOnChange, operator, value]);
 
+    // clear value on un-mount
+    useEffect(() => {
+        return () => handleOnChange('');
+    }, []);
+
     const handleSingleOnChange = (newValue: number | string | undefined) => {
         if (newValue !== undefined) {
             props.handleOnChange(newValue.toString());


### PR DESCRIPTION
## Description

I noticed during demo day that the advanced filter's value was retained after switch to is null and back. When submitting an is null rule, then the old value was submitted, which is probably not problematic, but also not good. This PR fixes that