### PR TITLE
[APP-751] fix: fix up error page styling

### DIFF
--- a/apps/modernization-ui/src/apps/report/layout/layout.module.scss
+++ b/apps/modernization-ui/src/apps/report/layout/layout.module.scss
@@ -84,16 +84,6 @@ $header-height: 6rem;
     }
 }
 
-.fullPageBlock {
-    display: grid;
-    place-items: center;
-    place-content: center;
-    margin: 1rem;
-    padding: 2rem;
-    background-color: colors.$base-white;
-    flex-grow: 1;
-}
-
 .alertMessage {
     flex-grow: unset;
 }

--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -19,6 +19,7 @@ import { ReportExecuteForm } from './ReportRunPage';
 import { FieldErrors, useFormState } from 'react-hook-form';
 import { ValidationErrorBanner, ValidationErrorSection } from 'design-system/errors/ValidationError';
 import { Heading } from 'components/heading';
+import { FullPageBlock } from 'components/FullPageBlock';
 
 const BASIC_SECTIONS = [
     {
@@ -163,7 +164,7 @@ const ReportConfigurationPage = ({
     return (
         <ReportLayout title={config.title} startHref={NBS_MANAGE_REPORT_PAGE} startPage="reports" actions={actions}>
             {!sectionData.length ? (
-                <div className={layoutStyles.fullPageBlock}>
+                <FullPageBlock>
                     <Heading level={2}>No filters available</Heading>
                     <p className="maxw-mobile-lg text-center">
                         This report will return all available results, which might be a large dataset. If you have{' '}
@@ -172,7 +173,7 @@ const ReportConfigurationPage = ({
                     <div className="display-flex flex-row" style={{ gap: '0.5rem' }}>
                         {actions}
                     </div>
-                </div>
+                </FullPageBlock>
             ) : (
                 <>
                     <aside>

--- a/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
@@ -14,6 +14,7 @@ import { SaveAsReportFormData, SaveAsReportModal } from './modals/SaveAsReportMo
 import { redirectToNBS6 } from 'utils';
 import classNames from 'classnames';
 import { ApiErrorBanner } from 'design-system/errors/ApiError.tsx';
+import { FullPageBlock } from 'components/FullPageBlock';
 
 import layoutStyles from '../layout/layout.module.scss';
 
@@ -174,10 +175,10 @@ const ReportResultPage = ({
 
 const TextCard = ({ loading = false, children }: { loading?: boolean; children: ReactNode }) => {
     return (
-        <div className={layoutStyles.fullPageBlock}>
+        <FullPageBlock>
             {children}
             {loading && <LoadingIndicator />}
-        </div>
+        </FullPageBlock>
     );
 };
 

--- a/apps/modernization-ui/src/components/FullPageBlock/FullPageBlock.tsx
+++ b/apps/modernization-ui/src/components/FullPageBlock/FullPageBlock.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import classNames from 'classnames';
 import styles from './full-page-block.module.scss';
 
-// Needs to be inside a space that will grow to space, otherwise defaults to minimum height
+// Will not take up full page unless inside an element that will grow to the full space, otherwise defaults to minimum height
 const FullPageBlock = ({ className, children }: { className?: string; children?: ReactNode }) => {
     return <div className={classNames(className, styles.layout)}>{children}</div>;
 };

--- a/apps/modernization-ui/src/components/FullPageBlock/FullPageBlock.tsx
+++ b/apps/modernization-ui/src/components/FullPageBlock/FullPageBlock.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+import classNames from 'classnames';
+import styles from './full-page-block.module.scss';
+
+// Needs to be inside a space that will grow to space, otherwise defaults to minimum height
+const FullPageBlock = ({ className, children }: { className?: string; children?: ReactNode }) => {
+    return <div className={classNames(className, styles.layout)}>{children}</div>;
+};
+
+export { FullPageBlock };

--- a/apps/modernization-ui/src/components/FullPageBlock/full-page-block.module.scss
+++ b/apps/modernization-ui/src/components/FullPageBlock/full-page-block.module.scss
@@ -1,0 +1,12 @@
+@use 'styles/colors';
+
+.layout {
+    display: grid;
+    place-items: center;
+    place-content: center;
+    margin: 1rem;
+    padding: 2rem;
+    background-color: colors.$base-white;
+    flex-grow: 1;
+    min-height: 70vh;
+}

--- a/apps/modernization-ui/src/components/FullPageBlock/index.ts
+++ b/apps/modernization-ui/src/components/FullPageBlock/index.ts
@@ -1,0 +1,1 @@
+export { FullPageBlock } from './FullPageBlock';

--- a/apps/modernization-ui/src/pages/error/ErrorPage.spec.tsx
+++ b/apps/modernization-ui/src/pages/error/ErrorPage.spec.tsx
@@ -1,0 +1,100 @@
+import { render } from '@testing-library/react';
+import { ApiError } from 'generated';
+import { useRouteError } from 'react-router';
+import { ErrorPage } from './ErrorPage';
+import { NotFoundError } from './NotFoundError';
+
+vi.mock('react-router');
+
+describe('ErrorPage', () => {
+    it('handles ApiError with string body', () => {
+        const error = new ApiError(
+            { method: 'GET', url: '/test' },
+            { url: '/test', status: 500, statusText: 'SERVER ERROR', ok: false, body: '' },
+            'Uh oh'
+        );
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('500')).toBeVisible();
+        expect(getByText('SERVER ERROR')).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+
+    it('handles ApiError with message body', () => {
+        const error = new ApiError(
+            { method: 'GET', url: '/test' },
+            { url: '/test', status: 500, statusText: 'SERVER ERROR', ok: false, body: { message: 'Uh oh' } },
+            'Uh oh'
+        );
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('500')).toBeVisible();
+        expect(getByText('SERVER ERROR')).toBeVisible();
+        expect(getByText('Uh oh')).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+
+    it('handles 404 ApiError', () => {
+        const error = new ApiError(
+            { method: 'GET', url: '/test' },
+            { url: '/test', status: 404, statusText: 'Not found', ok: false, body: { message: 'Uh oh' } },
+            'Uh oh'
+        );
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('404')).toBeVisible();
+        expect(getByText('Not found')).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+
+    it('handles NotFoundError', () => {
+        const error = new NotFoundError();
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('404')).toBeVisible();
+        expect(getByText('Not found')).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+
+    it('handles arbitrary error', () => {
+        const error = new RangeError('Too big!');
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('Error')).toBeVisible();
+        expect(getByText('Too big!')).toBeVisible();
+        expect(getByText('The stack trace is:')).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+
+    it('handles arbitrary string data', () => {
+        const error = 'what have we here';
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('Unknown error')).toBeVisible();
+        expect(getByText(/what have we here/)).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+
+    it('handles arbitrary object data', () => {
+        const error = { data: 'what have we here' };
+        vi.fn(useRouteError).mockReturnValue(error);
+
+        const { getByText, getByRole } = render(<ErrorPage />);
+
+        expect(getByText('Unknown error')).toBeVisible();
+        expect(getByText(/what have we here/)).toBeVisible();
+        expect(getByRole('link', { name: 'Return to home' })).toBeVisible();
+    });
+});

--- a/apps/modernization-ui/src/pages/error/ErrorPage.tsx
+++ b/apps/modernization-ui/src/pages/error/ErrorPage.tsx
@@ -2,34 +2,54 @@ import { Heading } from 'components/heading';
 import { isRouteErrorResponse, useRouteError } from 'react-router';
 import { logErrorToUserConsole } from 'utils/logging';
 import { NotFoundError } from './NotFoundError';
+import { FullPageBlock } from 'components/FullPageBlock';
+import { ApiError } from 'generated';
+import { LinkButton } from 'design-system/button';
 
 const ErrorPage = () => {
-    let error = useRouteError();
+    const error = useRouteError();
 
     logErrorToUserConsole(error);
 
     return (
-        <main className="margin-8">
-            {isRouteErrorResponse(error) || error instanceof NotFoundError ? (
-                <>
-                    <Heading level={1}>
-                        {error.status} {error.statusText}
-                    </Heading>
-                    <p>{error.data}</p>
-                </>
-            ) : error instanceof Error ? (
-                <>
-                    <Heading level={1}>Error</Heading>
-                    <p>{error.message}</p>
-                    <p>The stack trace is:</p>
-                    <pre>{error.stack}</pre>
-                </>
-            ) : (
-                <>
-                    <Heading level={1}>Unknown Error</Heading>
-                    <p>{JSON.stringify(error)}</p>
-                </>
-            )}
+        <main className="display-flex flex-column">
+            <FullPageBlock>
+                {isRouteErrorResponse(error) || error instanceof NotFoundError || error instanceof ApiError ? (
+                    <>
+                        <p className="text-base text-bold margin-y-4" style={{ fontSize: '8rem' }}>
+                            {error.status}
+                        </p>
+                        <Heading level={1}>{error.statusText}</Heading>
+                        {error.status === 404 ? (
+                            <>
+                                <p className="margin-top-4 margin-bottom-0">
+                                    We couldn't find the page you were looking for.
+                                </p>
+                                <p className="margin-top-1 margin-bottom-1">
+                                    Check the URL to make sure it's correct and try again.
+                                </p>
+                            </>
+                        ) : (
+                            <p>{'data' in error ? JSON.stringify(error.data) : error?.body?.message}</p>
+                        )}
+                    </>
+                ) : error instanceof Error ? (
+                    <>
+                        <Heading level={1}>Error</Heading>
+                        <p>{error.message}</p>
+                        <p>The stack trace is:</p>
+                        <pre>{error.stack}</pre>
+                    </>
+                ) : (
+                    <>
+                        <Heading level={1}>Unknown Error</Heading>
+                        <p>{JSON.stringify(error)}</p>
+                    </>
+                )}
+                <LinkButton className="margin-top-4" href="/nbs/HomePage.do?method=loadHomePage">
+                    Return to home
+                </LinkButton>
+            </FullPageBlock>
         </main>
     );
 };

--- a/apps/modernization-ui/src/pages/error/ErrorPage.tsx
+++ b/apps/modernization-ui/src/pages/error/ErrorPage.tsx
@@ -42,7 +42,7 @@ const ErrorPage = () => {
                     </>
                 ) : (
                     <>
-                        <Heading level={1}>Unknown Error</Heading>
+                        <Heading level={1}>Unknown error</Heading>
                         <p>{JSON.stringify(error)}</p>
                     </>
                 )}


### PR DESCRIPTION
## Description

Update the error page styling to be less bare bones. Skipped the part of the design about the go back button if we're in NBS as it turned out to be finnicky and the last thing we want in an error page is finnicky code that might error or cause errors

<img width="1274" height="975" alt="image" src="https://github.com/user-attachments/assets/5c6327da-7972-4a4b-a11a-0a82b5b9029f" />


## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-751

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
