### PR TITLE
[APP-609] PA01 Conversion, Fourth PR

### DIFF
--- a/apps/modernization-api/src/main/resources/db/changelog/report-execution-changelog.yml
+++ b/apps/modernization-api/src/main/resources/db/changelog/report-execution-changelog.yml
@@ -81,3 +81,9 @@ databaseChangeLog:
         - sqlFile:
             path: db/report/execution/libraries/pa_03.sql
             splitStatements: false
+        - sqlFile:
+            path: db/report/execution/libraries/pa_01_hiv.sql
+            splitStatements: false
+        - sqlFile:
+            path: db/report/execution/libraries/pa_01_std.sql
+            splitStatements: false

--- a/apps/modernization-api/src/main/resources/db/report/execution/libraries/pa_01_hiv.sql
+++ b/apps/modernization-api/src/main/resources/db/report/execution/libraries/pa_01_hiv.sql
@@ -1,0 +1,49 @@
+-- Migrate the PA01_HIV.sas library to the pa_01 python library
+
+USE [NBS_ODSE]
+
+DECLARE @pyLib VARCHAR(50) = 'pa_01'
+DECLARE @sasLib VARCHAR(50) = 'PA01_HIV.SAS'
+DECLARE @desc VARCHAR(300) = 'PA01: Case Management Report - HIV'
+DECLARE @libraryParams VARCHAR(300) = '{"report_variant": "HIV"}'
+
+IF EXISTS (SELECT * FROM [dbo].[Report_Library] WHERE UPPER(library_name) = @sasLib)
+BEGIN
+    UPDATE [dbo].[Report_Library]
+    SET
+        library_params = @libraryParams,
+        library_name = @pyLib,
+        runner = 'python',
+        desc_txt = @desc,
+        last_chg_time = CURRENT_TIMESTAMP,
+        last_chg_user_id = 99999999
+    WHERE
+        UPPER(library_name) = @sasLib;
+END
+ELSE IF NOT EXISTS (SELECT * FROM [dbo].[Report_Library] WHERE library_name = @pyLib)
+BEGIN
+    -- Create a row for this library
+    INSERT INTO [dbo].[Report_Library] (
+        library_name,
+        desc_txt,
+        runner,
+        column_select_ind,
+        is_builtin_ind,
+        library_params,
+        add_time,
+        add_user_id,
+        last_chg_time,
+        last_chg_user_id
+    ) VALUES (
+        @pyLib,
+        @desc,
+        'python',
+        'N',
+        'Y',
+        @libraryParams,
+        CURRENT_TIMESTAMP,
+        99999999,
+        CURRENT_TIMESTAMP,
+        99999999
+    );
+END

--- a/apps/modernization-api/src/main/resources/db/report/execution/libraries/pa_01_std.sql
+++ b/apps/modernization-api/src/main/resources/db/report/execution/libraries/pa_01_std.sql
@@ -1,0 +1,49 @@
+-- Migrate the PA01_STD.sas library to the pa_01 python library
+
+USE [NBS_ODSE]
+
+DECLARE @pyLib VARCHAR(50) = 'pa_01'
+DECLARE @sasLib VARCHAR(50) = 'PA01_STD.SAS'
+DECLARE @desc VARCHAR(300) = 'PA01: Case Management Report - STD'
+DECLARE @libraryParams VARCHAR(300) = '{"report_variant": "STD"}'
+
+IF EXISTS (SELECT * FROM [dbo].[Report_Library] WHERE UPPER(library_name) = @sasLib)
+BEGIN
+    UPDATE [dbo].[Report_Library]
+    SET
+        library_params = @libraryParams,
+        library_name = @pyLib,
+        runner = 'python',
+        desc_txt = @desc,
+        last_chg_time = CURRENT_TIMESTAMP,
+        last_chg_user_id = 99999999
+    WHERE
+        UPPER(library_name) = @sasLib;
+END
+ELSE IF NOT EXISTS (SELECT * FROM [dbo].[Report_Library] WHERE library_name = @pyLib)
+BEGIN
+    -- Create a row for this library
+    INSERT INTO [dbo].[Report_Library] (
+        library_name,
+        desc_txt,
+        runner,
+        column_select_ind,
+        is_builtin_ind,
+        library_params,
+        add_time,
+        add_user_id,
+        last_chg_time,
+        last_chg_user_id
+    ) VALUES (
+        @pyLib,
+        @desc,
+        'python',
+        'N',
+        'Y',
+        @libraryParams,
+        CURRENT_TIMESTAMP,
+        99999999,
+        CURRENT_TIMESTAMP,
+        99999999
+    );
+END

--- a/apps/report-execution/pyproject.toml
+++ b/apps/report-execution/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "pytest-mock>=3.15.1",
     "pytest-snapshot>=0.9.0",
     "pyyaml>=6.0.3",
+    "types-pyyaml>=6.0.12.20260518",
     "ruff>=0.15.0,<1.0.0",
     "tablefaker>=1.11.1",
     "testcontainers>=4.14.1",

--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -1,63 +1,22 @@
-from dataclasses import dataclass
-
 from src.db_transaction import Transaction
+from src.libraries.support.pa_01.calculations import build_output_for_worker
+from src.libraries.support.pa_01.models import (
+    CSV_COLUMNS,
+    Pa01Row,
+    Pa01Worker,
+)
+from src.libraries.support.pa_01.queries import (
+    case_interview_rows_query,
+    cases_with_no_clusters_query,
+    cases_with_no_partners_query,
+    clusters_initiated_query,
+    filtered_cases_query,
+    partner_notification_query,
+    period_partners_query,
+    testing_index_query,
+    timed_interviews_query,
+)
 from src.models import ReportResult, Table
-
-"""
-    Go backs:
-    - once all stats for ALL WORKERS are done, need to re-tool to calculate grouped
-      by workers
-"""
-
-# Constants
-ALL = 'ALL'
-CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
-CASES_IXD = "Cases IX'D"
-
-# CSV row data shape
-Pa01Row = tuple[
-    str,  # Worker
-    str,  # Category 1
-    str,  # Category 2
-    str | None,  # Category 3
-    int | None,  # Count
-    str | None,  # Percentage
-    str | None,  # Index
-]
-
-# CSV columns
-CSV_COLUMNS = [
-    'Worker',
-    'Category 1',
-    'Category 2',
-    'Category 3',
-    'Count',
-    'Percentage',
-    'Index',
-]
-
-# The date field differs in SAS for HIV vs. STD
-PA1_NEW_DATE_COL = {
-    'HIV': 'CA_INTERVIEWER_ASSIGN_DT',
-    'STD': 'CA_INIT_INTVWR_ASSGN_DT',
-}
-
-# The date field for "days" differs in SAS for HIV vs. STD
-PA1_DTE_DATE_COL = {
-    'HIV': 'CA_INIT_INTVWR_ASSGN_DT',
-    'STD': 'CA_INTERVIEWER_ASSIGN_DT',
-}
-
-
-@dataclass(frozen=True)
-class Pa01Tables:
-    """Query result Tables for the report."""
-
-    filtered_cases: Table
-    case_interview_rows: Table
-    timed_interviews: Table
-    partner_notification: Table
-    testing_index: Table
 
 
 def execute(
@@ -70,9 +29,22 @@ def execute(
     """PA01 HIV and STD: Case Management Report.
 
     Conversion notes:
+    * Report is too large for a single file, additional files found in
+      directory `./support/pa_01/`
     * This report is the combination of both `PA01_HIV.sas` and `PA01_STD.sas`
     * The variant (STD or HIV) is determined by `library_params['report_variant']`
       which is defined in the Report_Library db table.
+    * For the data point "HIV Tested", the SAS PDF output does not include
+      percentages for individual workers, only "ALL WORKERS".  This report
+      includes percentages for individual workers.
+    * There are some rounding peculiarities between SAS and Python, so for instance
+      a value of 0.075 rounded to 2 decimal places in Python will yield 0.07, but in
+      SAS it will be 0.08.  In such cases the Python value will be used as is.
+    * There is a bug in PA01_HIV.sas in which the "CASES /W NO CLUSTERS" shows up as
+      0 for "ALL WORKERS" even if there is data present.  This is because the SAS
+      template for this calculation for "ALL WORKERS" uses a slightly different string:
+      "CASES W/NO CLUSTERS" (note the difference in "/W" vs. "W/").  The Python library
+      will give the proper answer, so in that way it differs from the SAS source.
     """
     if not isinstance(library_params, dict):
         raise ValueError(
@@ -85,6 +57,10 @@ def execute(
         raise ValueError(
             f"Parameter 'library_params' missing key 'report_variant': {library_params}"
         )
+    elif report_variant not in ['HIV', 'STD']:
+        raise ValueError(
+            f'Report variant can only be "STD" or "HIV" and was: {report_variant}'
+        )
 
     # short circuit if there's no data from subset_query
     data_check = trx.query(subset_query)
@@ -96,597 +72,58 @@ def execute(
 
         return ReportResult(content_type='table', content=content)
 
-    # query result tables
-    filtered_cases = trx.query(_filtered_cases_query(subset_query))
-    case_interview_rows = trx.query(
-        _case_interview_rows_query(subset_query, report_variant)
+    # run queries
+    tables: dict[str, Table] = {}
+    tables['filtered_cases'] = trx.query(filtered_cases_query(subset_query))
+    tables['case_interview_rows'] = trx.query(
+        case_interview_rows_query(subset_query, report_variant)
     )
-    timed_interviews = trx.query(_timed_interviews_query(subset_query, report_variant))
-    partner_notification = trx.query(_partner_notification_query(subset_query))
-    testing_index = trx.query(_testing_index_query(subset_query))
-
-    pa01_tables = Pa01Tables(
-        filtered_cases,
-        case_interview_rows,
-        timed_interviews,
-        partner_notification,
-        testing_index,
+    tables['timed_interviews'] = trx.query(
+        timed_interviews_query(subset_query, report_variant)
+    )
+    tables['partner_notification'] = trx.query(partner_notification_query(subset_query))
+    tables['testing_index'] = trx.query(testing_index_query(subset_query))
+    tables['period_partners'] = trx.query(period_partners_query(subset_query))
+    tables['cases_with_no_partners'] = trx.query(
+        cases_with_no_partners_query(subset_query)
+    )
+    tables['clusters_initiated'] = trx.query(clusters_initiated_query(subset_query))
+    tables['cases_with_no_clusters'] = trx.query(
+        cases_with_no_clusters_query(subset_query)
     )
 
-    # output CSV data
-    rows = _build_output_for_worker(pa01_tables)
+    # get list of workers (nb. None treated as "ALL WORKERS")
+    workers: list[Pa01Worker | None] = [None]
+    workers.extend(_get_workers(tables['case_interview_rows']))
+
+    # build output CSV data for each worker
+    output_rows: list[Pa01Row] = []
+    for worker in workers:
+        output_rows.extend(build_output_for_worker(tables, worker))
 
     content = Table(
         columns=CSV_COLUMNS,
-        data=rows,
+        data=output_rows,
     )
 
     return ReportResult(content_type='table', content=content)
 
 
-def _filtered_cases_query(subset_query: str) -> str:
-    # equivalent of STD_HIV_DATAMART1 in SAS
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      )
-      SELECT b.*
-      FROM base b
-        INNER JOIN RDB.dbo.INVESTIGATION i
-                ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-               AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-               AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL;
+def _get_workers(case_interview_rows: Table) -> list[Pa01Worker]:
+    """Get all unique workers within the report's data.  A worker is defined as the
+    combination of 'investigator_interview_key' and 'provider_quick_code'.
     """
-
-
-def _case_interview_rows_query(subset_query: str, report_variant: str) -> str:
-    # equivalent of pa1_new in SAS
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      ),
-      filtered_cases AS
-      (
-        -- STD_HIV_DATAMART1 in SAS
-        SELECT b.*
-        FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
-                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
-      )
-      SELECT DISTINCT
-             fc.INV_LOCAL_ID,
-             di.IX_TYPE,
-             i.INV_CASE_STATUS,
-             i.RECORD_STATUS_CD,
-             fc.CC_CLOSED_DT,
-             fc.ADI_900_STATUS_CD,
-             fc.HIV_POST_TEST_900_COUNSELING,
-             fc.HIV_900_RESULT,
-             fc.ADI_900_STATUS,
-             fc.HIV_900_TEST_IND,
-             fc.SOURCE_SPREAD,
-             fc.FL_FUP_INIT_ASSGN_DT,
-             i.CURR_PROCESS_STATE,
-             fc.CA_PATIENT_INTV_STATUS,
-             fc.INVESTIGATOR_INTERVIEW_KEY,
-             fc.INVESTIGATOR_INTERVIEW_QC,
-             DATEDIFF(
-               DAY,
-               CAST(fc.{PA1_NEW_DATE_COL[report_variant]} AS DATE),
-               CAST(di.IX_DATE AS DATE)
-             ) AS Days,
-             dp.PROVIDER_QUICK_CODE
-      FROM filtered_cases fc
-        LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
-               ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-        LEFT JOIN RDB.dbo.D_INTERVIEW di
-               ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
-              AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-        LEFT JOIN RDB.dbo.D_PROVIDER dp
-               ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
-        LEFT JOIN RDB.dbo.INVESTIGATION i
-               ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY;
-    """
-
-
-def _timed_interviews_query(subset_query: str, report_variant: str) -> str:
-    # equivalent of pa1_dte in SAS
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      ),
-      filtered_base AS
-      (
-        -- STD_HIV_DATAMART1 in PA01_HIV.sas
-        SELECT b.*
-        FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
-                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
-      )
-      SELECT DISTINCT fb.INV_LOCAL_ID,
-             di.IX_TYPE,
-             i.INV_CASE_STATUS,
-             i.RECORD_STATUS_CD,
-             fb.CC_CLOSED_DT,
-             fb.ADI_900_STATUS_CD,
-             fb.HIV_POST_TEST_900_COUNSELING,
-             fb.HIV_900_RESULT,
-             fb.ADI_900_STATUS,
-             fb.HIV_900_TEST_IND,
-             fb.SOURCE_SPREAD,
-             fb.FL_FUP_INIT_ASSGN_DT,
-             i.CURR_PROCESS_STATE,
-             fb.CA_PATIENT_INTV_STATUS,
-             fb.INVESTIGATOR_INTERVIEW_KEY,
-             fb.INVESTIGATOR_INTERVIEW_QC,
-             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS Days,
-             dp.PROVIDER_QUICK_CODE
-      FROM filtered_base fb
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
-                ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW di
-                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
-               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_PROVIDER dp
-                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.INVESTIGATION i
-                ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-      WHERE CAST(di.IX_DATE AS DATE) >=
-                CAST(fb.CA_INIT_INTVWR_ASSGN_DT AS DATE);
-    """
-
-
-def _partner_notification_query(subset_query: str) -> str:
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      ),
-      filtered_base AS
-      (
-        SELECT b.*
-        FROM base b
-          JOIN RDB.dbo.INVESTIGATION i
-            ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-           AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-           AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
-      )
-      SELECT COUNT(DISTINCT fb.INV_LOCAL_ID) AS partner_notification_count
-      FROM filtered_base fb
-             JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
-               ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-             JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
-               ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
-             JOIN RDB.dbo.D_CONTACT_RECORD dcr
-               ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
-              AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
-        LEFT JOIN RDB.dbo.D_PROVIDER dp
-               ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
-      WHERE dcr.CTT_REFERRAL_BASIS IN (
-        'P1 - Partner, Sex',
-        'P2 - Partner, Needle-Sharing',
-        'P3 - Partner, Both'
-      )
-      AND contact_dm.FL_FUP_DISPOSITION IN (
-        '2 - Prev. Neg, New Pos',
-        '3 - Prev. Neg, Still Neg',
-        '5 - No Prev Test, New Pos',
-        '6 - No Prev Test, New Neg'
-      );
-    """
-
-
-def _testing_index_query(subset_query: str) -> str:
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      ),
-      filtered_base AS
-      (
-        -- STD_HIV_DATAMART1 in PA01_HIV.sas
-        SELECT b.*
-        FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
-                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
-      )
-      SELECT COUNT(DISTINCT dcr.LOCAL_ID) AS testing_index_count
-      FROM filtered_base fb
-        INNER JOIN RDB.dbo.INVESTIGATION i 
-                ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
-                ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
-                ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
-                ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
-               AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
-         LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
-                ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-         LEFT JOIN RDB.dbo.D_INTERVIEW di
-                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
-               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-         LEFT JOIN RDB.dbo.D_PROVIDER dp
-                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
-      WHERE dcr.CTT_REFERRAL_BASIS IN (
-         'P1 - Partner, Sex',
-         'P2 - Partner, Needle-Sharing',
-         'P3 - Partner, Both'
-      )
-      AND contact_dm.FL_FUP_DISPOSITION IN (
-         '2 - Prev. Neg, New Pos',
-         '3 - Prev. Neg, Still Neg',
-         '5 - No Prev Test, New Pos',
-         '6 - No Prev Test, New Neg'
-      );
-    """
-
-
-def _build_output_for_worker(tables: Pa01Tables, worker=None) -> list[Pa01Row]:
-    """Perform all needed calculations for a given worker, output data for
-    the final CSV.
-
-    Args:
-        tables: Query results within a Pa01Tables instance
-        worker: The worker the data is being calculated for (None means "ALL")
-
-    Returns:
-        List of calculated data for a given worker, meant for the final CSV of PA01
-    """
-    # "Case Assignments & Outcomes" section
-    cases_assigned = _calc_cases_assigned(tables.filtered_cases)
-    cases_closed, cases_closed_percent = _calc_cases_closed(
-        tables.filtered_cases, cases_assigned
-    )
-    cases_ixd, cases_ixd_percent = _calc_cases_ixd(
-        tables.filtered_cases, cases_assigned
-    )
-    cases_ixd_buckets = _calc_interview_day_buckets(tables.timed_interviews, cases_ixd)
-    cases_reinterviewed, cases_reinterviewed_percent = _calc_cases_reinterviewed(
-        tables.case_interview_rows, cases_ixd
-    )
-    hiv_previous_positive, hiv_previous_positive_percent = _calc_hiv_previous_positive(
-        tables.filtered_cases, cases_assigned
-    )
-    hiv_tested, hiv_tested_percent = _calc_hiv_tested(
-        tables.case_interview_rows, cases_assigned
-    )
-    hiv_new_positive, hiv_new_positive_percent = _calc_hiv_new_positive(
-        tables.case_interview_rows, hiv_tested
-    )
-    hiv_posttest_counsel, hiv_posttest_counsel_percent = _calc_hiv_posttest_counsel(
-        tables.case_interview_rows, hiv_tested
-    )
-    partner_notification_index = _calc_partner_notification_index(
-        tables.partner_notification, cases_ixd
-    )
-    testing_index = _calc_testing_index(tables.testing_index, cases_ixd)
-
-    # output CSV data
-    rows: list[Pa01Row] = [
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'Cases Assigned',
-            None,
-            cases_assigned,
-            None,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'Cases Closed',
-            None,
-            cases_closed,
-            cases_closed_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            CASES_IXD,
-            None,
-            cases_ixd,
-            cases_ixd_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            CASES_IXD,
-            'Within 3 days',
-            cases_ixd_buckets[3][0],
-            cases_ixd_buckets[3][1],
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            CASES_IXD,
-            'Within 5 days',
-            cases_ixd_buckets[5][0],
-            cases_ixd_buckets[5][1],
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            CASES_IXD,
-            'Within 7 days',
-            cases_ixd_buckets[7][0],
-            cases_ixd_buckets[7][1],
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            CASES_IXD,
-            'Within 14 days',
-            cases_ixd_buckets[14][0],
-            cases_ixd_buckets[14][1],
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'Cases Reinterviewed',
-            None,
-            cases_reinterviewed,
-            cases_reinterviewed_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'HIV Previous Positive',
-            None,
-            hiv_previous_positive,
-            hiv_previous_positive_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'HIV Tested',
-            None,
-            hiv_tested,
-            hiv_tested_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'HIV New Positive',
-            None,
-            hiv_new_positive,
-            hiv_new_positive_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'HIV Posttest Counsel',
-            None,
-            hiv_posttest_counsel,
-            hiv_posttest_counsel_percent,
-            None,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'Partner Notification Index',
-            None,
-            None,
-            None,
-            partner_notification_index,
-        ),
-        (
-            ALL,
-            CASE_ASSIGNMENTS_AND_OUTCOMES,
-            'Testing Index',
-            None,
-            None,
-            None,
-            testing_index,
-        ),
-    ]
-
-    return rows
-
-
-def _calc_cases_assigned(table: Table) -> int:
-    """Calculate 'Cases Assigned' count."""
-    return len(table.get_unique_column('INV_LOCAL_ID'))
-
-
-def _calc_cases_closed(table: Table, cases_assigned: int) -> tuple[int, str]:
-    """Calculate 'Cases Closed' count and percentage."""
-    data = {
-        d['INV_LOCAL_ID']
-        for d in table.data_as_dicts()
-        if d['CA_INTERVIEWER_ASSIGN_DT'] is not None and d['CC_CLOSED_DT'] is not None
+    workers = {
+        Pa01Worker(
+            row['INVESTIGATOR_INTERVIEW_KEY'],
+            row['PROVIDER_QUICK_CODE'],
+        )
+        for row in case_interview_rows.data_as_dicts()
+        if row['INVESTIGATOR_INTERVIEW_KEY'] is not None
+        and row['PROVIDER_QUICK_CODE'] is not None
     }
 
-    cases_closed = len(data)
-
-    return cases_closed, _percent_for_csv(cases_closed, cases_assigned)
-
-
-def _calc_cases_ixd(table: Table, cases_assigned: int) -> tuple[int, str]:
-    """Calculate "Cases IX'D" count and percentage."""
-    data = table.data_as_dicts()
-    case_ids = {
-        d['INV_LOCAL_ID']
-        for d in data
-        if d['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
-    }
-
-    count = len(case_ids)
-
-    return count, _percent_for_csv(count, cases_assigned)
-
-
-def _calc_interview_day_buckets(
-    table: Table, cases_ixd: int
-) -> dict[int, tuple[int, str]]:
-    """Calculate "Cases IX'D" count and percentage for within 3, 5, 7, and 14 days."""
-    rows = [
-        d
-        for d in table.data_as_dicts()
-        if d['IX_TYPE'] == 'Initial/Original'
-        and d['Days'] is not None
-        and d['Days'] <= 14
-    ]
-
-    results = dict()
-    for threshold in (3, 5, 7, 14):
-        count = sum(1 for d in rows if d['Days'] <= threshold)
-        results[threshold] = (count, _percent_for_csv(count, cases_ixd))
-
-    return results
-
-
-def _calc_cases_reinterviewed(
-    case_interview_rows: Table, cases_ixd: int
-) -> tuple[int, str]:
-    """Calculate 'Cases Reinterviewed' count and percentage."""
-    case_ids = {
-        d['INV_LOCAL_ID']
-        for d in case_interview_rows.data_as_dicts()
-        if d['IX_TYPE'] == 'Re-Interview'
-        and d['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
-    }
-
-    count = len(case_ids)
-
-    return count, _percent_for_csv(count, cases_ixd)
-
-
-def _calc_hiv_previous_positive(
-    filtered_cases: Table, cases_assigned: int
-) -> tuple[int, str]:
-    """Calculate 'HIV Previous Positive' count and percentage."""
-    case_ids = {
-        d['INV_LOCAL_ID']
-        for d in filtered_cases.data_as_dicts()
-        if d['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
-        and d['ADI_900_STATUS_CD'] in ('03', '04', '05')
-    }
-
-    count = len(case_ids)
-
-    return count, _percent_for_csv(count, cases_assigned)
-
-
-def _calc_hiv_tested(
-    case_interview_rows: Table, cases_assigned: int
-) -> tuple[int, str]:
-    """Calculate 'HIV Tested' count and percentage."""
-    groups: dict[tuple, set] = {}
-
-    # mirrors creation of "hiv_tested" table in SAS
-    for row in case_interview_rows.data_as_dicts():
-        if (
-            row['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
-            and row['HIV_900_TEST_IND'] == 'Yes'
-        ):
-            worker_key = (
-                row['INVESTIGATOR_INTERVIEW_KEY'],
-                row['PROVIDER_QUICK_CODE'],
-            )
-
-            groups.setdefault(worker_key, set()).add(row['INV_LOCAL_ID'])
-
-    # this will need to be updated for worker specific calculations
-    count = sum(len(case_ids) for case_ids in groups.values())
-
-    return count, _percent_for_csv(count, cases_assigned)
-
-
-def _calc_hiv_new_positive(filtered_cases: Table, hiv_tested: int) -> tuple[int, str]:
-    """Calculate 'HIV New Positive' count and percentage."""
-    positive_results = {
-        '13-Positive/Reactive',
-        '21-HIV-1 Pos',
-        '22-HIV-1 Pos, Possible Acute',
-        '23-HIV-2 Pos',
-        '24-HIV-Undifferentiated',
-        '12-Prelim Positive',
-    }
-
-    case_ids = {
-        d['INV_LOCAL_ID']
-        for d in filtered_cases.data_as_dicts()
-        if d['HIV_900_RESULT'] in positive_results
-    }
-
-    count = len(case_ids)
-
-    return count, _percent_for_csv(count, hiv_tested)
-
-
-def _calc_hiv_posttest_counsel(
-    case_interview_rows: Table, hiv_tested: int
-) -> tuple[int, str]:
-    """Calculate 'HIV Posttest Counsel' count and percentage."""
-    groups: dict[tuple, set] = {}
-
-    # mirrors creation of "hiv_post_test" table in SAS
-    for row in case_interview_rows.data_as_dicts():
-        if (
-            row['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
-            and row['HIV_POST_TEST_900_COUNSELING'] == 'Yes'
-        ):
-            worker_key = (
-                row['PROVIDER_QUICK_CODE'],
-                row['INVESTIGATOR_INTERVIEW_KEY'],
-            )
-
-            groups.setdefault(worker_key, set()).add(row['INV_LOCAL_ID'])
-
-    # this will need to be updated for worker specific calculations
-    count = sum(len(case_ids) for case_ids in groups.values())
-
-    return count, _percent_for_csv(count, hiv_tested)
-
-
-def _calc_partner_notification_index(
-    partner_notification: Table, cases_ixd: int
-) -> str:
-    """Calculate 'Partner Notification Index'."""
-    if len(partner_notification.data) != 1 or len(partner_notification.data[0]) != 1:
-        raise ValueError('Query data for "Partner Notification Index" is malformed')
-
-    partner_notification_count = partner_notification.data[0][0]
-
-    return _index_for_csv(partner_notification_count, cases_ixd)
-
-
-def _calc_testing_index(testing_index: Table, cases_ixd: int) -> str:
-    """Calculate 'Testing Index'."""
-    if len(testing_index.data) != 1 or len(testing_index.data[0]) != 1:
-        raise ValueError('Query data for "Testing Index" is malformed')
-
-    testing_index_count = testing_index.data[0][0]
-
-    return _index_for_csv(testing_index_count, cases_ixd)
-
-
-def _percent_for_csv(numerator: int, denominator: int) -> str:
-    """Format a percent that matches the PDF format for output in the CSV."""
-    return f'{round((numerator / denominator) * 100, 1) if denominator else 0}%'
-
-
-def _index_for_csv(numerator: int, denominator: int) -> str:
-    """Format an index that matches the PDF format for output in the CSV."""
-    return f'{round(numerator / denominator, 2) if denominator else 0:0.2f}'
+    # nb. sorting should mimic the ordering of workers found in the PDF output
+    return sorted(
+        workers, key=lambda w: (w.provider_quick_code, w.investigator_interview_key)
+    )

--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -1,0 +1,692 @@
+from dataclasses import dataclass
+
+from src.db_transaction import Transaction
+from src.models import ReportResult, Table
+
+"""
+    Go backs:
+    - once all stats for ALL WORKERS are done, need to re-tool to calculate grouped
+      by workers
+"""
+
+# Constants
+ALL = 'ALL'
+CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
+CASES_IXD = "Cases IX'D"
+
+# CSV row data shape
+Pa01Row = tuple[
+    str,  # Worker
+    str,  # Category 1
+    str,  # Category 2
+    str | None,  # Category 3
+    int | None,  # Count
+    str | None,  # Percentage
+    str | None,  # Index
+]
+
+# CSV columns
+CSV_COLUMNS = [
+    'Worker',
+    'Category 1',
+    'Category 2',
+    'Category 3',
+    'Count',
+    'Percentage',
+    'Index',
+]
+
+# The date field differs in SAS for HIV vs. STD
+PA1_NEW_DATE_COL = {
+    'HIV': 'CA_INTERVIEWER_ASSIGN_DT',
+    'STD': 'CA_INIT_INTVWR_ASSGN_DT',
+}
+
+# The date field for "days" differs in SAS for HIV vs. STD
+PA1_DTE_DATE_COL = {
+    'HIV': 'CA_INIT_INTVWR_ASSGN_DT',
+    'STD': 'CA_INTERVIEWER_ASSIGN_DT',
+}
+
+
+@dataclass(frozen=True)
+class Pa01Tables:
+    """Query result Tables for the report."""
+
+    filtered_cases: Table
+    case_interview_rows: Table
+    timed_interviews: Table
+    partner_notification: Table
+    testing_index: Table
+
+
+def execute(
+    trx: Transaction,
+    subset_query: str,
+    data_source_name: str,
+    library_params: dict,
+    **kwargs,
+):
+    """PA01 HIV and STD: Case Management Report.
+
+    Conversion notes:
+    * This report is the combination of both `PA01_HIV.sas` and `PA01_STD.sas`
+    * The variant (STD or HIV) is determined by `library_params['report_variant']`
+      which is defined in the Report_Library db table.
+    """
+    if not isinstance(library_params, dict):
+        raise ValueError(
+            f"Parameter 'library_params' is not a dict (is {type(library_params)})"
+        )
+
+    report_variant = library_params.get('report_variant')
+
+    if report_variant is None:
+        raise ValueError(
+            f"Parameter 'library_params' missing key 'report_variant': {library_params}"
+        )
+
+    # short circuit if there's no data from subset_query
+    data_check = trx.query(subset_query)
+    if len(data_check.data) == 0:
+        content = Table(
+            columns=CSV_COLUMNS,
+            data=[],
+        )
+
+        return ReportResult(content_type='table', content=content)
+
+    # query result tables
+    filtered_cases = trx.query(_filtered_cases_query(subset_query))
+    case_interview_rows = trx.query(
+        _case_interview_rows_query(subset_query, report_variant)
+    )
+    timed_interviews = trx.query(_timed_interviews_query(subset_query, report_variant))
+    partner_notification = trx.query(_partner_notification_query(subset_query))
+    testing_index = trx.query(_testing_index_query(subset_query))
+
+    pa01_tables = Pa01Tables(
+        filtered_cases,
+        case_interview_rows,
+        timed_interviews,
+        partner_notification,
+        testing_index,
+    )
+
+    # output CSV data
+    rows = _build_output_for_worker(pa01_tables)
+
+    content = Table(
+        columns=CSV_COLUMNS,
+        data=rows,
+    )
+
+    return ReportResult(content_type='table', content=content)
+
+
+def _filtered_cases_query(subset_query: str) -> str:
+    # equivalent of STD_HIV_DATAMART1 in SAS
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      )
+      SELECT b.*
+      FROM base b
+        INNER JOIN RDB.dbo.INVESTIGATION i
+                ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+               AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+               AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL;
+    """
+
+
+def _case_interview_rows_query(subset_query: str, report_variant: str) -> str:
+    # equivalent of pa1_new in SAS
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT
+             fc.INV_LOCAL_ID,
+             di.IX_TYPE,
+             i.INV_CASE_STATUS,
+             i.RECORD_STATUS_CD,
+             fc.CC_CLOSED_DT,
+             fc.ADI_900_STATUS_CD,
+             fc.HIV_POST_TEST_900_COUNSELING,
+             fc.HIV_900_RESULT,
+             fc.ADI_900_STATUS,
+             fc.HIV_900_TEST_IND,
+             fc.SOURCE_SPREAD,
+             fc.FL_FUP_INIT_ASSGN_DT,
+             i.CURR_PROCESS_STATE,
+             fc.CA_PATIENT_INTV_STATUS,
+             fc.INVESTIGATOR_INTERVIEW_KEY,
+             fc.INVESTIGATOR_INTERVIEW_QC,
+             DATEDIFF(
+               DAY,
+               CAST(fc.{PA1_NEW_DATE_COL[report_variant]} AS DATE),
+               CAST(di.IX_DATE AS DATE)
+             ) AS Days,
+             dp.PROVIDER_QUICK_CODE
+      FROM filtered_cases fc
+        LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
+               ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+        LEFT JOIN RDB.dbo.D_INTERVIEW di
+               ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+              AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+        LEFT JOIN RDB.dbo.D_PROVIDER dp
+               ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
+        LEFT JOIN RDB.dbo.INVESTIGATION i
+               ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY;
+    """
+
+
+def _timed_interviews_query(subset_query: str, report_variant: str) -> str:
+    # equivalent of pa1_dte in SAS
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_base AS
+      (
+        -- STD_HIV_DATAMART1 in PA01_HIV.sas
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT fb.INV_LOCAL_ID,
+             di.IX_TYPE,
+             i.INV_CASE_STATUS,
+             i.RECORD_STATUS_CD,
+             fb.CC_CLOSED_DT,
+             fb.ADI_900_STATUS_CD,
+             fb.HIV_POST_TEST_900_COUNSELING,
+             fb.HIV_900_RESULT,
+             fb.ADI_900_STATUS,
+             fb.HIV_900_TEST_IND,
+             fb.SOURCE_SPREAD,
+             fb.FL_FUP_INIT_ASSGN_DT,
+             i.CURR_PROCESS_STATE,
+             fb.CA_PATIENT_INTV_STATUS,
+             fb.INVESTIGATOR_INTERVIEW_KEY,
+             fb.INVESTIGATOR_INTERVIEW_QC,
+             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS Days,
+             dp.PROVIDER_QUICK_CODE
+      FROM filtered_base fb
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+                ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW di
+                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_PROVIDER dp
+                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.INVESTIGATION i
+                ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+      WHERE CAST(di.IX_DATE AS DATE) >=
+                CAST(fb.CA_INIT_INTVWR_ASSGN_DT AS DATE);
+    """
+
+
+def _partner_notification_query(subset_query: str) -> str:
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_base AS
+      (
+        SELECT b.*
+        FROM base b
+          JOIN RDB.dbo.INVESTIGATION i
+            ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+           AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+           AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT COUNT(DISTINCT fb.INV_LOCAL_ID) AS partner_notification_count
+      FROM filtered_base fb
+             JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+               ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+             JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+               ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
+             JOIN RDB.dbo.D_CONTACT_RECORD dcr
+               ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+              AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+        LEFT JOIN RDB.dbo.D_PROVIDER dp
+               ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
+      WHERE dcr.CTT_REFERRAL_BASIS IN (
+        'P1 - Partner, Sex',
+        'P2 - Partner, Needle-Sharing',
+        'P3 - Partner, Both'
+      )
+      AND contact_dm.FL_FUP_DISPOSITION IN (
+        '2 - Prev. Neg, New Pos',
+        '3 - Prev. Neg, Still Neg',
+        '5 - No Prev Test, New Pos',
+        '6 - No Prev Test, New Neg'
+      );
+    """
+
+
+def _testing_index_query(subset_query: str) -> str:
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_base AS
+      (
+        -- STD_HIV_DATAMART1 in PA01_HIV.sas
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT COUNT(DISTINCT dcr.LOCAL_ID) AS testing_index_count
+      FROM filtered_base fb
+        INNER JOIN RDB.dbo.INVESTIGATION i 
+                ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+                ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+                ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+                ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+               AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+         LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
+                ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+         LEFT JOIN RDB.dbo.D_INTERVIEW di
+                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+         LEFT JOIN RDB.dbo.D_PROVIDER dp
+                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
+      WHERE dcr.CTT_REFERRAL_BASIS IN (
+         'P1 - Partner, Sex',
+         'P2 - Partner, Needle-Sharing',
+         'P3 - Partner, Both'
+      )
+      AND contact_dm.FL_FUP_DISPOSITION IN (
+         '2 - Prev. Neg, New Pos',
+         '3 - Prev. Neg, Still Neg',
+         '5 - No Prev Test, New Pos',
+         '6 - No Prev Test, New Neg'
+      );
+    """
+
+
+def _build_output_for_worker(tables: Pa01Tables, worker=None) -> list[Pa01Row]:
+    """Perform all needed calculations for a given worker, output data for
+    the final CSV.
+
+    Args:
+        tables: Query results within a Pa01Tables instance
+        worker: The worker the data is being calculated for (None means "ALL")
+
+    Returns:
+        List of calculated data for a given worker, meant for the final CSV of PA01
+    """
+    # "Case Assignments & Outcomes" section
+    cases_assigned = _calc_cases_assigned(tables.filtered_cases)
+    cases_closed, cases_closed_percent = _calc_cases_closed(
+        tables.filtered_cases, cases_assigned
+    )
+    cases_ixd, cases_ixd_percent = _calc_cases_ixd(
+        tables.filtered_cases, cases_assigned
+    )
+    cases_ixd_buckets = _calc_interview_day_buckets(tables.timed_interviews, cases_ixd)
+    cases_reinterviewed, cases_reinterviewed_percent = _calc_cases_reinterviewed(
+        tables.case_interview_rows, cases_ixd
+    )
+    hiv_previous_positive, hiv_previous_positive_percent = _calc_hiv_previous_positive(
+        tables.filtered_cases, cases_assigned
+    )
+    hiv_tested, hiv_tested_percent = _calc_hiv_tested(
+        tables.case_interview_rows, cases_assigned
+    )
+    hiv_new_positive, hiv_new_positive_percent = _calc_hiv_new_positive(
+        tables.case_interview_rows, hiv_tested
+    )
+    hiv_posttest_counsel, hiv_posttest_counsel_percent = _calc_hiv_posttest_counsel(
+        tables.case_interview_rows, hiv_tested
+    )
+    partner_notification_index = _calc_partner_notification_index(
+        tables.partner_notification, cases_ixd
+    )
+    testing_index = _calc_testing_index(tables.testing_index, cases_ixd)
+
+    # output CSV data
+    rows: list[Pa01Row] = [
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Cases Assigned',
+            None,
+            cases_assigned,
+            None,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Cases Closed',
+            None,
+            cases_closed,
+            cases_closed_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            None,
+            cases_ixd,
+            cases_ixd_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 3 days',
+            cases_ixd_buckets[3][0],
+            cases_ixd_buckets[3][1],
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 5 days',
+            cases_ixd_buckets[5][0],
+            cases_ixd_buckets[5][1],
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 7 days',
+            cases_ixd_buckets[7][0],
+            cases_ixd_buckets[7][1],
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 14 days',
+            cases_ixd_buckets[14][0],
+            cases_ixd_buckets[14][1],
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Cases Reinterviewed',
+            None,
+            cases_reinterviewed,
+            cases_reinterviewed_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV Previous Positive',
+            None,
+            hiv_previous_positive,
+            hiv_previous_positive_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV Tested',
+            None,
+            hiv_tested,
+            hiv_tested_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV New Positive',
+            None,
+            hiv_new_positive,
+            hiv_new_positive_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV Posttest Counsel',
+            None,
+            hiv_posttest_counsel,
+            hiv_posttest_counsel_percent,
+            None,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Partner Notification Index',
+            None,
+            None,
+            None,
+            partner_notification_index,
+        ),
+        (
+            ALL,
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Testing Index',
+            None,
+            None,
+            None,
+            testing_index,
+        ),
+    ]
+
+    return rows
+
+
+def _calc_cases_assigned(table: Table) -> int:
+    """Calculate 'Cases Assigned' count."""
+    return len(table.get_unique_column('INV_LOCAL_ID'))
+
+
+def _calc_cases_closed(table: Table, cases_assigned: int) -> tuple[int, str]:
+    """Calculate 'Cases Closed' count and percentage."""
+    data = {
+        d['INV_LOCAL_ID']
+        for d in table.data_as_dicts()
+        if d['CA_INTERVIEWER_ASSIGN_DT'] is not None and d['CC_CLOSED_DT'] is not None
+    }
+
+    cases_closed = len(data)
+
+    return cases_closed, _percent_for_csv(cases_closed, cases_assigned)
+
+
+def _calc_cases_ixd(table: Table, cases_assigned: int) -> tuple[int, str]:
+    """Calculate "Cases IX'D" count and percentage."""
+    data = table.data_as_dicts()
+    case_ids = {
+        d['INV_LOCAL_ID']
+        for d in data
+        if d['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
+    }
+
+    count = len(case_ids)
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_interview_day_buckets(
+    table: Table, cases_ixd: int
+) -> dict[int, tuple[int, str]]:
+    """Calculate "Cases IX'D" count and percentage for within 3, 5, 7, and 14 days."""
+    rows = [
+        d
+        for d in table.data_as_dicts()
+        if d['IX_TYPE'] == 'Initial/Original'
+        and d['Days'] is not None
+        and d['Days'] <= 14
+    ]
+
+    results = dict()
+    for threshold in (3, 5, 7, 14):
+        count = sum(1 for d in rows if d['Days'] <= threshold)
+        results[threshold] = (count, _percent_for_csv(count, cases_ixd))
+
+    return results
+
+
+def _calc_cases_reinterviewed(
+    case_interview_rows: Table, cases_ixd: int
+) -> tuple[int, str]:
+    """Calculate 'Cases Reinterviewed' count and percentage."""
+    case_ids = {
+        d['INV_LOCAL_ID']
+        for d in case_interview_rows.data_as_dicts()
+        if d['IX_TYPE'] == 'Re-Interview'
+        and d['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
+    }
+
+    count = len(case_ids)
+
+    return count, _percent_for_csv(count, cases_ixd)
+
+
+def _calc_hiv_previous_positive(
+    filtered_cases: Table, cases_assigned: int
+) -> tuple[int, str]:
+    """Calculate 'HIV Previous Positive' count and percentage."""
+    case_ids = {
+        d['INV_LOCAL_ID']
+        for d in filtered_cases.data_as_dicts()
+        if d['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
+        and d['ADI_900_STATUS_CD'] in ('03', '04', '05')
+    }
+
+    count = len(case_ids)
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_hiv_tested(
+    case_interview_rows: Table, cases_assigned: int
+) -> tuple[int, str]:
+    """Calculate 'HIV Tested' count and percentage."""
+    groups: dict[tuple, set] = {}
+
+    # mirrors creation of "hiv_tested" table in SAS
+    for row in case_interview_rows.data_as_dicts():
+        if (
+            row['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
+            and row['HIV_900_TEST_IND'] == 'Yes'
+        ):
+            worker_key = (
+                row['INVESTIGATOR_INTERVIEW_KEY'],
+                row['PROVIDER_QUICK_CODE'],
+            )
+
+            groups.setdefault(worker_key, set()).add(row['INV_LOCAL_ID'])
+
+    # this will need to be updated for worker specific calculations
+    count = sum(len(case_ids) for case_ids in groups.values())
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_hiv_new_positive(filtered_cases: Table, hiv_tested: int) -> tuple[int, str]:
+    """Calculate 'HIV New Positive' count and percentage."""
+    positive_results = {
+        '13-Positive/Reactive',
+        '21-HIV-1 Pos',
+        '22-HIV-1 Pos, Possible Acute',
+        '23-HIV-2 Pos',
+        '24-HIV-Undifferentiated',
+        '12-Prelim Positive',
+    }
+
+    case_ids = {
+        d['INV_LOCAL_ID']
+        for d in filtered_cases.data_as_dicts()
+        if d['HIV_900_RESULT'] in positive_results
+    }
+
+    count = len(case_ids)
+
+    return count, _percent_for_csv(count, hiv_tested)
+
+
+def _calc_hiv_posttest_counsel(
+    case_interview_rows: Table, hiv_tested: int
+) -> tuple[int, str]:
+    """Calculate 'HIV Posttest Counsel' count and percentage."""
+    groups: dict[tuple, set] = {}
+
+    # mirrors creation of "hiv_post_test" table in SAS
+    for row in case_interview_rows.data_as_dicts():
+        if (
+            row['CA_PATIENT_INTV_STATUS'] == 'I - Interviewed'
+            and row['HIV_POST_TEST_900_COUNSELING'] == 'Yes'
+        ):
+            worker_key = (
+                row['PROVIDER_QUICK_CODE'],
+                row['INVESTIGATOR_INTERVIEW_KEY'],
+            )
+
+            groups.setdefault(worker_key, set()).add(row['INV_LOCAL_ID'])
+
+    # this will need to be updated for worker specific calculations
+    count = sum(len(case_ids) for case_ids in groups.values())
+
+    return count, _percent_for_csv(count, hiv_tested)
+
+
+def _calc_partner_notification_index(
+    partner_notification: Table, cases_ixd: int
+) -> str:
+    """Calculate 'Partner Notification Index'."""
+    if len(partner_notification.data) != 1 or len(partner_notification.data[0]) != 1:
+        raise ValueError('Query data for "Partner Notification Index" is malformed')
+
+    partner_notification_count = partner_notification.data[0][0]
+
+    return _index_for_csv(partner_notification_count, cases_ixd)
+
+
+def _calc_testing_index(testing_index: Table, cases_ixd: int) -> str:
+    """Calculate 'Testing Index'."""
+    if len(testing_index.data) != 1 or len(testing_index.data[0]) != 1:
+        raise ValueError('Query data for "Testing Index" is malformed')
+
+    testing_index_count = testing_index.data[0][0]
+
+    return _index_for_csv(testing_index_count, cases_ixd)
+
+
+def _percent_for_csv(numerator: int, denominator: int) -> str:
+    """Format a percent that matches the PDF format for output in the CSV."""
+    return f'{round((numerator / denominator) * 100, 1) if denominator else 0}%'
+
+
+def _index_for_csv(numerator: int, denominator: int) -> str:
+    """Format an index that matches the PDF format for output in the CSV."""
+    return f'{round(numerator / denominator, 2) if denominator else 0:0.2f}'

--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -9,8 +9,14 @@ from src.libraries.support.pa_01.queries import (
     case_interview_rows_query,
     cases_with_no_clusters_query,
     cases_with_no_partners_query,
+    cluster_previous_pos_query,
     clusters_initiated_query,
     filtered_cases_query,
+    not_notified_clusters_query,
+    not_notified_partners_query,
+    notified_clusters_query,
+    notified_partners_query,
+    partner_case_dispositions_query,
     partner_notification_query,
     period_partners_query,
     testing_index_query,
@@ -34,17 +40,36 @@ def execute(
     * This report is the combination of both `PA01_HIV.sas` and `PA01_STD.sas`
     * The variant (STD or HIV) is determined by `library_params['report_variant']`
       which is defined in the Report_Library db table.
-    * For the data point "HIV Tested", the SAS PDF output does not include
-      percentages for individual workers, only "ALL WORKERS".  This report
-      includes percentages for individual workers.
     * There are some rounding peculiarities between SAS and Python, so for instance
       a value of 0.075 rounded to 2 decimal places in Python will yield 0.07, but in
       SAS it will be 0.08.  In such cases the Python value will be used as is.
+    * There is a quirk in PA01_HIV.sas in which the data point "HIV Tested" output does
+      not include percentages for individual workers, only "ALL WORKERS".  This report
+      includes percentages for individual workers.
     * There is a bug in PA01_HIV.sas in which the "CASES /W NO CLUSTERS" shows up as
       0 for "ALL WORKERS" even if there is data present.  This is because the SAS
       template for this calculation for "ALL WORKERS" uses a slightly different string:
       "CASES W/NO CLUSTERS" (note the difference in "/W" vs. "W/").  The Python library
       will give the proper answer, so in that way it differs from the SAS source.
+    * There is a bug in PA01_HIV.sas in which subsections of "NEW PARTNERS NOT
+      NOTIFIED" will show a percentage of 0.0% when they have more than 0 items.  The
+      Python version of this will show the actual percentages.
+    * There is a quirk in PA01_HIV.sas in which the "NEW CLUSTERS NOTIFIED" count
+      for "ALL WORKERS" doesn't use the distinct case id count like most other
+      calculations.  I have replicated this behavior in Python but it is likely
+      incorrect.
+    * In the "DISPOSITIONS - PARTNERS & CLUSTERS" section, there are 2 occurances of
+      "PREVIOUS POS" and "OPEN" that come at the bottom of each column of the report
+      section.  Since these names are identical, and they contain no other grouping
+      I have labled them as:
+
+      - New Partners Previous Pos
+      - New Partners Open
+      - New Clusters Previous Pos
+      - New Clusters Open
+
+      in order to distinguish them in the CSV.  Otherwise if the CSV data were ever
+      sorted it would lose its positional meaning.
     """
     if not isinstance(library_params, dict):
         raise ValueError(
@@ -90,6 +115,20 @@ def execute(
     tables['clusters_initiated'] = trx.query(clusters_initiated_query(subset_query))
     tables['cases_with_no_clusters'] = trx.query(
         cases_with_no_clusters_query(subset_query)
+    )
+    tables['notified_partners'] = trx.query(notified_partners_query(subset_query))
+    tables['not_notified_partners'] = trx.query(
+        not_notified_partners_query(subset_query)
+    )
+    tables['notified_clusters'] = trx.query(notified_clusters_query(subset_query))
+    tables['not_notified_clusters'] = trx.query(
+        not_notified_clusters_query(subset_query)
+    )
+    tables['partner_case_dispositions'] = trx.query(
+        partner_case_dispositions_query(subset_query)
+    )
+    tables['clusters_previous_pos'] = trx.query(
+        cluster_previous_pos_query(subset_query)
     )
 
     # get list of workers (nb. None treated as "ALL WORKERS")

--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -11,10 +11,10 @@ from src.libraries.support.pa_01.queries import (
     cases_with_no_partners_query,
     cluster_previous_pos_query,
     clusters_initiated_query,
-    filtered_cases_query,
     not_notified_clusters_query,
     not_notified_partners_query,
     notified_clusters_query,
+    notified_partners_by_speed_query,
     notified_partners_query,
     partner_case_dispositions_query,
     partner_notification_query,
@@ -70,6 +70,10 @@ def execute(
 
       in order to distinguish them in the CSV.  Otherwise if the CSV data were ever
       sorted it would lose its positional meaning.
+    * In the "SPEED OF NOTIFICATION - PARTNERS & CLUSTERS" section, under "New Clusters
+      Notified" for "ALL WORKERS", the percentages appear as 0.0% even if there are
+      counts.  This is due to an issue in the SAS and the Python library includes the
+      correct percentages.
     """
     if not isinstance(library_params, dict):
         raise ValueError(
@@ -99,7 +103,6 @@ def execute(
 
     # run queries
     tables: dict[str, Table] = {}
-    tables['filtered_cases'] = trx.query(filtered_cases_query(subset_query))
     tables['case_interview_rows'] = trx.query(
         case_interview_rows_query(subset_query, report_variant)
     )
@@ -129,6 +132,9 @@ def execute(
     )
     tables['clusters_previous_pos'] = trx.query(
         cluster_previous_pos_query(subset_query)
+    )
+    tables['notified_partners_by_speed'] = trx.query(
+        notified_partners_by_speed_query(subset_query)
     )
 
     # get list of workers (nb. None treated as "ALL WORKERS")

--- a/apps/report-execution/src/libraries/support/pa_01/calculations.py
+++ b/apps/report-execution/src/libraries/support/pa_01/calculations.py
@@ -5,7 +5,7 @@ from src.models import Table
 CASES_IXD = "Cases IX'D"
 CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
 CA_PATIENT_INTV_STATUS = 'CA_PATIENT_INTV_STATUS'
-DAYS = 'Days'
+DAYS = 'DAYS'
 DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS = 'Dispositions - New Partners & Clusters'
 DISPO_DOMESTIC_VIOLENCE_RISK = 'V - Domestic Violence Risk'
 DISPO_INSUFFICIENT_INFO = 'G - Insufficient Info to Begin Investigation'
@@ -30,8 +30,15 @@ NEW_PARTNERS_NOTIFIED = 'New Partners Notified'
 NEW_PARTNERS_NOT_NOTIFIED = 'New Partners Not Notified'
 PARTNERS_AND_CLUSTERS_INITIATED = 'Partners & Clusters Initiated'
 PROVIDER_QUICK_CODE = 'PROVIDER_QUICK_CODE'
+SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS = (
+    'Speed of Notification - Partners & Clusters'
+)
 TOTAL_CLUSTERS_INITIATED = 'Total Clusters Initiated'
 TOTAL_PARTNERS_INITIATED = 'Total Partners Initiated'
+WITHIN_THREE_DAYS = 'Within 3 Days'
+WITHIN_FIVE_DAYS = 'Within 5 Days'
+WITHIN_SEVEN_DAYS = 'Within 7 Days'
+WITHIN_FOURTEEN_DAYS = 'Within 14 Days'
 
 
 def build_output_for_worker(
@@ -52,6 +59,7 @@ def build_output_for_worker(
     rows.extend(_build_case_assignments_and_outcomes_output(tables, worker))
     rows.extend(_build_partners_and_clusters_initiated_output(tables, worker))
     rows.extend(_build_dispositions_new_partners_and_clusters_output(tables, worker))
+    rows.extend(_build_speed_of_notification_partners_and_clusters(tables, worker))
 
     return rows
 
@@ -125,7 +133,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 3 days',
+            WITHIN_THREE_DAYS,
             cases_ixd_buckets[3][0],
             cases_ixd_buckets[3][1],
             None,
@@ -134,7 +142,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 5 days',
+            WITHIN_FIVE_DAYS,
             cases_ixd_buckets[5][0],
             cases_ixd_buckets[5][1],
             None,
@@ -143,7 +151,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 7 days',
+            WITHIN_SEVEN_DAYS,
             cases_ixd_buckets[7][0],
             cases_ixd_buckets[7][1],
             None,
@@ -152,7 +160,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 14 days',
+            WITHIN_FOURTEEN_DAYS,
             cases_ixd_buckets[14][0],
             cases_ixd_buckets[14][1],
             None,
@@ -724,6 +732,127 @@ def _build_dispositions_new_partners_and_clusters_output(
     return rows
 
 
+def _build_speed_of_notification_partners_and_clusters(
+    tables: dict[str, Table], worker: Pa01Worker | None = None
+) -> list[Pa01Row]:
+    """Perform all needed calculations for the "Speed of Notification - Partners &
+    Clusters" section for a given worker, output data for the final CSV.
+    """
+    total_partners_initiated = _calc_total_partners_initiated(
+        tables['period_partners'], worker
+    )
+    total_clusters_initiated = _calc_total_clusters_initiated(
+        tables['clusters_initiated'], worker
+    )
+    new_partners_notified, _ = _calc_new_partners_notified(
+        tables['notified_partners'], total_partners_initiated, worker
+    )
+    new_clusters_notified, _ = _calc_new_clusters_notified(
+        tables['notified_clusters'], total_clusters_initiated, worker
+    )
+    new_partners_notified_day_buckets = _calc_new_partners_notified_day_buckets(
+        tables['notified_partners_by_speed'], new_partners_notified, worker
+    )
+    new_clusters_notified_day_buckets = _calc_new_clusters_notified_day_buckets(
+        tables['notified_clusters'], new_clusters_notified, worker
+    )
+
+    rows: list[Pa01Row] = [
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            None,
+            new_partners_notified,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_THREE_DAYS,
+            new_partners_notified_day_buckets[3][0],
+            new_partners_notified_day_buckets[3][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_FIVE_DAYS,
+            new_partners_notified_day_buckets[5][0],
+            new_partners_notified_day_buckets[5][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_SEVEN_DAYS,
+            new_partners_notified_day_buckets[7][0],
+            new_partners_notified_day_buckets[7][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_FOURTEEN_DAYS,
+            new_partners_notified_day_buckets[14][0],
+            new_partners_notified_day_buckets[14][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            None,
+            new_clusters_notified,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_THREE_DAYS,
+            new_clusters_notified_day_buckets[3][0],
+            new_clusters_notified_day_buckets[3][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_FIVE_DAYS,
+            new_clusters_notified_day_buckets[5][0],
+            new_clusters_notified_day_buckets[5][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_SEVEN_DAYS,
+            new_clusters_notified_day_buckets[7][0],
+            new_clusters_notified_day_buckets[7][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_FOURTEEN_DAYS,
+            new_clusters_notified_day_buckets[14][0],
+            new_clusters_notified_day_buckets[14][1],
+            None,
+        ),
+    ]
+
+    return rows
+
+
 # actual calculations
 def _calc_cases_assigned(
     case_interview_rows: Table, worker: Pa01Worker | None = None
@@ -777,12 +906,7 @@ def _calc_interview_day_buckets(
         and row[DAYS] <= 14
     ]
 
-    results = dict()
-    for threshold in (3, 5, 7, 14):
-        count = sum(1 for d in rows if d[DAYS] <= threshold)
-        results[threshold] = (count, _percent_for_csv(count, cases_ixd))
-
-    return results
+    return _count_and_percent_day_buckets(rows, cases_ixd)
 
 
 def _calc_cases_reinterviewed(
@@ -1262,6 +1386,34 @@ def _calc_new_clusters_open(
     return count, _percent_for_csv(count, total_clusters_initiated)
 
 
+def _calc_new_partners_notified_day_buckets(
+    notified_partners_by_speed: Table,
+    new_partners_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[int, tuple[int, str]]:
+    """Calculate "New Partners Notified" count and percentage for within 3, 5, 7, and
+    14 days.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(notified_partners_by_speed, worker)
+    rows = [row for row in rows if row[DAYS] is not None and 0 <= row[DAYS] <= 14]
+
+    return _count_and_percent_day_buckets(rows, new_partners_notified)
+
+
+def _calc_new_clusters_notified_day_buckets(
+    notified_clusters: Table,
+    new_clusters_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[int, tuple[int, str]]:
+    """Calculate "New Clusters Notified" count and percentage for within 3, 5, 7, and
+    14 days.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(notified_clusters, worker)
+    rows = [row for row in rows if row[DAYS] is not None and 0 <= row[DAYS] <= 14]
+
+    return _count_and_percent_day_buckets(rows, new_clusters_notified)
+
+
 # helpers
 def _rows_for_worker(table: Table, worker: Pa01Worker | None = None) -> list[dict]:
     """Filter a given table's data for the given worker.  If the given worker is None
@@ -1306,6 +1458,22 @@ def _count_distinct_case_ids_and_percent_by_dispo(
         result[dispo] = (count, _percent_for_csv(count, denominator))
 
     return result
+
+
+def _count_and_percent_day_buckets(
+    rows: list[dict],
+    denominator: int,
+) -> dict[int, tuple[int, str]]:
+    """Given a list of query result rows that contain the column 'DAYS', tally up the
+    number of each in buckets of 3, 5, 7, and 14 days.  Includes the count and the
+    percentage with the given denominator.
+    """
+    results = {}
+    for threshold in (3, 5, 7, 14):
+        count = sum(1 for d in rows if d[DAYS] <= threshold)
+        results[threshold] = (count, _percent_for_csv(count, denominator))
+
+    return results
 
 
 def _percent_for_csv(numerator: int, denominator: int, precision: int = 1) -> str:

--- a/apps/report-execution/src/libraries/support/pa_01/calculations.py
+++ b/apps/report-execution/src/libraries/support/pa_01/calculations.py
@@ -1,0 +1,685 @@
+from src.libraries.support.pa_01.models import Pa01Row, Pa01Worker
+from src.models import Table
+
+# Constants
+ALL = 'ALL'
+CA_PATIENT_INTV_STATUS = 'CA_PATIENT_INTV_STATUS'
+CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
+CASES_IXD = "Cases IX'D"
+DAYS = 'Days'
+INV_LOCAL_ID = 'INV_LOCAL_ID'
+INVESTIGATOR_INTERVIEW_KEY = 'INVESTIGATOR_INTERVIEW_KEY'
+IX_TYPE = 'IX_TYPE'
+PARTNERS_AND_CLUSTERS_INITIATED = 'Partners & Clusters Initiated'
+PROVIDER_QUICK_CODE = 'PROVIDER_QUICK_CODE'
+TOTAL_CLUSTERS_INITIATED = 'Total Clusters Initiated'
+TOTAL_PARTNERS_INITIATED = 'Total Partners Initiated'
+
+
+def build_output_for_worker(
+    tables: dict[str, Table], worker: Pa01Worker | None = None
+) -> list[Pa01Row]:
+    """Perform all needed calculations for a given worker, output data for
+    the final CSV.
+
+    Args:
+        tables: Query results within a dict
+        worker: The worker the data is being calculated for (None means "ALL")
+
+    Returns:
+        List of calculated data for a given worker, meant for the final CSV of PA01
+    """
+    rows: list[Pa01Row] = []
+
+    rows.extend(_build_case_assignments_and_outcomes_output(tables, worker))
+    rows.extend(_build_partners_and_clusters_initiated_output(tables, worker))
+
+    return rows
+
+
+def _build_case_assignments_and_outcomes_output(
+    tables: dict, worker: Pa01Worker | None = None
+) -> list[Pa01Row]:
+    """Perform all needed calculations for the "Case Assignments and Outcomes" section
+    for a given worker, output data for the final CSV.
+    """
+    cases_assigned = _calc_cases_assigned(tables['case_interview_rows'], worker)
+    cases_closed, cases_closed_percent = _calc_cases_closed(
+        tables['case_interview_rows'], cases_assigned, worker
+    )
+    cases_ixd, cases_ixd_percent = _calc_cases_ixd(
+        tables['case_interview_rows'], cases_assigned, worker
+    )
+    cases_ixd_buckets = _calc_interview_day_buckets(
+        tables['timed_interviews'], cases_ixd, worker
+    )
+    cases_reinterviewed, cases_reinterviewed_percent = _calc_cases_reinterviewed(
+        tables['case_interview_rows'], cases_ixd, worker
+    )
+    hiv_previous_positive, hiv_previous_positive_percent = _calc_hiv_previous_positive(
+        tables['case_interview_rows'], cases_assigned, worker
+    )
+    hiv_tested, hiv_tested_percent = _calc_hiv_tested(
+        tables['case_interview_rows'], cases_assigned, worker
+    )
+    hiv_new_positive, hiv_new_positive_percent = _calc_hiv_new_positive(
+        tables['case_interview_rows'], hiv_tested, worker
+    )
+    hiv_posttest_counsel, hiv_posttest_counsel_percent = _calc_hiv_posttest_counsel(
+        tables['case_interview_rows'], hiv_tested, worker
+    )
+    partner_notification_index = _calc_partner_notification_index(
+        tables['partner_notification'], cases_ixd, worker
+    )
+    testing_index = _calc_testing_index(tables['testing_index'], cases_ixd, worker)
+
+    # output CSV data
+    rows: list[Pa01Row] = [
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Cases Assigned',
+            None,
+            cases_assigned,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Cases Closed',
+            None,
+            cases_closed,
+            cases_closed_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            None,
+            cases_ixd,
+            cases_ixd_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 3 days',
+            cases_ixd_buckets[3][0],
+            cases_ixd_buckets[3][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 5 days',
+            cases_ixd_buckets[5][0],
+            cases_ixd_buckets[5][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 7 days',
+            cases_ixd_buckets[7][0],
+            cases_ixd_buckets[7][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            CASES_IXD,
+            'Within 14 days',
+            cases_ixd_buckets[14][0],
+            cases_ixd_buckets[14][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Cases Reinterviewed',
+            None,
+            cases_reinterviewed,
+            cases_reinterviewed_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV Previous Positive',
+            None,
+            hiv_previous_positive,
+            hiv_previous_positive_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV Tested',
+            None,
+            hiv_tested,
+            hiv_tested_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV New Positive',
+            None,
+            hiv_new_positive,
+            hiv_new_positive_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'HIV Posttest Counsel',
+            None,
+            hiv_posttest_counsel,
+            hiv_posttest_counsel_percent,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Partner Notification Index',
+            None,
+            None,
+            None,
+            partner_notification_index,
+        ),
+        (
+            _worker_for_csv(worker),
+            CASE_ASSIGNMENTS_AND_OUTCOMES,
+            'Testing Index',
+            None,
+            None,
+            None,
+            testing_index,
+        ),
+    ]
+
+    return rows
+
+
+def _build_partners_and_clusters_initiated_output(
+    tables: dict[str, Table], worker: Pa01Worker | None = None
+) -> list[Pa01Row]:
+    """Perform all needed calculations for the "Partners and Clusters Initiated"
+    section for a given worker, output data for the final CSV.
+    """
+    cases_assigned = _calc_cases_assigned(tables['case_interview_rows'], worker)
+    cases_ixd, _ = _calc_cases_ixd(
+        tables['case_interview_rows'], cases_assigned, worker
+    )
+    total_period_partners, total_period_partners_index = _calc_total_period_partners(
+        tables['period_partners'], cases_ixd, worker
+    )
+    total_partners_initiated = _calc_total_partners_initiated(
+        tables['period_partners'], worker
+    )
+    total_partners_initiated_oi = _calc_total_partners_initiated_oi(
+        tables['period_partners'], worker
+    )
+    total_partners_initiated_ri = _calc_total_partners_initiated_ri(
+        tables['period_partners'], worker
+    )
+    contact_index = _calc_contact_index(tables['period_partners'], cases_ixd, worker)
+    cases_with_no_partners, cases_with_no_partners_percentage = (
+        _calc_cases_with_no_partners(
+            tables['cases_with_no_partners'], cases_ixd, worker
+        )
+    )
+    total_clusters_initiated = _calc_total_clusters_initiated(
+        tables['clusters_initiated'], worker
+    )
+    cluster_index = _calc_cluster_index(tables['clusters_initiated'], cases_ixd, worker)
+    cases_with_no_clusters, cases_with_no_clusters_percentage = (
+        _calc_cases_with_no_clusters(
+            tables['cases_with_no_clusters'], cases_ixd, worker
+        )
+    )
+
+    # output CSV data
+    rows: list[Pa01Row] = [
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            'Total Period Partners',
+            None,
+            total_period_partners,
+            None,
+            total_period_partners_index,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            TOTAL_PARTNERS_INITIATED,
+            None,
+            total_partners_initiated,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            TOTAL_PARTNERS_INITIATED,
+            'From OI',
+            total_partners_initiated_oi,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            TOTAL_PARTNERS_INITIATED,
+            'From RI',
+            total_partners_initiated_ri,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            'Contact Index',
+            None,
+            None,
+            None,
+            contact_index,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            'Cases W/No Partners',
+            None,
+            cases_with_no_partners,
+            cases_with_no_partners_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            TOTAL_CLUSTERS_INITIATED,
+            None,
+            total_clusters_initiated,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            TOTAL_CLUSTERS_INITIATED,
+            'Cluster Index',
+            None,
+            None,
+            cluster_index,
+        ),
+        (
+            _worker_for_csv(worker),
+            PARTNERS_AND_CLUSTERS_INITIATED,
+            TOTAL_CLUSTERS_INITIATED,
+            'Cases /W No Clusters',
+            cases_with_no_clusters,
+            cases_with_no_clusters_percentage,
+            None,
+        ),
+    ]
+
+    return rows
+
+
+def _calc_cases_assigned(
+    case_interview_rows: Table, worker: Pa01Worker | None = None
+) -> int:
+    """Calculate 'Cases Assigned' count for a given worker.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+
+    return _count_distinct_case_ids(rows)
+
+
+def _calc_cases_closed(
+    case_interview_rows: Table, cases_assigned: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'Cases Closed' count and percentage for a given worker.  Calculates
+    for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+    count = _count_distinct_case_ids(rows, lambda row: row['CC_CLOSED_DT'] is not None)
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_cases_ixd(
+    case_interview_rows: Table, cases_assigned: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate "Cases IX'D" count and percentage.  Calculates for all workers if
+    passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+    count = _count_distinct_case_ids(
+        rows, lambda row: row[CA_PATIENT_INTV_STATUS] == 'I - Interviewed'
+    )
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_interview_day_buckets(
+    timed_interviews: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> dict[int, tuple[int, str]]:
+    """Calculate "Cases IX'D" count and percentage for within 3, 5, 7, and 14 days.
+    Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(timed_interviews, worker)
+    rows = [
+        row
+        for row in rows
+        if row[IX_TYPE] == 'Initial/Original'
+        and row[DAYS] is not None
+        and row[DAYS] <= 14
+    ]
+
+    results = dict()
+    for threshold in (3, 5, 7, 14):
+        count = sum(1 for d in rows if d[DAYS] <= threshold)
+        results[threshold] = (count, _percent_for_csv(count, cases_ixd))
+
+    return results
+
+
+def _calc_cases_reinterviewed(
+    case_interview_rows: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'Cases Reinterviewed' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+    count = _count_distinct_case_ids(
+        rows,
+        lambda row: (
+            row[IX_TYPE] == 'Re-Interview'
+            and row[CA_PATIENT_INTV_STATUS] == 'I - Interviewed'
+        ),
+    )
+
+    return count, _percent_for_csv(count, cases_ixd)
+
+
+def _calc_hiv_previous_positive(
+    case_interview_rows: Table, cases_assigned: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'HIV Previous Positive' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+    count = _count_distinct_case_ids(
+        rows,
+        lambda row: (
+            row[CA_PATIENT_INTV_STATUS] == 'I - Interviewed'
+            and row['ADI_900_STATUS_CD'] in ('03', '04', '05')
+        ),
+    )
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_hiv_tested(
+    case_interview_rows: Table, cases_assigned: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'HIV Tested' count and percentage.  Calculates for all workers if
+    passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+
+    # nb. mirrors creation of "hiv_tested" table in SAS
+    groups: dict[tuple, set] = {}
+    for row in rows:
+        if (
+            row[CA_PATIENT_INTV_STATUS] == 'I - Interviewed'
+            and row['HIV_900_TEST_IND'] == 'Yes'
+        ):
+            worker_key = (
+                row[INVESTIGATOR_INTERVIEW_KEY],
+                row[PROVIDER_QUICK_CODE],
+            )
+
+            groups.setdefault(worker_key, set()).add(row[INV_LOCAL_ID])
+
+    count = sum(len(case_ids) for case_ids in groups.values())
+
+    return count, _percent_for_csv(count, cases_assigned)
+
+
+def _calc_hiv_new_positive(
+    case_interview_rows: Table, hiv_tested: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'HIV New Positive' count and percentage.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+
+    positive_results = {
+        '13-Positive/Reactive',
+        '21-HIV-1 Pos',
+        '22-HIV-1 Pos, Possible Acute',
+        '23-HIV-2 Pos',
+        '24-HIV-Undifferentiated',
+        '12-Prelim Positive',
+    }
+
+    count = _count_distinct_case_ids(
+        rows, lambda row: row['HIV_900_RESULT'] in positive_results
+    )
+
+    return count, _percent_for_csv(count, hiv_tested)
+
+
+def _calc_hiv_posttest_counsel(
+    case_interview_rows: Table, hiv_tested: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'HIV Posttest Counsel' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(case_interview_rows, worker)
+
+    # mirrors creation of "hiv_post_test" table in SAS
+    groups: dict[tuple, set] = {}
+    for row in rows:
+        if (
+            row[CA_PATIENT_INTV_STATUS] == 'I - Interviewed'
+            and row['HIV_POST_TEST_900_COUNSELING'] == 'Yes'
+        ):
+            worker_key = (
+                row[PROVIDER_QUICK_CODE],
+                row[INVESTIGATOR_INTERVIEW_KEY],
+            )
+
+            groups.setdefault(worker_key, set()).add(row[INV_LOCAL_ID])
+
+    count = sum(len(case_ids) for case_ids in groups.values())
+
+    return count, _percent_for_csv(count, hiv_tested)
+
+
+def _calc_partner_notification_index(
+    partner_notification: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> str:
+    """Calculate 'Partner Notification Index'.  Calculates for all workers if passed
+    in worker is None.
+    """
+    rows = _rows_for_worker(partner_notification, worker)
+    count = sum(row['partner_notification_count'] for row in rows)
+
+    return _index_for_csv(count, cases_ixd)
+
+
+def _calc_testing_index(
+    testing_index: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> str:
+    """Calculate 'Testing Index'.  Calculates for all workers if passed in
+    worker is None.
+    """
+    rows = _rows_for_worker(testing_index, worker)
+    count = sum(row['testing_index_count'] for row in rows)
+
+    return _index_for_csv(count, cases_ixd)
+
+
+def _calc_total_period_partners(
+    period_partners: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'Total Period Partners' count and index.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(period_partners, worker)
+    count = sum(row['count_Q'] for row in rows)
+
+    return count, _index_for_csv(count, cases_ixd, 1)
+
+
+def _calc_total_partners_initiated(
+    period_partners: Table, worker: Pa01Worker | None = None
+) -> int:
+    """Calculate 'Total Partners Initiated' count.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(period_partners, worker)
+
+    return _count_distinct_case_ids(rows)
+
+
+def _calc_total_partners_initiated_oi(
+    period_partners: Table, worker: Pa01Worker | None = None
+) -> int:
+    """Calculate 'Total Partners Initiated From OI' count.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(period_partners, worker)
+    count = _count_distinct_case_ids(
+        rows, lambda row: row[IX_TYPE] == 'Initial/Original'
+    )
+
+    return count
+
+
+def _calc_total_partners_initiated_ri(
+    period_partners: Table, worker: Pa01Worker | None = None
+) -> int:
+    """Calculate 'Total Partners Initiated From RI' count.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(period_partners, worker)
+    count = _count_distinct_case_ids(rows, lambda row: row[IX_TYPE] == 'Re-Interview')
+
+    return count
+
+
+def _calc_contact_index(
+    period_partners: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> str:
+    """Calculate 'Contact Index'.  Calculates for all workers if passed in worker is
+    None.
+    """
+    rows = _rows_for_worker(period_partners, worker)
+    count = _count_distinct_case_ids(rows)
+
+    # nb. this is to align with the precision found in the SAS report
+    precision = 2 if worker is None else 1
+    return _index_for_csv(count, cases_ixd, precision)
+
+
+def _calc_cases_with_no_partners(
+    cases_with_no_partners: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'Cases W/No Partners' count and percentage.  Calculates for all workers
+    if passed in worker is None.
+    """
+    rows = _rows_for_worker(cases_with_no_partners, worker)
+    count = _count_distinct_case_ids(rows)
+
+    return count, _percent_for_csv(count, cases_ixd)
+
+
+def _calc_total_clusters_initiated(
+    clusters_initiated: Table, worker: Pa01Worker | None = None
+) -> int:
+    """Calculate 'Total Clusters Initiated' count. Calculates for all workers if passed
+    in worker is None.
+    """
+    rows = _rows_for_worker(clusters_initiated, worker)
+    return _count_distinct_case_ids(rows)
+
+
+def _calc_cluster_index(
+    clusters_initiated: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> str:
+    """Calculate 'Cluster Index'.  Calculates for all workers if passed in worker is
+    None.
+    """
+    rows = _rows_for_worker(clusters_initiated, worker)
+    count = _count_distinct_case_ids(rows)
+
+    return _index_for_csv(count, cases_ixd)
+
+
+def _calc_cases_with_no_clusters(
+    cases_with_no_clusters: Table, cases_ixd: int, worker: Pa01Worker | None = None
+) -> tuple[int, str]:
+    """Calculate 'Cases /W No Clusters' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(cases_with_no_clusters, worker)
+    count = _count_distinct_case_ids(rows)
+
+    return count, _percent_for_csv(count, cases_ixd)
+
+
+# helpers
+def _rows_for_worker(table: Table, worker: Pa01Worker | None = None) -> list[dict]:
+    """Filter a given table's data for the given worker.  If the given worker is None
+    then return all rows.
+    """
+    rows = table.data_as_dicts()
+    return _filter_rows_for_worker(rows, worker) if worker else rows
+
+
+def _filter_rows_for_worker(rows: list[dict], worker: Pa01Worker) -> list[dict]:
+    """Given rows from a table (via table.data_as_dicts()), filter them so they only
+    represent rows associated with the given worker.  Assumes necessary columns are
+    available.
+    """
+    return [
+        row
+        for row in rows
+        if row[INVESTIGATOR_INTERVIEW_KEY] == worker.investigator_interview_key
+        and row[PROVIDER_QUICK_CODE] == worker.provider_quick_code
+    ]
+
+
+def _count_distinct_case_ids(rows: list[dict], predicate=lambda row: True) -> int:
+    """Count distinct case ids in the given rows, applying the given predicate to each.
+    If no predicate is given then the rows will not be filtered.
+    """
+    return len({row[INV_LOCAL_ID] for row in rows if predicate(row)})
+
+
+def _percent_for_csv(numerator: int, denominator: int, precision: int = 1) -> str:
+    """Format a percent that matches the PDF format for output in the CSV."""
+    return f'{round((numerator / denominator) * 100, precision) if denominator else 0}%'
+
+
+def _index_for_csv(numerator: int, denominator: int, precision: int = 2) -> str:
+    """Format an index that matches the PDF format for output in the CSV."""
+    return f'{round(numerator / denominator, precision) if denominator else 0}'
+
+
+def _worker_for_csv(worker: Pa01Worker | None = None) -> str:
+    """Return the str value for the worker column for output in the CSV.  If worker
+    is None then ALL is returned.
+    """
+    return ALL if worker is None else worker.provider_quick_code

--- a/apps/report-execution/src/libraries/support/pa_01/calculations.py
+++ b/apps/report-execution/src/libraries/support/pa_01/calculations.py
@@ -2,14 +2,32 @@ from src.libraries.support.pa_01.models import Pa01Row, Pa01Worker
 from src.models import Table
 
 # Constants
-ALL = 'ALL'
-CA_PATIENT_INTV_STATUS = 'CA_PATIENT_INTV_STATUS'
-CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
 CASES_IXD = "Cases IX'D"
+CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
+CA_PATIENT_INTV_STATUS = 'CA_PATIENT_INTV_STATUS'
 DAYS = 'Days'
-INV_LOCAL_ID = 'INV_LOCAL_ID'
+DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS = 'Dispositions - New Partners & Clusters'
+DISPO_DOMESTIC_VIOLENCE_RISK = 'V - Domestic Violence Risk'
+DISPO_INSUFFICIENT_INFO = 'G - Insufficient Info to Begin Investigation'
+DISPO_NO_PREV_TEST_NEW_NEG = '6 - No Prev Test, New Neg'
+DISPO_NO_PREV_TEST_NEW_POS = '5 - No Prev Test, New Pos'
+DISPO_NO_PREV_TEST_NO_TEST = '7 - No Prev Test, No Test'
+DISPO_OOJ = 'K - Sent Out Of Jurisdiction'
+DISPO_OTHER = 'L - Other'
+DISPO_PATIENT_DECEASED = 'X - Patient Deceased'
+DISPO_PREV_NEG_NEW_POS = '2 - Prev. Neg, New Pos'
+DISPO_PREV_NEG_NO_TEST = '4 - Prev. Neg, No Test'
+DISPO_PREV_NEG_STILL_NEG = '3 - Prev. Neg, Still Neg'
+DISPO_REFUSED_EXAM = 'J - Located, Not Examined and/or Interviewed'
+DISPO_UNABLE_TO_LOCATE = 'H - Unable to Locate'
+FL_FUP_DISPOSITION = 'FL_FUP_DISPOSITION'
 INVESTIGATOR_INTERVIEW_KEY = 'INVESTIGATOR_INTERVIEW_KEY'
+INV_LOCAL_ID = 'INV_LOCAL_ID'
 IX_TYPE = 'IX_TYPE'
+NEW_CLUSTERS_NOTIFIED = 'New Clusters Notified'
+NEW_CLUSTERS_NOT_NOTIFIED = 'New Clusters Not Notified'
+NEW_PARTNERS_NOTIFIED = 'New Partners Notified'
+NEW_PARTNERS_NOT_NOTIFIED = 'New Partners Not Notified'
 PARTNERS_AND_CLUSTERS_INITIATED = 'Partners & Clusters Initiated'
 PROVIDER_QUICK_CODE = 'PROVIDER_QUICK_CODE'
 TOTAL_CLUSTERS_INITIATED = 'Total Clusters Initiated'
@@ -33,6 +51,7 @@ def build_output_for_worker(
 
     rows.extend(_build_case_assignments_and_outcomes_output(tables, worker))
     rows.extend(_build_partners_and_clusters_initiated_output(tables, worker))
+    rows.extend(_build_dispositions_new_partners_and_clusters_output(tables, worker))
 
     return rows
 
@@ -332,6 +351,380 @@ def _build_partners_and_clusters_initiated_output(
     return rows
 
 
+def _build_dispositions_new_partners_and_clusters_output(
+    tables: dict[str, Table], worker: Pa01Worker | None = None
+) -> list[Pa01Row]:
+    """Perform all needed calculations for the "Dispositions - New Partners & Clusters"
+    section for a given worker, output data for the final CSV.
+    """
+    total_partners_initiated = _calc_total_partners_initiated(
+        tables['period_partners'], worker
+    )
+    new_partners_notified, new_partners_notified_percentage = (
+        _calc_new_partners_notified(
+            tables['notified_partners'], total_partners_initiated, worker
+        )
+    )
+    new_partners_notified_buckets = _calc_new_partners_notified_buckets(
+        tables['notified_partners'], new_partners_notified, worker
+    )
+    new_partners_not_notified, new_partners_not_notified_percentage = (
+        _calc_new_partners_not_notified(
+            tables['not_notified_partners'], total_partners_initiated, worker
+        )
+    )
+    new_partners_not_notified_buckets = _calc_new_partners_not_notified_buckets(
+        tables['not_notified_partners'], new_partners_not_notified, worker
+    )
+    new_partners_previous_pos, new_partners_previous_pos_percentage = (
+        _calc_new_partners_previous_pos(
+            tables['partner_case_dispositions'], total_partners_initiated, worker
+        )
+    )
+    new_partners_open, new_partners_open_percentage = _calc_new_partners_open(
+        tables['partner_case_dispositions'], total_partners_initiated, worker
+    )
+    total_clusters_initiated = _calc_total_clusters_initiated(
+        tables['clusters_initiated'], worker
+    )
+    new_clusters_notified, new_clusters_notified_percentage = (
+        _calc_new_clusters_notified(
+            tables['notified_clusters'], total_clusters_initiated, worker
+        )
+    )
+    new_clusters_notified_buckets = _calc_new_clusters_notified_buckets(
+        tables['notified_clusters'], new_clusters_notified, worker
+    )
+    new_clusters_not_notified, new_clusters_not_notified_percentage = (
+        _calc_new_clusters_not_notified(
+            tables['not_notified_clusters'], total_clusters_initiated, worker
+        )
+    )
+    new_clusters_not_notified_buckets = _calc_new_clusters_not_notified_buckets(
+        tables['not_notified_clusters'], new_clusters_not_notified, worker
+    )
+    new_clusters_previous_pos, new_clusters_previous_pos_percentage = (
+        _calc_new_clusters_previous_pos(
+            tables['clusters_previous_pos'], total_clusters_initiated, worker
+        )
+    )
+    new_clusters_open, new_clusters_open_percentage = _calc_new_clusters_open(
+        tables['clusters_initiated'], total_clusters_initiated, worker
+    )
+
+    rows: list[Pa01Row] = [
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            None,
+            new_partners_notified,
+            new_partners_notified_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            'Prev. Neg, New Pos',
+            new_partners_notified_buckets[DISPO_PREV_NEG_NEW_POS][0],
+            new_partners_notified_buckets[DISPO_PREV_NEG_NEW_POS][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            'Prev. Neg, Still Neg',
+            new_partners_notified_buckets[DISPO_PREV_NEG_STILL_NEG][0],
+            new_partners_notified_buckets[DISPO_PREV_NEG_STILL_NEG][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            'Prev. Neg, No Test',
+            new_partners_notified_buckets[DISPO_PREV_NEG_NO_TEST][0],
+            new_partners_notified_buckets[DISPO_PREV_NEG_NO_TEST][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            'No Prev. Test, New Pos',
+            new_partners_notified_buckets[DISPO_NO_PREV_TEST_NEW_POS][0],
+            new_partners_notified_buckets[DISPO_NO_PREV_TEST_NEW_POS][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            'No Prev. Test, New Neg',
+            new_partners_notified_buckets[DISPO_NO_PREV_TEST_NEW_NEG][0],
+            new_partners_notified_buckets[DISPO_NO_PREV_TEST_NEW_NEG][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            'No Prev. Test, No Test',
+            new_partners_notified_buckets[DISPO_NO_PREV_TEST_NO_TEST][0],
+            new_partners_notified_buckets[DISPO_NO_PREV_TEST_NO_TEST][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            None,
+            new_partners_not_notified,
+            new_partners_not_notified_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'Insufficient Info',
+            new_partners_not_notified_buckets[DISPO_INSUFFICIENT_INFO][0],
+            new_partners_not_notified_buckets[DISPO_INSUFFICIENT_INFO][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'Unable to Locate',
+            new_partners_not_notified_buckets[DISPO_UNABLE_TO_LOCATE][0],
+            new_partners_not_notified_buckets[DISPO_UNABLE_TO_LOCATE][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'Refused Exam',
+            new_partners_not_notified_buckets[DISPO_REFUSED_EXAM][0],
+            new_partners_not_notified_buckets[DISPO_REFUSED_EXAM][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'OOJ',
+            new_partners_not_notified_buckets[DISPO_OOJ][0],
+            new_partners_not_notified_buckets[DISPO_OOJ][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'Other',
+            new_partners_not_notified_buckets[DISPO_OTHER][0],
+            new_partners_not_notified_buckets[DISPO_OTHER][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'Domestic Violence Risk',
+            new_partners_not_notified_buckets[DISPO_DOMESTIC_VIOLENCE_RISK][0],
+            new_partners_not_notified_buckets[DISPO_DOMESTIC_VIOLENCE_RISK][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOT_NOTIFIED,
+            'Patient Deceased',
+            new_partners_not_notified_buckets[DISPO_PATIENT_DECEASED][0],
+            new_partners_not_notified_buckets[DISPO_PATIENT_DECEASED][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            'New Partners Previous Pos',
+            None,
+            new_partners_previous_pos,
+            new_partners_previous_pos_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            'New Partners Open',
+            None,
+            new_partners_open,
+            new_partners_open_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            None,
+            new_clusters_notified,
+            new_clusters_notified_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            'Prev. Neg, New Pos',
+            new_clusters_notified_buckets[DISPO_PREV_NEG_NEW_POS][0],
+            new_clusters_notified_buckets[DISPO_PREV_NEG_NEW_POS][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            'Prev. Neg, Still Neg',
+            new_clusters_notified_buckets[DISPO_PREV_NEG_STILL_NEG][0],
+            new_clusters_notified_buckets[DISPO_PREV_NEG_STILL_NEG][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            'Prev. Neg, No Test',
+            new_clusters_notified_buckets[DISPO_PREV_NEG_NO_TEST][0],
+            new_clusters_notified_buckets[DISPO_PREV_NEG_NO_TEST][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            'No Prev. Test, New Pos',
+            new_clusters_notified_buckets[DISPO_NO_PREV_TEST_NEW_POS][0],
+            new_clusters_notified_buckets[DISPO_NO_PREV_TEST_NEW_POS][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            'No Prev. Test, New Neg',
+            new_clusters_notified_buckets[DISPO_NO_PREV_TEST_NEW_NEG][0],
+            new_clusters_notified_buckets[DISPO_NO_PREV_TEST_NEW_NEG][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            'No Prev. Test, No Test',
+            new_clusters_notified_buckets[DISPO_NO_PREV_TEST_NO_TEST][0],
+            new_clusters_notified_buckets[DISPO_NO_PREV_TEST_NO_TEST][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            None,
+            new_clusters_not_notified,
+            new_clusters_not_notified_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'Insufficient Info',
+            new_clusters_not_notified_buckets[DISPO_INSUFFICIENT_INFO][0],
+            new_clusters_not_notified_buckets[DISPO_INSUFFICIENT_INFO][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'Unable to Locate',
+            new_clusters_not_notified_buckets[DISPO_UNABLE_TO_LOCATE][0],
+            new_clusters_not_notified_buckets[DISPO_UNABLE_TO_LOCATE][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'Refused Exam',
+            new_clusters_not_notified_buckets[DISPO_REFUSED_EXAM][0],
+            new_clusters_not_notified_buckets[DISPO_REFUSED_EXAM][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'OOJ',
+            new_clusters_not_notified_buckets[DISPO_OOJ][0],
+            new_clusters_not_notified_buckets[DISPO_OOJ][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'Other',
+            new_clusters_not_notified_buckets[DISPO_OTHER][0],
+            new_clusters_not_notified_buckets[DISPO_OTHER][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'Domestic Violence Risk',
+            new_clusters_not_notified_buckets[DISPO_DOMESTIC_VIOLENCE_RISK][0],
+            new_clusters_not_notified_buckets[DISPO_DOMESTIC_VIOLENCE_RISK][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOT_NOTIFIED,
+            'Patient Deceased',
+            new_clusters_not_notified_buckets[DISPO_PATIENT_DECEASED][0],
+            new_clusters_not_notified_buckets[DISPO_PATIENT_DECEASED][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            'New Clusters Previous Pos',
+            None,
+            new_clusters_previous_pos,
+            new_clusters_previous_pos_percentage,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS,
+            'New Clusters Open',
+            None,
+            new_clusters_open,
+            new_clusters_open_percentage,
+            None,
+        ),
+    ]
+
+    return rows
+
+
+# actual calculations
 def _calc_cases_assigned(
     case_interview_rows: Table, worker: Pa01Worker | None = None
 ) -> int:
@@ -436,7 +829,9 @@ def _calc_hiv_tested(
     """
     rows = _rows_for_worker(case_interview_rows, worker)
 
-    # nb. mirrors creation of "hiv_tested" table in SAS
+    # nb. mirrors the creation of "hiv_tested" table in SAS and the calculation of "HIV
+    #     Tested" (have to do this instead of _count_distinct_case_ids because
+    #     of how it is counted for "ALL WORKERS" in SAS)
     groups: dict[tuple, set] = {}
     for row in rows:
         if (
@@ -639,6 +1034,234 @@ def _calc_cases_with_no_clusters(
     return count, _percent_for_csv(count, cases_ixd)
 
 
+def _calc_new_partners_notified(
+    notified_partners: Table,
+    total_partners_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate 'New Partners Notified' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(notified_partners, worker)
+    count = _count_distinct_case_ids(rows)
+
+    return count, _percent_for_csv(count, total_partners_initiated)
+
+
+def _calc_new_partners_notified_buckets(
+    notified_partners: Table,
+    new_partners_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[str, tuple[int, str]]:
+    """Calculate the count and percentage for all of the sub sections of 'New Partners
+    Notified'.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(notified_partners, worker)
+    fl_fup_dispositions = [
+        DISPO_PREV_NEG_NEW_POS,
+        DISPO_PREV_NEG_STILL_NEG,
+        DISPO_PREV_NEG_NO_TEST,
+        DISPO_NO_PREV_TEST_NEW_POS,
+        DISPO_NO_PREV_TEST_NEW_NEG,
+        DISPO_NO_PREV_TEST_NO_TEST,
+    ]
+
+    return _count_distinct_case_ids_and_percent_by_dispo(
+        rows, fl_fup_dispositions, new_partners_notified
+    )
+
+
+def _calc_new_partners_not_notified(
+    not_notified_partners: Table,
+    total_partners_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate the count and percentage for 'New Partners Not Notified'.  Calculates
+    for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(not_notified_partners, worker)
+    count = _count_distinct_case_ids(rows)
+
+    return count, _percent_for_csv(count, total_partners_initiated)
+
+
+def _calc_new_partners_not_notified_buckets(
+    not_notified_partners: Table,
+    new_partners_not_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[str, tuple[int, str]]:
+    """Calculate the count and percentage for all of the sub sections of 'New Partners
+    Not Notified'.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(not_notified_partners, worker)
+    fl_fup_dispositions = [
+        DISPO_INSUFFICIENT_INFO,
+        DISPO_UNABLE_TO_LOCATE,
+        DISPO_REFUSED_EXAM,
+        DISPO_OOJ,
+        DISPO_OTHER,
+        DISPO_DOMESTIC_VIOLENCE_RISK,
+        DISPO_PATIENT_DECEASED,
+    ]
+
+    return _count_distinct_case_ids_and_percent_by_dispo(
+        rows, fl_fup_dispositions, new_partners_not_notified
+    )
+
+
+def _calc_new_partners_previous_pos(
+    partner_case_dispositions: Table,
+    total_partners_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate the count and percentage of 'New Partners Previous Pos'.  Calculates
+    for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(partner_case_dispositions, worker)
+    count = _count_distinct_case_ids(
+        rows,
+        lambda row: (
+            row[FL_FUP_DISPOSITION] == 'E - Previously Treated for This Infection'
+        ),
+    )
+
+    return count, _percent_for_csv(count, total_partners_initiated)
+
+
+def _calc_new_partners_open(
+    partner_case_dispositions: Table,
+    total_partners_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate the count and percentage of 'New Partners Open'.  Calculates
+    for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(partner_case_dispositions, worker)
+    count = _count_distinct_case_ids(rows, lambda row: row[FL_FUP_DISPOSITION] is None)
+
+    return count, _percent_for_csv(count, total_partners_initiated)
+
+
+def _calc_new_clusters_notified(
+    clusters_notified: Table,
+    total_clusters_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate 'New Clusters Notified' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(clusters_notified, worker)
+
+    # nb. normally I would use the _count_distinct_case_ids for both ALL WORKERS
+    #     and individual workers.  However the SAS script has a different count
+    #     approach when ALL WORKERS is being calculated.
+    count = len(rows) if worker is None else _count_distinct_case_ids(rows)
+
+    return count, _percent_for_csv(count, total_clusters_initiated)
+
+
+def _calc_new_clusters_notified_buckets(
+    clusters_notified: Table,
+    new_clusters_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[str, tuple[int, str]]:
+    """Calculate the count and percentage for all of the sub sections of 'New Clusters
+    Notified'.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(clusters_notified, worker)
+    fl_fup_dispositions = [
+        DISPO_PREV_NEG_NEW_POS,
+        DISPO_PREV_NEG_STILL_NEG,
+        DISPO_PREV_NEG_NO_TEST,
+        DISPO_NO_PREV_TEST_NEW_POS,
+        DISPO_NO_PREV_TEST_NEW_NEG,
+        DISPO_NO_PREV_TEST_NO_TEST,
+    ]
+
+    return _count_distinct_case_ids_and_percent_by_dispo(
+        rows, fl_fup_dispositions, new_clusters_notified
+    )
+
+
+def _calc_new_clusters_not_notified(
+    not_notified_clusters: Table,
+    total_clusters_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate 'New Clusters Not Notified' count and percentage.  Calculates for all
+    workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(not_notified_clusters, worker)
+    count = _count_distinct_case_ids(rows)
+
+    return count, _percent_for_csv(count, total_clusters_initiated)
+
+
+def _calc_new_clusters_not_notified_buckets(
+    not_notified_clusters: Table,
+    new_clusters_not_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[str, tuple[int, str]]:
+    """Calculate the count and percentage for all of the sub sections of 'New Clusters
+    Not Notified'.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(not_notified_clusters, worker)
+    fl_fup_dispositions = [
+        DISPO_INSUFFICIENT_INFO,
+        DISPO_UNABLE_TO_LOCATE,
+        DISPO_REFUSED_EXAM,
+        DISPO_OOJ,
+        DISPO_OTHER,
+        DISPO_DOMESTIC_VIOLENCE_RISK,
+        DISPO_PATIENT_DECEASED,
+    ]
+
+    return _count_distinct_case_ids_and_percent_by_dispo(
+        rows, fl_fup_dispositions, new_clusters_not_notified
+    )
+
+
+def _calc_new_clusters_previous_pos(
+    clusters_previous_pos: Table,
+    total_clusters_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate the count and percentage of 'New Clusters Previous Pos'.  Calculates
+    for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(clusters_previous_pos, worker)
+    count = sum(row['clusters_prev_positive_count'] for row in rows)
+
+    return count, _percent_for_csv(count, total_clusters_initiated)
+
+
+def _calc_new_clusters_open(
+    clusters_initiated: Table,
+    total_clusters_initiated: int,
+    worker: Pa01Worker | None = None,
+) -> tuple[int, str]:
+    """Calculate the count and percentage of 'New Clusters Open'.  Calculates
+    for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(clusters_initiated, worker)
+
+    # nb. mirrors the creation of "Co" table in SAS and the calculation of "New
+    #     Clusters Open" (have to do this instead of _count_distinct_case_ids because
+    #     of how it is counted for "ALL WORKERS" in SAS)
+    groups: dict[tuple, set] = {}
+    for row in rows:
+        if row[FL_FUP_DISPOSITION] is None:
+            worker_key = (
+                row[INVESTIGATOR_INTERVIEW_KEY],
+                row[PROVIDER_QUICK_CODE],
+            )
+            groups.setdefault(worker_key, set()).add(row[INV_LOCAL_ID])
+
+    count = sum(len(cluster_ids) for cluster_ids in groups.values())
+
+    return count, _percent_for_csv(count, total_clusters_initiated)
+
+
 # helpers
 def _rows_for_worker(table: Table, worker: Pa01Worker | None = None) -> list[dict]:
     """Filter a given table's data for the given worker.  If the given worker is None
@@ -668,6 +1291,23 @@ def _count_distinct_case_ids(rows: list[dict], predicate=lambda row: True) -> in
     return len({row[INV_LOCAL_ID] for row in rows if predicate(row)})
 
 
+def _count_distinct_case_ids_and_percent_by_dispo(
+    rows: list[dict], dispositions: list[str], denominator: int
+) -> dict[str, tuple[int, str]]:
+    """Given a list of dispositions (column FL_FUP_DISPOSITION), create buckets for
+    the count of distinct case ids and percentages for each given disposition.
+    """
+    result = {}
+    for dispo in dispositions:
+        count = _count_distinct_case_ids(
+            rows,
+            lambda row, dispo=dispo: row[FL_FUP_DISPOSITION] == dispo,
+        )
+        result[dispo] = (count, _percent_for_csv(count, denominator))
+
+    return result
+
+
 def _percent_for_csv(numerator: int, denominator: int, precision: int = 1) -> str:
     """Format a percent that matches the PDF format for output in the CSV."""
     return f'{round((numerator / denominator) * 100, precision) if denominator else 0}%'
@@ -682,4 +1322,4 @@ def _worker_for_csv(worker: Pa01Worker | None = None) -> str:
     """Return the str value for the worker column for output in the CSV.  If worker
     is None then ALL is returned.
     """
-    return ALL if worker is None else worker.provider_quick_code
+    return 'ALL' if worker is None else worker.provider_quick_code

--- a/apps/report-execution/src/libraries/support/pa_01/models.py
+++ b/apps/report-execution/src/libraries/support/pa_01/models.py
@@ -1,0 +1,33 @@
+"""Models and constants for pa_01."""
+
+from dataclasses import dataclass
+
+# CSV columns
+CSV_COLUMNS = [
+    'Worker',
+    'Category 1',
+    'Category 2',
+    'Category 3',
+    'Count',
+    'Percentage',
+    'Index',
+]
+
+# CSV row data shape
+Pa01Row = tuple[
+    str,  # Worker
+    str,  # Category 1
+    str,  # Category 2
+    str | None,  # Category 3
+    int | None,  # Count
+    str | None,  # Percentage
+    str | None,  # Index
+]
+
+
+@dataclass(frozen=True)
+class Pa01Worker:
+    """Individual worker within the context of this report."""
+
+    investigator_interview_key: int
+    provider_quick_code: str

--- a/apps/report-execution/src/libraries/support/pa_01/queries.py
+++ b/apps/report-execution/src/libraries/support/pa_01/queries.py
@@ -528,7 +528,7 @@ def cases_with_no_clusters_query(subset_query: str) -> str:
                      'S2 - Social Contact 2',
                      'S3 - Social Contact 3'
                    )
-      ) 
+      )
       SELECT DISTINCT a.INV_LOCAL_ID,
              a.INVESTIGATION_KEY,
              PROVIDER_QUICK_CODE,
@@ -560,4 +560,365 @@ def cases_with_no_clusters_query(subset_query: str) -> str:
       AND NOT EXISTS (
         SELECT 1 FROM clusters c WHERE c.STD_INV_LOCAL_ID = a.INV_LOCAL_ID
       );
+    """
+
+
+def notified_partners_query(subset_query: str) -> str:
+    """Return notified partner rows used for partner disposition counts.
+
+    This is the SQL equivalent of SAS `partner2`, which is used to calculate
+    New Partners Notified and its HIV partner disposition breakdowns.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             f.INV_LOCAL_ID,
+             a.INIT_FUP_INITIAL_FOLL_UP,
+             f.FL_FUP_DISPOSITION,
+             a.FL_FUP_DISPO_DT,
+             a.FL_FUP_INIT_ASSGN_DT,
+             datepart(DAY,a.FL_FUP_DISPO_DT) - datepart(DAY,a.FL_FUP_INIT_ASSGN_DT)
+                AS days,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+               AND e.CTT_REFERRAL_BASIS IN (
+                     'P1 - Partner, Sex',
+                     'P2 - Partner, Needle-Sharing',
+                     'P3 - Partner, Both'
+                   )
+               AND f.FL_FUP_DISPOSITION IN (
+                     '2 - Prev. Neg, New Pos',
+                     '3 - Prev. Neg, Still Neg',
+                     '4 - Prev. Neg, No Test',
+                     '5 - No Prev Test, New Pos',
+                     '6 - No Prev Test, New Neg',
+                     '7 - No Prev Test, No Test'
+                   )
+    """
+
+
+def not_notified_partners_query(subset_query: str) -> str:
+    """Return non-notified partner rows used for partner disposition counts.
+
+    This is the SQL equivalent of SAS `pn`, which is used to calculate
+    New Partners Not Notified and its HIV partner disposition breakdowns.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT c.IX_TYPE,
+             a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             h.FL_FUP_DISPOSITION,
+             g.CTT_REFERRAL_BASIS,
+             h.INV_LOCAL_ID,
+             a.INVESTIGATOR_INTERVIEW_KEY
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON b.INVESTIGATION_KEY = a.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider d
+                ON d.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.investigation e
+                ON e.investigation_key = a.investigation_KEY
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE f
+                ON a.investigation_key = f.SUBJECT_investigation_key
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART h
+                ON f.CONTACT_INVESTIGATION_KEY = h.Investigation_key
+        INNER JOIN RDB.dbo.d_contact_record g
+                ON f.d_contact_record_key = g.d_contact_record_key
+               AND g.RECORD_STATUS_CD <> 'LOG_DEL'
+      WHERE g.CTT_REFERRAL_BASIS IN (
+              'P1 - Partner, Sex',
+              'P2 - Partner, Needle-Sharing',
+              'P3 - Partner, Both'
+            )
+      AND   a.CA_PATIENT_INTV_STATUS IN ('I - Interviewed')
+      AND   h.FL_FUP_DISPOSITION IN (
+              'G - Insufficient Info to Begin Investigation',
+              'H - Unable to Locate',
+              'J - Located, Not Examined and/or Interviewed',
+              'K - Sent Out Of Jurisdiction',
+              'L - Other',
+              'V - Domestic Violence Risk',
+              'X - Patient Deceased'
+            )
+    """
+
+
+def notified_clusters_query(subset_query: str) -> str:
+    """Return notified cluster rows used for cluster disposition counts.
+
+    This is the SQL equivalent of SAS `cm`, which is used to calculate
+    New Clusters Notified and its HIV partner disposition breakdowns.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             a.FL_FUP_DISPOSITION,
+             f.INV_LOCAL_ID,
+             f.FL_FUP_DISPO_DT,
+             f.FL_FUP_INVESTIGATOR_ASSGN_DT,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC,
+             datepart(day, f.FL_FUP_DISPO_DT)
+               - datepart(day, f.FL_FUP_INVESTIGATOR_ASSGN_DT) AS days
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+               AND d.contact_interview_key = c.D_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+      WHERE e.CTT_REFERRAL_BASIS IN (
+              'A1 - Associate 1',
+              'A2 - Associate 2',
+              'A3 - Associate 3',
+              'S1 - Social Contact 1',
+              'S2 - Social Contact 2',
+              'S3 - Social Contact 3'
+            )
+      AND   f.fl_fup_disposition IN (
+              '2 - Prev. Neg, New Pos',
+              '3 - Prev. Neg, Still Neg',
+              '4 - Prev. Neg, No Test',
+              '5 - No Prev Test, New Pos',
+              '6 - No Prev Test, New Neg',
+              '7 - No Prev Test, No Test'
+            );
+    """
+
+
+def not_notified_clusters_query(subset_query: str) -> str:
+    """Return non-notified cluster rows used for cluster disposition counts.
+
+    This is the equivalent of SAS's `cn`, which is a slight variation on SAS's
+    `cluster` table, containing just a simple extra where clause.  Used to calculate
+    New Clusters Not Notified and its HIV partner disposition breakdowns.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             a.INV_LOCAL_ID AS STD_INV_LOCAL_ID,
+             f.FL_FUP_DISPOSITION,
+             e.LOCAL_ID AS INV_LOCAL_ID,
+             a.FL_FUP_DISPO_DT,
+             a.FL_FUP_INIT_ASSGN_DT,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+               AND c.d_interview_key = d.CONTACT_INTERVIEW_KEY
+               AND d.CONTACT_INTERVIEW_KEY <> 1
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+               AND e.CTT_REFERRAL_BASIS IN (
+                 'A1 - Associate 1',
+                 'A2 - Associate 2',
+                 'A3 - Associate 3',
+                 'S1 - Social Contact 1',
+                 'S2 - Social Contact 2',
+                 'S3 - Social Contact 3'
+               )
+      WHERE f.FL_FUP_DISPOSITION IN (
+        'G - Insufficient Info to Begin Investigation',
+        'H - Unable to Locate',
+        'J - Located, Not Examined and/or Interviewed',
+        'K - Sent Out Of Jurisdiction',
+        'L - Other',
+        'V - Domestic Violence Risk',
+        'X - Patient Deceased',
+        'Z - Previous Preventative Treatment'
+      )
+    """
+
+
+def partner_case_dispositions_query(subset_query: str) -> str:
+    """Return interviewed case rows used for partner disposition counts.
+
+    This is the SQL equivalent of SAS `pp1`, which is used to calculate the
+    partner-side Previous Pos and Open rows.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT COALESCE(TRY_CONVERT (INT,a.STD_PRTNRS_PRD_TRNSGNDR_TTL),0)
+               AS STD_PRTNRS_TRNSGNDR_TTL,
+             a.FL_FUP_DISPOSITION,
+             COALESCE(TRY_CONVERT (INT,a.SOC_PRTNRS_PRD_FML_TTL),0)
+               AS SOC_PRTNRS_FML_TTL,
+             COALESCE(TRY_CONVERT (INT,a.SOC_PRTNRS_PRD_MALE_TTL),0)
+               AS SOC_PRTNRS_MALE_TTL,
+             COALESCE(TRY_CONVERT (INT,a.STD_PRTNRS_PRD_TRNSGNDR_TTL),0)
+               + COALESCE(TRY_CONVERT (INT,a.SOC_PRTNRS_PRD_FML_TTL),0)
+               + COALESCE(TRY_CONVERT (INT,a.SOC_PRTNRS_PRD_MALE_TTL),0) AS count_Q,
+             D_provider.PROVIDER_QUICK_CODE,
+             a.INV_LOCAL_ID,
+             a.CA_PATIENT_INTV_STATUS,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.investigation
+                ON investigation.investigation_key = a.investigation_KEY
+               AND a.CA_PATIENT_INTV_STATUS IN ('I - Interviewed');
+    """
+
+
+def cluster_previous_pos_query(subset_query: str) -> str:
+    """Used to calculate 'Previous Pos' for 'new clusters' in the Dispositions
+    report section.
+
+    Equivalent of the SAS `c1` table.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT a.INVESTIGATOR_INTERVIEW_KEY,
+             PROVIDER_QUICK_CODE,
+             COUNT(DISTINCT f.INV_LOCAL_ID) AS clusters_prev_positive_count
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+      WHERE a.FL_FUP_DISPOSITION IN ('1 - Prev. Pos')
+      AND   e.CTT_REFERRAL_BASIS IN (
+              'A1 - Associate 1',
+              'A2 - Associate 2',
+              'A3 - Associate 3',
+              'S1 - Social Contact 1',
+              'S2 - Social Contact 2',
+              'S3 - Social Contact 3'
+            )
+      GROUP BY a.INVESTIGATOR_INTERVIEW_KEY,
+               PROVIDER_QUICK_CODE
+      ORDER BY a.INVESTIGATOR_INTERVIEW_KEY,
+               PROVIDER_QUICK_CODE
     """

--- a/apps/report-execution/src/libraries/support/pa_01/queries.py
+++ b/apps/report-execution/src/libraries/support/pa_01/queries.py
@@ -1,0 +1,563 @@
+"""Queries for use in pa_01."""
+
+# The date field differs in SAS for HIV vs. STD
+PA1_NEW_DATE_COL = {
+    'HIV': 'CA_INTERVIEWER_ASSIGN_DT',
+    'STD': 'CA_INIT_INTVWR_ASSGN_DT',
+}
+
+# The date field for "days" differs in SAS for HIV vs. STD
+PA1_DTE_DATE_COL = {
+    'HIV': 'CA_INIT_INTVWR_ASSGN_DT',
+    'STD': 'CA_INTERVIEWER_ASSIGN_DT',
+}
+
+
+def filtered_cases_query(subset_query: str) -> str:
+    """Return the base PA01 case population.
+
+    This is the SQL equivalent of SAS `STD_HIV_DATAMART1`: cases from the
+    report subset that are probable/confirmed and have an interviewer assigned.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      )
+      SELECT b.*
+      FROM base b
+        INNER JOIN RDB.dbo.INVESTIGATION i
+                ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+               AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+               AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL;
+    """
+
+
+def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
+    """Return case rows joined to interview and worker details.
+
+    This is the SQL equivalent of SAS `pa1_new`, which preserves cases with
+    missing interview rows by using left joins.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT
+             fc.INV_LOCAL_ID,
+             di.IX_TYPE,
+             i.INV_CASE_STATUS,
+             i.RECORD_STATUS_CD,
+             fc.CC_CLOSED_DT,
+             fc.ADI_900_STATUS_CD,
+             fc.HIV_POST_TEST_900_COUNSELING,
+             fc.HIV_900_RESULT,
+             fc.ADI_900_STATUS,
+             fc.HIV_900_TEST_IND,
+             fc.SOURCE_SPREAD,
+             fc.FL_FUP_INIT_ASSGN_DT,
+             i.CURR_PROCESS_STATE,
+             fc.CA_PATIENT_INTV_STATUS,
+             fc.INVESTIGATOR_INTERVIEW_KEY,
+             fc.INVESTIGATOR_INTERVIEW_QC,
+             DATEDIFF(
+               DAY,
+               CAST(fc.{PA1_NEW_DATE_COL[report_variant]} AS DATE),
+               CAST(di.IX_DATE AS DATE)
+             ) AS Days,
+             dp.PROVIDER_QUICK_CODE
+      FROM filtered_cases fc
+        LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
+               ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+        LEFT JOIN RDB.dbo.D_INTERVIEW di
+               ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+              AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+        LEFT JOIN RDB.dbo.D_PROVIDER dp
+               ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
+        LEFT JOIN RDB.dbo.INVESTIGATION i
+               ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY;
+    """
+
+
+def timed_interviews_query(subset_query: str, report_variant: str) -> str:
+    """Return interview rows used for the days-to-interview buckets.
+
+    This is the SQL equivalent of SAS `pa1_dte`, which only keeps cases with
+    matching interview and worker rows and calculates the `Days` value.
+    """
+    # equivalent of pa1_dte in SAS
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_base AS
+      (
+        -- STD_HIV_DATAMART1 in PA01_HIV.sas
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT fb.INV_LOCAL_ID,
+             di.IX_TYPE,
+             i.INV_CASE_STATUS,
+             i.RECORD_STATUS_CD,
+             fb.CC_CLOSED_DT,
+             fb.ADI_900_STATUS_CD,
+             fb.HIV_POST_TEST_900_COUNSELING,
+             fb.HIV_900_RESULT,
+             fb.ADI_900_STATUS,
+             fb.HIV_900_TEST_IND,
+             fb.SOURCE_SPREAD,
+             fb.FL_FUP_INIT_ASSGN_DT,
+             i.CURR_PROCESS_STATE,
+             fb.CA_PATIENT_INTV_STATUS,
+             fb.INVESTIGATOR_INTERVIEW_KEY,
+             fb.INVESTIGATOR_INTERVIEW_QC,
+             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS Days,
+             dp.PROVIDER_QUICK_CODE
+      FROM filtered_base fb
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+                ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW di
+                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_PROVIDER dp
+                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.INVESTIGATION i
+                ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+      WHERE CAST(di.IX_DATE AS DATE) >=
+                CAST(fb.CA_INIT_INTVWR_ASSGN_DT AS DATE);
+    """
+
+
+def partner_notification_query(subset_query: str) -> str:
+    """Return partner notification counts grouped by worker.
+
+    This is the SQL equivalent of SAS `pix`, used to calculate the Partner
+    Notification Index.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_base AS
+      (
+        SELECT b.*
+        FROM base b
+          JOIN RDB.dbo.INVESTIGATION i
+            ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+           AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+           AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT dp.PROVIDER_QUICK_CODE,
+             fb.INVESTIGATOR_INTERVIEW_KEY,
+             COUNT(DISTINCT fb.INV_LOCAL_ID) AS partner_notification_count
+      FROM filtered_base fb
+             JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+               ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+             JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+               ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
+             JOIN RDB.dbo.D_CONTACT_RECORD dcr
+               ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+              AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+        LEFT JOIN RDB.dbo.D_PROVIDER dp
+               ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
+      WHERE dcr.CTT_REFERRAL_BASIS IN (
+        'P1 - Partner, Sex',
+        'P2 - Partner, Needle-Sharing',
+        'P3 - Partner, Both'
+      )
+      AND contact_dm.FL_FUP_DISPOSITION IN (
+        '2 - Prev. Neg, New Pos',
+        '3 - Prev. Neg, Still Neg',
+        '5 - No Prev Test, New Pos',
+        '6 - No Prev Test, New Neg'
+      )
+      GROUP BY dp.PROVIDER_QUICK_CODE,
+               fb.INVESTIGATOR_INTERVIEW_KEY;
+    """
+
+
+def testing_index_query(subset_query: str) -> str:
+    """Return tested partner counts grouped by worker.
+
+    This is the SQL equivalent of SAS `testindex`, used to calculate the
+    Testing Index.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_base AS
+      (
+        -- STD_HIV_DATAMART1 in PA01_HIV.sas
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT dp.PROVIDER_QUICK_CODE,
+             fb.INVESTIGATOR_INTERVIEW_KEY,
+             COUNT(DISTINCT dcr.LOCAL_ID) AS testing_index_count
+      FROM filtered_base fb
+        INNER JOIN RDB.dbo.INVESTIGATION i
+                ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+                ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+                ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+                ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+               AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+         LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
+                ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
+         LEFT JOIN RDB.dbo.D_INTERVIEW di
+                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+         LEFT JOIN RDB.dbo.D_PROVIDER dp
+                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
+      WHERE dcr.CTT_REFERRAL_BASIS IN (
+         'P1 - Partner, Sex',
+         'P2 - Partner, Needle-Sharing',
+         'P3 - Partner, Both'
+      )
+      AND contact_dm.FL_FUP_DISPOSITION IN (
+         '2 - Prev. Neg, New Pos',
+         '3 - Prev. Neg, Still Neg',
+         '5 - No Prev Test, New Pos',
+         '6 - No Prev Test, New Neg'
+      )
+      GROUP BY dp.PROVIDER_QUICK_CODE,
+               fb.INVESTIGATOR_INTERVIEW_KEY;
+    """
+
+
+def period_partners_query(subset_query: str) -> str:
+    """Return period partner rows used for total period partner counts.
+
+    This is the SQL equivalent of SAS `pp`, including the calculated `count_Q`
+    value later summed for Total Period Partners.
+    """
+    return f"""
+      WITH base AS
+      (
+          {subset_query}
+      ),
+      filtered_cases AS
+      (
+          -- STD_HIV_DATAMART1 in SAS
+          SELECT b.*
+          FROM base b
+            INNER JOIN RDB.dbo.INVESTIGATION i
+                    ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                   AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                   AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT
+             fcrc.CONTACT_INVESTIGATION_KEY,
+             TRY_CONVERT(int, fc.STD_PRTNRS_PRD_TRNSGNDR_TTL)
+                AS STD_PRTNRS_TRNSGNDR_TTL,
+             contact_dm.FL_FUP_DISPOSITION,
+             fc.INV_LOCAL_ID AS STD_INV_LOCAL_ID,
+             TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_FML_TTL) AS SOC_PRTNRS_FML_TTL,
+             TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_MALE_TTL) AS SOC_PRTNRS_MALE_TTL,
+             COALESCE(TRY_CONVERT(int, fc.STD_PRTNRS_PRD_TRNSGNDR_TTL), 0)
+             + COALESCE(TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_FML_TTL), 0)
+             + COALESCE(TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_MALE_TTL), 0) AS count_Q,
+             di.IX_TYPE,
+             dp.PROVIDER_QUICK_CODE,
+             dcr.LOCAL_ID AS INV_LOCAL_ID,
+             fc.CA_PATIENT_INTV_STATUS,
+             fc.INVESTIGATOR_INTERVIEW_KEY,
+             fc.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases fc
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+                ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW di
+                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_PROVIDER dp
+                ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.INVESTIGATION i
+                ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+                ON fcrc.SUBJECT_INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+               AND fcrc.CONTACT_INTERVIEW_KEY = di.D_INTERVIEW_KEY
+               AND fcrc.CONTACT_INTERVIEW_KEY <> 1
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+                ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+                ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+               AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+      WHERE dcr.CTT_REFERRAL_BASIS IN (
+          'P1 - Partner, Sex',
+          'P2 - Partner, Needle-Sharing',
+          'P3 - Partner, Both'
+      )
+      AND fc.CA_PATIENT_INTV_STATUS = 'I - Interviewed';
+    """
+
+
+def cases_with_no_partners_query(subset_query: str) -> str:
+    """Return interviewed cases with no initiated partner records.
+
+    This is the SQL equivalent of SAS `part2`, used for Cases With No Partners.
+    """
+    return f"""
+      WITH base AS
+      (
+          {subset_query}
+      ),
+      filtered_cases AS
+      (
+          -- STD_HIV_DATAMART1 in SAS
+          SELECT b.*
+          FROM base b
+            INNER JOIN RDB.dbo.INVESTIGATION i
+                    ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                   AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                   AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      ),
+      pp AS
+      (
+          SELECT DISTINCT
+                 fcrc.CONTACT_INVESTIGATION_KEY,
+                 TRY_CONVERT(int, fc.STD_PRTNRS_PRD_TRNSGNDR_TTL)
+                    AS STD_PRTNRS_TRNSGNDR_TTL,
+                 contact_dm.FL_FUP_DISPOSITION,
+                 fc.INV_LOCAL_ID AS STD_INV_LOCAL_ID,
+                 TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_FML_TTL) AS SOC_PRTNRS_FML_TTL,
+                 TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_MALE_TTL) AS SOC_PRTNRS_MALE_TTL,
+                 COALESCE(TRY_CONVERT(int, fc.STD_PRTNRS_PRD_TRNSGNDR_TTL), 0)
+                 + COALESCE(TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_FML_TTL), 0)
+                 + COALESCE(TRY_CONVERT(int, fc.SOC_PRTNRS_PRD_MALE_TTL), 0) AS count_Q,
+                 di.IX_TYPE,
+                 dp.PROVIDER_QUICK_CODE,
+                 dcr.LOCAL_ID AS INV_LOCAL_ID,
+                 fc.CA_PATIENT_INTV_STATUS,
+                 fc.INVESTIGATOR_INTERVIEW_KEY,
+                 fc.INVESTIGATOR_INTERVIEW_QC
+          FROM filtered_cases fc
+            INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+                    ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+            INNER JOIN RDB.dbo.D_INTERVIEW di
+                    ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
+                   AND di.RECORD_STATUS_CD <> 'LOG_DEL'
+            INNER JOIN RDB.dbo.D_PROVIDER dp
+                    ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
+            INNER JOIN RDB.dbo.INVESTIGATION i
+                    ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+            INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+                    ON fcrc.SUBJECT_INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+                   AND fcrc.CONTACT_INTERVIEW_KEY = di.D_INTERVIEW_KEY
+                   AND fcrc.CONTACT_INTERVIEW_KEY <> 1
+            INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+                    ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
+            INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+                    ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+                   AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+          WHERE dcr.CTT_REFERRAL_BASIS IN (
+              'P1 - Partner, Sex',
+              'P2 - Partner, Needle-Sharing',
+              'P3 - Partner, Both'
+          )
+          AND fc.CA_PATIENT_INTV_STATUS = 'I - Interviewed'
+      )
+      SELECT DISTINCT
+             fc.INV_LOCAL_ID,
+             fc.INVESTIGATION_KEY,
+             dp.PROVIDER_QUICK_CODE,
+             dcr.CTT_REFERRAL_BASIS,
+             dcr.CTT_PROCESSING_DECISION,
+             fc.INVESTIGATOR_INTERVIEW_KEY,
+             fc.INVESTIGATOR_INTERVIEW_QC,
+             fcrc.CONTACT_INVESTIGATION_KEY
+      FROM filtered_cases fc
+        INNER JOIN RDB.dbo.D_PROVIDER dp
+                ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
+        LEFT JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+               ON fcrc.SUBJECT_INVESTIGATION_KEY = fc.INVESTIGATION_KEY
+        LEFT JOIN RDB.dbo.D_CONTACT_RECORD dcr
+               ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
+              AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
+      WHERE (
+        dcr.CTT_REFERRAL_BASIS NOT IN (
+            'P1 - Partner, Sex',
+            'P2 - Partner, Needle-Sharing',
+            'P3 - Partner, Both'
+        )
+        OR dcr.CTT_REFERRAL_BASIS IS NULL
+      )
+      AND fc.CA_PATIENT_INTV_STATUS = 'I - Interviewed'
+      AND fc.INV_LOCAL_ID NOT IN (
+          SELECT DISTINCT STD_INV_LOCAL_ID
+          FROM pp
+      );
+    """
+
+
+def clusters_initiated_query(subset_query: str) -> str:
+    """Return initiated cluster rows.
+
+    This is the SQL equivalent of SAS `cluster`, used for Total Clusters Initiated and
+    related cluster calculations.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             a.inv_local_id AS STD_INV_LOCAL_ID,
+             f.FL_FUP_DISPOSITION,
+             e.LOCAL_ID AS INV_LOCAL_ID,
+             a.FL_FUP_DISPO_DT,
+             a.FL_FUP_INIT_ASSGN_DT,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+               AND c.d_interview_key = d.CONTACT_INTERVIEW_KEY
+               AND d.CONTACT_INTERVIEW_KEY <> 1
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+               AND e.CTT_REFERRAL_BASIS IN (
+                 'A1 - Associate 1',
+                 'A2 - Associate 2',
+                 'A3 - Associate 3',
+                 'S1 - Social Contact 1',
+                 'S2 - Social Contact 2',
+                 'S3 - Social Contact 3'
+               );
+    """
+
+
+def cases_with_no_clusters_query(subset_query: str) -> str:
+    """Return cases that do not have clusters associated.
+
+    Equivalent SAS query is `clusters_No`.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      ),
+      clusters AS (
+        SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             a.inv_local_id AS STD_INV_LOCAL_ID,
+             f.FL_FUP_DISPOSITION,
+             e.LOCAL_ID AS INV_LOCAL_ID,
+             a.FL_FUP_DISPO_DT,
+             a.FL_FUP_INIT_ASSGN_DT,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+               AND c.d_interview_key = d.CONTACT_INTERVIEW_KEY
+               AND d.CONTACT_INTERVIEW_KEY <> 1
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+               AND e.CTT_REFERRAL_BASIS IN (
+                     'A1 - Associate 1',
+                     'A2 - Associate 2',
+                     'A3 - Associate 3',
+                     'S1 - Social Contact 1',
+                     'S2 - Social Contact 2',
+                     'S3 - Social Contact 3'
+                   )
+      ) 
+      SELECT DISTINCT a.INV_LOCAL_ID,
+             a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             f.CTT_REFERRAL_BASIS,
+             f.CTT_PROCESSING_DECISION,
+             INVESTIGATOR_INTERVIEW_KEY,
+             INVESTIGATOR_INTERVIEW_QC,
+             e.CONTACT_INVESTIGATION_KEY
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+        LEFT OUTER JOIN RDB.dbo.F_CONTACT_RECORD_CASE e
+                     ON e.SUBJECT_INVESTIGATION_KEY = a.Investigation_key
+        LEFT OUTER JOIN RDB.dbo.d_contact_record f
+                     ON e.D_contact_record_key = f.d_contact_record_key
+                    AND f.RECORD_STATUS_CD <> 'LOG_DEL'
+      WHERE (
+          f.CTT_REFERRAL_BASIS NOT IN (
+              'A1 - Associate 1',
+              'A2 - Associate 2',
+              'A3 - Associate 3',
+              'S1 - Social Contact 1',
+              'S2 - Social Contact 2',
+              'S3 - Social Contact 3'
+          )
+          OR f.CTT_REFERRAL_BASIS IS NULL
+      )
+      AND a.CA_PATIENT_INTV_STATUS IN ('I - Interviewed')
+      AND NOT EXISTS (
+        SELECT 1 FROM clusters c WHERE c.STD_INV_LOCAL_ID = a.INV_LOCAL_ID
+      );
+    """

--- a/apps/report-execution/src/libraries/support/pa_01/queries.py
+++ b/apps/report-execution/src/libraries/support/pa_01/queries.py
@@ -13,26 +13,6 @@ PA1_DTE_DATE_COL = {
 }
 
 
-def filtered_cases_query(subset_query: str) -> str:
-    """Return the base PA01 case population.
-
-    This is the SQL equivalent of SAS `STD_HIV_DATAMART1`: cases from the
-    report subset that are probable/confirmed and have an interviewer assigned.
-    """
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      )
-      SELECT b.*
-      FROM base b
-        INNER JOIN RDB.dbo.INVESTIGATION i
-                ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-               AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-               AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL;
-    """
-
-
 def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
     """Return case rows joined to interview and worker details.
 
@@ -75,7 +55,7 @@ def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
                DAY,
                CAST(fc.{PA1_NEW_DATE_COL[report_variant]} AS DATE),
                CAST(di.IX_DATE AS DATE)
-             ) AS Days,
+             ) AS DAYS,
              dp.PROVIDER_QUICK_CODE
       FROM filtered_cases fc
         LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
@@ -128,7 +108,7 @@ def timed_interviews_query(subset_query: str, report_variant: str) -> str:
              fb.CA_PATIENT_INTV_STATUS,
              fb.INVESTIGATOR_INTERVIEW_KEY,
              fb.INVESTIGATOR_INTERVIEW_QC,
-             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS Days,
+             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS DAYS,
              dp.PROVIDER_QUICK_CODE
       FROM filtered_base fb
         INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
@@ -591,8 +571,11 @@ def notified_partners_query(subset_query: str) -> str:
              f.FL_FUP_DISPOSITION,
              a.FL_FUP_DISPO_DT,
              a.FL_FUP_INIT_ASSGN_DT,
-             datepart(DAY,a.FL_FUP_DISPO_DT) - datepart(DAY,a.FL_FUP_INIT_ASSGN_DT)
-                AS days,
+             DATEDIFF(
+                DAY,
+                CAST(a.FL_FUP_INIT_ASSGN_DT AS DATE),
+                CAST(a.FL_FUP_DISPO_DT AS DATE)
+             ) AS DAYS,
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
@@ -718,8 +701,11 @@ def notified_clusters_query(subset_query: str) -> str:
              f.FL_FUP_INVESTIGATOR_ASSGN_DT,
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC,
-             datepart(day, f.FL_FUP_DISPO_DT)
-               - datepart(day, f.FL_FUP_INVESTIGATOR_ASSGN_DT) AS days
+             DATEDIFF(
+               DAY,
+               CAST(f.FL_FUP_INVESTIGATOR_ASSGN_DT AS DATE),
+               CAST(f.FL_FUP_DISPO_DT AS DATE)
+             ) AS DAYS
       FROM filtered_cases a
         INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
@@ -921,4 +907,71 @@ def cluster_previous_pos_query(subset_query: str) -> str:
                PROVIDER_QUICK_CODE
       ORDER BY a.INVESTIGATOR_INTERVIEW_KEY,
                PROVIDER_QUICK_CODE
+    """
+
+
+def notified_partners_by_speed_query(subset_query: str) -> str:
+    """Query used to calculate the "New Partners Notified" counts in the "SPEED OF
+    NOTIFICATION - PARTNERS & CLUSTERS" section.
+
+    Equivalent of `partner2_dte` in SAS.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             f.INV_LOCAL_ID,
+             f.FL_FUP_DISPOSITION,
+             f.FL_FUP_DISPO_DT,
+             f.FL_FUP_INVESTIGATOR_ASSGN_DT,
+             DATEDIFF(
+                DAY,
+                CAST(f.FL_FUP_INVESTIGATOR_ASSGN_DT AS DATE),
+                CAST(f.FL_FUP_DISPO_DT AS DATE)
+             ) AS DAYS,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+               AND e.CTT_REFERRAL_BASIS IN (
+                     'P1 - Partner, Sex',
+                     'P2 - Partner, Needle-Sharing',
+                     'P3 - Partner, Both'
+                   )
+               AND f.FL_FUP_DISPOSITION IN (
+                     '2 - Prev. Neg, New Pos',
+                     '3 - Prev. Neg, Still Neg',
+                     '4 - Prev. Neg, No Test',
+                     '5 - No Prev Test, New Pos',
+                     '6 - No Prev Test, New Neg',
+                     '7 - No Prev Test, No Test'
+                   )
+               AND CAST(f.FL_FUP_DISPO_DT AS DATE) >=
+                     CAST(f.FL_FUP_INVESTIGATOR_ASSGN_DT AS DATE);
     """

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -51,6 +51,24 @@ class Table(BaseModel):
         # Sort with None first (False < True, so None comes before non-None)
         return sorted(values, key=lambda x: (x is not None, x))
 
+    def data_as_dicts(self) -> list[dict]:
+        """Return data as a list of dicts where the keys are the column names
+        and the values are the data values.
+
+        Returns:
+            Table data in the form of dicts where the column names are the keys
+        """
+
+        def row_to_dict(row: tuple) -> dict:
+            d = dict()
+
+            for i, col in enumerate(self.columns):
+                d[col] = row[i]
+
+            return d
+
+        return list(map(row_to_dict, self.data))
+
 
 def serialize_table(table: Table) -> str:
     """Turn a Table into a CSV for returning to the user.

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/pa03.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/pa03.yaml
@@ -3,6 +3,7 @@ config:
   nbs:
     fk_tables:
       - '[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]'
+      - '[RDB].[dbo].[CASE_COUNT]'
 
 tables:
   - table_name: "[RDB].[dbo].[INVESTIGATION]"

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
@@ -1,0 +1,200 @@
+config:
+  seed: 19
+  nbs:
+    fk_tables:
+      - "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]"
+
+tables:
+  - table_name: "[RDB].[dbo].[INVESTIGATION]"
+    row_count: 500
+    columns:
+      - column_name: INVESTIGATION_KEY
+        data: row_id
+        is_primary_key: true
+      - column_name: INV_CASE_STATUS
+        data: random.choice(["Confirmed", "Probable", "Suspect", "Unknown"])
+      - column_name: RECORD_STATUS_CD
+        data: random.choice(["ACTIVE", "INACTIVE"])
+      - column_name: INV_LOCAL_ID
+        data: |
+          id_num = fake.unique.random_int(10000, 99999)
+          return f"CAS100{id_num}GA01"
+        is_primary_key: true
+      - column_name: CASE_UID
+        data: row_id + 10000000
+
+  - table_name: "[RDB].[dbo].[D_PROVIDER]"
+    row_count: 5
+    columns:
+      - column_name: PROVIDER_KEY
+        data: row_id
+        is_primary_key: true
+      - column_name: PROVIDER_FIRST_NAME
+        data: fake.first_name()
+      - column_name: PROVIDER_LAST_NAME
+        data: fake.last_name()
+      - column_name: PROVIDER_NAME_SUFFIX
+        data: random.choice(["Jr.", "Sr.", "II", "III", "MD", "PhD"])
+      - column_name: PROVIDER_QUICK_CODE
+        data: |
+          if row_id == 1:
+            return "gfreeman"
+          elif row_id == 2:
+            return "avance"
+          elif row_id == 3:
+            return "adevraj"
+          elif row_id == 4:
+            return "dbowman"
+          else:
+            return "fpoole"
+        is_primary_key: true
+
+  - table_name: "[RDB].[dbo].[STD_HIV_DATAMART]"
+    row_count: 1000
+    columns:
+      # pretty sure program_jurisdiction_oid is needed for priv reasons?
+      - column_name: PROGRAM_JURISDICTION_OID
+        data: random.choice(["1300400010", "1300400011", "1300400008", "1300400009", "1300400014", "1300400015", "1300400012"])
+
+      - column_name: INV_LOCAL_ID
+        data: foreign_key("[RDB].[dbo].[INVESTIGATION]", "INV_LOCAL_ID")
+      - column_name: CC_CLOSED_DT
+        data: fake.date_between(start_date=date(2018, 5, 5), end_date=date(2025, 1, 5))
+      - column_name: ADI_900_STATUS_CD
+        data: random.choice(["01", "02", "03", "04", "09"])
+      - column_name: HIV_POST_TEST_900_COUNSELING
+        data: random.choice(["Yes", "No"])
+      - column_name: HIV_900_RESULT
+        data: random.choice(["11-Negative", "12-Prelim Positive", "13-Positive/Reactive", "21-HIV-1 Pos", "22-HIV-1 Pos, Possible Acute"])
+      - column_name: ADI_900_STATUS
+        data: random.choice(["1 - Negative", "2 - Newly Diagnosed", "3 - Prior Positive - Not Previously Known", "4 - Prior Positive - New STD or Pregnancy", "9 - Unknown"])
+      - column_name: HIV_900_TEST_IND
+        data: random.choice(["Yes", "No"])
+      - column_name: SOURCE_SPREAD
+        data: random.choice(["1 - Spread", "2 - Source"])
+      - column_name: FL_FUP_INIT_ASSGN_DT
+        data: fake.date_between(start_date=date(2018, 5, 5), end_date=date(2025, 1, 5))
+      - column_name: CA_PATIENT_INTV_STATUS
+        data: r"I - Interviewed"
+      - column_name: INVESTIGATOR_INTERVIEW_KEY
+        data: foreign_key("[RDB].[dbo].[D_PROVIDER]", "PROVIDER_KEY")
+      - column_name: INVESTIGATOR_INTERVIEW_QC
+        data: foreign_key("[RDB].[dbo].[D_PROVIDER]", "PROVIDER_QUICK_CODE")
+      - column_name: CA_INTERVIEWER_ASSIGN_DT
+        data: date(2024, 1, 1)
+      - column_name: CA_INIT_INTVWR_ASSGN_DT
+        data: date(2024, 1, 1)
+      - column_name: INVESTIGATION_KEY
+        data: row_id
+      - column_name: STD_PRTNRS_PRD_TRNSGNDR_TTL
+        data: fake.random_digit()
+      - column_name: SOC_PRTNRS_PRD_FML_TTL
+        data: fake.random_digit()
+      - column_name: SOC_PRTNRS_PRD_MALE_TTL
+        data: fake.random_digit()
+      - column_name: FL_FUP_DISPOSITION
+        data: |
+          return random.choice([
+            "2 - Prev. Neg, New Pos",
+            "3 - Prev. Neg, Still Neg",
+            "4 - Prev. Neg, No Test",
+            "5 - No Prev Test, New Pos",
+            "6 - No Prev Test, New Neg",
+            "7 - No Prev Test, No Test",
+            "A - Preventative Treatment",
+            "B - Refused Preventative Treatment",
+            "C - Infected, Brought to Treatment",
+            "D - Infected, Not Treated",
+            "F - Not Infected",
+            "G - Insufficient Info to Begin Investigation",
+            "H - Unable to Locate",
+            "J - Located, Not Examined and/or Interviewed",
+            "K - Sent Out Of Jurisdiction",
+            "L - Other",
+            "V - Domestic Violence Risk",
+            "X - Patient Deceased",
+            "Z - Previous Preventative Treatment",
+            "E - Previously Treated for This Infection",
+            "1 - Prev. Pos"
+          ])
+      - column_name: FL_FUP_DISPO_DT
+        data: date(2024, 1, min(row_id, 28))
+      - column_name: FL_FUP_INVESTIGATOR_ASSGN_DT
+        data: date(2024, 1, 1)
+      - column_name: INIT_FUP_INITIAL_FOLL_UP
+        data: random.choice(["OOJ", "Field Follow-up", "Record Search Closure"])
+
+
+  - table_name: "[RDB].[dbo].[D_INTERVIEW]"
+    row_count: 500
+    columns:
+      - column_name: D_INTERVIEW_KEY
+        data: row_id
+        is_primary_key: true
+      - column_name: RECORD_STATUS_CD
+        data: r"ACTIVE"
+      - column_name: IX_TYPE
+        data: random.choice(["Initial/Original", "Re-Interview"])
+      - column_name: IX_DATE
+        data: date(2024, 1, min(row_id, 14))
+
+  - table_name: "[RDB].[dbo].[F_INTERVIEW_CASE]"
+    row_count: 500
+    columns:
+      - column_name: INVESTIGATION_KEY
+        data: row_id
+      - column_name: D_INTERVIEW_KEY
+        data: row_id
+
+  - table_name: "[RDB].[dbo].[D_CONTACT_RECORD]"
+    row_count: 50
+    columns:
+      - column_name: D_CONTACT_RECORD_KEY
+        data: row_id
+        is_primary_key: true
+      - column_name: LOCAL_ID
+        data: |
+          return f"CTRPA03{row_id:03d}"
+      - column_name: RECORD_STATUS_CD
+        data: random.choice(["ACTIVE", "INACTIVE"])
+      - column_name: RECORD_STATUS_TIME
+        data: |
+          return datetime(2024, 3, min(row_id, 28), 8, 0, 0)
+      - column_name: CTT_REFERRAL_BASIS
+        data: random.choice(["P1 - Partner, Sex", "S1 - Social Contact 1", "A1 - Associate 1", "P2 - Partner, Needle-Sharing"])
+      - column_name: CTT_PROCESSING_DECISION
+        data: random.choice(["Field Follow-up", "Secondary Referral", "Record Search Closure"])
+      - column_name: ADD_TIME
+        data: |
+          return datetime(2024, 1, min(row_id, 28), 9, 0, 0)
+      - column_name: LAST_CHG_TIME
+        data: |
+          return datetime(2024, 2, min(row_id, 28), 9, 0, 0)
+
+  - table_name: "[RDB].[dbo].[F_CONTACT_RECORD_CASE]"
+    row_count: 40
+    columns:
+      - column_name: D_CONTACT_RECORD_KEY
+        data: row_id
+      - column_name: SUBJECT_INVESTIGATION_KEY
+        data: row_id
+      - column_name: CONTACT_INVESTIGATION_KEY
+        data: row_id + 100
+      - column_name: THIRD_PARTY_ENTITY_KEY
+        data: 1
+      - column_name: CONTACT_KEY
+        data: |
+          return 1000 + row_id
+      - column_name: SUBJECT_KEY
+        data: |
+          return 2000 + (1 if row_id in (1, 2, 3) else 2)
+      - column_name: THIRD_PARTY_INVESTIGATION_KEY
+        data: 1
+      - column_name: CONTACT_INTERVIEW_KEY
+        data: row_id
+      - column_name: DISPOSITIONED_BY_KEY
+        data: 1
+      - column_name: CONTACT_EXPOSURE_SITE_KEY
+        data: 1
+      - column_name: CONTACT_INVESTIGATOR_KEY
+        data: foreign_key("[RDB].[dbo].[D_PROVIDER]", "PROVIDER_KEY")

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
@@ -3,6 +3,7 @@ config:
   nbs:
     fk_tables:
       - "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]"
+      - "[RDB].[dbo].[CASE_COUNT]"
 
 tables:
   - table_name: "[RDB].[dbo].[INVESTIGATION]"
@@ -12,7 +13,10 @@ tables:
         data: row_id
         is_primary_key: true
       - column_name: INV_CASE_STATUS
-        data: random.choice(["Confirmed", "Probable", "Suspect", "Unknown"])
+        data: |
+          if row_id <= 350:
+            return random.choice(["Confirmed", "Probable"])
+          return random.choice(["Confirmed", "Probable", "Suspect", "Unknown"])
       - column_name: RECORD_STATUS_CD
         data: random.choice(["ACTIVE", "INACTIVE"])
       - column_name: INV_LOCAL_ID
@@ -87,13 +91,57 @@ tables:
       - column_name: INVESTIGATION_KEY
         data: row_id
       - column_name: STD_PRTNRS_PRD_TRNSGNDR_TTL
-        data: fake.random_digit()
+        data: |
+          if row_id <= 300:
+            return 1 if row_id % 4 == 0 else 0
+          return fake.random_digit()
       - column_name: SOC_PRTNRS_PRD_FML_TTL
-        data: fake.random_digit()
+        data: |
+          if row_id <= 300:
+            return 0
+          return fake.random_digit()
       - column_name: SOC_PRTNRS_PRD_MALE_TTL
-        data: fake.random_digit()
+        data: |
+          if row_id <= 300:
+            return 0
+          return fake.random_digit()
       - column_name: FL_FUP_DISPOSITION
         data: |
+          notified_dispositions = [
+            "2 - Prev. Neg, New Pos",
+            "3 - Prev. Neg, Still Neg",
+            "4 - Prev. Neg, No Test",
+            "5 - No Prev Test, New Pos",
+            "6 - No Prev Test, New Neg",
+            "7 - No Prev Test, No Test"
+          ]
+          not_notified_dispositions = [
+            "G - Insufficient Info to Begin Investigation",
+            "H - Unable to Locate",
+            "J - Located, Not Examined and/or Interviewed",
+            "K - Sent Out Of Jurisdiction",
+            "L - Other",
+            "V - Domestic Violence Risk",
+            "X - Patient Deceased"
+          ]
+          cluster_not_notified_dispositions = not_notified_dispositions + [
+            "Z - Previous Preventative Treatment"
+          ]
+          if 101 <= row_id <= 400:
+            contact_row_id = row_id - 100
+            bucket = contact_row_id % 4
+            if bucket == 0:
+              return notified_dispositions[contact_row_id % len(notified_dispositions)]
+            if bucket == 1:
+              return not_notified_dispositions[
+                contact_row_id % len(not_notified_dispositions)
+              ]
+            if bucket == 2:
+              return notified_dispositions[contact_row_id % len(notified_dispositions)]
+            return cluster_not_notified_dispositions[
+              contact_row_id % len(cluster_not_notified_dispositions)
+            ]
+
           return random.choice([
             "2 - Prev. Neg, New Pos",
             "3 - Prev. Neg, Still Neg",
@@ -117,6 +165,7 @@ tables:
             "E - Previously Treated for This Infection",
             "1 - Prev. Pos"
           ])
+        null_percentage: 0.1
       - column_name: FL_FUP_DISPO_DT
         data: date(2024, 1, min(row_id, 28))
       - column_name: FL_FUP_INVESTIGATOR_ASSGN_DT
@@ -147,7 +196,7 @@ tables:
         data: row_id
 
   - table_name: "[RDB].[dbo].[D_CONTACT_RECORD]"
-    row_count: 50
+    row_count: 300
     columns:
       - column_name: D_CONTACT_RECORD_KEY
         data: row_id
@@ -156,12 +205,28 @@ tables:
         data: |
           return f"CTRPA03{row_id:03d}"
       - column_name: RECORD_STATUS_CD
-        data: random.choice(["ACTIVE", "INACTIVE"])
+        data: r"ACTIVE"
       - column_name: RECORD_STATUS_TIME
         data: |
           return datetime(2024, 3, min(row_id, 28), 8, 0, 0)
       - column_name: CTT_REFERRAL_BASIS
-        data: random.choice(["P1 - Partner, Sex", "S1 - Social Contact 1", "A1 - Associate 1", "P2 - Partner, Needle-Sharing"])
+        data: |
+          partner_bases = [
+            "P1 - Partner, Sex",
+            "P2 - Partner, Needle-Sharing",
+            "P3 - Partner, Both"
+          ]
+          cluster_bases = [
+            "A1 - Associate 1",
+            "A2 - Associate 2",
+            "A3 - Associate 3",
+            "S1 - Social Contact 1",
+            "S2 - Social Contact 2",
+            "S3 - Social Contact 3"
+          ]
+          if row_id % 4 in (0, 1):
+            return partner_bases[row_id % len(partner_bases)]
+          return cluster_bases[row_id % len(cluster_bases)]
       - column_name: CTT_PROCESSING_DECISION
         data: random.choice(["Field Follow-up", "Secondary Referral", "Record Search Closure"])
       - column_name: ADD_TIME
@@ -172,7 +237,7 @@ tables:
           return datetime(2024, 2, min(row_id, 28), 9, 0, 0)
 
   - table_name: "[RDB].[dbo].[F_CONTACT_RECORD_CASE]"
-    row_count: 40
+    row_count: 300
     columns:
       - column_name: D_CONTACT_RECORD_KEY
         data: row_id

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
@@ -77,7 +77,10 @@ tables:
       - column_name: SOURCE_SPREAD
         data: random.choice(["1 - Spread", "2 - Source"])
       - column_name: FL_FUP_INIT_ASSGN_DT
-        data: fake.date_between(start_date=date(2018, 5, 5), end_date=date(2025, 1, 5))
+        data: |
+          if row_id <= 400:
+            return date(2024, 1, 1)
+          return fake.date_between(start_date=date(2018, 5, 5), end_date=date(2025, 1, 5))
       - column_name: CA_PATIENT_INTV_STATUS
         data: r"I - Interviewed"
       - column_name: INVESTIGATOR_INTERVIEW_KEY
@@ -167,7 +170,11 @@ tables:
           ])
         null_percentage: 0.1
       - column_name: FL_FUP_DISPO_DT
-        data: date(2024, 1, min(row_id, 28))
+        data: |
+          if row_id <= 400:
+            day_offsets = [2, 4, 6, 10, 16]
+            return date(2024, 1, 1 + day_offsets[row_id % len(day_offsets)])
+          return date(2024, 1, min(row_id, 28))
       - column_name: FL_FUP_INVESTIGATOR_ASSGN_DT
         data: date(2024, 1, 1)
       - column_name: INIT_FUP_INITIAL_FOLL_UP

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/qa_06.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/qa_06.yaml
@@ -1,7 +1,9 @@
 config:
   seed: 19
   nbs:
-    fk_tables: [ "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]" ]
+    fk_tables:
+      - "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]"
+      - "[RDB].[dbo].[CASE_COUNT]"
 
 tables:
   - table_name: "[RDB].[dbo].[USER_PROFILE]"

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/std_hiv_datamart.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/std_hiv_datamart.yaml
@@ -3,6 +3,7 @@ config:
   nbs:
     fk_tables:
       - "[RDB].[dbo].[CONFIRMATION_METHOD_GROUP]"
+      - "[RDB].[dbo].[CASE_COUNT]"
 
 tables:
   - table_name: "[RDB].[dbo].[INVESTIGATION]"

--- a/apps/report-execution/tests/integration/execute_report.py
+++ b/apps/report-execution/tests/integration/execute_report.py
@@ -1,6 +1,6 @@
-import http
 import json
 import os
+from http import client
 from typing import cast
 
 import mssql_python
@@ -131,7 +131,7 @@ class TestIntegrationExecuteReport:
         }
         invalid_spec.pop(missing_prop)
 
-        connection = http.client.HTTPConnection(
+        connection = client.HTTPConnection(
             f'localhost:{os.getenv("UVICORN_PORT", "8001")}'
         )
 
@@ -169,7 +169,7 @@ class TestIntegrationExecuteReport:
         invalid_spec.pop(empty_string_prop)
         invalid_spec[empty_string_prop] = ''
 
-        connection = http.client.HTTPConnection(
+        connection = client.HTTPConnection(
             f'localhost:{os.getenv("UVICORN_PORT", "8001")}'
         )
 

--- a/apps/report-execution/tests/integration/libraries/pa_01.py
+++ b/apps/report-execution/tests/integration/libraries/pa_01.py
@@ -45,6 +45,11 @@ class TestIntegrationPa01Library:
         with pytest.raises(ValueError, match=r'.*missing key.*'):
             execute_report(report_spec)
 
+        report_spec = self.create_spec(library_params='{"report_variant": "HIVV"}')
+
+        with pytest.raises(ValueError, match=r'.*only be "STD" or "HIV".*'):
+            execute_report(report_spec)
+
     def test_execute_report_check_data_hiv(self, snapshot):
         report_spec = self.create_spec()
 

--- a/apps/report-execution/tests/integration/libraries/pa_01.py
+++ b/apps/report-execution/tests/integration/libraries/pa_01.py
@@ -1,0 +1,99 @@
+import pytest
+import yaml
+
+from src.execute_report import execute_report
+from src.models import ReportSpec
+
+faker_schema = 'pa_01.yaml'
+
+
+@pytest.mark.usefixtures('setup_containers', 'fake_db_table')
+@pytest.mark.integration
+class TestIntegrationPa01Library:
+    """Integration tests for the pa_01 library."""
+
+    def create_spec(self, **overrides):
+        base = {
+            'is_export': True,
+            'is_builtin': True,
+            'report_title': (
+                'PA01 Case Management Report (Interview Assign Date) - HIV'
+            ),
+            'library_name': 'pa_01',
+            'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
+            'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
+            'library_params': '{"report_variant": "HIV"}',
+        }
+
+        base.update(overrides)
+
+        return ReportSpec.model_validate(base)
+
+    def test_execute_report_bad_input(self):
+        report_spec = self.create_spec(library_params=None)
+
+        with pytest.raises(ValueError, match=r'.*is not a dict.*'):
+            execute_report(report_spec)
+
+        report_spec = self.create_spec(library_params='19')
+
+        with pytest.raises(ValueError, match=r'.*is not a dict.*'):
+            execute_report(report_spec)
+
+        report_spec = self.create_spec(library_params='{"foo": 19}')
+
+        with pytest.raises(ValueError, match=r'.*missing key.*'):
+            execute_report(report_spec)
+
+    def test_execute_report_check_data_hiv(self, snapshot):
+        report_spec = self.create_spec()
+
+        result = execute_report(report_spec)
+
+        assert result is not None
+
+        assert result.content.columns == [
+            'Worker',
+            'Category 1',
+            'Category 2',
+            'Category 3',
+            'Count',
+            'Percentage',
+            'Index',
+        ]
+
+        data = result.content.data
+
+        assert len(data) > 0
+
+        for row in data:
+            assert isinstance(row[0], str)
+            assert isinstance(row[1], str)
+            assert isinstance(row[2], str)
+            assert row[3] is None or isinstance(row[3], str)
+            assert row[4] is None or isinstance(row[4], int)
+            assert row[5] is None or isinstance(row[5], str)
+            assert row[6] is None or isinstance(row[6], str)
+
+        snapshot.assert_match(yaml.dump(data), 'snapshot.yml')
+
+    def test_execute_report_no_data_hiv(self):
+        report_spec = self.create_spec(
+            subset_query='SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
+        )
+
+        result = execute_report(report_spec)
+
+        assert result is not None
+
+        assert result.content.columns == [
+            'Worker',
+            'Category 1',
+            'Category 2',
+            'Category 3',
+            'Count',
+            'Percentage',
+            'Index',
+        ]
+
+        assert len(result.content.data) == 0

--- a/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
+++ b/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
@@ -3,7 +3,7 @@
   - Case Assignments & Outcomes
   - Cases Assigned
   - null
-  - 185
+  - 287
   - null
   - null
 - !!python/tuple
@@ -11,7 +11,7 @@
   - Case Assignments & Outcomes
   - Cases Closed
   - null
-  - 185
+  - 287
   - 100.0%
   - null
 - !!python/tuple
@@ -19,7 +19,7 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - null
-  - 185
+  - 287
   - 100.0%
   - null
 - !!python/tuple
@@ -27,72 +27,72 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 3 days
-  - 0
-  - 0.0%
+  - 2
+  - 0.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 5 days
-  - 1
-  - 0.5%
+  - 2
+  - 0.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 7 days
-  - 1
-  - 0.5%
+  - 2
+  - 0.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 14 days
-  - 116
-  - 62.7%
+  - 214
+  - 74.6%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 97
-  - 52.4%
+  - 172
+  - 59.9%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 86
-  - 46.5%
+  - 145
+  - 50.5%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 117
-  - 63.2%
+  - 217
+  - 75.6%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 150
-  - 128.2%
+  - 245
+  - 112.9%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 108
-  - 92.3%
+  - 210
+  - 96.8%
   - null
 - !!python/tuple
   - ALL
@@ -101,7 +101,7 @@
   - null
   - null
   - null
-  - '0.01'
+  - '0.16'
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
@@ -109,21 +109,21 @@
   - null
   - null
   - null
-  - '0.01'
+  - '0.16'
 - !!python/tuple
   - ALL
   - Partners & Clusters Initiated
   - Total Period Partners
   - null
-  - 76
+  - 75
   - null
-  - '0.4'
+  - '0.3'
 - !!python/tuple
   - ALL
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - null
-  - 5
+  - 149
   - null
   - null
 - !!python/tuple
@@ -131,7 +131,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 1
+  - 68
   - null
   - null
 - !!python/tuple
@@ -139,7 +139,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 4
+  - 81
   - null
   - null
 - !!python/tuple
@@ -149,21 +149,21 @@
   - null
   - null
   - null
-  - '0.03'
+  - '0.52'
 - !!python/tuple
   - ALL
   - Partners & Clusters Initiated
   - Cases W/No Partners
   - null
-  - 180
-  - 97.3%
+  - 161
+  - 56.1%
   - null
 - !!python/tuple
   - ALL
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - null
-  - 8
+  - 150
   - null
   - null
 - !!python/tuple
@@ -173,21 +173,293 @@
   - Cluster Index
   - null
   - null
-  - '0.04'
+  - '0.52'
 - !!python/tuple
   - ALL
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - Cases /W No Clusters
-  - 177
-  - 95.7%
+  - 155
+  - 54.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - null
+  - 63
+  - 42.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, New Pos
+  - 24
+  - 38.1%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, No Test
+  - 21
+  - 33.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Neg
+  - 22
+  - 34.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - null
+  - 63
+  - 42.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Insufficient Info
+  - 7
+  - 11.1%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Unable to Locate
+  - 10
+  - 15.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Refused Exam
+  - 10
+  - 15.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - OOJ
+  - 10
+  - 15.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Other
+  - 8
+  - 12.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Domestic Violence Risk
+  - 11
+  - 17.5%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Patient Deceased
+  - 11
+  - 17.5%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Previous Pos
+  - null
+  - 11
+  - 7.4%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Partners Open
+  - null
+  - 31
+  - 20.8%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 69
+  - 46.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, New Pos
+  - 15
+  - 21.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, No Test
+  - 13
+  - 18.8%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Neg
+  - 14
+  - 20.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, No Test
+  - 2
+  - 2.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - null
+  - 71
+  - 47.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Unable to Locate
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Refused Exam
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - OOJ
+  - 35
+  - 49.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Other
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Domestic Violence Risk
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Previous Pos
+  - null
+  - 2
+  - 1.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Dispositions - New Partners & Clusters
+  - New Clusters Open
+  - null
+  - 10
+  - 6.7%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases Assigned
   - null
-  - 34
+  - 71
   - null
   - null
 - !!python/tuple
@@ -195,7 +467,7 @@
   - Case Assignments & Outcomes
   - Cases Closed
   - null
-  - 34
+  - 71
   - 100.0%
   - null
 - !!python/tuple
@@ -203,7 +475,7 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - null
-  - 34
+  - 71
   - 100.0%
   - null
 - !!python/tuple
@@ -211,72 +483,72 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 3 days
-  - 0
-  - 0.0%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 5 days
-  - 0
-  - 0.0%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 7 days
-  - 0
-  - 0.0%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 14 days
-  - 18
-  - 52.9%
+  - 40
+  - 56.3%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 17
-  - 50.0%
+  - 37
+  - 52.1%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 17
-  - 50.0%
+  - 25
+  - 35.2%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 24
-  - 70.6%
+  - 36
+  - 50.7%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 31
-  - 129.2%
+  - 57
+  - 158.3%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 15
-  - 62.5%
+  - 43
+  - 119.4%
   - null
 - !!python/tuple
   - adevraj
@@ -285,7 +557,7 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.17'
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
@@ -293,21 +565,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.17'
 - !!python/tuple
   - adevraj
   - Partners & Clusters Initiated
   - Total Period Partners
   - null
-  - 10
+  - 16
   - null
-  - '0.3'
+  - '0.2'
 - !!python/tuple
   - adevraj
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - null
-  - 1
+  - 28
   - null
   - null
 - !!python/tuple
@@ -315,7 +587,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 0
+  - 12
   - null
   - null
 - !!python/tuple
@@ -323,7 +595,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 1
+  - 16
   - null
   - null
 - !!python/tuple
@@ -333,21 +605,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.4'
 - !!python/tuple
   - adevraj
   - Partners & Clusters Initiated
   - Cases W/No Partners
   - null
   - 32
-  - 94.1%
+  - 45.1%
   - null
 - !!python/tuple
   - adevraj
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - null
-  - 0
+  - 28
   - null
   - null
 - !!python/tuple
@@ -357,21 +629,293 @@
   - Cluster Index
   - null
   - null
-  - '0.0'
+  - '0.39'
 - !!python/tuple
   - adevraj
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - Cases /W No Clusters
-  - 33
-  - 97.1%
+  - 35
+  - 49.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - null
+  - 15
+  - 53.6%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, New Pos
+  - 9
+  - 60.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, No Test
+  - 3
+  - 20.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Neg
+  - 3
+  - 20.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - null
+  - 11
+  - 39.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Insufficient Info
+  - 1
+  - 9.1%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Unable to Locate
+  - 1
+  - 9.1%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Refused Exam
+  - 3
+  - 27.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - OOJ
+  - 1
+  - 9.1%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Other
+  - 2
+  - 18.2%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Domestic Violence Risk
+  - 3
+  - 27.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Previous Pos
+  - null
+  - 3
+  - 10.7%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Partners Open
+  - null
+  - 6
+  - 21.4%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 16
+  - 57.1%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, New Pos
+  - 3
+  - 18.8%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, No Test
+  - 2
+  - 12.5%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Neg
+  - 5
+  - 31.2%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, No Test
+  - 1
+  - 6.2%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - null
+  - 11
+  - 39.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Unable to Locate
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Refused Exam
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - OOJ
+  - 6
+  - 54.5%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Other
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Domestic Violence Risk
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Previous Pos
+  - null
+  - 1
+  - 3.6%
+  - null
+- !!python/tuple
+  - adevraj
+  - Dispositions - New Partners & Clusters
+  - New Clusters Open
+  - null
+  - 1
+  - 3.6%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - Cases Assigned
   - null
-  - 49
+  - 73
   - null
   - null
 - !!python/tuple
@@ -379,7 +923,7 @@
   - Case Assignments & Outcomes
   - Cases Closed
   - null
-  - 49
+  - 73
   - 100.0%
   - null
 - !!python/tuple
@@ -387,7 +931,7 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - null
-  - 49
+  - 73
   - 100.0%
   - null
 - !!python/tuple
@@ -419,48 +963,48 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 14 days
-  - 27
-  - 55.1%
+  - 37
+  - 50.7%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 22
-  - 44.9%
+  - 45
+  - 61.6%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 18
-  - 36.7%
+  - 27
+  - 37.0%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 24
-  - 49.0%
+  - 42
+  - 57.5%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 40
-  - 166.7%
+  - 57
+  - 135.7%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 23
-  - 95.8%
+  - 40
+  - 95.2%
   - null
 - !!python/tuple
   - avance
@@ -469,7 +1013,7 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.07'
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
@@ -477,21 +1021,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.07'
 - !!python/tuple
   - avance
   - Partners & Clusters Initiated
   - Total Period Partners
   - null
-  - 19
+  - 12
   - null
-  - '0.4'
+  - '0.2'
 - !!python/tuple
   - avance
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - null
-  - 1
+  - 27
   - null
   - null
 - !!python/tuple
@@ -499,7 +1043,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 0
+  - 14
   - null
   - null
 - !!python/tuple
@@ -507,7 +1051,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 1
+  - 13
   - null
   - null
 - !!python/tuple
@@ -517,21 +1061,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.4'
 - !!python/tuple
   - avance
   - Partners & Clusters Initiated
   - Cases W/No Partners
   - null
-  - 48
-  - 98.0%
+  - 42
+  - 57.5%
   - null
 - !!python/tuple
   - avance
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - null
-  - 0
+  - 26
   - null
   - null
 - !!python/tuple
@@ -541,21 +1085,293 @@
   - Cluster Index
   - null
   - null
-  - '0.0'
+  - '0.36'
 - !!python/tuple
   - avance
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - Cases /W No Clusters
-  - 48
-  - 98.0%
+  - 36
+  - 49.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - null
+  - 9
+  - 33.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, New Pos
+  - 2
+  - 22.2%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, No Test
+  - 4
+  - 44.4%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Neg
+  - 3
+  - 33.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - null
+  - 15
+  - 55.6%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Unable to Locate
+  - 3
+  - 20.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Refused Exam
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - OOJ
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Other
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Domestic Violence Risk
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Patient Deceased
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Previous Pos
+  - null
+  - 1
+  - 3.7%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Partners Open
+  - null
+  - 9
+  - 33.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - 46.2%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, New Pos
+  - 2
+  - 16.7%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, No Test
+  - 4
+  - 33.3%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Neg
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - null
+  - 13
+  - 50.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Unable to Locate
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Refused Exam
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - OOJ
+  - 5
+  - 38.5%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Other
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Domestic Violence Risk
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Previous Pos
+  - null
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Dispositions - New Partners & Clusters
+  - New Clusters Open
+  - null
+  - 1
+  - 3.8%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases Assigned
   - null
-  - 48
+  - 80
   - null
   - null
 - !!python/tuple
@@ -563,7 +1379,7 @@
   - Case Assignments & Outcomes
   - Cases Closed
   - null
-  - 48
+  - 80
   - 100.0%
   - null
 - !!python/tuple
@@ -571,7 +1387,7 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - null
-  - 48
+  - 80
   - 100.0%
   - null
 - !!python/tuple
@@ -603,23 +1419,23 @@
   - Case Assignments & Outcomes
   - Cases IX'D
   - Within 14 days
-  - 29
-  - 60.4%
+  - 49
+  - 61.3%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 20
-  - 41.7%
+  - 36
+  - 45.0%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 24
+  - 40
   - 50.0%
   - null
 - !!python/tuple
@@ -627,24 +1443,24 @@
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 26
-  - 54.2%
+  - 49
+  - 61.3%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 38
-  - 146.2%
+  - 64
+  - 130.6%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 30
-  - 115.4%
+  - 39
+  - 79.6%
   - null
 - !!python/tuple
   - dbowman
@@ -653,7 +1469,7 @@
   - null
   - null
   - null
-  - '0.02'
+  - '0.11'
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
@@ -661,29 +1477,29 @@
   - null
   - null
   - null
-  - '0.02'
+  - '0.11'
 - !!python/tuple
   - dbowman
   - Partners & Clusters Initiated
   - Total Period Partners
+  - null
+  - 16
+  - null
+  - '0.2'
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
   - null
   - 28
   - null
-  - '0.6'
-- !!python/tuple
-  - dbowman
-  - Partners & Clusters Initiated
-  - Total Partners Initiated
-  - null
-  - 2
-  - null
   - null
 - !!python/tuple
   - dbowman
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 0
+  - 15
   - null
   - null
 - !!python/tuple
@@ -691,7 +1507,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 2
+  - 13
   - null
   - null
 - !!python/tuple
@@ -701,21 +1517,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.3'
 - !!python/tuple
   - dbowman
   - Partners & Clusters Initiated
   - Cases W/No Partners
   - null
-  - 46
-  - 95.8%
+  - 41
+  - 51.2%
   - null
 - !!python/tuple
   - dbowman
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - null
-  - 2
+  - 35
   - null
   - null
 - !!python/tuple
@@ -725,294 +1541,838 @@
   - Cluster Index
   - null
   - null
-  - '0.04'
+  - '0.44'
 - !!python/tuple
   - dbowman
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - Cases /W No Clusters
-  - 46
-  - 95.8%
+  - 34
+  - 42.5%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases Assigned
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
   - null
-  - 41
-  - null
-  - null
-- !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases Closed
-  - null
-  - 41
-  - 100.0%
+  - 14
+  - 50.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - null
-  - 41
-  - 100.0%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, New Pos
+  - 1
+  - 7.1%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 3 days
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, Still Neg
   - 0
   - 0.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 5 days
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, No Test
+  - 5
+  - 35.7%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Pos
   - 0
   - 0.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 7 days
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Neg
+  - 8
+  - 57.1%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, No Test
   - 0
   - 0.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 14 days
-  - 20
-  - 48.8%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - null
+  - 8
+  - 28.6%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Cases Reinterviewed
-  - null
-  - 23
-  - 56.1%
-  - null
-- !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - HIV Previous Positive
-  - null
-  - 13
-  - 31.7%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Insufficient Info
+  - 2
+  - 25.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - HIV Tested
-  - null
-  - 20
-  - 48.8%
-  - null
-- !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - HIV New Positive
-  - null
-  - 31
-  - 155.0%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Unable to Locate
+  - 1
+  - 12.5%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - HIV Posttest Counsel
-  - null
-  - 19
-  - 95.0%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Refused Exam
+  - 2
+  - 25.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Partner Notification Index
-  - null
-  - null
-  - null
-  - '0.0'
-- !!python/tuple
-  - fpoole
-  - Case Assignments & Outcomes
-  - Testing Index
-  - null
-  - null
-  - null
-  - '0.0'
-- !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Period Partners
-  - null
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - OOJ
   - 0
+  - 0.0%
   - null
-  - '0.0'
 - !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Partners Initiated
-  - null
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Other
   - 0
-  - null
-  - null
-- !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Partners Initiated
-  - From OI
-  - 0
-  - null
+  - 0.0%
   - null
 - !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Partners Initiated
-  - From RI
-  - 0
-  - null
-  - null
-- !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Contact Index
-  - null
-  - null
-  - null
-  - '0.0'
-- !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Cases W/No Partners
-  - null
-  - 40
-  - 97.6%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Domestic Violence Risk
+  - 1
+  - 12.5%
   - null
 - !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Clusters Initiated
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Patient Deceased
+  - 2
+  - 25.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Previous Pos
   - null
   - 3
-  - null
-  - null
-- !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Clusters Initiated
-  - Cluster Index
-  - null
-  - null
-  - '0.07'
-- !!python/tuple
-  - fpoole
-  - Partners & Clusters Initiated
-  - Total Clusters Initiated
-  - Cases /W No Clusters
-  - 37
-  - 90.2%
+  - 10.7%
   - null
 - !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases Assigned
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Partners Open
   - null
-  - 40
-  - null
-  - null
-- !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases Closed
-  - null
-  - 40
-  - 100.0%
+  - 9
+  - 32.1%
   - null
 - !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases IX'D
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
   - null
-  - 40
-  - 100.0%
+  - 12
+  - 34.3%
   - null
 - !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 3 days
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, New Pos
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, Still Neg
   - 0
   - 0.0%
   - null
 - !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 5 days
-  - 1
-  - 2.5%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, No Test
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 7 days
-  - 1
-  - 2.5%
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
-  - gfreeman
-  - Case Assignments & Outcomes
-  - Cases IX'D
-  - Within 14 days
-  - 22
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Neg
+  - 1
+  - 8.3%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, No Test
+  - 1
+  - 8.3%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - null
+  - 20
+  - 57.1%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Unable to Locate
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Refused Exam
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - OOJ
+  - 11
   - 55.0%
   - null
 - !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Other
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Domestic Violence Risk
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Previous Pos
+  - null
+  - 1
+  - 2.9%
+  - null
+- !!python/tuple
+  - dbowman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Open
+  - null
+  - 2
+  - 5.7%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 80
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 80
+  - 100.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 80
+  - 100.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 43
+  - 53.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 45
+  - 56.2%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 35
+  - 43.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 45
+  - 56.2%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 63
+  - 140.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 46
+  - 102.2%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.12'
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.12'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 17
+  - null
+  - '0.2'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 38
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 14
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 24
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.5'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 37
+  - 46.2%
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 32
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.4'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 43
+  - 53.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - null
+  - 15
+  - 39.5%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, New Pos
+  - 5
+  - 33.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, No Test
+  - 5
+  - 33.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Neg
+  - 5
+  - 33.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - null
+  - 20
+  - 52.6%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Insufficient Info
+  - 4
+  - 20.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Unable to Locate
+  - 3
+  - 15.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Refused Exam
+  - 1
+  - 5.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - OOJ
+  - 5
+  - 25.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Other
+  - 2
+  - 10.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Domestic Violence Risk
+  - 2
+  - 10.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Patient Deceased
+  - 3
+  - 15.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Previous Pos
+  - null
+  - 3
+  - 7.9%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Partners Open
+  - null
+  - 5
+  - 13.2%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 15
+  - 46.9%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, New Pos
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, No Test
+  - 5
+  - 33.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Neg
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - null
+  - 14
+  - 43.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Unable to Locate
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Refused Exam
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - OOJ
+  - 9
+  - 64.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Other
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Domestic Violence Risk
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Previous Pos
+  - null
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Dispositions - New Partners & Clusters
+  - New Clusters Open
+  - null
+  - 3
+  - 9.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 79
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 79
+  - 100.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 79
+  - 100.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 1
+  - 1.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 1
+  - 1.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 1
+  - 1.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 45
+  - 57.0%
+  - null
+- !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 19
-  - 47.5%
+  - 35
+  - 44.3%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 21
-  - 52.5%
+  - 39
+  - 49.4%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 23
-  - 57.5%
+  - 45
+  - 57.0%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 31
-  - 134.8%
+  - 67
+  - 148.9%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 21
-  - 91.3%
+  - 42
+  - 93.3%
   - null
 - !!python/tuple
   - gfreeman
@@ -1021,7 +2381,7 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.13'
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
@@ -1029,21 +2389,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.13'
 - !!python/tuple
   - gfreeman
   - Partners & Clusters Initiated
   - Total Period Partners
   - null
-  - 19
+  - 14
   - null
-  - '0.5'
+  - '0.2'
 - !!python/tuple
   - gfreeman
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - null
-  - 1
+  - 28
   - null
   - null
 - !!python/tuple
@@ -1051,7 +2411,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 1
+  - 13
   - null
   - null
 - !!python/tuple
@@ -1059,7 +2419,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 0
+  - 15
   - null
   - null
 - !!python/tuple
@@ -1069,21 +2429,21 @@
   - null
   - null
   - null
-  - '0.0'
+  - '0.4'
 - !!python/tuple
   - gfreeman
   - Partners & Clusters Initiated
   - Cases W/No Partners
   - null
-  - 38
-  - 95.0%
+  - 41
+  - 51.9%
   - null
 - !!python/tuple
   - gfreeman
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - null
-  - 3
+  - 29
   - null
   - null
 - !!python/tuple
@@ -1093,12 +2453,284 @@
   - Cluster Index
   - null
   - null
-  - '0.07'
+  - '0.37'
 - !!python/tuple
   - gfreeman
   - Partners & Clusters Initiated
   - Total Clusters Initiated
   - Cases /W No Clusters
-  - 37
-  - 92.5%
+  - 43
+  - 54.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - null
+  - 14
+  - 50.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, New Pos
+  - 7
+  - 50.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - Prev. Neg, No Test
+  - 4
+  - 28.6%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, New Neg
+  - 3
+  - 21.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - null
+  - 13
+  - 46.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Unable to Locate
+  - 2
+  - 15.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Refused Exam
+  - 2
+  - 15.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - OOJ
+  - 2
+  - 15.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Other
+  - 2
+  - 15.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Domestic Violence Risk
+  - 3
+  - 23.1%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Not Notified
+  - Patient Deceased
+  - 2
+  - 15.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Previous Pos
+  - null
+  - 1
+  - 3.6%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Partners Open
+  - null
+  - 3
+  - 10.7%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - 41.4%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, New Pos
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, Still Neg
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - Prev. Neg, No Test
+  - 4
+  - 33.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Pos
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, New Neg
+  - 1
+  - 8.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Notified
+  - No Prev. Test, No Test
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - null
+  - 13
+  - 44.8%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Insufficient Info
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Unable to Locate
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Refused Exam
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - OOJ
+  - 4
+  - 30.8%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Other
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Domestic Violence Risk
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Not Notified
+  - Patient Deceased
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Previous Pos
+  - null
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Dispositions - New Partners & Clusters
+  - New Clusters Open
+  - null
+  - 3
+  - 10.3%
   - null

--- a/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
+++ b/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
@@ -1,0 +1,112 @@
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 185
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 185
+  - 100.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 185
+  - 100.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 1
+  - 0.5%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 1
+  - 0.5%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 116
+  - 62.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 97
+  - 52.4%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 86
+  - 46.5%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 117
+  - 63.2%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 150
+  - 128.2%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 108
+  - 92.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.01'
+- !!python/tuple
+  - ALL
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.01'

--- a/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
+++ b/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
@@ -110,3 +110,995 @@
   - null
   - null
   - '0.01'
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 76
+  - null
+  - '0.4'
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 5
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 4
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.03'
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 180
+  - 97.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 8
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.04'
+- !!python/tuple
+  - ALL
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 177
+  - 95.7%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 34
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 34
+  - 100.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 34
+  - 100.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 18
+  - 52.9%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 17
+  - 50.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 17
+  - 50.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 24
+  - 70.6%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 31
+  - 129.2%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 15
+  - 62.5%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 10
+  - null
+  - '0.3'
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 32
+  - 94.1%
+  - null
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - adevraj
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 33
+  - 97.1%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 49
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 49
+  - 100.0%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 49
+  - 100.0%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 27
+  - 55.1%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 22
+  - 44.9%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 18
+  - 36.7%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 24
+  - 49.0%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 40
+  - 166.7%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 23
+  - 95.8%
+  - null
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - avance
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 19
+  - null
+  - '0.4'
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 48
+  - 98.0%
+  - null
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - avance
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 48
+  - 98.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 48
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 48
+  - 100.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 48
+  - 100.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 29
+  - 60.4%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 20
+  - 41.7%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 24
+  - 50.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 26
+  - 54.2%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 38
+  - 146.2%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 30
+  - 115.4%
+  - null
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.02'
+- !!python/tuple
+  - dbowman
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.02'
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 28
+  - null
+  - '0.6'
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 2
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 2
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 46
+  - 95.8%
+  - null
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 2
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.04'
+- !!python/tuple
+  - dbowman
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 46
+  - 95.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 41
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 41
+  - 100.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 41
+  - 100.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 20
+  - 48.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 23
+  - 56.1%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 13
+  - 31.7%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 20
+  - 48.8%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 31
+  - 155.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 19
+  - 95.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - fpoole
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 0
+  - null
+  - '0.0'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 40
+  - 97.6%
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 3
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.07'
+- !!python/tuple
+  - fpoole
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 37
+  - 90.2%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases Assigned
+  - null
+  - 40
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases Closed
+  - null
+  - 40
+  - 100.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - null
+  - 40
+  - 100.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 3 days
+  - 0
+  - 0.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 5 days
+  - 1
+  - 2.5%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 7 days
+  - 1
+  - 2.5%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases IX'D
+  - Within 14 days
+  - 22
+  - 55.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Cases Reinterviewed
+  - null
+  - 19
+  - 47.5%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 21
+  - 52.5%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 23
+  - 57.5%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - HIV New Positive
+  - null
+  - 31
+  - 134.8%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - HIV Posttest Counsel
+  - null
+  - 21
+  - 91.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Partner Notification Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - gfreeman
+  - Case Assignments & Outcomes
+  - Testing Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Period Partners
+  - null
+  - 19
+  - null
+  - '0.5'
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - null
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From OI
+  - 1
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Partners Initiated
+  - From RI
+  - 0
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Contact Index
+  - null
+  - null
+  - null
+  - '0.0'
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Cases W/No Partners
+  - null
+  - 38
+  - 95.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - null
+  - 3
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cluster Index
+  - null
+  - null
+  - '0.07'
+- !!python/tuple
+  - gfreeman
+  - Partners & Clusters Initiated
+  - Total Clusters Initiated
+  - Cases /W No Clusters
+  - 37
+  - 92.5%
+  - null

--- a/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
+++ b/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
@@ -26,73 +26,73 @@
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
-  - 2
-  - 0.7%
+  - Within 3 Days
+  - 4
+  - 1.4%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 2
-  - 0.7%
+  - Within 5 Days
+  - 5
+  - 1.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 2
-  - 0.7%
+  - Within 7 Days
+  - 5
+  - 1.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 214
-  - 74.6%
+  - Within 14 Days
+  - 218
+  - 76.0%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 172
-  - 59.9%
+  - 159
+  - 55.4%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 145
-  - 50.5%
+  - 138
+  - 48.1%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 217
-  - 75.6%
+  - 215
+  - 74.9%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 245
-  - 112.9%
+  - 246
+  - 114.4%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 210
-  - 96.8%
+  - 215
+  - 100.0%
   - null
 - !!python/tuple
   - ALL
@@ -131,7 +131,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 68
+  - 83
   - null
   - null
 - !!python/tuple
@@ -139,7 +139,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 81
+  - 66
   - null
   - null
 - !!python/tuple
@@ -307,8 +307,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 11
-  - 7.4%
+  - 8
+  - 5.4%
   - null
 - !!python/tuple
   - ALL
@@ -339,8 +339,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, Still Neg
-  - 0
-  - 0.0%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - ALL
@@ -371,8 +371,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, No Test
-  - 2
-  - 2.9%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - ALL
@@ -443,8 +443,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 2
-  - 1.3%
+  - 4
+  - 2.7%
   - null
 - !!python/tuple
   - ALL
@@ -453,6 +453,86 @@
   - null
   - 10
   - 6.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 63
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 13
+  - 20.6%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 28
+  - 44.4%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 41
+  - 65.1%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 55
+  - 87.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 69
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 15
+  - 21.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 29
+  - 42.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 42
+  - 60.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 55
+  - 79.7%
   - null
 - !!python/tuple
   - adevraj
@@ -482,54 +562,38 @@
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
-  - 1
-  - 1.4%
+  - Within 3 Days
+  - 2
+  - 2.8%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 1
-  - 1.4%
+  - Within 5 Days
+  - 2
+  - 2.8%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 1
-  - 1.4%
+  - Within 7 Days
+  - 2
+  - 2.8%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 40
-  - 56.3%
+  - Within 14 Days
+  - 43
+  - 60.6%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases Reinterviewed
-  - null
-  - 37
-  - 52.1%
-  - null
-- !!python/tuple
-  - adevraj
-  - Case Assignments & Outcomes
-  - HIV Previous Positive
-  - null
-  - 25
-  - 35.2%
-  - null
-- !!python/tuple
-  - adevraj
-  - Case Assignments & Outcomes
-  - HIV Tested
   - null
   - 36
   - 50.7%
@@ -537,18 +601,34 @@
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 27
+  - 38.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 41
+  - 57.7%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 57
-  - 158.3%
+  - 65
+  - 158.5%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 43
-  - 119.4%
+  - 47
+  - 114.6%
   - null
 - !!python/tuple
   - adevraj
@@ -587,7 +667,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 12
+  - 17
   - null
   - null
 - !!python/tuple
@@ -595,7 +675,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 16
+  - 11
   - null
   - null
 - !!python/tuple
@@ -763,8 +843,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 3
-  - 10.7%
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
   - adevraj
@@ -819,8 +899,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, New Neg
-  - 5
-  - 31.2%
+  - 4
+  - 25.0%
   - null
 - !!python/tuple
   - adevraj
@@ -899,8 +979,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 1
-  - 3.6%
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
   - adevraj
@@ -909,6 +989,86 @@
   - null
   - 1
   - 3.6%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 15
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 5
+  - 33.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 11
+  - 73.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 16
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 5
+  - 31.2%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 7
+  - 43.8%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 11
+  - 68.8%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 13
+  - 81.2%
   - null
 - !!python/tuple
   - avance
@@ -938,7 +1098,7 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
+  - Within 3 Days
   - 0
   - 0.0%
   - null
@@ -946,7 +1106,7 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
+  - Within 5 Days
   - 0
   - 0.0%
   - null
@@ -954,7 +1114,7 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
+  - Within 7 Days
   - 0
   - 0.0%
   - null
@@ -962,33 +1122,33 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 37
-  - 50.7%
+  - Within 14 Days
+  - 44
+  - 60.3%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 45
-  - 61.6%
+  - 36
+  - 49.3%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 27
-  - 37.0%
+  - 39
+  - 53.4%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 42
-  - 57.5%
+  - 46
+  - 63.0%
   - null
 - !!python/tuple
   - avance
@@ -996,15 +1156,15 @@
   - HIV New Positive
   - null
   - 57
-  - 135.7%
+  - 123.9%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 40
-  - 95.2%
+  - 38
+  - 82.6%
   - null
 - !!python/tuple
   - avance
@@ -1355,8 +1515,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 0
-  - 0.0%
+  - 1
+  - 3.8%
   - null
 - !!python/tuple
   - avance
@@ -1365,6 +1525,86 @@
   - null
   - 1
   - 3.8%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 9
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 22.2%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 3
+  - 33.3%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 6
+  - 66.7%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 6
+  - 66.7%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 2
+  - 16.7%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 7
+  - 58.3%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 9
+  - 75.0%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 10
+  - 83.3%
   - null
 - !!python/tuple
   - dbowman
@@ -1394,57 +1634,57 @@
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
-  - 0
-  - 0.0%
+  - Within 3 Days
+  - 1
+  - 1.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 0
-  - 0.0%
+  - Within 5 Days
+  - 1
+  - 1.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 0
-  - 0.0%
+  - Within 7 Days
+  - 1
+  - 1.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 49
-  - 61.3%
+  - Within 14 Days
+  - 45
+  - 56.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 36
-  - 45.0%
+  - 42
+  - 52.5%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 40
-  - 50.0%
+  - 28
+  - 35.0%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 49
-  - 61.3%
+  - 39
+  - 48.8%
   - null
 - !!python/tuple
   - dbowman
@@ -1452,15 +1692,15 @@
   - HIV New Positive
   - null
   - 64
-  - 130.6%
+  - 164.1%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 39
-  - 79.6%
+  - 48
+  - 123.1%
   - null
 - !!python/tuple
   - dbowman
@@ -1499,7 +1739,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 15
+  - 17
   - null
   - null
 - !!python/tuple
@@ -1507,7 +1747,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 13
+  - 11
   - null
   - null
 - !!python/tuple
@@ -1675,8 +1915,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 3
-  - 10.7%
+  - 4
+  - 14.3%
   - null
 - !!python/tuple
   - dbowman
@@ -1739,8 +1979,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, No Test
-  - 1
-  - 8.3%
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
   - dbowman
@@ -1811,8 +2051,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 1
-  - 2.9%
+  - 2
+  - 5.7%
   - null
 - !!python/tuple
   - dbowman
@@ -1821,6 +2061,86 @@
   - null
   - 2
   - 5.7%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 14
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 5
+  - 35.7%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 8
+  - 57.1%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 8
+  - 57.1%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 10
+  - 71.4%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 4
+  - 33.3%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 6
+  - 50.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 9
+  - 75.0%
   - null
 - !!python/tuple
   - fpoole
@@ -1850,7 +2170,7 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
+  - Within 3 Days
   - 0
   - 0.0%
   - null
@@ -1858,7 +2178,7 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
+  - Within 5 Days
   - 0
   - 0.0%
   - null
@@ -1866,7 +2186,7 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
+  - Within 7 Days
   - 0
   - 0.0%
   - null
@@ -1874,49 +2194,49 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 43
-  - 53.8%
+  - Within 14 Days
+  - 41
+  - 51.2%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 45
-  - 56.2%
+  - 47
+  - 58.8%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 35
-  - 43.8%
+  - 31
+  - 38.8%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 45
-  - 56.2%
+  - 46
+  - 57.5%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 63
-  - 140.0%
+  - 65
+  - 141.3%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 46
-  - 102.2%
+  - 40
+  - 87.0%
   - null
 - !!python/tuple
   - fpoole
@@ -1955,7 +2275,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 14
+  - 18
   - null
   - null
 - !!python/tuple
@@ -1963,7 +2283,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 24
+  - 20
   - null
   - null
 - !!python/tuple
@@ -2131,8 +2451,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 3
-  - 7.9%
+  - 1
+  - 2.6%
   - null
 - !!python/tuple
   - fpoole
@@ -2163,16 +2483,16 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, Still Neg
-  - 0
-  - 0.0%
+  - 1
+  - 6.7%
   - null
 - !!python/tuple
   - fpoole
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, No Test
-  - 5
-  - 33.3%
+  - 4
+  - 26.7%
   - null
 - !!python/tuple
   - fpoole
@@ -2187,8 +2507,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, New Neg
-  - 4
-  - 26.7%
+  - 5
+  - 33.3%
   - null
 - !!python/tuple
   - fpoole
@@ -2279,6 +2599,86 @@
   - 9.4%
   - null
 - !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 15
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 6
+  - 40.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 11
+  - 73.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 14
+  - 93.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 15
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 8
+  - 53.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 9
+  - 60.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 13
+  - 86.7%
+  - null
+- !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases Assigned
@@ -2306,7 +2706,7 @@
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
+  - Within 3 Days
   - 1
   - 1.3%
   - null
@@ -2314,23 +2714,23 @@
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 1
-  - 1.3%
+  - Within 5 Days
+  - 2
+  - 2.5%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 1
-  - 1.3%
+  - Within 7 Days
+  - 2
+  - 2.5%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
+  - Within 14 Days
   - 45
   - 57.0%
   - null
@@ -2347,24 +2747,24 @@
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 39
-  - 49.4%
+  - 38
+  - 48.1%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 45
-  - 57.0%
+  - 43
+  - 54.4%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 67
-  - 148.9%
+  - 60
+  - 139.5%
   - null
 - !!python/tuple
   - gfreeman
@@ -2372,7 +2772,7 @@
   - HIV Posttest Counsel
   - null
   - 42
-  - 93.3%
+  - 97.7%
   - null
 - !!python/tuple
   - gfreeman
@@ -2411,7 +2811,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 13
+  - 17
   - null
   - null
 - !!python/tuple
@@ -2419,7 +2819,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 15
+  - 11
   - null
   - null
 - !!python/tuple
@@ -2587,8 +2987,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 1
-  - 3.6%
+  - 2
+  - 7.1%
   - null
 - !!python/tuple
   - gfreeman
@@ -2627,8 +3027,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, No Test
-  - 4
-  - 33.3%
+  - 5
+  - 41.7%
   - null
 - !!python/tuple
   - gfreeman
@@ -2723,8 +3123,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 0
-  - 0.0%
+  - 1
+  - 3.4%
   - null
 - !!python/tuple
   - gfreeman
@@ -2733,4 +3133,84 @@
   - null
   - 3
   - 10.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 14
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 14.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 7
+  - 50.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 11
+  - 78.6%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 14
+  - 100.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 1
+  - 8.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 7
+  - 58.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 10
+  - 83.3%
   - null

--- a/apps/report-execution/uv.lock
+++ b/apps/report-execution/uv.lock
@@ -947,6 +947,7 @@ dev = [
     { name = "tablefaker" },
     { name = "testcontainers" },
     { name = "time-machine" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -968,6 +969,7 @@ dev = [
     { name = "tablefaker", specifier = ">=1.11.1" },
     { name = "testcontainers", specifier = ">=4.14.1" },
     { name = "time-machine", specifier = ">=3.2.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 
 [[package]]
@@ -1194,6 +1196,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

The 4th PR for APP-609, meant for merging into `ab/app-609/feature`.

This PR is still only focused on the HIV version of this report.  A separate PR (or PRs) will be made for the implementation of the difference for the STD version of this report.

Changes in this PR:
- Adds fourth and final section "SPEED OF NOTIFICATION - PARTNERS & CLUSTERS"
- Fixes some errant use of `datepart` in existing SQL

**NOTE:** Found a bug in the SAS code where the percentages for the rightmost column show up as 0.  This is documented in the conversion notes and the Python version will give the real percentages.

Relevant section from PDF for "ALL WORKERS":
<img width="1018" height="291" alt="Screenshot 2026-07-07 at 15 03 42" src="https://github.com/user-attachments/assets/aee82137-47aa-478d-bb8f-e761ab63b513" />

Relevant section from CSV for "ALL WORKERS":
```csv
Worker,Category 1,Category 2,Category 3,Count,Percentage,Index
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,,63,,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 3 Days,13,20.6%,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 5 Days,28,44.4%,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 7 Days,41,65.1%,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 14 Days,55,87.3%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,,69,,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 3 Days,15,21.7%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 5 Days,29,42.0%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 7 Days,42,60.9%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 14 Days,55,79.7%,
```

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-609)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
