### PR TITLE
[APP-837] fix: allow include nulls to save with no values

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportService.java
@@ -209,7 +209,7 @@ public class ReportService {
                 BasicFilterRequest matchingReq = basicFilterReqsById.get(basicFilter.getId());
 
                 //  Then, if there's a matching request, add the new filter values from the request
-                if (matchingReq != null && !matchingReq.values().isEmpty()) {
+                if (matchingReq != null) {
                   List<FilterValue> basicFilterValues =
                       filterValueMapper.fromBasicFilterRequest(basicFilter, matchingReq);
                   basicFilter.getFilterValues().addAll(basicFilterValues);

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportServiceTest.java
@@ -674,8 +674,48 @@ class ReportServiceTest {
 
       Report result = service.saveReport(request, existingReport);
 
-      verify(basicFilter).getFilterValues();
+      verify(basicFilter, times(2)).getFilterValues();
       verify(existingFilterValues).clear();
+
+      verify(reportRepository).save(existingReport);
+      assertThat(result).isEqualTo(savedReport);
+    }
+
+    @Test
+    void saveReport_should_save_basic_filters_when_values_empty_but_include_nulls() {
+      Long basicFilterUid = 10L;
+      BasicFilterRequest basicFilterRequest =
+          new BasicFilterRequest(basicFilterUid, List.of(), true);
+      ReportExecutionRequest request =
+          new ReportExecutionRequest(
+              reportUid, dataSourceUid, true, List.of(), null, List.of(basicFilterRequest), null);
+
+      ReportFilter basicFilter = mock(ReportFilter.class);
+      when(basicFilter.isBasicFilter()).thenReturn(true);
+
+      FilterCode filterCode = mock(FilterCode.class);
+
+      Mockito.lenient()
+          .when(filterCode.getFilterType())
+          .thenReturn(FilterCode.BASIC_FILTER_PREFIX + "TEST");
+      Mockito.lenient().when(basicFilter.getId()).thenReturn(basicFilterUid);
+      Mockito.lenient().when(basicFilter.getFilterCode()).thenReturn(filterCode);
+
+      List<FilterValue> newFilterValues = List.of(mock(FilterValue.class));
+      Mockito.lenient()
+          .when(filterValueMapper.fromBasicFilterRequest(basicFilter, basicFilterRequest))
+          .thenReturn(newFilterValues);
+
+      List<FilterValue> existingFilterValues = spy(new ArrayList<>());
+      when(basicFilter.getFilterValues()).thenReturn(existingFilterValues);
+
+      when(existingReport.getReportFilters()).thenReturn(List.of(basicFilter));
+
+      Report result = service.saveReport(request, existingReport);
+
+      verify(basicFilter, times(2)).getFilterValues();
+      verify(existingFilterValues).clear();
+      verify(existingFilterValues).addAll(newFilterValues);
 
       verify(reportRepository).save(existingReport);
       assertThat(result).isEqualTo(savedReport);
@@ -1336,7 +1376,7 @@ class ReportServiceTest {
 
       Report result = service.saveAsReport(saveAsRequest, mockUser, existingReportId);
 
-      verify(basicFilter).getFilterValues();
+      verify(basicFilter, times(2)).getFilterValues();
       verify(existingFilterValues).clear();
 
       verify(reportRepository).save(duplicatedReport);


### PR DESCRIPTION
## Description

When no values are sent on the save/save-as request, but there is include nulls, still save things. The basic filter mapper already handled this case, but the call site had an empty value check

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-837

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
