### PR TITLE
[APP-824] fix: select clipping

### DIFF
--- a/apps/modernization-ui/src/components/FormInputs/SelectInput.tsx
+++ b/apps/modernization-ui/src/components/FormInputs/SelectInput.tsx
@@ -1,4 +1,5 @@
 import { Select } from '@trussworks/react-uswds';
+import classNames from 'classnames';
 
 import { EntryWrapper, Orientation, Sizing } from 'components/Entry';
 import { useId } from 'react';
@@ -44,6 +45,7 @@ export const SelectInput = ({
     error,
     required,
     onBlur,
+    className,
     ...props
 }: SelectProps) => {
     const defaultId = useId();
@@ -57,6 +59,7 @@ export const SelectInput = ({
             required={required}
             onChange={onChange}
             onBlur={onBlur}
+            className={classNames(className, 'padding-y-05')}
             {...props}
         >
             <Options options={options} />

--- a/apps/modernization-ui/src/design-system/select/single/Select.tsx
+++ b/apps/modernization-ui/src/design-system/select/single/Select.tsx
@@ -45,7 +45,7 @@ const Select = ({
     return (
         <select
             id={id}
-            className={classNames('usa-select', className)}
+            className={classNames('usa-select', 'padding-y-05', className)}
             name={inputProps.name ?? id}
             value={value?.value ?? ''}
             onChange={handleChange}


### PR DESCRIPTION
## Description

On chrome, single select display was sometimes clipping with letters that go below the baseline. This PR reduces the vertical padding to make sure there is space for the display given the component's height+font size

Before:
<img width="874" height="192" alt="image" src="https://github.com/user-attachments/assets/c3cb47c3-8fd2-46da-a412-f1f37a47dabd" />

After:
<img width="760" height="132" alt="image" src="https://github.com/user-attachments/assets/df3b056e-3e5e-4e67-88f4-fff2c2ac6f89" />

Jira Link: https://cdc-nbs.atlassian.net/browse/APP-824
