### PR TITLE
APP-875: Update DataSourceCodeset/DataSourceColumn mapping to reflect DB state

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/mappers/ReportColumnMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/mappers/ReportColumnMapper.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.report.mappers;
 import gov.cdc.nbs.entity.odse.DataSourceCodeset;
 import gov.cdc.nbs.entity.odse.DataSourceColumn;
 import gov.cdc.nbs.report.models.ReportColumn;
+import java.util.List;
 
 public class ReportColumnMapper {
   private ReportColumnMapper() {}
@@ -10,8 +11,11 @@ public class ReportColumnMapper {
   public static ReportColumn fromDataSourceColumn(DataSourceColumn dataSourceColumn) {
     String codeDescCd = null;
     String codesetNm = null;
-    DataSourceCodeset codeset = dataSourceColumn.getCodesets().stream().findFirst().orElse(null);
-    if (codeset != null) {
+
+    List<DataSourceCodeset> codesets = dataSourceColumn.getCodesets();
+    if (codesets != null && !codesets.isEmpty()) {
+      DataSourceCodeset codeset = codesets.getFirst();
+
       codeDescCd = codeset.getCodeDescCd();
       codesetNm = codeset.getCodesetNm();
     }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/mappers/ReportColumnMapper.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/mappers/ReportColumnMapper.java
@@ -10,7 +10,7 @@ public class ReportColumnMapper {
   public static ReportColumn fromDataSourceColumn(DataSourceColumn dataSourceColumn) {
     String codeDescCd = null;
     String codesetNm = null;
-    DataSourceCodeset codeset = dataSourceColumn.getCodeset();
+    DataSourceCodeset codeset = dataSourceColumn.getCodesets().stream().findFirst().orElse(null);
     if (codeset != null) {
       codeDescCd = codeset.getCodeDescCd();
       codesetNm = codeset.getCodesetNm();

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/DisplayColumnBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/DisplayColumnBuilderTest.java
@@ -110,7 +110,7 @@ class DisplayColumnBuilderTest {
         .columnTitle("Random Column Title")
         .columnSourceTypeCode("type code")
         .dataSource(mock(DataSource.class))
-        .codeset(mock(DataSourceCodeset.class))
+        .codesets(List.of(mock(DataSourceCodeset.class)))
         .descTxt("Some description test")
         .displayable('Y')
         .effectiveTime(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/ReportColumnMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/ReportColumnMapperTest.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.entity.odse.DataSourceCodeset;
 import gov.cdc.nbs.entity.odse.DataSourceColumn;
 import gov.cdc.nbs.report.models.ReportColumn;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ReportColumnMapperTest {
@@ -27,8 +28,13 @@ class ReportColumnMapperTest {
             .filterable('N')
             .statusCd('A')
             .statusTime(LocalDateTime.of(2024, 3, 31, 12, 0))
-            .codeset(
-                DataSourceCodeset.builder().id(2L).codeDescCd("D").codesetNm("RACE_CODE").build())
+            .codesets(
+                List.of(
+                    DataSourceCodeset.builder()
+                        .id(2L)
+                        .codeDescCd("D")
+                        .codesetNm("RACE_CODE")
+                        .build()))
             .build();
 
     ReportColumn mapped = ReportColumnMapper.fromDataSourceColumn(dbColumn);
@@ -43,8 +49,8 @@ class ReportColumnMapperTest {
     assertThat(mapped.isFilterable()).isFalse();
     assertThat(mapped.statusCd()).isEqualTo(dbColumn.getStatusCd());
     assertThat(mapped.statusTime()).isEqualTo(dbColumn.getStatusTime());
-    assertThat(mapped.codesetNm()).isEqualTo(dbColumn.getCodeset().getCodesetNm());
-    assertThat(mapped.codeDescCd()).isEqualTo(dbColumn.getCodeset().getCodeDescCd());
+    assertThat(mapped.codesetNm()).isEqualTo(dbColumn.getCodesets().getFirst().getCodesetNm());
+    assertThat(mapped.codeDescCd()).isEqualTo(dbColumn.getCodesets().getFirst().getCodeDescCd());
   }
 
   @Test
@@ -59,6 +65,7 @@ class ReportColumnMapperTest {
             .columnSourceTypeCode("VARCHAR")
             .dataSource(dataSource)
             .descTxt("Some description")
+            .codesets(List.of())
             .statusCd('A')
             .statusTime(LocalDateTime.of(2024, 3, 31, 12, 0))
             .build();

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/DataSourceCodeset.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/DataSourceCodeset.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -25,7 +25,8 @@ public class DataSourceCodeset {
   @Column(name = "data_source_codeset_uid", nullable = false)
   private Long id;
 
-  @OneToOne(fetch = FetchType.LAZY)
+  /** Should be 1:1 in practice, but the DB does not enforce this. */
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "column_uid")
   private DataSourceColumn column;
 

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/DataSourceColumn.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/entity/odse/DataSourceColumn.java
@@ -8,9 +8,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,8 +48,9 @@ public class DataSourceColumn {
   @JoinColumn(name = "data_source_uid")
   private DataSource dataSource;
 
-  @OneToOne(mappedBy = "column", fetch = FetchType.LAZY)
-  private DataSourceCodeset codeset;
+  /** Should be 1:1 in practice, but the DB does not enforce this. */
+  @OneToMany(mappedBy = "column", fetch = FetchType.LAZY)
+  private List<DataSourceCodeset> codesets;
 
   @Column(name = "desc_txt", length = 300)
   private String descTxt;

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/DataSourceColumnTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/DataSourceColumnTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gov.cdc.nbs.time.EffectiveTime;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class DataSourceColumnTest {
@@ -42,7 +43,7 @@ class DataSourceColumnTest {
             columnTitle,
             columnSourceTypeCode,
             dataSource,
-            dataSourceCodeset,
+            List.of(dataSourceCodeset),
             descTxt,
             displayable,
             effectiveTime,


### PR DESCRIPTION
## Description

This PR updates the DB relationship between `DataSourceCodeset` and `DataSourceColumn` defined in the codebase to match the actual state of the DB.  While in _practice_ it's a 1:1 relationship, there's no uniqueness constraint on `DataSourceCodeset` enforcing that, so we should (unfortunately) establish that it's technically N:1 and only ever fetch the first.

Confirmed the `Varicella Line Listing` report runs successfully with this change.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-875)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
