### PR TITLE
[APP-609] PA01 Conversion, Fourth PR

### DIFF
--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -11,10 +11,10 @@ from src.libraries.support.pa_01.queries import (
     cases_with_no_partners_query,
     cluster_previous_pos_query,
     clusters_initiated_query,
-    filtered_cases_query,
     not_notified_clusters_query,
     not_notified_partners_query,
     notified_clusters_query,
+    notified_partners_by_speed_query,
     notified_partners_query,
     partner_case_dispositions_query,
     partner_notification_query,
@@ -70,6 +70,10 @@ def execute(
 
       in order to distinguish them in the CSV.  Otherwise if the CSV data were ever
       sorted it would lose its positional meaning.
+    * In the "SPEED OF NOTIFICATION - PARTNERS & CLUSTERS" section, under "New Clusters
+      Notified" for "ALL WORKERS", the percentages appear as 0.0% even if there are
+      counts.  This is due to an issue in the SAS and the Python library includes the
+      correct percentages.
     """
     if not isinstance(library_params, dict):
         raise ValueError(
@@ -99,7 +103,6 @@ def execute(
 
     # run queries
     tables: dict[str, Table] = {}
-    tables['filtered_cases'] = trx.query(filtered_cases_query(subset_query))
     tables['case_interview_rows'] = trx.query(
         case_interview_rows_query(subset_query, report_variant)
     )
@@ -129,6 +132,9 @@ def execute(
     )
     tables['clusters_previous_pos'] = trx.query(
         cluster_previous_pos_query(subset_query)
+    )
+    tables['notified_partners_by_speed'] = trx.query(
+        notified_partners_by_speed_query(subset_query)
     )
 
     # get list of workers (nb. None treated as "ALL WORKERS")

--- a/apps/report-execution/src/libraries/support/pa_01/calculations.py
+++ b/apps/report-execution/src/libraries/support/pa_01/calculations.py
@@ -5,7 +5,7 @@ from src.models import Table
 CASES_IXD = "Cases IX'D"
 CASE_ASSIGNMENTS_AND_OUTCOMES = 'Case Assignments & Outcomes'
 CA_PATIENT_INTV_STATUS = 'CA_PATIENT_INTV_STATUS'
-DAYS = 'Days'
+DAYS = 'DAYS'
 DISPOSITIONS_NEW_PARTNERS_AND_CLUSTERS = 'Dispositions - New Partners & Clusters'
 DISPO_DOMESTIC_VIOLENCE_RISK = 'V - Domestic Violence Risk'
 DISPO_INSUFFICIENT_INFO = 'G - Insufficient Info to Begin Investigation'
@@ -30,8 +30,15 @@ NEW_PARTNERS_NOTIFIED = 'New Partners Notified'
 NEW_PARTNERS_NOT_NOTIFIED = 'New Partners Not Notified'
 PARTNERS_AND_CLUSTERS_INITIATED = 'Partners & Clusters Initiated'
 PROVIDER_QUICK_CODE = 'PROVIDER_QUICK_CODE'
+SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS = (
+    'Speed of Notification - Partners & Clusters'
+)
 TOTAL_CLUSTERS_INITIATED = 'Total Clusters Initiated'
 TOTAL_PARTNERS_INITIATED = 'Total Partners Initiated'
+WITHIN_THREE_DAYS = 'Within 3 Days'
+WITHIN_FIVE_DAYS = 'Within 5 Days'
+WITHIN_SEVEN_DAYS = 'Within 7 Days'
+WITHIN_FOURTEEN_DAYS = 'Within 14 Days'
 
 
 def build_output_for_worker(
@@ -52,6 +59,7 @@ def build_output_for_worker(
     rows.extend(_build_case_assignments_and_outcomes_output(tables, worker))
     rows.extend(_build_partners_and_clusters_initiated_output(tables, worker))
     rows.extend(_build_dispositions_new_partners_and_clusters_output(tables, worker))
+    rows.extend(_build_speed_of_notification_partners_and_clusters(tables, worker))
 
     return rows
 
@@ -125,7 +133,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 3 days',
+            WITHIN_THREE_DAYS,
             cases_ixd_buckets[3][0],
             cases_ixd_buckets[3][1],
             None,
@@ -134,7 +142,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 5 days',
+            WITHIN_FIVE_DAYS,
             cases_ixd_buckets[5][0],
             cases_ixd_buckets[5][1],
             None,
@@ -143,7 +151,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 7 days',
+            WITHIN_SEVEN_DAYS,
             cases_ixd_buckets[7][0],
             cases_ixd_buckets[7][1],
             None,
@@ -152,7 +160,7 @@ def _build_case_assignments_and_outcomes_output(
             _worker_for_csv(worker),
             CASE_ASSIGNMENTS_AND_OUTCOMES,
             CASES_IXD,
-            'Within 14 days',
+            WITHIN_FOURTEEN_DAYS,
             cases_ixd_buckets[14][0],
             cases_ixd_buckets[14][1],
             None,
@@ -724,6 +732,127 @@ def _build_dispositions_new_partners_and_clusters_output(
     return rows
 
 
+def _build_speed_of_notification_partners_and_clusters(
+    tables: dict[str, Table], worker: Pa01Worker | None = None
+) -> list[Pa01Row]:
+    """Perform all needed calculations for the "Speed of Notification - Partners &
+    Clusters" section for a given worker, output data for the final CSV.
+    """
+    total_partners_initiated = _calc_total_partners_initiated(
+        tables['period_partners'], worker
+    )
+    total_clusters_initiated = _calc_total_clusters_initiated(
+        tables['clusters_initiated'], worker
+    )
+    new_partners_notified, _ = _calc_new_partners_notified(
+        tables['notified_partners'], total_partners_initiated, worker
+    )
+    new_clusters_notified, _ = _calc_new_clusters_notified(
+        tables['notified_clusters'], total_clusters_initiated, worker
+    )
+    new_partners_notified_day_buckets = _calc_new_partners_notified_day_buckets(
+        tables['notified_partners_by_speed'], new_partners_notified, worker
+    )
+    new_clusters_notified_day_buckets = _calc_new_clusters_notified_day_buckets(
+        tables['notified_clusters'], new_clusters_notified, worker
+    )
+
+    rows: list[Pa01Row] = [
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            None,
+            new_partners_notified,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_THREE_DAYS,
+            new_partners_notified_day_buckets[3][0],
+            new_partners_notified_day_buckets[3][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_FIVE_DAYS,
+            new_partners_notified_day_buckets[5][0],
+            new_partners_notified_day_buckets[5][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_SEVEN_DAYS,
+            new_partners_notified_day_buckets[7][0],
+            new_partners_notified_day_buckets[7][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_PARTNERS_NOTIFIED,
+            WITHIN_FOURTEEN_DAYS,
+            new_partners_notified_day_buckets[14][0],
+            new_partners_notified_day_buckets[14][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            None,
+            new_clusters_notified,
+            None,
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_THREE_DAYS,
+            new_clusters_notified_day_buckets[3][0],
+            new_clusters_notified_day_buckets[3][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_FIVE_DAYS,
+            new_clusters_notified_day_buckets[5][0],
+            new_clusters_notified_day_buckets[5][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_SEVEN_DAYS,
+            new_clusters_notified_day_buckets[7][0],
+            new_clusters_notified_day_buckets[7][1],
+            None,
+        ),
+        (
+            _worker_for_csv(worker),
+            SPEED_OF_NOTIFICATION_PARTNERS_AND_CLUSTERS,
+            NEW_CLUSTERS_NOTIFIED,
+            WITHIN_FOURTEEN_DAYS,
+            new_clusters_notified_day_buckets[14][0],
+            new_clusters_notified_day_buckets[14][1],
+            None,
+        ),
+    ]
+
+    return rows
+
+
 # actual calculations
 def _calc_cases_assigned(
     case_interview_rows: Table, worker: Pa01Worker | None = None
@@ -777,12 +906,7 @@ def _calc_interview_day_buckets(
         and row[DAYS] <= 14
     ]
 
-    results = dict()
-    for threshold in (3, 5, 7, 14):
-        count = sum(1 for d in rows if d[DAYS] <= threshold)
-        results[threshold] = (count, _percent_for_csv(count, cases_ixd))
-
-    return results
+    return _count_and_percent_day_buckets(rows, cases_ixd)
 
 
 def _calc_cases_reinterviewed(
@@ -1262,6 +1386,34 @@ def _calc_new_clusters_open(
     return count, _percent_for_csv(count, total_clusters_initiated)
 
 
+def _calc_new_partners_notified_day_buckets(
+    notified_partners_by_speed: Table,
+    new_partners_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[int, tuple[int, str]]:
+    """Calculate "New Partners Notified" count and percentage for within 3, 5, 7, and
+    14 days.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(notified_partners_by_speed, worker)
+    rows = [row for row in rows if row[DAYS] is not None and 0 <= row[DAYS] <= 14]
+
+    return _count_and_percent_day_buckets(rows, new_partners_notified)
+
+
+def _calc_new_clusters_notified_day_buckets(
+    notified_clusters: Table,
+    new_clusters_notified: int,
+    worker: Pa01Worker | None = None,
+) -> dict[int, tuple[int, str]]:
+    """Calculate "New Clusters Notified" count and percentage for within 3, 5, 7, and
+    14 days.  Calculates for all workers if passed in worker is None.
+    """
+    rows = _rows_for_worker(notified_clusters, worker)
+    rows = [row for row in rows if row[DAYS] is not None and 0 <= row[DAYS] <= 14]
+
+    return _count_and_percent_day_buckets(rows, new_clusters_notified)
+
+
 # helpers
 def _rows_for_worker(table: Table, worker: Pa01Worker | None = None) -> list[dict]:
     """Filter a given table's data for the given worker.  If the given worker is None
@@ -1306,6 +1458,22 @@ def _count_distinct_case_ids_and_percent_by_dispo(
         result[dispo] = (count, _percent_for_csv(count, denominator))
 
     return result
+
+
+def _count_and_percent_day_buckets(
+    rows: list[dict],
+    denominator: int,
+) -> dict[int, tuple[int, str]]:
+    """Given a list of query result rows that contain the column 'DAYS', tally up the
+    number of each in buckets of 3, 5, 7, and 14 days.  Includes the count and the
+    percentage with the given denominator.
+    """
+    results = {}
+    for threshold in (3, 5, 7, 14):
+        count = sum(1 for d in rows if d[DAYS] <= threshold)
+        results[threshold] = (count, _percent_for_csv(count, denominator))
+
+    return results
 
 
 def _percent_for_csv(numerator: int, denominator: int, precision: int = 1) -> str:

--- a/apps/report-execution/src/libraries/support/pa_01/queries.py
+++ b/apps/report-execution/src/libraries/support/pa_01/queries.py
@@ -13,26 +13,6 @@ PA1_DTE_DATE_COL = {
 }
 
 
-def filtered_cases_query(subset_query: str) -> str:
-    """Return the base PA01 case population.
-
-    This is the SQL equivalent of SAS `STD_HIV_DATAMART1`: cases from the
-    report subset that are probable/confirmed and have an interviewer assigned.
-    """
-    return f"""
-      WITH base AS
-      (
-        {subset_query}
-      )
-      SELECT b.*
-      FROM base b
-        INNER JOIN RDB.dbo.INVESTIGATION i
-                ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-               AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
-               AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL;
-    """
-
-
 def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
     """Return case rows joined to interview and worker details.
 
@@ -75,7 +55,7 @@ def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
                DAY,
                CAST(fc.{PA1_NEW_DATE_COL[report_variant]} AS DATE),
                CAST(di.IX_DATE AS DATE)
-             ) AS Days,
+             ) AS DAYS,
              dp.PROVIDER_QUICK_CODE
       FROM filtered_cases fc
         LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
@@ -128,7 +108,7 @@ def timed_interviews_query(subset_query: str, report_variant: str) -> str:
              fb.CA_PATIENT_INTV_STATUS,
              fb.INVESTIGATOR_INTERVIEW_KEY,
              fb.INVESTIGATOR_INTERVIEW_QC,
-             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS Days,
+             DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS DAYS,
              dp.PROVIDER_QUICK_CODE
       FROM filtered_base fb
         INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
@@ -591,8 +571,11 @@ def notified_partners_query(subset_query: str) -> str:
              f.FL_FUP_DISPOSITION,
              a.FL_FUP_DISPO_DT,
              a.FL_FUP_INIT_ASSGN_DT,
-             datepart(DAY,a.FL_FUP_DISPO_DT) - datepart(DAY,a.FL_FUP_INIT_ASSGN_DT)
-                AS days,
+             DATEDIFF(
+                DAY,
+                CAST(a.FL_FUP_INIT_ASSGN_DT AS DATE),
+                CAST(a.FL_FUP_DISPO_DT AS DATE)
+             ) AS DAYS,
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
@@ -718,8 +701,11 @@ def notified_clusters_query(subset_query: str) -> str:
              f.FL_FUP_INVESTIGATOR_ASSGN_DT,
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC,
-             datepart(day, f.FL_FUP_DISPO_DT)
-               - datepart(day, f.FL_FUP_INVESTIGATOR_ASSGN_DT) AS days
+             DATEDIFF(
+               DAY,
+               CAST(f.FL_FUP_INVESTIGATOR_ASSGN_DT AS DATE),
+               CAST(f.FL_FUP_DISPO_DT AS DATE)
+             ) AS DAYS
       FROM filtered_cases a
         INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
@@ -921,4 +907,71 @@ def cluster_previous_pos_query(subset_query: str) -> str:
                PROVIDER_QUICK_CODE
       ORDER BY a.INVESTIGATOR_INTERVIEW_KEY,
                PROVIDER_QUICK_CODE
+    """
+
+
+def notified_partners_by_speed_query(subset_query: str) -> str:
+    """Query used to calculate the "New Partners Notified" counts in the "SPEED OF
+    NOTIFICATION - PARTNERS & CLUSTERS" section.
+
+    Equivalent of `partner2_dte` in SAS.
+    """
+    return f"""
+      WITH base AS
+      (
+        {subset_query}
+      ),
+      filtered_cases AS
+      (
+        -- STD_HIV_DATAMART1 in SAS
+        SELECT b.*
+        FROM base b
+          INNER JOIN RDB.dbo.INVESTIGATION i
+                  ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+                 AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
+                 AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
+      )
+      SELECT DISTINCT a.INVESTIGATION_KEY,
+             PROVIDER_QUICK_CODE,
+             f.INV_LOCAL_ID,
+             f.FL_FUP_DISPOSITION,
+             f.FL_FUP_DISPO_DT,
+             f.FL_FUP_INVESTIGATOR_ASSGN_DT,
+             DATEDIFF(
+                DAY,
+                CAST(f.FL_FUP_INVESTIGATOR_ASSGN_DT AS DATE),
+                CAST(f.FL_FUP_DISPO_DT AS DATE)
+             ) AS DAYS,
+             a.INVESTIGATOR_INTERVIEW_KEY,
+             a.INVESTIGATOR_INTERVIEW_QC
+      FROM filtered_cases a
+        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+                ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.D_INTERVIEW c
+                ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
+               AND c.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+                ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
+        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+                ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
+        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+                ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
+               AND e.RECORD_STATUS_CD <> 'LOG_DEL'
+        INNER JOIN RDB.dbo.D_provider
+                ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
+               AND e.CTT_REFERRAL_BASIS IN (
+                     'P1 - Partner, Sex',
+                     'P2 - Partner, Needle-Sharing',
+                     'P3 - Partner, Both'
+                   )
+               AND f.FL_FUP_DISPOSITION IN (
+                     '2 - Prev. Neg, New Pos',
+                     '3 - Prev. Neg, Still Neg',
+                     '4 - Prev. Neg, No Test',
+                     '5 - No Prev Test, New Pos',
+                     '6 - No Prev Test, New Neg',
+                     '7 - No Prev Test, No Test'
+                   )
+               AND CAST(f.FL_FUP_DISPO_DT AS DATE) >=
+                     CAST(f.FL_FUP_INVESTIGATOR_ASSGN_DT AS DATE);
     """

--- a/apps/report-execution/src/libraries/support/pa_01/queries.py
+++ b/apps/report-execution/src/libraries/support/pa_01/queries.py
@@ -1,5 +1,7 @@
 """Queries for use in pa_01."""
 
+from src.config import get_cached_config_value
+
 # The date field differs in SAS for HIV vs. STD
 PA1_NEW_DATE_COL = {
     'HIV': 'CA_INTERVIEWER_ASSIGN_DT',
@@ -19,6 +21,8 @@ def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
     This is the SQL equivalent of SAS `pa1_new`, which preserves cases with
     missing interview rows by using left joins.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -29,7 +33,7 @@ def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -58,14 +62,14 @@ def case_interview_rows_query(subset_query: str, report_variant: str) -> str:
              ) AS DAYS,
              dp.PROVIDER_QUICK_CODE
       FROM filtered_cases fc
-        LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
+        LEFT JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE fic
                ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-        LEFT JOIN RDB.dbo.D_INTERVIEW di
+        LEFT JOIN {nbs_rdb}.dbo.D_INTERVIEW di
                ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
               AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-        LEFT JOIN RDB.dbo.D_PROVIDER dp
+        LEFT JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
-        LEFT JOIN RDB.dbo.INVESTIGATION i
+        LEFT JOIN {nbs_rdb}.dbo.INVESTIGATION i
                ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY;
     """
 
@@ -76,7 +80,8 @@ def timed_interviews_query(subset_query: str, report_variant: str) -> str:
     This is the SQL equivalent of SAS `pa1_dte`, which only keeps cases with
     matching interview and worker rows and calculates the `Days` value.
     """
-    # equivalent of pa1_dte in SAS
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -87,7 +92,7 @@ def timed_interviews_query(subset_query: str, report_variant: str) -> str:
         -- STD_HIV_DATAMART1 in PA01_HIV.sas
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -111,14 +116,14 @@ def timed_interviews_query(subset_query: str, report_variant: str) -> str:
              DATEDIFF(DAY,fb.{PA1_DTE_DATE_COL[report_variant]},di.IX_DATE) AS DAYS,
              dp.PROVIDER_QUICK_CODE
       FROM filtered_base fb
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE fic
                 ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW di
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW di
                 ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
                AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_PROVIDER dp
+        INNER JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                 ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.INVESTIGATION i
+        INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                 ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
       WHERE CAST(di.IX_DATE AS DATE) >=
                 CAST(fb.CA_INIT_INTVWR_ASSGN_DT AS DATE);
@@ -131,6 +136,8 @@ def partner_notification_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `pix`, used to calculate the Partner
     Notification Index.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -140,7 +147,7 @@ def partner_notification_query(subset_query: str) -> str:
       (
         SELECT b.*
         FROM base b
-          JOIN RDB.dbo.INVESTIGATION i
+          JOIN {nbs_rdb}.dbo.INVESTIGATION i
             ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
            AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
            AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -149,14 +156,14 @@ def partner_notification_query(subset_query: str) -> str:
              fb.INVESTIGATOR_INTERVIEW_KEY,
              COUNT(DISTINCT fb.INV_LOCAL_ID) AS partner_notification_count
       FROM filtered_base fb
-             JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+             JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE fcrc
                ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-             JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+             JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART contact_dm
                ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
-             JOIN RDB.dbo.D_CONTACT_RECORD dcr
+             JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD dcr
                ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
               AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
-        LEFT JOIN RDB.dbo.D_PROVIDER dp
+        LEFT JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
       WHERE dcr.CTT_REFERRAL_BASIS IN (
         'P1 - Partner, Sex',
@@ -180,6 +187,8 @@ def testing_index_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `testindex`, used to calculate the
     Testing Index.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -190,7 +199,7 @@ def testing_index_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in PA01_HIV.sas
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -199,21 +208,21 @@ def testing_index_query(subset_query: str) -> str:
              fb.INVESTIGATOR_INTERVIEW_KEY,
              COUNT(DISTINCT dcr.LOCAL_ID) AS testing_index_count
       FROM filtered_base fb
-        INNER JOIN RDB.dbo.INVESTIGATION i
+        INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                 ON i.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE fcrc
                 ON fcrc.SUBJECT_INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART contact_dm
                 ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD dcr
                 ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
                AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
-         LEFT JOIN RDB.dbo.F_INTERVIEW_CASE fic
+         LEFT JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE fic
                 ON fic.INVESTIGATION_KEY = fb.INVESTIGATION_KEY
-         LEFT JOIN RDB.dbo.D_INTERVIEW di
+         LEFT JOIN {nbs_rdb}.dbo.D_INTERVIEW di
                 ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
                AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-         LEFT JOIN RDB.dbo.D_PROVIDER dp
+         LEFT JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                 ON dp.PROVIDER_KEY = fb.INVESTIGATOR_INTERVIEW_KEY
       WHERE dcr.CTT_REFERRAL_BASIS IN (
          'P1 - Partner, Sex',
@@ -237,6 +246,8 @@ def period_partners_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `pp`, including the calculated `count_Q`
     value later summed for Total Period Partners.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -247,7 +258,7 @@ def period_partners_query(subset_query: str) -> str:
           -- STD_HIV_DATAMART1 in SAS
           SELECT b.*
           FROM base b
-            INNER JOIN RDB.dbo.INVESTIGATION i
+            INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                     ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                    AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                    AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -270,22 +281,22 @@ def period_partners_query(subset_query: str) -> str:
              fc.INVESTIGATOR_INTERVIEW_KEY,
              fc.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases fc
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE fic
                 ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW di
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW di
                 ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
                AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_PROVIDER dp
+        INNER JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                 ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.INVESTIGATION i
+        INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                 ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE fcrc
                 ON fcrc.SUBJECT_INVESTIGATION_KEY = fc.INVESTIGATION_KEY
                AND fcrc.CONTACT_INTERVIEW_KEY = di.D_INTERVIEW_KEY
                AND fcrc.CONTACT_INTERVIEW_KEY <> 1
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART contact_dm
                 ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD dcr
                 ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
                AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
       WHERE dcr.CTT_REFERRAL_BASIS IN (
@@ -302,6 +313,8 @@ def cases_with_no_partners_query(subset_query: str) -> str:
 
     This is the SQL equivalent of SAS `part2`, used for Cases With No Partners.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -312,7 +325,7 @@ def cases_with_no_partners_query(subset_query: str) -> str:
           -- STD_HIV_DATAMART1 in SAS
           SELECT b.*
           FROM base b
-            INNER JOIN RDB.dbo.INVESTIGATION i
+            INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                     ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                    AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                    AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -337,22 +350,22 @@ def cases_with_no_partners_query(subset_query: str) -> str:
                  fc.INVESTIGATOR_INTERVIEW_KEY,
                  fc.INVESTIGATOR_INTERVIEW_QC
           FROM filtered_cases fc
-            INNER JOIN RDB.dbo.F_INTERVIEW_CASE fic
+            INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE fic
                     ON fic.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-            INNER JOIN RDB.dbo.D_INTERVIEW di
+            INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW di
                     ON di.D_INTERVIEW_KEY = fic.D_INTERVIEW_KEY
                    AND di.RECORD_STATUS_CD <> 'LOG_DEL'
-            INNER JOIN RDB.dbo.D_PROVIDER dp
+            INNER JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                     ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
-            INNER JOIN RDB.dbo.INVESTIGATION i
+            INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                     ON i.INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-            INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+            INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE fcrc
                     ON fcrc.SUBJECT_INVESTIGATION_KEY = fc.INVESTIGATION_KEY
                    AND fcrc.CONTACT_INTERVIEW_KEY = di.D_INTERVIEW_KEY
                    AND fcrc.CONTACT_INTERVIEW_KEY <> 1
-            INNER JOIN RDB.dbo.STD_HIV_DATAMART contact_dm
+            INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART contact_dm
                     ON contact_dm.INVESTIGATION_KEY = fcrc.CONTACT_INVESTIGATION_KEY
-            INNER JOIN RDB.dbo.D_CONTACT_RECORD dcr
+            INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD dcr
                     ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
                    AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
           WHERE dcr.CTT_REFERRAL_BASIS IN (
@@ -372,11 +385,11 @@ def cases_with_no_partners_query(subset_query: str) -> str:
              fc.INVESTIGATOR_INTERVIEW_QC,
              fcrc.CONTACT_INVESTIGATION_KEY
       FROM filtered_cases fc
-        INNER JOIN RDB.dbo.D_PROVIDER dp
+        INNER JOIN {nbs_rdb}.dbo.D_PROVIDER dp
                 ON dp.PROVIDER_KEY = fc.INVESTIGATOR_INTERVIEW_KEY
-        LEFT JOIN RDB.dbo.F_CONTACT_RECORD_CASE fcrc
+        LEFT JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE fcrc
                ON fcrc.SUBJECT_INVESTIGATION_KEY = fc.INVESTIGATION_KEY
-        LEFT JOIN RDB.dbo.D_CONTACT_RECORD dcr
+        LEFT JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD dcr
                ON dcr.D_CONTACT_RECORD_KEY = fcrc.D_CONTACT_RECORD_KEY
               AND dcr.RECORD_STATUS_CD <> 'LOG_DEL'
       WHERE (
@@ -401,6 +414,8 @@ def clusters_initiated_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `cluster`, used for Total Clusters Initiated and
     related cluster calculations.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -411,7 +426,7 @@ def clusters_initiated_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -426,21 +441,21 @@ def clusters_initiated_query(subset_query: str) -> str:
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
                AND c.d_interview_key = d.CONTACT_INTERVIEW_KEY
                AND d.CONTACT_INTERVIEW_KEY <> 1
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
                AND e.CTT_REFERRAL_BASIS IN (
                  'A1 - Associate 1',
@@ -458,6 +473,8 @@ def cases_with_no_clusters_query(subset_query: str) -> str:
 
     Equivalent SAS query is `clusters_No`.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -468,7 +485,7 @@ def cases_with_no_clusters_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -484,21 +501,21 @@ def cases_with_no_clusters_query(subset_query: str) -> str:
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
                AND c.d_interview_key = d.CONTACT_INTERVIEW_KEY
                AND d.CONTACT_INTERVIEW_KEY <> 1
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
                AND e.CTT_REFERRAL_BASIS IN (
                      'A1 - Associate 1',
@@ -518,11 +535,11 @@ def cases_with_no_clusters_query(subset_query: str) -> str:
              INVESTIGATOR_INTERVIEW_QC,
              e.CONTACT_INVESTIGATION_KEY
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        LEFT OUTER JOIN RDB.dbo.F_CONTACT_RECORD_CASE e
+        LEFT OUTER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE e
                      ON e.SUBJECT_INVESTIGATION_KEY = a.Investigation_key
-        LEFT OUTER JOIN RDB.dbo.d_contact_record f
+        LEFT OUTER JOIN {nbs_rdb}.dbo.d_contact_record f
                      ON e.D_contact_record_key = f.d_contact_record_key
                     AND f.RECORD_STATUS_CD <> 'LOG_DEL'
       WHERE (
@@ -549,6 +566,8 @@ def notified_partners_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `partner2`, which is used to calculate
     New Partners Notified and its HIV partner disposition breakdowns.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -559,7 +578,7 @@ def notified_partners_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -579,19 +598,19 @@ def notified_partners_query(subset_query: str) -> str:
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
                AND e.CTT_REFERRAL_BASIS IN (
                      'P1 - Partner, Sex',
@@ -615,6 +634,8 @@ def not_notified_partners_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `pn`, which is used to calculate
     New Partners Not Notified and its HIV partner disposition breakdowns.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -625,7 +646,7 @@ def not_notified_partners_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -638,20 +659,20 @@ def not_notified_partners_query(subset_query: str) -> str:
              h.INV_LOCAL_ID,
              a.INVESTIGATOR_INTERVIEW_KEY
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON b.INVESTIGATION_KEY = a.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider d
+        INNER JOIN {nbs_rdb}.dbo.D_provider d
                 ON d.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.investigation e
+        INNER JOIN {nbs_rdb}.dbo.investigation e
                 ON e.investigation_key = a.investigation_KEY
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE f
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE f
                 ON a.investigation_key = f.SUBJECT_investigation_key
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART h
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART h
                 ON f.CONTACT_INVESTIGATION_KEY = h.Investigation_key
-        INNER JOIN RDB.dbo.d_contact_record g
+        INNER JOIN {nbs_rdb}.dbo.d_contact_record g
                 ON f.d_contact_record_key = g.d_contact_record_key
                AND g.RECORD_STATUS_CD <> 'LOG_DEL'
       WHERE g.CTT_REFERRAL_BASIS IN (
@@ -678,6 +699,8 @@ def notified_clusters_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `cm`, which is used to calculate
     New Clusters Notified and its HIV partner disposition breakdowns.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -688,7 +711,7 @@ def notified_clusters_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -707,20 +730,20 @@ def notified_clusters_query(subset_query: str) -> str:
                CAST(f.FL_FUP_DISPO_DT AS DATE)
              ) AS DAYS
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
                AND d.contact_interview_key = c.D_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
       WHERE e.CTT_REFERRAL_BASIS IN (
               'A1 - Associate 1',
@@ -748,6 +771,8 @@ def not_notified_clusters_query(subset_query: str) -> str:
     `cluster` table, containing just a simple extra where clause.  Used to calculate
     New Clusters Not Notified and its HIV partner disposition breakdowns.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -758,7 +783,7 @@ def not_notified_clusters_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -773,21 +798,21 @@ def not_notified_clusters_query(subset_query: str) -> str:
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
                AND c.d_interview_key = d.CONTACT_INTERVIEW_KEY
                AND d.CONTACT_INTERVIEW_KEY <> 1
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
                AND e.CTT_REFERRAL_BASIS IN (
                  'A1 - Associate 1',
@@ -816,6 +841,8 @@ def partner_case_dispositions_query(subset_query: str) -> str:
     This is the SQL equivalent of SAS `pp1`, which is used to calculate the
     partner-side Previous Pos and Open rows.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -826,7 +853,7 @@ def partner_case_dispositions_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -847,9 +874,9 @@ def partner_case_dispositions_query(subset_query: str) -> str:
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.investigation
+        INNER JOIN {nbs_rdb}.dbo.investigation
                 ON investigation.investigation_key = a.investigation_KEY
                AND a.CA_PATIENT_INTV_STATUS IN ('I - Interviewed');
     """
@@ -861,6 +888,8 @@ def cluster_previous_pos_query(subset_query: str) -> str:
 
     Equivalent of the SAS `c1` table.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -871,7 +900,7 @@ def cluster_previous_pos_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -880,19 +909,19 @@ def cluster_previous_pos_query(subset_query: str) -> str:
              PROVIDER_QUICK_CODE,
              COUNT(DISTINCT f.INV_LOCAL_ID) AS clusters_prev_positive_count
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
       WHERE a.FL_FUP_DISPOSITION IN ('1 - Prev. Pos')
       AND   e.CTT_REFERRAL_BASIS IN (
@@ -916,6 +945,8 @@ def notified_partners_by_speed_query(subset_query: str) -> str:
 
     Equivalent of `partner2_dte` in SAS.
     """
+    nbs_rdb = get_cached_config_value('REPORT_DB_NBS_RDB')
+
     return f"""
       WITH base AS
       (
@@ -926,7 +957,7 @@ def notified_partners_by_speed_query(subset_query: str) -> str:
         -- STD_HIV_DATAMART1 in SAS
         SELECT b.*
         FROM base b
-          INNER JOIN RDB.dbo.INVESTIGATION i
+          INNER JOIN {nbs_rdb}.dbo.INVESTIGATION i
                   ON i.INVESTIGATION_KEY = b.INVESTIGATION_KEY
                  AND i.INV_CASE_STATUS IN ('Probable', 'Confirmed')
                  AND b.CA_INTERVIEWER_ASSIGN_DT IS NOT NULL
@@ -945,19 +976,19 @@ def notified_partners_by_speed_query(subset_query: str) -> str:
              a.INVESTIGATOR_INTERVIEW_KEY,
              a.INVESTIGATOR_INTERVIEW_QC
       FROM filtered_cases a
-        INNER JOIN RDB.dbo.F_INTERVIEW_CASE b
+        INNER JOIN {nbs_rdb}.dbo.F_INTERVIEW_CASE b
                 ON a.INVESTIGATION_KEY = b.INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.D_INTERVIEW c
+        INNER JOIN {nbs_rdb}.dbo.D_INTERVIEW c
                 ON c.D_INTERVIEW_KEY = b.D_INTERVIEW_KEY
                AND c.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.F_CONTACT_RECORD_CASE d
+        INNER JOIN {nbs_rdb}.dbo.F_CONTACT_RECORD_CASE d
                 ON a.INVESTIGATION_KEY = d.SUBJECT_INVESTIGATION_KEY
-        INNER JOIN RDB.dbo.STD_HIV_DATAMART f
+        INNER JOIN {nbs_rdb}.dbo.STD_HIV_DATAMART f
                 ON d.CONTACT_INVESTIGATION_KEY = f.Investigation_key
-        INNER JOIN RDB.dbo.D_CONTACT_RECORD e
+        INNER JOIN {nbs_rdb}.dbo.D_CONTACT_RECORD e
                 ON e.D_CONTACT_RECORD_KEY = d.D_CONTACT_RECORD_KEY
                AND e.RECORD_STATUS_CD <> 'LOG_DEL'
-        INNER JOIN RDB.dbo.D_provider
+        INNER JOIN {nbs_rdb}.dbo.D_provider
                 ON D_provider.provider_key = a.INVESTIGATOR_INTERVIEW_KEY
                AND e.CTT_REFERRAL_BASIS IN (
                      'P1 - Partner, Sex',

--- a/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
+++ b/apps/report-execution/tests/integration/assets/tablefaker_schema/pa_01.yaml
@@ -77,7 +77,10 @@ tables:
       - column_name: SOURCE_SPREAD
         data: random.choice(["1 - Spread", "2 - Source"])
       - column_name: FL_FUP_INIT_ASSGN_DT
-        data: fake.date_between(start_date=date(2018, 5, 5), end_date=date(2025, 1, 5))
+        data: |
+          if row_id <= 400:
+            return date(2024, 1, 1)
+          return fake.date_between(start_date=date(2018, 5, 5), end_date=date(2025, 1, 5))
       - column_name: CA_PATIENT_INTV_STATUS
         data: r"I - Interviewed"
       - column_name: INVESTIGATOR_INTERVIEW_KEY
@@ -167,7 +170,11 @@ tables:
           ])
         null_percentage: 0.1
       - column_name: FL_FUP_DISPO_DT
-        data: date(2024, 1, min(row_id, 28))
+        data: |
+          if row_id <= 400:
+            day_offsets = [2, 4, 6, 10, 16]
+            return date(2024, 1, 1 + day_offsets[row_id % len(day_offsets)])
+          return date(2024, 1, min(row_id, 28))
       - column_name: FL_FUP_INVESTIGATOR_ASSGN_DT
         data: date(2024, 1, 1)
       - column_name: INIT_FUP_INITIAL_FOLL_UP

--- a/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
+++ b/apps/report-execution/tests/integration/libraries/snapshots/pa_01/test_execute_report_check_data_hiv/snapshot.yml
@@ -26,73 +26,73 @@
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
-  - 2
-  - 0.7%
+  - Within 3 Days
+  - 4
+  - 1.4%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 2
-  - 0.7%
+  - Within 5 Days
+  - 5
+  - 1.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 2
-  - 0.7%
+  - Within 7 Days
+  - 5
+  - 1.7%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 214
-  - 74.6%
+  - Within 14 Days
+  - 218
+  - 76.0%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 172
-  - 59.9%
+  - 159
+  - 55.4%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 145
-  - 50.5%
+  - 138
+  - 48.1%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 217
-  - 75.6%
+  - 215
+  - 74.9%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 245
-  - 112.9%
+  - 246
+  - 114.4%
   - null
 - !!python/tuple
   - ALL
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 210
-  - 96.8%
+  - 215
+  - 100.0%
   - null
 - !!python/tuple
   - ALL
@@ -131,7 +131,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 68
+  - 83
   - null
   - null
 - !!python/tuple
@@ -139,7 +139,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 81
+  - 66
   - null
   - null
 - !!python/tuple
@@ -307,8 +307,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 11
-  - 7.4%
+  - 8
+  - 5.4%
   - null
 - !!python/tuple
   - ALL
@@ -339,8 +339,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, Still Neg
-  - 0
-  - 0.0%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - ALL
@@ -371,8 +371,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, No Test
-  - 2
-  - 2.9%
+  - 1
+  - 1.4%
   - null
 - !!python/tuple
   - ALL
@@ -443,8 +443,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 2
-  - 1.3%
+  - 4
+  - 2.7%
   - null
 - !!python/tuple
   - ALL
@@ -453,6 +453,86 @@
   - null
   - 10
   - 6.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 63
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 13
+  - 20.6%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 28
+  - 44.4%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 41
+  - 65.1%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 55
+  - 87.3%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 69
+  - null
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 15
+  - 21.7%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 29
+  - 42.0%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 42
+  - 60.9%
+  - null
+- !!python/tuple
+  - ALL
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 55
+  - 79.7%
   - null
 - !!python/tuple
   - adevraj
@@ -482,54 +562,38 @@
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
-  - 1
-  - 1.4%
+  - Within 3 Days
+  - 2
+  - 2.8%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 1
-  - 1.4%
+  - Within 5 Days
+  - 2
+  - 2.8%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 1
-  - 1.4%
+  - Within 7 Days
+  - 2
+  - 2.8%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 40
-  - 56.3%
+  - Within 14 Days
+  - 43
+  - 60.6%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - Cases Reinterviewed
-  - null
-  - 37
-  - 52.1%
-  - null
-- !!python/tuple
-  - adevraj
-  - Case Assignments & Outcomes
-  - HIV Previous Positive
-  - null
-  - 25
-  - 35.2%
-  - null
-- !!python/tuple
-  - adevraj
-  - Case Assignments & Outcomes
-  - HIV Tested
   - null
   - 36
   - 50.7%
@@ -537,18 +601,34 @@
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
+  - HIV Previous Positive
+  - null
+  - 27
+  - 38.0%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
+  - HIV Tested
+  - null
+  - 41
+  - 57.7%
+  - null
+- !!python/tuple
+  - adevraj
+  - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 57
-  - 158.3%
+  - 65
+  - 158.5%
   - null
 - !!python/tuple
   - adevraj
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 43
-  - 119.4%
+  - 47
+  - 114.6%
   - null
 - !!python/tuple
   - adevraj
@@ -587,7 +667,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 12
+  - 17
   - null
   - null
 - !!python/tuple
@@ -595,7 +675,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 16
+  - 11
   - null
   - null
 - !!python/tuple
@@ -763,8 +843,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 3
-  - 10.7%
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
   - adevraj
@@ -819,8 +899,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, New Neg
-  - 5
-  - 31.2%
+  - 4
+  - 25.0%
   - null
 - !!python/tuple
   - adevraj
@@ -899,8 +979,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 1
-  - 3.6%
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
   - adevraj
@@ -909,6 +989,86 @@
   - null
   - 1
   - 3.6%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 15
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 5
+  - 33.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 11
+  - 73.3%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 16
+  - null
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 5
+  - 31.2%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 7
+  - 43.8%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 11
+  - 68.8%
+  - null
+- !!python/tuple
+  - adevraj
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 13
+  - 81.2%
   - null
 - !!python/tuple
   - avance
@@ -938,7 +1098,7 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
+  - Within 3 Days
   - 0
   - 0.0%
   - null
@@ -946,7 +1106,7 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
+  - Within 5 Days
   - 0
   - 0.0%
   - null
@@ -954,7 +1114,7 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
+  - Within 7 Days
   - 0
   - 0.0%
   - null
@@ -962,33 +1122,33 @@
   - avance
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 37
-  - 50.7%
+  - Within 14 Days
+  - 44
+  - 60.3%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 45
-  - 61.6%
+  - 36
+  - 49.3%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 27
-  - 37.0%
+  - 39
+  - 53.4%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 42
-  - 57.5%
+  - 46
+  - 63.0%
   - null
 - !!python/tuple
   - avance
@@ -996,15 +1156,15 @@
   - HIV New Positive
   - null
   - 57
-  - 135.7%
+  - 123.9%
   - null
 - !!python/tuple
   - avance
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 40
-  - 95.2%
+  - 38
+  - 82.6%
   - null
 - !!python/tuple
   - avance
@@ -1355,8 +1515,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 0
-  - 0.0%
+  - 1
+  - 3.8%
   - null
 - !!python/tuple
   - avance
@@ -1365,6 +1525,86 @@
   - null
   - 1
   - 3.8%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 9
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 22.2%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 3
+  - 33.3%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 6
+  - 66.7%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 6
+  - 66.7%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - null
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 2
+  - 16.7%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 7
+  - 58.3%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 9
+  - 75.0%
+  - null
+- !!python/tuple
+  - avance
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 10
+  - 83.3%
   - null
 - !!python/tuple
   - dbowman
@@ -1394,57 +1634,57 @@
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
-  - 0
-  - 0.0%
+  - Within 3 Days
+  - 1
+  - 1.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 0
-  - 0.0%
+  - Within 5 Days
+  - 1
+  - 1.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 0
-  - 0.0%
+  - Within 7 Days
+  - 1
+  - 1.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 49
-  - 61.3%
+  - Within 14 Days
+  - 45
+  - 56.2%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 36
-  - 45.0%
+  - 42
+  - 52.5%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 40
-  - 50.0%
+  - 28
+  - 35.0%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 49
-  - 61.3%
+  - 39
+  - 48.8%
   - null
 - !!python/tuple
   - dbowman
@@ -1452,15 +1692,15 @@
   - HIV New Positive
   - null
   - 64
-  - 130.6%
+  - 164.1%
   - null
 - !!python/tuple
   - dbowman
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 39
-  - 79.6%
+  - 48
+  - 123.1%
   - null
 - !!python/tuple
   - dbowman
@@ -1499,7 +1739,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 15
+  - 17
   - null
   - null
 - !!python/tuple
@@ -1507,7 +1747,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 13
+  - 11
   - null
   - null
 - !!python/tuple
@@ -1675,8 +1915,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 3
-  - 10.7%
+  - 4
+  - 14.3%
   - null
 - !!python/tuple
   - dbowman
@@ -1739,8 +1979,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, No Test
-  - 1
-  - 8.3%
+  - 0
+  - 0.0%
   - null
 - !!python/tuple
   - dbowman
@@ -1811,8 +2051,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 1
-  - 2.9%
+  - 2
+  - 5.7%
   - null
 - !!python/tuple
   - dbowman
@@ -1821,6 +2061,86 @@
   - null
   - 2
   - 5.7%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 14
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 5
+  - 35.7%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 8
+  - 57.1%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 8
+  - 57.1%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 10
+  - 71.4%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - null
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 4
+  - 33.3%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 6
+  - 50.0%
+  - null
+- !!python/tuple
+  - dbowman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 9
+  - 75.0%
   - null
 - !!python/tuple
   - fpoole
@@ -1850,7 +2170,7 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
+  - Within 3 Days
   - 0
   - 0.0%
   - null
@@ -1858,7 +2178,7 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
+  - Within 5 Days
   - 0
   - 0.0%
   - null
@@ -1866,7 +2186,7 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
+  - Within 7 Days
   - 0
   - 0.0%
   - null
@@ -1874,49 +2194,49 @@
   - fpoole
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
-  - 43
-  - 53.8%
+  - Within 14 Days
+  - 41
+  - 51.2%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - Cases Reinterviewed
   - null
-  - 45
-  - 56.2%
+  - 47
+  - 58.8%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 35
-  - 43.8%
+  - 31
+  - 38.8%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 45
-  - 56.2%
+  - 46
+  - 57.5%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 63
-  - 140.0%
+  - 65
+  - 141.3%
   - null
 - !!python/tuple
   - fpoole
   - Case Assignments & Outcomes
   - HIV Posttest Counsel
   - null
-  - 46
-  - 102.2%
+  - 40
+  - 87.0%
   - null
 - !!python/tuple
   - fpoole
@@ -1955,7 +2275,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 14
+  - 18
   - null
   - null
 - !!python/tuple
@@ -1963,7 +2283,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 24
+  - 20
   - null
   - null
 - !!python/tuple
@@ -2131,8 +2451,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 3
-  - 7.9%
+  - 1
+  - 2.6%
   - null
 - !!python/tuple
   - fpoole
@@ -2163,16 +2483,16 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, Still Neg
-  - 0
-  - 0.0%
+  - 1
+  - 6.7%
   - null
 - !!python/tuple
   - fpoole
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, No Test
-  - 5
-  - 33.3%
+  - 4
+  - 26.7%
   - null
 - !!python/tuple
   - fpoole
@@ -2187,8 +2507,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - No Prev. Test, New Neg
-  - 4
-  - 26.7%
+  - 5
+  - 33.3%
   - null
 - !!python/tuple
   - fpoole
@@ -2279,6 +2599,86 @@
   - 9.4%
   - null
 - !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 15
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 13.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 6
+  - 40.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 11
+  - 73.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 14
+  - 93.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 15
+  - null
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 4
+  - 26.7%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 8
+  - 53.3%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 9
+  - 60.0%
+  - null
+- !!python/tuple
+  - fpoole
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 13
+  - 86.7%
+  - null
+- !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases Assigned
@@ -2306,7 +2706,7 @@
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 3 days
+  - Within 3 Days
   - 1
   - 1.3%
   - null
@@ -2314,23 +2714,23 @@
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 5 days
-  - 1
-  - 1.3%
+  - Within 5 Days
+  - 2
+  - 2.5%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 7 days
-  - 1
-  - 1.3%
+  - Within 7 Days
+  - 2
+  - 2.5%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - Cases IX'D
-  - Within 14 days
+  - Within 14 Days
   - 45
   - 57.0%
   - null
@@ -2347,24 +2747,24 @@
   - Case Assignments & Outcomes
   - HIV Previous Positive
   - null
-  - 39
-  - 49.4%
+  - 38
+  - 48.1%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV Tested
   - null
-  - 45
-  - 57.0%
+  - 43
+  - 54.4%
   - null
 - !!python/tuple
   - gfreeman
   - Case Assignments & Outcomes
   - HIV New Positive
   - null
-  - 67
-  - 148.9%
+  - 60
+  - 139.5%
   - null
 - !!python/tuple
   - gfreeman
@@ -2372,7 +2772,7 @@
   - HIV Posttest Counsel
   - null
   - 42
-  - 93.3%
+  - 97.7%
   - null
 - !!python/tuple
   - gfreeman
@@ -2411,7 +2811,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From OI
-  - 13
+  - 17
   - null
   - null
 - !!python/tuple
@@ -2419,7 +2819,7 @@
   - Partners & Clusters Initiated
   - Total Partners Initiated
   - From RI
-  - 15
+  - 11
   - null
   - null
 - !!python/tuple
@@ -2587,8 +2987,8 @@
   - Dispositions - New Partners & Clusters
   - New Partners Previous Pos
   - null
-  - 1
-  - 3.6%
+  - 2
+  - 7.1%
   - null
 - !!python/tuple
   - gfreeman
@@ -2627,8 +3027,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Notified
   - Prev. Neg, No Test
-  - 4
-  - 33.3%
+  - 5
+  - 41.7%
   - null
 - !!python/tuple
   - gfreeman
@@ -2723,8 +3123,8 @@
   - Dispositions - New Partners & Clusters
   - New Clusters Previous Pos
   - null
-  - 0
-  - 0.0%
+  - 1
+  - 3.4%
   - null
 - !!python/tuple
   - gfreeman
@@ -2733,4 +3133,84 @@
   - null
   - 3
   - 10.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - null
+  - 14
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 3 Days
+  - 2
+  - 14.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 5 Days
+  - 7
+  - 50.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 7 Days
+  - 11
+  - 78.6%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Partners Notified
+  - Within 14 Days
+  - 14
+  - 100.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - null
+  - 12
+  - null
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 3 Days
+  - 1
+  - 8.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 5 Days
+  - 3
+  - 25.0%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 7 Days
+  - 7
+  - 58.3%
+  - null
+- !!python/tuple
+  - gfreeman
+  - Speed of Notification - Partners & Clusters
+  - New Clusters Notified
+  - Within 14 Days
+  - 10
+  - 83.3%
   - null


### PR DESCRIPTION
## Description

[Data Parity Spreadsheet](https://docs.google.com/spreadsheets/d/18ag_gZxu38jF97_T9JZgDysKmo3A4Ybn-82KYtt3NpM/edit?gid=35403003#gid=35403003)

The 4th PR for APP-609, meant for merging into `ab/app-609/feature`.

This PR is still only focused on the HIV version of this report.  A separate PR (or PRs) will be made for the implementation of the difference for the STD version of this report.

Changes in this PR:
- Adds fourth and final section "SPEED OF NOTIFICATION - PARTNERS & CLUSTERS"
- Add use of `get_cached_config_value` in query building for proper DB names
- Fixes some errant use of `datepart` in existing SQL

**NOTE:** Found a bug in the SAS code where the percentages for the rightmost column show up as 0.  This is documented in the conversion notes and the Python version will give the real percentages.

Relevant section from PDF for "ALL WORKERS":
<img width="1018" height="291" alt="Screenshot 2026-07-07 at 15 03 42" src="https://github.com/user-attachments/assets/aee82137-47aa-478d-bb8f-e761ab63b513" />

Relevant section from CSV for "ALL WORKERS":
```csv
Worker,Category 1,Category 2,Category 3,Count,Percentage,Index
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,,63,,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 3 Days,13,20.6%,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 5 Days,28,44.4%,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 7 Days,41,65.1%,
ALL,Speed of Notification - Partners & Clusters,New Partners Notified,Within 14 Days,55,87.3%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,,69,,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 3 Days,15,21.7%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 5 Days,29,42.0%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 7 Days,42,60.9%,
ALL,Speed of Notification - Partners & Clusters,New Clusters Notified,Within 14 Days,55,79.7%,
```

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-609)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
