### PR TITLE
test: e2es for saving/(as) every filter

### DIFF
--- a/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
@@ -1,0 +1,37 @@
+Feature: View report configuration
+
+    Background:
+        Given I am logged in as secure user
+        Given I navigate to manage reports
+
+    Scenario: I create, save, and save as all the filters
+        When I click the "Create button" button
+        Then I should see the "Add" configuration page
+        # == Data source selecting ==
+        Then The "Confirm data source" "button" should be disabled
+        When I select value "nbs_ods.PHCDemographic (Disease Counts by County)" in the "Data source" field
+        When I click the "Confirm data source" button
+        Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Disease Counts by County)"
+        When I click the "Cancel" button
+        When I select value "nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)" in the "Data source" field
+        When I click the "Confirm data source" button
+        Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)"
+        When I click the "Confirm" button
+        Then The "Data source" "combobox" should be disabled
+        # == General fields ==
+        When I type "All filter test" into the "Name" field
+        When I type "All filter test is the best report" into the "Description" field
+        When I select value "System" in the "Owner" field
+        When I select radio "Public" in the "Group" field
+        When I select value "Default Report Section" in the "Section name" field
+        When I select value "nbs_custom (Recommended default. Basic tabular report. Executes the query described by the data source and filters and returns the table)" in the "Report execution library" field
+        # == Filters ==
+        When I add all filters
+        Then I should see 22 available filters
+        When I click the "Submit" button
+        Then I should see the "View" configuration page
+        And I navigate to list reports
+        And I click on the "Expand Subsections" link
+        And I click on the "Expand Subsections" link
+        And I click on the "Run" link
+        Then I should see a "heading" labelled "All filter test"

--- a/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
@@ -27,7 +27,7 @@ Feature: View report configuration
         When I select value "nbs_custom (Recommended default. Basic tabular report. Executes the query described by the data source and filters and returns the table)" in the "Report execution library" field
         # == Filters ==
         When I add all filters
-        Then I should see 22 available filters
+        Then I should see 20 available filters
         When I click the "Submit" button
         Then I should see the "View" configuration page
         And I navigate to list reports
@@ -48,6 +48,7 @@ Feature: View report configuration
         And I should see "Private" radio selected in the "Group" field
         And I click the "Save as new" button
         Then I am redirected to "/nbs/ManageReports.do"
+#        When I navigate to list reports
         And I click on the "Expand Subsections" link
         And I click on the "Run" link
         Then All filters should be filled out with 1

--- a/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
@@ -58,7 +58,7 @@ Feature: View report configuration
         And I click on the "Expand Subsections" link
         And I click the "All filter test" report
         Then I should see a "heading" labelled "All filter test"
-        And All filters should be empty
+        And All filters should be empty or the default value
 
         # Runs with only "Include nulls" checked
         When I click all include nulls
@@ -88,7 +88,7 @@ Feature: View report configuration
         And I click on the "Expand Subsections" link
         And I click the "Test include nulls report" report
         Then I should see a "heading" labelled "Test include nulls report"
-        And All filters should be empty
+        And All filters should be empty or the default value
 
     Scenario Outline: I delete test reports
         Given I navigate to manage reports

--- a/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
@@ -33,7 +33,7 @@ Feature: View report configuration
         And I navigate to list reports
         And I click on the "Expand Subsections" link
         And I click on the "Expand Subsections" link
-        And I click on the "Run" link
+        And I click the "All filter test" report
         Then I should see a "heading" labelled "All filter test"
         When I fill out all filters with 1
         And I click the "Run" button
@@ -48,7 +48,58 @@ Feature: View report configuration
         And I should see "Private" radio selected in the "Group" field
         And I click the "Save as new" button
         Then I am redirected to "/nbs/ManageReports.do"
-#        When I navigate to list reports
         And I click on the "Expand Subsections" link
-        And I click on the "Run" link
+        And I click the "Test save as all filter report" report
         Then All filters should be filled out with 1
+
+        # Check existing report has not changed
+        When I navigate to list reports
+        And I click on the "Expand Subsections" link
+        And I click on the "Expand Subsections" link
+        And I click the "All filter test" report
+        Then I should see a "heading" labelled "All filter test"
+        And All filters should be empty
+
+        # Runs with only "Include nulls" checked
+        When I click all include nulls
+        And I click the "Run" button
+        Then I should see a "heading" labelled "Your report has opened in a new tab."
+        When I click the "Save as new" button
+        And I should see a modal labelled "Save as a new report"
+        And I type "Test include nulls report" into the "Name" field
+        And I type "Testing include nulls report" into the "Description" field
+        And I select value "Default Report Section" in the "Section name" field
+        And I should see "Private" radio selected in the "Group" field
+        And I click the "Save as new" button
+        Then I am redirected to "/nbs/ManageReports.do"
+        And I click on the "Expand Subsections" link
+        And I click the "Test include nulls report" report
+        Then I should see a "heading" labelled "Test include nulls report"
+        And All include nulls checkboxes should be checked
+
+        # Save report
+        When I click all include nulls
+        And I click the "Run" button
+        Then I should see a "heading" labelled "Your report has opened in a new tab."
+        When I click the "Save" button
+        And I should see a modal labelled "Overwrite saved report?"
+        And I click the "Save" button
+        Then I am redirected to "/nbs/ManageReports.do"
+        And I click on the "Expand Subsections" link
+        And I click the "Test include nulls report" report
+        Then I should see a "heading" labelled "Test include nulls report"
+        And All filters should be empty
+
+    Scenario Outline: I delete test reports
+        Given I navigate to manage reports
+        When I click on the <reportName> link
+        Then I should see the "View" configuration page
+        When I click the "Delete" button
+        When I click the "Yes, delete" button
+        Then I should see the report list
+
+        Examples:
+            | reportName                       |
+            | "All filter test"                |
+            | "Test save as all filter report" |
+            | "Test include nulls report"      |

--- a/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
@@ -2,36 +2,52 @@ Feature: View report configuration
 
     Background:
         Given I am logged in as secure user
-        Given I navigate to manage reports
+        # Given I navigate to manage reports
 
     Scenario: I create, save, and save as all the filters
-        When I click the "Create button" button
-        Then I should see the "Add" configuration page
-        # == Data source selecting ==
-        Then The "Confirm data source" "button" should be disabled
-        When I select value "nbs_ods.PHCDemographic (Disease Counts by County)" in the "Data source" field
-        When I click the "Confirm data source" button
-        Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Disease Counts by County)"
-        When I click the "Cancel" button
-        When I select value "nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)" in the "Data source" field
-        When I click the "Confirm data source" button
-        Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)"
-        When I click the "Confirm" button
-        Then The "Data source" "combobox" should be disabled
-        # == General fields ==
-        When I type "All filter test" into the "Name" field
-        When I type "All filter test is the best report" into the "Description" field
-        When I select value "System" in the "Owner" field
-        When I select radio "Public" in the "Group" field
-        When I select value "Default Report Section" in the "Section name" field
-        When I select value "nbs_custom (Recommended default. Basic tabular report. Executes the query described by the data source and filters and returns the table)" in the "Report execution library" field
-        # == Filters ==
-        When I add all filters
-        Then I should see 22 available filters
-        When I click the "Submit" button
-        Then I should see the "View" configuration page
+        # When I click the "Create button" button
+        # Then I should see the "Add" configuration page
+        # # == Data source selecting ==
+        # Then The "Confirm data source" "button" should be disabled
+        # When I select value "nbs_ods.PHCDemographic (Disease Counts by County)" in the "Data source" field
+        # When I click the "Confirm data source" button
+        # Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Disease Counts by County)"
+        # When I click the "Cancel" button
+        # When I select value "nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)" in the "Data source" field
+        # When I click the "Confirm data source" button
+        # Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)"
+        # When I click the "Confirm" button
+        # Then The "Data source" "combobox" should be disabled
+        # # == General fields ==
+        # When I type "All filter test" into the "Name" field
+        # When I type "All filter test is the best report" into the "Description" field
+        # When I select value "System" in the "Owner" field
+        # When I select radio "Public" in the "Group" field
+        # When I select value "Default Report Section" in the "Section name" field
+        # When I select value "nbs_custom (Recommended default. Basic tabular report. Executes the query described by the data source and filters and returns the table)" in the "Report execution library" field
+        # # == Filters ==
+        # When I add all filters
+        # Then I should see 22 available filters
+        # When I click the "Submit" button
+        # Then I should see the "View" configuration page
         And I navigate to list reports
         And I click on the "Expand Subsections" link
         And I click on the "Expand Subsections" link
         And I click on the "Run" link
         Then I should see a "heading" labelled "All filter test"
+        When I fill out all filters with 1
+        And I click the "Run" button
+        Then I should see a "heading" labelled "Your report has opened in a new tab."
+
+        # Save as the report
+        When I click the "Save as new" button
+        And I should see a modal labelled "Save as a new report"
+        And I type "Test save as all filter report" into the "Name" field
+        And I type "Testing saving as a report" into the "Description" field
+        And I select value "Default Report Section" in the "Section name" field
+        And I should see "Private" radio selected in the "Group" field
+        And I click the "Save as new" button
+        Then I am redirected to "/nbs/ManageReports.do"
+        And I click on the "Expand Subsections" link
+        And I click on the "Run" link
+        Then All filters should be filled out with 1

--- a/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/all-filter-save.feature
@@ -2,34 +2,34 @@ Feature: View report configuration
 
     Background:
         Given I am logged in as secure user
-        # Given I navigate to manage reports
 
     Scenario: I create, save, and save as all the filters
-        # When I click the "Create button" button
-        # Then I should see the "Add" configuration page
-        # # == Data source selecting ==
-        # Then The "Confirm data source" "button" should be disabled
-        # When I select value "nbs_ods.PHCDemographic (Disease Counts by County)" in the "Data source" field
-        # When I click the "Confirm data source" button
-        # Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Disease Counts by County)"
-        # When I click the "Cancel" button
-        # When I select value "nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)" in the "Data source" field
-        # When I click the "Confirm data source" button
-        # Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)"
-        # When I click the "Confirm" button
-        # Then The "Data source" "combobox" should be disabled
-        # # == General fields ==
-        # When I type "All filter test" into the "Name" field
-        # When I type "All filter test is the best report" into the "Description" field
-        # When I select value "System" in the "Owner" field
-        # When I select radio "Public" in the "Group" field
-        # When I select value "Default Report Section" in the "Section name" field
-        # When I select value "nbs_custom (Recommended default. Basic tabular report. Executes the query described by the data source and filters and returns the table)" in the "Report execution library" field
-        # # == Filters ==
-        # When I add all filters
-        # Then I should see 22 available filters
-        # When I click the "Submit" button
-        # Then I should see the "View" configuration page
+        When I navigate to manage reports
+        And I click the "Create button" button
+        Then I should see the "Add" configuration page
+        # == Data source selecting ==
+        Then The "Confirm data source" "button" should be disabled
+        When I select value "nbs_ods.PHCDemographic (Disease Counts by County)" in the "Data source" field
+        When I click the "Confirm data source" button
+        Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Disease Counts by County)"
+        When I click the "Cancel" button
+        When I select value "nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)" in the "Data source" field
+        When I click the "Confirm data source" button
+        Then I should see a modal labelled "Confirm data source: nbs_ods.PHCDemographic (Line List of Diseases with NBS Security)"
+        When I click the "Confirm" button
+        Then The "Data source" "combobox" should be disabled
+        # == General fields ==
+        When I type "All filter test" into the "Name" field
+        When I type "All filter test is the best report" into the "Description" field
+        When I select value "System" in the "Owner" field
+        When I select radio "Public" in the "Group" field
+        When I select value "Default Report Section" in the "Section name" field
+        When I select value "nbs_custom (Recommended default. Basic tabular report. Executes the query described by the data source and filters and returns the table)" in the "Report execution library" field
+        # == Filters ==
+        When I add all filters
+        Then I should see 22 available filters
+        When I click the "Submit" button
+        Then I should see the "View" configuration page
         And I navigate to list reports
         And I click on the "Expand Subsections" link
         And I click on the "Expand Subsections" link

--- a/testing/regression/cypress/step_definitions/report/admin.steps.js
+++ b/testing/regression/cypress/step_definitions/report/admin.steps.js
@@ -43,7 +43,7 @@ When('I add all filters', () => {
                 cy.findAllByRole('combobox').each(($item) => {
                     const name = $item.attr('name')
                     if (name === 'selectType') {
-                        cy.wrap($item).select('Multi')
+                        cy.wrap($item).select('Multi-select filter')
                     } else if (name === 'associatedColumn') {
                         cy.wrap($item).select(1);
                     }

--- a/testing/regression/cypress/step_definitions/report/admin.steps.js
+++ b/testing/regression/cypress/step_definitions/report/admin.steps.js
@@ -23,3 +23,33 @@ Then('I should see {int} available filters', (filterCount) => {
 When('I click the filter {int} {string} button', (filterInd, name) => {
     cy.findAllByRole('button', { name }).eq(filterInd).click();
 });
+
+When('I add all filters', () => {
+    const optionValues = [];
+    cy.findByRole('combobox', { name: 'Filter' })
+        .findAllByRole('option')
+        .each(($option) => {
+            // skip placeholder
+            if (!$option.val()) return;
+            optionValues.push($option.val());
+        })
+        .then(() => {
+            cy.log(`Available filters: ${optionValues.length}`);
+
+            for (const value of optionValues) {
+                cy.log(`Selecting filter: ${value}`);
+                cy.findByRole('combobox', { name: 'Filter' }).select(value);
+
+                cy.findAllByRole('combobox').each(($item) => {
+                    const name = $item.attr('name')
+                    if (name === 'selectType') {
+                        cy.wrap($item).select('Multi')
+                    } else if (name === 'associatedColumn') {
+                        cy.wrap($item).select(1);
+                    }
+                })
+
+                cy.findByRole('button', { name: 'Add filter' }).click();
+            }
+        });
+});

--- a/testing/regression/cypress/step_definitions/report/run.steps.js
+++ b/testing/regression/cypress/step_definitions/report/run.steps.js
@@ -1,5 +1,15 @@
 import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
+const GROUP_LOOKUP = {
+  Public: 'S',
+  Private: 'P',
+  Template: 'T',
+  'Reporting Facility': 'R',
+};
+
+const YEARS_BACK = 20;
+const getThisYear = () => new Date().getFullYear();
+
 // Navigation steps
 
 When('I navigate to list reports', () => {
@@ -7,12 +17,12 @@ When('I navigate to list reports', () => {
     cy.contains('Private Reports').should('be.visible');
 });
 
-const GROUP_LOOKUP = {
-    Public: 'S',
-    Private: 'P',
-    Template: 'T',
-    'Reporting Facility': 'R',
-};
+When('I click the {string} report', (reportTitle) => {
+    cy.contains('td', reportTitle)
+      .parent('tr')
+      .contains('a', 'Run')
+      .click();
+})
 
 When(
     'I navigate to {string} report with reportUid: {int} and dataSourceUid: {int}',
@@ -62,6 +72,18 @@ When('I select the column {string}', (columnName) => {
 });
 
 When('I fill out all filters with {int}', (index) => {
+    // add extra advanced filter rule before so steps below adds value
+    cy.findByRole('button', { name: 'Add rule' }).click();
+
+    // select columns (needs to happen for the sort single-selects to be happy)
+    checkSelectAll();
+
+    // single selects
+    cy.get('select').each(($select) => cy.wrap($select).select(index));
+
+    // finish advanced filter
+    cy.findAllByRole('combobox', { name: 'Logic' }).each(($combobox) => cy.wrap($combobox).select(index));
+
     // dates and text filters
     cy.findAllByRole('textbox').each(($input) => cy.wrap($input).type(`01/01/202${index}`));
     // number inputs
@@ -69,33 +91,14 @@ When('I fill out all filters with {int}', (index) => {
     // allow nulls
     cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).click({ force: true }));
 
-    // select columns (needs to happen for the sort single-selects to be happy)
-    cy.findByRole('checkbox', { name: 'Select all' }).click({ force: true });
-
-    // single selects
-    cy.get('select').each(($select) => cy.wrap($select).select(index));
-
     // multi-selects
     cy.get('.multi-select')
-      // reverse the array to select the state first so counties do not get cleared
-      .then(($elements) => $elements.toArray().reverse())
       .each(($select) => {
-        cy
-          .wrap($select)
-          .then(($multiselect) => {
-              if ($multiselect.find('.multi-select__clear-indicator').length > 0) {
-                  cy.wrap($multiselect).find('.multi-select__clear-indicator').click({force: true});
-              }
-          })
-
         cy
           .wrap($select)
           .click()
           .then(() => cy.get('.multi-select__option').eqOrLast(index).click().then(() => cy.get('body').type('{esc}')))
     });
-
-    // finish advanced filter
-    cy.findByRole('combobox', { name: 'Logic' }).select('Is Null');
 });
 
 Then('All filters should be filled out with {int}', (index) => {
@@ -110,7 +113,9 @@ Then('All filters should be filled out with {int}', (index) => {
     cy.findByRole('checkbox', { name: 'Deselect all' }).should('not.be.checked');
 
     // single selects
-    cy.get('select').each(($select) => cy.wrap($select).select(index));
+    cy.get('select').each(($select) => {
+      cy.wrap($select).should('have.prop', 'selectedIndex', index);
+    });
 
     // multi-selects
     cy.get('.multi-select').each(($select) => {
@@ -126,20 +131,90 @@ Then('All filters should be filled out with {int}', (index) => {
             .find('.multi-select__multi-value__label')
             .invoke('text')
             .then((displayedText) => {
-              expect(displayedText).to.equal(optionText);
+              expect(displayedText).contains(optionText);
             });
         });
 
       // close dropdown without clearing next input
       cy.wrap($select).find('input.multi-select__input').blur();
     });
-
-    // finish advanced filter
-    cy.findByRole('combobox', { name: 'Logic' }).select('Is Null');
 });
+
+Then('All filters should be empty', () => {
+    // dates and text filters
+    cy.findAllByRole('textbox').each(($input) => cy.wrap($input).should('have.value', ''));
+    // number inputs
+    cy.findAllByRole('spinbutton').each($input => cy.wrap($input).should('have.value', ''))
+    // allow nulls
+    cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).should('not.be.checked'));
+
+    cy.get('body').then(($body) => {
+      const selectAllExists = $body.find('[label="Select all"]').length > 0;
+      if (selectAllExists) {
+        cy.findByRole('checkbox', { name: 'Select all' }).should('not.be.checked');
+      }
+    });
+
+    // single selects
+    cy.get('select').each(($select) => {
+      const selectId = $select.attr('id');
+
+      // check value is default or empty
+      cy.get(`label[for="${selectId}"]`).invoke('text').then((labelText) => {
+        if (labelText === 'From') {
+          cy.wrap($select).should('have.value', getThisYear() - YEARS_BACK);
+        } else if (labelText === 'To') {
+          cy.wrap($select).should('have.value', getThisYear());
+        }  else if (labelText === 'Sort order') {
+          cy.wrap($select).should('have.value', 'ASC');
+        } else if (labelText === 'Combinator') {
+          cy.wrap($select).should('have.value', 'and');
+        }  else if (labelText === 'Field') {
+          cy.wrap($select).should('have.value', '~');
+        } else {
+          cy.wrap($select).should('have.value', '');
+        }
+      });
+    });
+
+    // multi-selects
+    cy.get('.multi-select').each(($select) => {
+      const selectId = $select.find('input.multi-select__input').attr('id');
+
+      cy.get(`span[id="${selectId}-hint"]`).invoke('text').then((hintText) => {
+        // this basic filter has a default
+        if (hintText === 'States') {
+          cy.wrap($select)
+            .find('.multi-select__multi-value__label')
+            .should('have.text', 'Georgia');
+        } else {
+          cy.wrap($select).find('.multi-select__multi-value__label').should('not.exist');
+        }
+      });
+    });
+});
+
+Then('I click all include nulls', () => {
+  // select columns (needs to happen for the sort single-selects to be happy)
+  checkSelectAll();
+  cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).click({ force: true }));
+})
+
+Then('All include nulls checkboxes should be checked', () => {
+  cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).should('be.checked'));
+})
 
 // Confirmation steps
 
 Then('I see the {string} report', (title) => {
     cy.contains(title).should('be.visible');
 });
+
+const checkSelectAll = () => {
+  cy.get('body').then(($body) => {
+    const selectAllExists = $body.find('[label="Select all"]').length > 0;
+    if (selectAllExists) {
+      cy.findByRole('checkbox', { name: 'Select all' }).click({ force: true });
+    }
+  });
+}

--- a/testing/regression/cypress/step_definitions/report/run.steps.js
+++ b/testing/regression/cypress/step_definitions/report/run.steps.js
@@ -43,13 +43,13 @@ When('I enter {string} to the To date', (date) => {
 });
 
 When('I enter From Month: {string} and From Year: {string}', (month, year) => {
-    cy.selectDropdownByLabel(0, "From month", month);
-    cy.selectDropdownByLabel(0, "From year", year);
+    cy.selectDropdownByLabel(0, 'From month', month);
+    cy.selectDropdownByLabel(0, 'From year', year);
 });
 
 When('I enter To Month: {string} and To Year: {string}', (month, year) => {
-    cy.selectDropdownByLabel(0, "To month", month);
-    cy.selectDropdownByLabel(0, "To year", year);
+    cy.selectDropdownByLabel(0, 'To month', month);
+    cy.selectDropdownByLabel(0, 'To year', year);
 });
 
 When('I select {string} from the {string} dropdown menu', (value, label) => {
@@ -59,6 +59,58 @@ When('I select {string} from the {string} dropdown menu', (value, label) => {
 When('I select the column {string}', (columnName) => {
     cy.get('input[name="column-search"]').type(columnName);
     cy.contains('label', columnName).find('input[type="checkbox"]').check({ force: true });
+});
+
+When('I fill out all filters with {int}', (index) => {
+    // dates and text filters
+    cy.findAllByRole('textbox').each(($input) => cy.wrap($input).type(`01/01/202${index}`));
+    // number inputs
+    cy.findAllByRole('spinbutton').each($input => cy.wrap($input).type(`${index}`))
+    // allow nulls
+    cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).click({ force: true }));
+
+    // select columns (needs to happen for the sort single-selects to be happy)
+    cy.findByRole('checkbox', { name: 'Select all' }).click({ force: true });
+
+    // single selects
+    cy.get('select').each(($select) => cy.wrap($select).select(index));
+
+    // multi-selects
+    cy.get('.multi-select').each(($select) =>
+        cy
+            .wrap($select)
+            .click()
+            .then(() => cy.get('.multi-select__option').eqOrLast(index).click().then(() => cy.get('body').type('{esc}')))
+    );
+
+    // finish advanced filter
+    cy.findByRole('combobox', { name: 'Logic' }).select('Is Null');
+});
+
+Then('All filters should be filled out with {int}', (index) => {
+    // dates and text filters
+    cy.findAllByRole('textbox').each(($input) => cy.wrap($input).should('have.value', `01/01/202${index}`));
+    // number inputs
+    cy.findAllByRole('spinbutton').each($input => cy.wrap($input).should('have.value', index))
+    // allow nulls
+    cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).should('be.checked'));
+
+    // select columns (needs to happen for the sort single-selects to be happy)
+    cy.findByRole('checkbox', { name: 'Deselect all' }).should('be.visible');
+
+    // single selects
+    cy.get('select').each(($select) => cy.wrap($select).select(index));
+
+    // multi-selects
+    cy.get('.multi-select').each(($select) =>
+        cy
+            .wrap($select)
+            .click()
+            .then(() => cy.get('.multi-select__option').eqOrLast(index).should())
+    );
+
+    // finish advanced filter
+    cy.findByRole('combobox', { name: 'Logic' }).select('Is Null');
 });
 
 // Confirmation steps

--- a/testing/regression/cypress/step_definitions/report/run.steps.js
+++ b/testing/regression/cypress/step_definitions/report/run.steps.js
@@ -76,12 +76,23 @@ When('I fill out all filters with {int}', (index) => {
     cy.get('select').each(($select) => cy.wrap($select).select(index));
 
     // multi-selects
-    cy.get('.multi-select').each(($select) =>
+    cy.get('.multi-select')
+      // reverse the array to select the state first so counties do not get cleared
+      .then(($elements) => $elements.toArray().reverse())
+      .each(($select) => {
         cy
-            .wrap($select)
-            .click()
-            .then(() => cy.get('.multi-select__option').eqOrLast(index).click().then(() => cy.get('body').type('{esc}')))
-    );
+          .wrap($select)
+          .then(($multiselect) => {
+              if ($multiselect.find('.multi-select__clear-indicator').length > 0) {
+                  cy.wrap($multiselect).find('.multi-select__clear-indicator').click({force: true});
+              }
+          })
+
+        cy
+          .wrap($select)
+          .click()
+          .then(() => cy.get('.multi-select__option').eqOrLast(index).click().then(() => cy.get('body').type('{esc}')))
+    });
 
     // finish advanced filter
     cy.findByRole('combobox', { name: 'Logic' }).select('Is Null');
@@ -96,18 +107,32 @@ Then('All filters should be filled out with {int}', (index) => {
     cy.findAllByRole('checkbox', { name: /Include nulls/ }).each(($input) => cy.wrap($input).should('be.checked'));
 
     // select columns (needs to happen for the sort single-selects to be happy)
-    cy.findByRole('checkbox', { name: 'Deselect all' }).should('be.visible');
+    cy.findByRole('checkbox', { name: 'Deselect all' }).should('not.be.checked');
 
     // single selects
     cy.get('select').each(($select) => cy.wrap($select).select(index));
 
     // multi-selects
-    cy.get('.multi-select').each(($select) =>
-        cy
-            .wrap($select)
-            .click()
-            .then(() => cy.get('.multi-select__option').eqOrLast(index).should())
-    );
+    cy.get('.multi-select').each(($select) => {
+      // open dropdown
+      cy.wrap($select).find('input.multi-select__input').click();
+
+      cy.wrap($select)
+        .find('.multi-select__option')
+        .eqOrLast(index)
+        .invoke('text') // get the dropdown's first index value
+        .then((optionText) => {
+          cy.wrap($select)
+            .find('.multi-select__multi-value__label')
+            .invoke('text')
+            .then((displayedText) => {
+              expect(displayedText).to.equal(optionText);
+            });
+        });
+
+      // close dropdown without clearing next input
+      cy.wrap($select).find('input.multi-select__input').blur();
+    });
 
     // finish advanced filter
     cy.findByRole('combobox', { name: 'Logic' }).select('Is Null');

--- a/testing/regression/cypress/step_definitions/report/run.steps.js
+++ b/testing/regression/cypress/step_definitions/report/run.steps.js
@@ -125,7 +125,7 @@ Then('All filters should be filled out with {int}', (index) => {
       cy.wrap($select)
         .find('.multi-select__option')
         .eqOrLast(index)
-        .invoke('text') // get the dropdown's first index value
+        .invoke('text') // get the dropdown's value at the index
         .then((optionText) => {
           cy.wrap($select)
             .find('.multi-select__multi-value__label')
@@ -140,7 +140,7 @@ Then('All filters should be filled out with {int}', (index) => {
     });
 });
 
-Then('All filters should be empty', () => {
+Then('All filters should be empty or the default value', () => {
     // dates and text filters
     cy.findAllByRole('textbox').each(($input) => cy.wrap($input).should('have.value', ''));
     // number inputs

--- a/testing/regression/cypress/support/commands.js
+++ b/testing/regression/cypress/support/commands.js
@@ -23,12 +23,12 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-import '@testing-library/cypress/add-commands'
+import '@testing-library/cypress/add-commands';
 
 Cypress.Commands.add('selectDropdownByLabel', (selectIndex, labelText, value) => {
     // Get the ID string instead of holding a live element reference
     cy.findAllByLabelText(labelText)
-      .eq(selectIndex)
+        .eq(selectIndex)
         .invoke('attr', 'id')
         .then((id) => {
             const escapedId = CSS.escape(id);
@@ -40,9 +40,24 @@ Cypress.Commands.add('selectDropdownByLabel', (selectIndex, labelText, value) =>
                 } else {
                     // React Select / Custom Checkbox Input
                     cy.get(`input#${escapedId}`).click({ force: true }).clear({ force: true }).type(value);
-                    cy.contains('[class*="__option"], [class*="-option"]', value).should('be.visible').click({ force: true });
+                    cy.contains('[class*="__option"], [class*="-option"]', value)
+                        .should('be.visible')
+                        .click({ force: true });
                     cy.get(`input#${escapedId}`).type('{esc}');
                 }
             });
         });
 });
+
+Cypress.Commands.add(
+    'eqOrLast',
+    {
+        prevSubject: true,
+    },
+    ($subject, index) => {
+        cy.log($subject, index);
+        const i = index < $subject.length ? index : $subject.length - 1;
+
+        return cy.wrap($subject).eq(i);
+    }
+);


### PR DESCRIPTION
## Description

- Adds e2e test for running/saving as with every filter applied
- Adds e2e test for running/saving a report with just "Include nulls" checked

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-806)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
