### PR TITLE
APP-836: Better handle empty date range values with `includeNulls` set to true

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -466,16 +466,18 @@ public class WhereClauseService {
     if (values.size() != 2 && !includeNulls) return "";
 
     String colType = column.sourceTypeCode();
-    List<String> formattedValues;
+    List<String> formattedValues = new ArrayList<>();
 
-    if (colType.equals("DATE") || colType.equals("DATETIME")) {
-      formattedValues = fieldFormatter.convertToSQLFromDateRange(values);
-    } else {
-      formattedValues =
-          values.stream()
-              .filter(Objects::nonNull)
-              .map(v -> fieldFormatter.formatField(colType, v))
-              .toList();
+    if (!values.isEmpty()) {
+      if (colType.equals("DATE") || colType.equals("DATETIME")) {
+        formattedValues = fieldFormatter.convertToSQLFromDateRange(values);
+      } else {
+        formattedValues =
+            values.stream()
+                .filter(Objects::nonNull)
+                .map(v -> fieldFormatter.formatField(colType, v))
+                .toList();
+      }
     }
 
     StringBuilder criteria = new StringBuilder();
@@ -483,24 +485,21 @@ public class WhereClauseService {
     String colName = fieldFormatter.convertToSQLColName(column.name(), colType);
 
     if (!formattedValues.isEmpty()) {
-      criteria.append("(")
-              .append(colName)
-              .append(" BETWEEN ")
-              .append(formattedValues.get(0))
-              .append(SQL_AND)
-              .append(formattedValues.get(1))
-              .append(")");
+      criteria
+          .append("(")
+          .append(colName)
+          .append(" BETWEEN ")
+          .append(formattedValues.get(0))
+          .append(SQL_AND)
+          .append(formattedValues.get(1))
+          .append(")");
     }
 
     if (includeNulls) {
       String isNullClause = "(" + buildNullCriteria(column, false) + ")";
 
       if (!criteria.isEmpty()) {
-        criteria
-                .insert(0, "(")
-                .append(" OR ")
-                .append(isNullClause)
-                .append(")");
+        criteria.insert(0, "(").append(" OR ").append(isNullClause).append(")");
       } else {
         criteria.append(isNullClause);
       }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -478,24 +478,35 @@ public class WhereClauseService {
               .toList();
     }
 
-    StringBuilder criteria = new StringBuilder("(");
+    StringBuilder criteria = new StringBuilder();
 
     String colName = fieldFormatter.convertToSQLColName(column.name(), colType);
 
     if (!formattedValues.isEmpty()) {
-      criteria
+      criteria.append("(")
               .append(colName)
               .append(" BETWEEN ")
               .append(formattedValues.get(0))
               .append(SQL_AND)
-              .append(formattedValues.get(1));
+              .append(formattedValues.get(1))
+              .append(")");
     }
 
     if (includeNulls) {
-      criteria.insert(0, "(").append(") OR (").append(buildNullCriteria(column, false)).append(")");
+      String isNullClause = "(" + buildNullCriteria(column, false) + ")";
+
+      if (!criteria.isEmpty()) {
+        criteria
+                .insert(0, "(")
+                .append(" OR ")
+                .append(isNullClause)
+                .append(")");
+      } else {
+        criteria.append(isNullClause);
+      }
     }
 
-    return criteria.append(")").toString();
+    return criteria.toString();
   }
 
   private String buildBasicBetweenCriteria(

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -482,12 +482,14 @@ public class WhereClauseService {
 
     String colName = fieldFormatter.convertToSQLColName(column.name(), colType);
 
-    criteria
-        .append(colName)
-        .append(" BETWEEN ")
-        .append(formattedValues.get(0))
-        .append(SQL_AND)
-        .append(formattedValues.get(1));
+    if (!formattedValues.isEmpty()) {
+      criteria
+              .append(colName)
+              .append(" BETWEEN ")
+              .append(formattedValues.get(0))
+              .append(SQL_AND)
+              .append(formattedValues.get(1));
+    }
 
     if (includeNulls) {
       criteria.insert(0, "(").append(") OR (").append(buildNullCriteria(column, false)).append(")");

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
@@ -229,7 +229,7 @@ class WhereClauseServiceTest {
   }
 
   @Test
-  void should_disregard_basic_filters_requests_without_values() {
+  void should_disregard_basic_filters_requests_without_values_and_includeNulls_set_to_false() {
     Long filter1 = 101L;
     Long col1 = 1L;
     Long filter2 = 102L;
@@ -257,7 +257,7 @@ class WhereClauseServiceTest {
   }
 
   @Test
-  void should_handle_allow_nulls_operator() {
+  void should_handle_includeNulls_operator_with_values() {
     Long filterUid = 100L;
     Long columnUid = 1L;
     FilterType filterType = createFilterType("BAS_TXT", "");
@@ -278,7 +278,7 @@ class WhereClauseServiceTest {
   }
 
   @Test
-  void should_handle_allow_nulls_operator_with_multiple_fields() {
+  void should_handle_includeNulls_operator_with_multiple_fields() {
     Long filterUid = 100L;
     Long columnUid = 1L;
     Long filterUid2 = 101L;
@@ -351,7 +351,7 @@ class WhereClauseServiceTest {
   }
 
   @Test
-  void should_handle_time_range_with_nulls() {
+  void should_handle_time_range_values_with_includeNulls() {
     Long filterUid = 200L;
     Long columnUid = 5L;
     FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
@@ -370,6 +370,44 @@ class WhereClauseServiceTest {
     assertThat(whereFragment)
         .isEqualTo(
             "(([date_column] BETWEEN '2023-01-01' AND '2023-01-31') OR ([date_column] IS NULL))");
+  }
+
+  @Test
+  void should_handle_empty_time_range_values_with_includeNulls() {
+    Long filterUid = 200L;
+    Long columnUid = 5L;
+    FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
+
+    BasicFilterConfiguration config =
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType);
+
+    ReportColumn reportColumn = mockReportColumn(columnUid, "DATE", "date_column");
+    ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
+
+    List<BasicFilterRequest> request = List.of(new BasicFilterRequest(filterUid, List.of(), true));
+
+    String whereFragment = whereClauseService.buildBasicWhereFragment(reportConfig, request);
+
+    assertThat(whereFragment).isEqualTo("([date_column] IS NULL)");
+  }
+
+  @Test
+  void should_handle_empty_time_range_values_for_non_date_field_with_includeNulls() {
+    Long filterUid = 200L;
+    Long columnUid = 5L;
+    FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
+
+    BasicFilterConfiguration config =
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType);
+
+    ReportColumn reportColumn = mockReportColumn(columnUid, "STRING", "non_date_column");
+    ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
+
+    List<BasicFilterRequest> request = List.of(new BasicFilterRequest(filterUid, List.of(), true));
+
+    String whereFragment = whereClauseService.buildBasicWhereFragment(reportConfig, request);
+
+    assertThat(whereFragment).isEqualTo("([non_date_column] IS NULL)");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR updates the `WhereClauseService` to better handle the absence of any values on an incoming time-range/date range `BasicFilterRequest` when `includeNulls` is set to `true`.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-836)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
