### PR TITLE
update tablefaker schemas to fix FK issues

### DIFF
--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/pa03.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/pa03.yaml
@@ -3,6 +3,7 @@ config:
   nbs:
     fk_tables:
       - '[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]'
+      - '[RDB].[dbo].[CASE_COUNT]'
 
 tables:
   - table_name: "[RDB].[dbo].[INVESTIGATION]"

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/qa_06.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/qa_06.yaml
@@ -1,7 +1,9 @@
 config:
   seed: 19
   nbs:
-    fk_tables: [ "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]" ]
+    fk_tables:
+      - "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]"
+      - "[RDB].[dbo].[CASE_COUNT]"
 
 tables:
   - table_name: "[RDB].[dbo].[USER_PROFILE]"

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/std_hiv_datamart.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/std_hiv_datamart.yaml
@@ -3,6 +3,7 @@ config:
   nbs:
     fk_tables:
       - "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]"
+      - "[RDB].[dbo].[CASE_COUNT]"
 
 tables:
   - table_name: "[RDB].[dbo].[INVESTIGATION]"


### PR DESCRIPTION
## Description

The recent updates to the DB golden backup appear to have broken the integration tests.  These updates to the tablefaker schemas fixes those issues.