### PR TITLE
fix: clean up field and null styling

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -357,7 +357,7 @@ describe('report run page', () => {
 
                     expect(mockApi).toHaveBeenCalled();
 
-                    const checkbox = await findByLabelText('Include Nulls for Basic Text Filter');
+                    const checkbox = await findByLabelText('Include nulls for Basic Text Filter');
                     expect(checkbox).not.toBeChecked();
                     const user = userEvent.setup();
                     await user.click(checkbox);
@@ -388,7 +388,7 @@ describe('report run page', () => {
 
                     expect(mockApi).toHaveBeenCalled();
 
-                    const checkbox = await findByLabelText('Include Nulls for Basic Text Filter');
+                    const checkbox = await findByLabelText('Include nulls for Basic Text Filter');
                     expect(checkbox).toBeChecked();
                     const user = userEvent.setup();
                     await user.click(checkbox);
@@ -805,13 +805,13 @@ describe('report run page', () => {
                 expect(await findAllByText('Time')).toHaveLength(2);
 
                 expect(await findByLabelText('Full Name')).toBeVisible();
-                const fromMonthInput = await findByLabelText('From Month');
+                const fromMonthInput = await findByLabelText('From month');
                 await userEvent.selectOptions(fromMonthInput, '1');
-                const fromYearInput = await findByLabelText('From Year');
+                const fromYearInput = await findByLabelText('From year');
                 await userEvent.selectOptions(fromYearInput, '2025');
-                const toMonthInput = await findByLabelText('To Month');
+                const toMonthInput = await findByLabelText('To month');
                 await userEvent.selectOptions(toMonthInput, '1');
-                const toYearInput = await findByLabelText('To Year');
+                const toYearInput = await findByLabelText('To year');
                 await userEvent.selectOptions(toYearInput, '2026');
 
                 expect(fromMonthInput).toHaveValue('1');
@@ -847,10 +847,10 @@ describe('report run page', () => {
                 expect(mockConfigApi).toHaveBeenCalled();
 
                 expect(await findByLabelText('Full Name')).toBeVisible();
-                const fromMonthInput = await findByLabelText('From Month');
-                const fromYearInput = await findByLabelText('From Year');
-                const toMonthInput = await findByLabelText('To Month');
-                const toYearInput = await findByLabelText('To Year');
+                const fromMonthInput = await findByLabelText('From month');
+                const fromYearInput = await findByLabelText('From year');
+                const toMonthInput = await findByLabelText('To month');
+                const toYearInput = await findByLabelText('To year');
 
                 expect(fromMonthInput).toHaveValue('');
                 expect(fromYearInput).toHaveValue('');
@@ -885,10 +885,10 @@ describe('report run page', () => {
                 expect(mockConfigApi).toHaveBeenCalled();
 
                 expect(await findByLabelText('Full Name')).toBeVisible();
-                const fromMonthInput = await findByLabelText('From Month');
-                const fromYearInput = await findByLabelText('From Year');
-                const toMonthInput = await findByLabelText('To Month');
-                const toYearInput = await findByLabelText('To Year');
+                const fromMonthInput = await findByLabelText('From month');
+                const fromYearInput = await findByLabelText('From year');
+                const toMonthInput = await findByLabelText('To month');
+                const toYearInput = await findByLabelText('To year');
 
                 expect(fromMonthInput).toHaveValue('1');
                 expect(fromYearInput).toHaveValue('2024');

--- a/apps/modernization-ui/src/apps/report/run/filters/basic/BasicFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/basic/BasicFilter.tsx
@@ -12,6 +12,9 @@ import { getYearRange, YearRangeFilter } from './YearRangeFilter';
 import { getMonthYearRange, MonthYearRangeFilter, monthYearRangeValidator } from './MonthYearRangeFilter';
 import { getNumericValue, NumericFilter, numericValidator } from './NumericFilter.tsx';
 import { Checkbox } from 'design-system/checkbox';
+import classNames from 'classnames';
+
+import styles from './basic-filter.module.scss';
 
 export type BasicFilterProps = {
     filter: BasicFilterConfiguration;
@@ -115,9 +118,11 @@ const BasicFilter = ({ filter, columns }: { filter: BasicFilterConfiguration; co
         rules.validate = validationRule(filter, label);
     }
 
+    const allowsNulls = filter.filterType.code?.endsWith('_N');
+
     return (
-        <div className="display-flex flex-row">
-            <div className="flex-3">
+        <div className={classNames(styles.row, { [styles.fieldWithNulls]: allowsNulls })}>
+            <div className={styles.field}>
                 <Controller
                     control={control}
                     // add `id_` prefix to make sure the id is treated as an object key and not array index
@@ -141,8 +146,8 @@ const BasicFilter = ({ filter, columns }: { filter: BasicFilterConfiguration; co
                     )}
                 />
             </div>
-            {filter.filterType.code?.endsWith('_N') && (
-                <div className="flex-1">
+            {allowsNulls && (
+                <div className={styles.nulls}>
                     <Controller
                         control={control}
                         // add `id_` prefix to make sure the id is treated as an object key and not array index
@@ -150,20 +155,14 @@ const BasicFilter = ({ filter, columns }: { filter: BasicFilterConfiguration; co
                         defaultValue={filter.defaultIncludeNulls ?? null}
                         // ignoring the ref as it does not pass down well and isn't critical
                         render={({ field: { value, onChange } }) => (
-                            <Field
-                                htmlFor={`${id}-include-nulls`}
-                                orientation="horizontal"
-                                sizing="medium"
-                                label="Include Nulls"
-                                className="height-full"
-                            >
-                                <Checkbox
-                                    id={`${id}-include-nulls`}
-                                    aria-label={`Include Nulls for ${label}`}
-                                    selected={value}
-                                    onChange={onChange}
-                                ></Checkbox>
-                            </Field>
+                            <Checkbox
+                                id={`${id}-include-nulls`}
+                                label="Include nulls"
+                                className="padding-right-2"
+                                aria-label={`Include nulls for ${label}`}
+                                selected={value}
+                                onChange={onChange}
+                            ></Checkbox>
                         )}
                     />
                 </div>

--- a/apps/modernization-ui/src/apps/report/run/filters/basic/basic-filter.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/filters/basic/basic-filter.module.scss
@@ -1,0 +1,21 @@
+@use 'styles/borders';
+
+.row {
+    @extend %thin-bottom;
+}
+
+.fieldWithNulls {
+    display: grid;
+    grid-template-areas: 'field nulls';
+    grid-template-columns: auto 1fr;
+
+    .field {
+        grid-area: field;
+    }
+
+    .nulls {
+        grid-area: nulls;
+        font-size: 0.875rem;
+        align-self: center;
+    }
+}

--- a/apps/modernization-ui/src/apps/report/run/filters/basic/basic-filter.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/filters/basic/basic-filter.module.scss
@@ -1,7 +1,9 @@
 @use 'styles/borders';
 
 .row {
-    @extend %thin-bottom;
+    &:not(:last-child) {
+        @extend %thin-bottom;
+    }
 }
 
 .fieldWithNulls {

--- a/apps/modernization-ui/src/design-system/date/criteria/exact/MonthYearField.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/exact/MonthYearField.tsx
@@ -67,7 +67,7 @@ const MonthYearField = ({
     return (
         <div role="group" id={id} className={styles['exact-date-entry']} aria-label={label}>
             <div className={classNames(styles['numeric-wrapper'], styles['month'])}>
-                <label htmlFor={`${id}-month`}>{label} Month</label>
+                <label htmlFor={`${id}-month`}>{label} month</label>
                 <Select
                     id={`${id}-month`}
                     sizing={sizing}
@@ -79,7 +79,7 @@ const MonthYearField = ({
                 />
             </div>
             <div className={classNames(styles['numeric-wrapper'], styles['year'])}>
-                <label htmlFor={`${id}-year`}>{label} Year</label>
+                <label htmlFor={`${id}-year`}>{label} year</label>
                 <Select
                     id={`${id}-year`}
                     sizing={sizing}

--- a/apps/modernization-ui/src/design-system/date/criteria/range/MonthYearRangeField.spec.tsx
+++ b/apps/modernization-ui/src/design-system/date/criteria/range/MonthYearRangeField.spec.tsx
@@ -32,10 +32,10 @@ describe('MonthYearRangeField Component', () => {
                 onChange={vi.fn()}
             />
         );
-        const fromMonth = getByRole('combobox', { name: 'From Month' });
-        const fromYear = getByRole('combobox', { name: 'From Year' });
-        const toMonth = getByRole('combobox', { name: 'To Month' });
-        const toYear = getByRole('combobox', { name: 'To Year' });
+        const fromMonth = getByRole('combobox', { name: 'From month' });
+        const fromYear = getByRole('combobox', { name: 'From year' });
+        const toMonth = getByRole('combobox', { name: 'To month' });
+        const toYear = getByRole('combobox', { name: 'To year' });
 
         expect(fromMonth).toHaveValue('1');
         expect(fromYear).toHaveValue('2004');
@@ -54,7 +54,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const from = getByRole('combobox', { name: 'From Month' });
+        const from = getByRole('combobox', { name: 'From month' });
 
         const user = userEvent.setup();
         await user.selectOptions(from, '2');
@@ -73,7 +73,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const from = getByRole('combobox', { name: 'From Year' });
+        const from = getByRole('combobox', { name: 'From year' });
 
         const user = userEvent.setup();
         await user.selectOptions(from, '2018');
@@ -97,7 +97,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const from = getByRole('combobox', { name: 'From Month' });
+        const from = getByRole('combobox', { name: 'From month' });
 
         const user = userEvent.setup();
         await user.selectOptions(from, '8');
@@ -121,7 +121,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const from = getByRole('combobox', { name: 'From Year' });
+        const from = getByRole('combobox', { name: 'From year' });
 
         const user = userEvent.setup();
         await user.selectOptions(from, '2010');
@@ -140,7 +140,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const to = getByRole('combobox', { name: 'To Month' });
+        const to = getByRole('combobox', { name: 'To month' });
 
         const user = userEvent.setup();
         await user.selectOptions(to, '2');
@@ -159,7 +159,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const to = getByRole('combobox', { name: 'To Year' });
+        const to = getByRole('combobox', { name: 'To year' });
 
         const user = userEvent.setup();
         await user.selectOptions(to, '2018');
@@ -183,7 +183,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const to = getByRole('combobox', { name: 'To Month' });
+        const to = getByRole('combobox', { name: 'To month' });
 
         const user = userEvent.setup();
         await user.selectOptions(to, '8');
@@ -207,7 +207,7 @@ describe('MonthYearRangeField Component', () => {
             />
         );
 
-        const to = getByRole('combobox', { name: 'To Year' });
+        const to = getByRole('combobox', { name: 'To year' });
 
         const user = userEvent.setup();
         await user.selectOptions(to, '2010');

--- a/apps/modernization-ui/src/design-system/date/criteria/range/date-range-field.module.scss
+++ b/apps/modernization-ui/src/design-system/date/criteria/range/date-range-field.module.scss
@@ -1,12 +1,13 @@
 .date-range-entry {
     display: flex;
-    justify-content: space-between;
+    justify-content: start;
     gap: 1rem;
 
     .range-wrapper {
         display: flex;
         gap: 0.25rem;
         flex-direction: column;
+        width: 100%;
     }
 
     input {

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -45,7 +45,7 @@
         align-items: center;
 
         .children {
-            min-width: fit-content;
+            min-width: max-content;
             width: 20rem;
         }
 


### PR DESCRIPTION
## Description

During #3416 found some very unfortunate looking field styling and after conferring with @kenieh did some tweaking to get things cleaner

**Before:**

wide:
<img width="4110" height="2018" alt="image" src="https://github.com/user-attachments/assets/c18a6bc9-7e53-420e-b4c8-fd5ce7455e87" />

squishy:
<img width="2018" height="2172" alt="image" src="https://github.com/user-attachments/assets/6539cf73-4627-4e81-8cbb-786b0d7e52f5" />

**After:**

wide:
<img width="2003" height="1059" alt="image" src="https://github.com/user-attachments/assets/36573791-ab33-4f4f-9dfe-aa8e3d8013d3" />

squishy:
<img width="974" height="1095" alt="image" src="https://github.com/user-attachments/assets/86d773fc-24c2-463f-943d-897591099f96" />



## Tickets

* [Jira Ticket](url)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
