### PR TITLE
[APP-816] fix: add min-width, fix padding on confirmation modal

### DIFF
--- a/apps/modernization-ui/src/confirmation/confirmationModal.module.scss
+++ b/apps/modernization-ui/src/confirmation/confirmationModal.module.scss
@@ -1,9 +1,8 @@
 @use 'styles/modal.scss';
 
 .content {
-    .heading {
-        margin: 0.5rem;
-    }
+    min-width: min-content;
+
     .message {
         #confirmation-description,
         #confirmation-modal-details {


### PR DESCRIPTION
## Description

Fix the styling to have a min-width of at least the content's min width (max width comes from uswds)

Before:
<img width="1276" height="840" alt="image" src="https://github.com/user-attachments/assets/b26226a0-0d05-4eac-8dfa-4f99303d8a79" />
<img width="1286" height="734" alt="image" src="https://github.com/user-attachments/assets/bdf88550-2673-40a9-8802-2b8024ebded5" />


After:
<img width="1279" height="757" alt="image" src="https://github.com/user-attachments/assets/952910e2-8f3a-4e30-87cb-b5e5f2a2b90c" />
<img width="1281" height="794" alt="image" src="https://github.com/user-attachments/assets/24749a5d-d89d-4259-90a5-d0c094e6b07c" />


## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-816

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
