### PR TITLE
[APP-750] fix: sort component label sizing

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/columns/SortSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/columns/SortSelector.tsx
@@ -8,6 +8,7 @@ import { EnumSelectable } from 'apps/report/utils';
 import { EntryWrapper } from 'components/Entry';
 
 import styles from './sort-selector.module.scss';
+import { SIZING } from 'apps/report/constants';
 
 const DIRECTION_OPTIONS: EnumSelectable<SortSpec.direction>[] = [
     { value: SortSpec.direction.ASC, name: 'Ascending' },
@@ -46,7 +47,7 @@ const SortSelector = ({
 
     return (
         <EntryWrapper
-            sizing="medium"
+            sizing={SIZING}
             label="Report data sorting"
             htmlFor={groupId}
             orientation="horizontal"
@@ -54,6 +55,7 @@ const SortSelector = ({
         >
             <div role="group" id={groupId} className={styles.layout}>
                 <SingleSelect
+                    sizing={SIZING}
                     label="Sort by"
                     id={`${groupId}-col`}
                     orientation="vertical"
@@ -66,6 +68,7 @@ const SortSelector = ({
                     defaultValue={defaultSort?.direction ?? DIRECTION_OPTIONS[0].value}
                     render={({ field: { value, onChange } }) => (
                         <SingleSelect
+                            sizing={SIZING}
                             label="Sort order"
                             id={`${groupId}-dir`}
                             orientation="vertical"

--- a/apps/modernization-ui/src/apps/report/run/columns/SortSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/columns/SortSelector.tsx
@@ -6,9 +6,9 @@ import { SingleSelect } from 'design-system/select';
 import { toSelectable } from './utils';
 import { EnumSelectable } from 'apps/report/utils';
 import { EntryWrapper } from 'components/Entry';
+import { SIZING } from 'apps/report/constants';
 
 import styles from './sort-selector.module.scss';
-import { SIZING } from 'apps/report/constants';
 
 const DIRECTION_OPTIONS: EnumSelectable<SortSpec.direction>[] = [
     { value: SortSpec.direction.ASC, name: 'Ascending' },


### PR DESCRIPTION
## Description

We've been using medium across the board, but this got missed on the sort component drop downs. Add it.

Before:
<img width="914" height="88" alt="image" src="https://github.com/user-attachments/assets/e4890421-a37c-42c1-b19d-068b19f2edc9" />


After:
<img width="2114" height="162" alt="image" src="https://github.com/user-attachments/assets/514893ff-58f9-484b-923b-75d209b9b5ce" />


## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-750

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
