### PR TITLE
fix: use user options to populate owner dropdown

### DIFF
--- a/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
@@ -12,7 +12,7 @@ import { SingleSelect } from 'design-system/select';
 import { AdminReportRequest, ReportConfiguration } from 'generated';
 import { Selectable } from 'options';
 import { useReportDataSources, useReportLibraries, useReportSections } from 'options/report';
-import { useUserProfileOptions } from 'options/users';
+import { useUserOptions } from 'options/users';
 import { ReactComponentLike } from 'prop-types';
 import { ReactNode, useId, useRef, useState } from 'react';
 import { Controller, useFormState, useWatch } from 'react-hook-form';
@@ -96,7 +96,7 @@ const ReportConfigurationContent = ({ config, isEditable }: { config?: ReportCon
                     label="Owner"
                     defaultValue={config?.ownerUid.toString()}
                     getOptions={() => {
-                        const options = useUserProfileOptions();
+                        const options = useUserOptions();
                         if (options.length === 0) return options;
                         // add system option once loaded (to avoid options appearing loaded when not)
                         return [{ value: '0', name: 'System' }, ...options];

--- a/apps/report-execution/Dockerfile
+++ b/apps/report-execution/Dockerfile
@@ -14,7 +14,7 @@ ENV UV_FROZEN=1
 WORKDIR /usr/report-execution
 
 # Install mssql driver deps
-RUN microdnf update && microdnf install -y libtool-ltdl krb5-libs
+RUN microdnf update -y && microdnf install -y libtool-ltdl krb5-libs
 
 # Copy relevant dependency code
 COPY pyproject.toml pyproject.toml

--- a/testing/regression/cypress/e2e/features/reports/run-save.feature
+++ b/testing/regression/cypress/e2e/features/reports/run-save.feature
@@ -1,9 +1,9 @@
 Feature: Save report after report run
     Background:
         Given I am logged in as secure user
-        And I navigate to list reports
 
     Scenario: I cannot see the save button after running the report if I am not the owner
+        And I navigate to list reports
         And I navigate to "Public" report with reportUid: 8 and dataSourceUid: 1
         And I select "AIDS" from the "Condition Code" dropdown menu
         And I select "Appling County" from the "County Code" dropdown menu
@@ -12,6 +12,7 @@ Feature: Save report after report run
         And I should not see the "Save" "button"
 
     Scenario: I can save as the report after running the report
+        And I navigate to list reports
         When I navigate to "Public" report with reportUid: 8 and dataSourceUid: 1
         And I select "Anthrax" from the "Condition Code" dropdown menu
         And I select "Fulton County" from the "County Code" dropdown menu
@@ -36,6 +37,7 @@ Feature: Save report after report run
         Then I should see a "link" labelled "Test save as report"
 
     Scenario: I can save the report after running the report if I am the owner
+        And I navigate to list reports
         When I click on the "Expand Subsections" link
         And I click on the "Run" link
         Then I should see option "Anthrax" in the "Condition Code" combobox input field
@@ -60,6 +62,13 @@ Feature: Save report after report run
         Then I should see option "Fulton County" in the "County Code" multi-select combobox input field
         When I click on the "Back to reports" link
         Then I am redirected to "/nbs/ManageReports.do"
-        When I click on the "Expand Subsections" link
-        Then I should see a "link" labelled "Test save as report"
-        And I click on the "Delete" link
+
+    Scenario: I can delete the reports I created
+        And I navigate to manage reports
+        And I click on the "Test save as report" link
+        Then I should see the "View" configuration page
+        And I should see value "Ariella Kent" in the "Owner" field
+        When I click the "Delete" button
+        Then I should see a modal labelled "Delete report: Test save as report"
+        When I click the "Yes, delete" button
+        Then I should see the report list


### PR DESCRIPTION
## Description

- Changes decision made in [this PR](https://github.com/CDCgov/NEDSS-Modernization/pull/3354)
- Use user options instead of user profile options to populate "Owner" list for creating a report
- Save as new report flow should properly set the owner to the user creating the report

- ⚠️ It still displays a blank system owner for our superuser but it should display correctly in the modernized View Report page

<img width="600" height="77" alt="Screenshot 2026-07-20 at 16 54 32" src="https://github.com/user-attachments/assets/1bc5bb37-d987-46f1-b176-1955c1cbd356" />
<img width="1505" height="546" alt="Screenshot 2026-07-20 at 16 55 45" src="https://github.com/user-attachments/assets/1fbb527e-5eb4-4c2f-9062-ebc041bf4911" />
<img width="642" height="546" alt="Screenshot 2026-07-20 at 16 46 34" src="https://github.com/user-attachments/assets/db7f6e29-161f-4684-afbf-4ce86f2c23f1" />


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-876)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
