### PR TITLE
[APP- 741] fix: clean up api error display and handling

### DIFF
--- a/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.tsx
@@ -6,12 +6,12 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { ReportControllerService } from 'generated';
 import { NBS_LIST_REPORT_CONFIG_PAGE } from './constants';
 import { useNavigate } from 'react-router';
-import { AlertMessage } from 'design-system/message';
 
 import styles from 'apps/report/layout/layout.module.scss';
+import { ApiErrorBanner } from 'design-system/errors/ApiError';
 
 const AddReportConfiguration = () => {
-    const [error, setError] = useState<string | null>(null);
+    const [error, setError] = useState<unknown | null>(null);
     const [submitting, setSubmitting] = useState<boolean>(false);
 
     const navigate = useNavigate();
@@ -30,9 +30,7 @@ const AddReportConfiguration = () => {
             .then((reportId) => {
                 navigate(`/report/management/configuration/${reportId.reportUid}/${reportId.dataSourceUid}`);
             })
-            .catch((err) => {
-                setError(JSON.stringify(err));
-            })
+            .catch(setError)
             .finally(() => setSubmitting(false));
     });
 
@@ -51,7 +49,7 @@ const AddReportConfiguration = () => {
             }
         >
             <div className={styles.columnContent}>
-                {error && <AlertMessage type="error">{error}</AlertMessage>}
+                {!!error && <ApiErrorBanner action="adding" item="report" error={error} />}
                 <FormProvider {...form}>
                     <form className={styles.columnContent} onSubmit={handleSubmit}>
                         <ReportConfigurationContent isEditable={true} />

--- a/apps/modernization-ui/src/apps/report/management/configuration/EditReportConfiguration.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/EditReportConfiguration.tsx
@@ -1,4 +1,3 @@
-import { AlertBanner } from 'apps/page-builder/components/AlertBanner/AlertBanner';
 import { ReportLayout } from 'apps/report/layout/ReportLayout';
 import { Button, LinkButton } from 'design-system/button';
 import { useState } from 'react';
@@ -6,16 +5,17 @@ import { ConfigForm, formToRequest, ReportConfigurationContent } from './ReportC
 import { FormProvider, useForm } from 'react-hook-form';
 import { ReportControllerService, ReportConfiguration } from 'generated';
 import { useLoaderData, useNavigate, useParams } from 'react-router';
+import { LoadingBlock } from 'libs/loading/block';
+import { ApiErrorBanner } from 'design-system/errors/ApiError';
 
 import styles from 'apps/report/layout/layout.module.scss';
-import { LoadingBlock } from 'libs/loading/block';
 
 const EditReportConfiguration = () => {
     const params = useParams();
     const reportUid = parseInt(params.reportUid ?? '0');
     const dataSourceUid = parseInt(params.dataSourceUid ?? '0');
     const viewUrl = `/report/management/configuration/${reportUid}/${dataSourceUid}`;
-    const [error, setError] = useState<string | null>(null);
+    const [error, setError] = useState<unknown | null>(null);
     const [submitting, setSubmitting] = useState<boolean>(false);
     const config = useLoaderData<ReportConfiguration>();
 
@@ -37,9 +37,7 @@ const EditReportConfiguration = () => {
             .then(() => {
                 navigate(viewUrl);
             })
-            .catch((err) => {
-                setError(JSON.stringify(err));
-            })
+            .catch(setError)
             .finally(() => setSubmitting(false));
     });
 
@@ -60,7 +58,7 @@ const EditReportConfiguration = () => {
             }
         >
             <div className={styles.columnContent}>
-                {error && <AlertBanner type="error">{error}</AlertBanner>}
+                {!!error && <ApiErrorBanner action="editing" item="report" error={error} />}
                 <FormProvider {...form}>
                     <form className={styles.columnContent} onSubmit={handleSubmit}>
                         <ReportConfigurationContent isEditable={true} config={config} />

--- a/apps/modernization-ui/src/apps/report/management/configuration/ViewReportConfiguration.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/ViewReportConfiguration.tsx
@@ -10,8 +10,8 @@ import { ModalRef } from '@trussworks/react-uswds';
 import { ConfirmationModal } from 'confirmation';
 import { ReportConfiguration, ReportControllerService } from 'generated';
 import { LoadingBlock } from 'libs/loading/block';
-import { AlertMessage } from 'design-system/message';
 import { redirectToNBS6 } from 'utils';
+import { ApiErrorBanner } from 'design-system/errors/ApiError';
 
 const ViewReportConfiguration = () => {
     const params = useParams();
@@ -19,7 +19,7 @@ const ViewReportConfiguration = () => {
     const dataSourceUid = parseInt(params.dataSourceUid ?? '0');
     const confirmDeleteRef = useRef<ModalRef>(null);
     const [deleting, setDeleting] = useState<boolean>(false);
-    const [error, setError] = useState<string>('');
+    const [error, setError] = useState<unknown | null>(null);
     const config = useLoaderData<ReportConfiguration>();
 
     return !config ? (
@@ -40,7 +40,7 @@ const ViewReportConfiguration = () => {
                 </>
             }
         >
-            {error && <AlertMessage type="error">{error}</AlertMessage>}
+            {!!error && <ApiErrorBanner action="viewing" item="report" error={error} />}
             <div className={styles.columnContent}>
                 <ReportConfigurationContent isEditable={false} config={config} />
             </div>
@@ -58,7 +58,7 @@ const ViewReportConfiguration = () => {
                             redirectToNBS6(NBS_LIST_REPORT_CONFIG_PAGE);
                         })
                         .catch((err) => {
-                            setError(JSON.stringify(err));
+                            setError(err);
                             confirmDeleteRef.current?.toggleModal();
                         })
                         .finally(() => setDeleting(false));

--- a/apps/modernization-ui/src/apps/report/run/ReportResultPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportResultPage.spec.tsx
@@ -211,7 +211,7 @@ describe('report result page', () => {
             await user.click(confirmSaveButton);
 
             expect(await findByText('Issue with saving report')).toBeVisible();
-            expect(await findByText(/There was an error saving your report/)).toBeVisible();
+            expect(await findByText(/There was an error saving this report/)).toBeVisible();
             expect(window.location.href).not.toBe('/nbs/ManageReports.do');
         });
     });
@@ -262,7 +262,7 @@ describe('report result page', () => {
             await fillAndSubmitSaveAsForm(user, render);
 
             expect(await render.findByText('Issue with saving report as new')).toBeVisible();
-            expect(await render.findByText(/There was an error saving your report/)).toBeVisible();
+            expect(await render.findByText(/There was an error saving this report/)).toBeVisible();
             expect(window.location.href).not.toBe('/nbs/ManageReports.do');
         });
     });

--- a/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
@@ -7,15 +7,15 @@ import { Heading } from 'components/heading';
 import { permissions, permitsAny, Permitted } from 'libs/permission';
 import { Shown } from 'conditional-render';
 import { useUser } from 'user';
-
-import layoutStyles from '../layout/layout.module.scss';
 import { NBS_MANAGE_REPORT_PAGE, PERMISSION_GROUP_MAP } from '../constants';
 import { ModalRef } from '@trussworks/react-uswds';
 import { SaveReportModal } from './modals/SaveReportModal.tsx';
-import { AlertMessage } from 'design-system/message';
 import { SaveAsReportFormData, SaveAsReportModal } from './modals/SaveAsReportModal.tsx';
 import { redirectToNBS6 } from 'utils';
 import classNames from 'classnames';
+import { ApiErrorBanner } from 'design-system/errors/ApiError.tsx';
+
+import layoutStyles from '../layout/layout.module.scss';
 
 const ReportResultPage = ({
     config,
@@ -26,7 +26,7 @@ const ReportResultPage = ({
     executionRequest,
 }: {
     config: ReportConfiguration;
-    error: string | null;
+    error: unknown | null;
     wasExported: boolean;
     resultLoading: boolean;
     handleRefineReport: () => void;
@@ -67,7 +67,7 @@ const ReportResultPage = ({
             .catch((err) => {
                 const modalRef = isSaveAs ? saveAsReportModalRef : saveReportModalRef;
                 modalRef.current?.toggleModal();
-                setSaveError(err.message);
+                setSaveError(err);
             })
             .finally(() => {
                 setSaving(false);
@@ -99,12 +99,10 @@ const ReportResultPage = ({
                             permissions.reports.public.create,
                             permissions.reports.private.create,
                             permissions.reports.reportingFacility.create
-                        )}
-                    >
+                        )}>
                         <Button
                             onClick={() => saveAsReportModalRef.current?.toggleModal()}
-                            disabled={resultLoading || !!error}
-                        >
+                            disabled={resultLoading || !!error}>
                             Save as new
                         </Button>
                         <SaveAsReportModal
@@ -117,30 +115,22 @@ const ReportResultPage = ({
                         <Permitted permission={PERMISSION_GROUP_MAP[config.group].edit}>
                             <Button
                                 onClick={() => saveReportModalRef.current?.toggleModal()}
-                                disabled={resultLoading || !!error}
-                            >
+                                disabled={resultLoading || !!error}>
                                 Save
                             </Button>
                             <SaveReportModal saveReportModalRef={saveReportModalRef} saving={saving} onSave={onSave} />
                         </Permitted>
                     </Shown>
                 </>
-            }
-        >
+            }>
             <div className="display-flex flex-column">
                 {(error || saveError) && (
-                    <AlertMessage
+                    <ApiErrorBanner
                         className={classNames(layoutStyles.alertMessage, 'margin-top-2 margin-x-2')}
-                        type="error"
-                        title={`There was an error ${saveError ? 'saving' : wasExported ? 'exporting' : 'running'} 
-                        your report. If this error persists, contact your NBS administrator for help.`}
-                    >
-                        <>
-                            {/* In practice, only one of these will be populated at a time */}
-                            {saveError}
-                            {error}
-                        </>
-                    </AlertMessage>
+                        action={saveError ? 'saving' : wasExported ? 'exporting' : 'running'}
+                        item="report"
+                        error={error ?? saveError}
+                    />
                 )}
                 {resultLoading ? (
                     <TextCard loading={true}>

--- a/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
@@ -99,10 +99,12 @@ const ReportResultPage = ({
                             permissions.reports.public.create,
                             permissions.reports.private.create,
                             permissions.reports.reportingFacility.create
-                        )}>
+                        )}
+                    >
                         <Button
                             onClick={() => saveAsReportModalRef.current?.toggleModal()}
-                            disabled={resultLoading || !!error}>
+                            disabled={resultLoading || !!error}
+                        >
                             Save as new
                         </Button>
                         <SaveAsReportModal
@@ -115,14 +117,16 @@ const ReportResultPage = ({
                         <Permitted permission={PERMISSION_GROUP_MAP[config.group].edit}>
                             <Button
                                 onClick={() => saveReportModalRef.current?.toggleModal()}
-                                disabled={resultLoading || !!error}>
+                                disabled={resultLoading || !!error}
+                            >
                                 Save
                             </Button>
                             <SaveReportModal saveReportModalRef={saveReportModalRef} saving={saving} onSave={onSave} />
                         </Permitted>
                     </Shown>
                 </>
-            }>
+            }
+        >
             <div className="display-flex flex-column">
                 {(error || saveError) && (
                     <ApiErrorBanner
@@ -132,26 +136,25 @@ const ReportResultPage = ({
                         error={error ?? saveError}
                     />
                 )}
-                {resultLoading ? (
-                    <TextCard loading={true}>
-                        <Heading level={2}>
-                            {`Your report is ${wasExported ? 'downloading' : 'opening in a new tab'}. 
+                {!error &&
+                    (resultLoading ? (
+                        <TextCard loading={true}>
+                            <Heading level={2}>
+                                {`Your report is ${wasExported ? 'downloading' : 'opening in a new tab'}. 
                             Please do not leave this page while your report is generating.`}
-                        </Heading>
-                        <p>
-                            This might take several minutes for large reports. To be sure it opens, check that pop-ups
-                            are enabled in your browser.
-                        </p>
-                    </TextCard>
-                ) : (
-                    !error && (
+                            </Heading>
+                            <p>
+                                This might take several minutes for large reports. To be sure it opens, check that
+                                pop-ups are enabled in your browser.
+                            </p>
+                        </TextCard>
+                    ) : (
                         <TextCard>
                             <Heading level={2}>
                                 {`Your report has ${wasExported ? 'downloaded' : 'opened in a new tab'}.`}
                             </Heading>
                         </TextCard>
-                    )
-                )}
+                    ))}
             </div>
         </ReportLayout>
     );

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
@@ -139,7 +139,7 @@ const ReportRunPage = () => {
                         setError(err);
                     }
                 })
-                .catch((err) => setError(err));
+                .catch(setError);
         },
         [config]
     );

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
@@ -22,6 +22,7 @@ import { LoadingBlock } from 'libs/loading/block';
 import { NotFoundError } from 'pages/error/NotFoundError';
 import { permitsAll } from 'libs/permission';
 import { AlertMessage } from 'design-system/message';
+import { ApiErrorBanner } from 'design-system/errors/ApiError';
 
 export type ReportExecuteForm = {
     // key is the report's ID
@@ -46,7 +47,7 @@ const ReportRunPage = () => {
     const reportUid = parseInt(params.reportUid ?? '0');
     const dataSourceUid = parseInt(params.dataSourceUid ?? '0');
     const [status, setStatus] = useState<'configuring' | 'submitting' | 'complete'>('configuring');
-    const [error, setError] = useState<string | null>(null);
+    const [error, setError] = useState<unknown | null>(null);
     const [wasExported, setWasExported] = useState<boolean>(true);
     const [lastReportExecutionRequest, setLastReportExecutionRequest] = useState<ReportExecutionRequest | undefined>(
         undefined
@@ -136,17 +137,17 @@ const ReportRunPage = () => {
                             );
                         }
                     } catch (err) {
-                        setError(JSON.stringify(err));
+                        setError(err);
                     }
                 })
-                .catch((err) => setError(JSON.stringify(err)));
+                .catch((err) => setError(err));
         },
         [config]
     );
 
     return !config ? (
         <>
-            {error && <AlertMessage type="error">{error}</AlertMessage>}
+            {error && <ApiErrorBanner action="loading" item="report" error={error} />}
             <LoadingBlock />
         </>
     ) : status === 'configuring' ? (

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
@@ -21,7 +21,6 @@ import { PERMISSION_GROUP_MAP } from '../constants';
 import { LoadingBlock } from 'libs/loading/block';
 import { NotFoundError } from 'pages/error/NotFoundError';
 import { permitsAll } from 'libs/permission';
-import { AlertMessage } from 'design-system/message';
 import { ApiErrorBanner } from 'design-system/errors/ApiError';
 
 export type ReportExecuteForm = {

--- a/apps/modernization-ui/src/design-system/errors/ApiError.spec.tsx
+++ b/apps/modernization-ui/src/design-system/errors/ApiError.spec.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react';
+import { ApiError } from 'generated';
+import { ApiErrorBanner } from './ApiError';
+
+describe('ApiError', () => {
+    const consoleError = console.error; // save original console.error function
+    beforeEach(() => {
+        console.error = vi.fn().mockImplementation(() => {}); // check it's called, but don't log
+    });
+    afterAll(() => {
+        console.error = consoleError; // restore original console.error after all tests
+    });
+
+    it('handles ApiError with string body', () => {
+        const error = new ApiError(
+            { method: 'GET', url: '/test' },
+            { url: '/test', status: 500, statusText: 'SERVER ERROR', ok: false, body: '' },
+            'Uh oh'
+        );
+
+        const { getByText, getByRole } = render(<ApiErrorBanner action="doing" item="thing" error={error} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(
+            getByRole('heading', {
+                name: 'There was an error doing this thing. If this error persists, contact your system administrator.',
+            })
+        );
+        expect(getByText(/ApiError Details:/)).toBeVisible();
+        expect(getByText(/500 SERVER ERROR/)).toBeVisible();
+    });
+
+    it('handles ApiError with json body with message', () => {
+        const error = new ApiError(
+            { method: 'GET', url: '/test' },
+            { url: '/test', status: 500, statusText: 'SERVER ERROR', ok: false, body: { message: 'I am details' } },
+            'Uh oh'
+        );
+
+        const { getByText } = render(<ApiErrorBanner action="doing" item="thing" error={error} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(getByText(/500 SERVER ERROR/)).toBeVisible();
+        expect(getByText('I am details')).toBeVisible();
+    });
+
+    it('handles ApiError with json body with no message', () => {
+        const error = new ApiError(
+            { method: 'GET', url: '/test' },
+            { url: '/test', status: 500, statusText: 'SERVER ERROR', ok: false, body: { notAMessage: 'I am details' } },
+            'Uh oh'
+        );
+
+        const { getByText } = render(<ApiErrorBanner action="doing" item="thing" error={error} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(getByText(/500 SERVER ERROR/)).toBeVisible();
+    });
+
+    it('handles other error', () => {
+        const error = new RangeError('Something broke');
+
+        const { getByText } = render(<ApiErrorBanner action="doing" item="thing" error={error} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(getByText(/RangeError Details:/)).toBeVisible();
+        expect(getByText('Something broke')).toBeVisible();
+    });
+
+    it('handles string', () => {
+        const error = 'Something broke';
+
+        const { getByText } = render(<ApiErrorBanner action="doing" item="thing" error={error} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(getByText(/Details:/)).toBeVisible();
+        expect(getByText('Something broke')).toBeVisible();
+    });
+
+    it('handles arbitrary object', () => {
+        const error = { key: 'uh oh' };
+
+        const { getByText } = render(<ApiErrorBanner action="doing" item="thing" error={error} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(getByText(/Details:/)).toBeVisible();
+        expect(getByText(/"key": "uh oh"/)).toBeVisible();
+    });
+});

--- a/apps/modernization-ui/src/design-system/errors/ApiError.tsx
+++ b/apps/modernization-ui/src/design-system/errors/ApiError.tsx
@@ -16,14 +16,18 @@ const ApiErrorBanner = ({
     error: unknown;
     className?: string;
 }) => {
+    // Log the error to the user's console as a backup method of getting any/all details if needed
+    // for debugging
     logErrorToUserConsole(error);
+
     return (
         <AlertMessage
             type="error"
             className={className}
             // eslint-disable-next-line max-len
             title={`There was an error ${action} this ${item}. If this error persists, contact your system administrator.`}
-            level={level}>
+            level={level}
+        >
             <p>{error instanceof Error && error.name} Details:</p>
             {error instanceof ApiError ? (
                 <>

--- a/apps/modernization-ui/src/design-system/errors/ApiError.tsx
+++ b/apps/modernization-ui/src/design-system/errors/ApiError.tsx
@@ -1,0 +1,50 @@
+import { HeadingLevel } from 'components/heading';
+import { AlertMessage } from 'design-system/message';
+import { ApiError } from 'generated';
+import { logErrorToUserConsole } from 'utils/logging';
+
+const ApiErrorBanner = ({
+    action,
+    item,
+    level = 2,
+    error,
+    className,
+}: {
+    action: string;
+    item: string;
+    level?: HeadingLevel;
+    error: unknown;
+    className?: string;
+}) => {
+    logErrorToUserConsole(error);
+    return (
+        <AlertMessage
+            type="error"
+            className={className}
+            // eslint-disable-next-line max-len
+            title={`There was an error ${action} this ${item}. If this error persists, contact your system administrator.`}
+            level={level}>
+            <p>{error instanceof Error && error.name} Details:</p>
+            {error instanceof ApiError ? (
+                <>
+                    <pre>
+                        {error.status} {error.statusText}
+                    </pre>
+                    {!!error.body.message && <pre>{error.body.message}</pre>}
+                </>
+            ) : error instanceof Error ? (
+                <>
+                    <pre>{error.message}</pre>
+                    <p>The stack trace is:</p>
+                    <pre>{error.stack}</pre>
+                </>
+            ) : typeof error === 'string' ? (
+                <pre>{error}</pre>
+            ) : (
+                <pre>{JSON.stringify(error, null, 2)}</pre>
+            )}
+        </AlertMessage>
+    );
+};
+
+export { ApiErrorBanner };


### PR DESCRIPTION
## Description

Add API error handling/cleanup across the reporting workflows. Make the `ApiErrorBanner` a common component so it can (eventually) be used across NBS 7)

unexpected exception
<img width="1361" height="946" alt="image" src="https://github.com/user-attachments/assets/998c54f7-ced7-41ba-a8ee-bb88ae7a5099" />

api error without message
<img width="1364" height="594" alt="image" src="https://github.com/user-attachments/assets/855f8edc-cdba-413c-8470-d78b9b071c41" />

api error with message
<img width="1359" height="552" alt="image" src="https://github.com/user-attachments/assets/f66e929b-0e67-4795-b105-d01d2a363d28" />

string thrown
<img width="1365" height="371" alt="image" src="https://github.com/user-attachments/assets/cf55736f-5704-4733-a0b0-28e2501448f5" />

something else thrown
<img width="1359" height="479" alt="image" src="https://github.com/user-attachments/assets/c477a03a-dbe8-44ac-91d5-be416a01efb9" />



## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-741

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
