### PR TITLE
[SEER] Update DOB search criteria comparison

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -329,6 +329,12 @@ class PatientDemographicQueryResolver {
     return Optional.empty();
   }
 
+  private QueryVariant asFullDayRange(final String field, final LocalDate date) {
+    String start = FlexibleInstantConverter.toString(date);
+    String end = FlexibleInstantConverter.toString(date.plusDays(1));
+    return RangeQuery.of(range -> range.term(term -> term.field(field).gte(start).lt(end)));
+  }
+
   private Optional<QueryVariant> applyDateOfBirthCriteria(final PatientSearchCriteria criteria) {
 
     LocalDate dateOfBirth = criteria.getDateOfBirth();
@@ -342,12 +348,7 @@ class PatientDemographicQueryResolver {
             Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).lt(value))));
         case "after" ->
             Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).gt(value))));
-        default -> {
-          String nextDayValue = FlexibleInstantConverter.toString(dateOfBirth.plusDays(1));
-          yield Optional.of(
-              RangeQuery.of(
-                  range -> range.term(term -> term.field(BIRTHDAY).gte(value).lt(nextDayValue))));
-        }
+        default -> Optional.of(asFullDayRange(BIRTHDAY, dateOfBirth));
       };
     }
 
@@ -357,12 +358,7 @@ class PatientDemographicQueryResolver {
         && dateCriteria.equals().isCompleteDate()) {
       Equals equals = dateCriteria.equals();
       LocalDate targetDate = LocalDate.of(equals.year(), equals.month(), equals.day());
-      String value = FlexibleInstantConverter.toString(targetDate);
-
-      String nextDayValue = FlexibleInstantConverter.toString(targetDate.plusDays(1));
-      return Optional.of(
-          RangeQuery.of(
-              range -> range.term(term -> term.field(BIRTHDAY).gte(value).lt(nextDayValue))));
+      return Optional.of(asFullDayRange(BIRTHDAY, targetDate));
     }
 
     return Optional.empty();
@@ -395,9 +391,10 @@ class PatientDemographicQueryResolver {
       return Optional.empty();
     }
 
-    String value = FlexibleInstantConverter.toString(betweenDate.to());
+    LocalDate toDate = betweenDate.to();
+    String nextDayValue = FlexibleInstantConverter.toString(toDate.plusDays(1));
 
-    return Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).lte(value))));
+    return Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).lt(nextDayValue))));
   }
 
   private String resolveDateOperator(final String operator) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -342,7 +342,12 @@ class PatientDemographicQueryResolver {
             Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).lt(value))));
         case "after" ->
             Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).gt(value))));
-        default -> Optional.of(MatchQuery.of(match -> match.field(BIRTHDAY).query(value)));
+        default -> {
+          String nextDayValue = FlexibleInstantConverter.toString(dateOfBirth.plusDays(1));
+          yield Optional.of(
+              RangeQuery.of(
+                  range -> range.term(term -> term.field(BIRTHDAY).gte(value).lt(nextDayValue))));
+        }
       };
     }
 
@@ -351,10 +356,13 @@ class PatientDemographicQueryResolver {
         && dateCriteria.equals() != null
         && dateCriteria.equals().isCompleteDate()) {
       Equals equals = dateCriteria.equals();
-      String value =
-          FlexibleInstantConverter.toString(
-              LocalDate.of(equals.year(), equals.month(), equals.day()));
-      return Optional.of(MatchQuery.of(match -> match.field(BIRTHDAY).query(value)));
+      LocalDate targetDate = LocalDate.of(equals.year(), equals.month(), equals.day());
+      String value = FlexibleInstantConverter.toString(targetDate);
+
+      String nextDayValue = FlexibleInstantConverter.toString(targetDate.plusDays(1));
+      return Optional.of(
+          RangeQuery.of(
+              range -> range.term(term -> term.field(BIRTHDAY).gte(value).lt(nextDayValue))));
     }
 
     return Optional.empty();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -394,7 +394,8 @@ class PatientDemographicQueryResolver {
     LocalDate toDate = betweenDate.to();
     String nextDayValue = FlexibleInstantConverter.toString(toDate.plusDays(1));
 
-    return Optional.of(RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).lt(nextDayValue))));
+    return Optional.of(
+        RangeQuery.of(range -> range.term(term -> term.field(BIRTHDAY).lt(nextDayValue))));
   }
 
   private String resolveDateOperator(final String operator) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/search/PatientDemographicQueryResolver.java
@@ -329,6 +329,7 @@ class PatientDemographicQueryResolver {
     return Optional.empty();
   }
 
+  // Accounts for datetime comparison (i.e. DOB values with time components)
   private QueryVariant asFullDayRange(final String field, final LocalDate date) {
     String start = FlexibleInstantConverter.toString(date);
     String end = FlexibleInstantConverter.toString(date.plusDays(1));
@@ -391,6 +392,7 @@ class PatientDemographicQueryResolver {
       return Optional.empty();
     }
 
+    // Day+1 accounts for datetime comparison (i.e. DOB values with time components)
     LocalDate toDate = betweenDate.to();
     String nextDayValue = FlexibleInstantConverter.toString(toDate.plusDays(1));
 

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/birth/PatientBirthDemographicApplier.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/birth/PatientBirthDemographicApplier.java
@@ -6,6 +6,7 @@ import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
 import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.support.util.RandomUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
 
@@ -45,11 +46,15 @@ public class PatientBirthDemographicApplier {
   }
 
   void withBirthday(final PatientIdentifier identifier, final LocalDate birthday) {
+    withBirthday(identifier, RandomUtil.dateInPast(), birthday.atStartOfDay());
+  }
+
+  void withBirthday(final PatientIdentifier identifier, final LocalDateTime birthday) {
     withBirthday(identifier, RandomUtil.dateInPast(), birthday);
   }
 
   void withBirthday(
-      final PatientIdentifier identifier, final LocalDate asOf, final LocalDate birthday) {
+      final PatientIdentifier identifier, final LocalDate asOf, final LocalDateTime birthday) {
 
     client
         .sql(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/birth/PatientBirthDemographicsSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/patient/demographics/birth/PatientBirthDemographicsSteps.java
@@ -4,6 +4,7 @@ import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import gov.cdc.nbs.testing.support.Active;
 import io.cucumber.java.en.Given;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class PatientBirthDemographicsSteps {
 
@@ -21,9 +22,18 @@ public class PatientBirthDemographicsSteps {
     this.active.maybeActive().ifPresent(patient -> applier.withBirthday(patient, value));
   }
 
+  @Given("the patient was born exactly at {string}")
+  public void bornOnWithTime(final String timestamp) {
+    LocalDateTime exactBirthday = LocalDateTime.parse(timestamp);
+
+    this.active.maybeActive().ifPresent(patient -> applier.withBirthday(patient, exactBirthday));
+  }
+
   @Given("the patient was born on {localDate} as of {localDate}")
   public void bornOn(final LocalDate value, final LocalDate asOf) {
-    this.active.maybeActive().ifPresent(patient -> applier.withBirthday(patient, asOf, value));
+    this.active
+        .maybeActive()
+        .ifPresent(patient -> applier.withBirthday(patient, asOf, value.atStartOfDay()));
   }
 
   @Given("the patient was born {int} years ago")

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.born-on.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.born-on.feature
@@ -7,6 +7,28 @@ Feature: Patient Search by Date of birth
     Given I have a patient
     And I have another patient
 
+  Scenario: I can find patients born on a specific date even if the record contains a birth time
+    Given the patient was born on 02/02/1990
+    And I have another patient
+    And the patient was born exactly at "1990-01-01T00:26:00"
+    And patients are available for search
+    And I add the patient criteria for patient's born in the month of January
+    And I add the patient criteria for patient's born on the 1st day of the month
+    And I add the patient criteria for patient's born in the year 1990
+    When I search for patients
+    Then the patient is in the search results
+    And there is only one patient search result
+
+  Scenario: I can find patients with a birth time when they fall on the exact upper boundary of a date range search
+    Given the patient was born on 01/02/1990
+    And I have another patient
+    And the patient was born exactly at "1990-01-01T23:45:00"
+    And patients are available for search
+    And I add the patient criteria for patient's born between 01/01/1990 and 01/01/1990
+    When I search for patients
+    Then the patient is in the search results
+    And there is only one patient search result
+
   Scenario: I can find patients born on a specific day
     Given the patient was born on 01/15/1974
     And I have another patient

--- a/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.born-on.feature
+++ b/apps/modernization-api/src/test/resources/features/patient/search/PatientSearch.born-on.feature
@@ -8,7 +8,7 @@ Feature: Patient Search by Date of birth
     And I have another patient
 
   Scenario: I can find patients born on a specific date even if the record contains a birth time
-    Given the patient was born on 02/02/1990
+    Given the patient was born on 01/02/1990
     And I have another patient
     And the patient was born exactly at "1990-01-01T00:26:00"
     And patients are available for search


### PR DESCRIPTION
## **Description**

### **Overview**
This PR resolves an issue in NBS 7 Patient Search where patient records are excluded from exact Date of Birth (DOB) and high-range boundary searches if their database profile contains an explicit time component. 

---

### **Changes**

#### **1. Code**
* **`PatientDemographicQueryResolver.java`**: 
  * Add `asFullDayRange()` with an inclusive 24-hour range query.
  * Corrected `applyDateOfBirthHighRangeCriteria()` to properly target the end of the boundary day.

#### **2. Tests**
* **`PatientBirthDemographicApplier.java`**: Overloaded the `withBirthday` hook to accept `LocalDateTime`. 
* **`PatientDemographicQueryResolverTest.java`**: Added unit tests to isolate the query resolver methods and assert that the correct range elements are consistently generated for exact-match and born-on parameter blocks.

## Tickets

* [APP-810](https://cdc-nbs.atlassian.net/jira/software/c/projects/APP/boards/626?selectedIssue=APP-810)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests


[APP-810]: https://cdc-nbs.atlassian.net/browse/APP-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ