### PR TITLE
[APP-869] fix: less aggressive form validation

### DIFF
--- a/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
@@ -137,7 +137,11 @@ describe('add report configuration page', () => {
 
         // Partially add filter
         await user.selectOptions(await findByLabelText('Filter'), '1');
+        await user.click(await findByRole('button', { name: 'Add filter' }));
+        expect(await findAllByText(/The Associated column is required./)).toHaveLength(2);
 
+        // revalidate
+        await user.click(await findByRole('button', { name: 'Submit' }));
         expect(
             await findByText(
                 /Data have been entered in the Available filters section. Please press Add or clear the data and submit again/
@@ -147,6 +151,8 @@ describe('add report configuration page', () => {
 
         // clear the filter and check validation error clears as well
         await user.click(await findByRole('button', { name: 'Clear' }));
+        expect(queryByRole('link', { name: /The Associated column is required./ })).toBeNull();
+        await user.click(await findByRole('button', { name: 'Submit' }));
         expect(queryByRole('link', { name: 'Available filters' })).toBeNull();
     });
 

--- a/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.tsx
@@ -18,6 +18,7 @@ const AddReportConfiguration = () => {
 
     const form = useForm<ConfigForm>({
         mode: 'onSubmit',
+        reValidateMode: 'onSubmit',
     });
 
     const handleSubmit = form.handleSubmit((data) => {

--- a/apps/modernization-ui/src/apps/report/management/configuration/EditReportConfiguration.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/EditReportConfiguration.tsx
@@ -23,6 +23,7 @@ const EditReportConfiguration = () => {
 
     const form = useForm<ConfigForm>({
         mode: 'onSubmit',
+        reValidateMode: 'onSubmit',
     });
 
     const handleSubmit = form.handleSubmit((data) => {

--- a/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
@@ -157,6 +157,7 @@ const FilterRepeatingBlockImpl = ({
             disabled={!dataSourceSelected}
             onChange={onChange}
             isDirty={setFiltersIsDirty}
+            reValidateMode="onSubmit"
             viewRenderer={(entry: FilterConfig) =>
                 filterColumns.map((fc) => (
                     <ValueField key={fc.id} label={fc.name} sizing={SIZING}>

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -2846,7 +2846,6 @@ describe('report run page', () => {
                 { value: '456', name: 'Not so awful disease' },
             ]);
             const {
-                queryByText,
                 getByText,
                 findAllByRole,
                 findAllByText,
@@ -2877,32 +2876,34 @@ describe('report run page', () => {
             expect(opSelect).toHaveValue('~');
             await user.selectOptions(opSelect, 'contains');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter a value for Full Name.')).toHaveLength(2);
 
             const valueBox = getByLabelText('Value');
             expect(valueBox).toHaveValue('');
             await user.type(valueBox, 'hi');
 
-            expect(queryByText('Enter a value for Full Name.')).toBeNull();
-
             // generally filled in number value
             await user.selectOptions(fieldSelect, 'DAYS_OLD');
-            expect(opSelect).toHaveValue('~');
-            await user.selectOptions(opSelect, '=');
+            expect(getByLabelText('Logic')).toHaveValue('~');
+            await user.selectOptions(getByLabelText('Logic'), '=');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter a value for Days Old.')).toHaveLength(2);
 
             const numberBox = await findByLabelText('Value');
             expect(numberBox).toHaveValue(null);
             await user.type(numberBox, '0{tab}');
 
-            expect(queryByText('Enter a value for Days Old.')).toBeNull();
-
             // generally filled in coded list
             await user.selectOptions(fieldSelect, 'Condition Code');
-            expect(opSelect).toHaveValue('~');
-            await user.selectOptions(opSelect, 'in');
+            expect(getByLabelText('Logic')).toHaveValue('~');
+            await user.selectOptions(getByLabelText('Logic'), 'in');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter a value for Condition Code.')).toHaveLength(2);
 
             await waitFor(() => expect(codedValueGetter).toHaveBeenCalledWith(`/nbs/api/options/races`));
@@ -2912,13 +2913,13 @@ describe('report run page', () => {
             await user.click(dropDown);
             await user.click(getByText('Terrible disease'));
 
-            expect(queryByText('Enter a value for Condition Code.')).toBeNull();
-
             // dates between
             await user.selectOptions(fieldSelect, 'DATE_OF_BIRTH');
-            expect(opSelect).toHaveValue('~');
-            await user.selectOptions(opSelect, 'between');
+            expect(getByLabelText('Logic')).toHaveValue('~');
+            await user.selectOptions(getByLabelText('Logic'), 'between');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter From and To values for Date of Birth.')).toHaveLength(2);
 
             // The date entry will likely need to change once we switch to NBS components
@@ -2927,21 +2928,25 @@ describe('report run page', () => {
             const dtInputTo = await within(dtContainer).findByLabelText('To');
             await user.type(dtInputFrom, '10/18/2022{tab}');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter From and To values for Date of Birth.')).toHaveLength(2);
 
             await user.type(dtInputTo, '10/17/2022{tab}');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('From date must be before To date for Date of Birth.')).toHaveLength(2);
             await user.clear(dtInputTo);
             await user.type(dtInputTo, '10/20/2022{tab}');
 
-            expect(queryByText('From date must be before To date for Date of Birth.')).toBeNull();
-
             // numbers between
             await user.selectOptions(fieldSelect, 'DAYS_OLD');
-            expect(opSelect).toHaveValue('~');
-            await user.selectOptions(opSelect, 'between');
+            expect(getByLabelText('Logic')).toHaveValue('~');
+            await user.selectOptions(getByLabelText('Logic'), 'between');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter From and To values for Days Old.')).toHaveLength(2);
 
             const numContainer = getByTestId('number-range-editor');
@@ -2949,10 +2954,14 @@ describe('report run page', () => {
             const numInputTo = await within(numContainer).findByLabelText('To');
             await user.type(numInputFrom, '10');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('Enter From and To values for Days Old.')).toHaveLength(2);
 
             await user.type(numInputTo, '0');
 
+            // re-validate
+            await user.click(exportButton);
             expect(await findAllByText('From value must be before To value for Days Old.')).toHaveLength(2);
 
             await user.clear(numInputTo);
@@ -3489,7 +3498,8 @@ describe('report run page', () => {
 
             await user.click(await findByLabelText('Select all'));
 
-            expect(queryByText('Select at least one column from the Available columns list.')).toBeNull();
+            // only re-validate on submit
+            expect(await findAllByText('Select at least one column from the Available columns list.')).toHaveLength(2);
 
             await user.click(await findByRole('button', { name: 'Clear selections' }));
 

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.tsx
@@ -69,6 +69,7 @@ const ReportRunPage = () => {
 
     const form = useForm<ReportExecuteForm>({
         mode: 'onSubmit',
+        reValidateMode: 'onSubmit',
     });
 
     const onSubmit = (event: React.BaseSyntheticEvent, isExport: boolean) => {

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
@@ -13,6 +13,7 @@ import QueryBuilder, {
     RuleGroup as DefaultRuleGroup,
     Rule as DefaultRule,
     RuleProps,
+    FullField,
 } from 'react-querybuilder';
 
 import { ReportExecuteForm } from '../../ReportRunPage';
@@ -32,7 +33,7 @@ import { RemoveButton } from '././RemoveButton.tsx';
 import { validateRule } from './validator.ts';
 import { AddButton } from './AddButton.tsx';
 import { ALL_OPERATORS, LIST_OPERATORS, NULL_OPERATORS, OPERATOR_MAP } from './operators.ts';
-import { ReactNode, useEffect, useState } from 'react';
+import { ComponentType, ReactNode, useEffect, useState } from 'react';
 import { ValidationErrorBanner } from 'design-system/errors/ValidationError.tsx';
 import { AlertMessage } from 'design-system/message/index.ts';
 import classNames from 'classnames';
@@ -310,7 +311,10 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
                             addRuleAction: AddButton,
                             removeGroupAction: RemoveButton,
                             removeRuleAction: RemoveButton,
-                            ruleGroup: RuleGroupWithErrors,
+                            // KLUDGE: This is using the literal default component, but ts is very unhappy
+                            ruleGroup: RuleGroupWithErrors as unknown as ComponentType<
+                                RuleGroupProps<ValueSetMetadata & FullField, string>
+                            >,
                             rule: RuleWithErrors,
                         }}
                     />

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
@@ -6,9 +6,13 @@ import QueryBuilder, {
     isRuleType,
     joinWith,
     QueryValidator,
+    RuleGroupProps,
     RuleGroupType,
     splitBy,
     ValidationResult,
+    RuleGroup as DefaultRuleGroup,
+    Rule as DefaultRule,
+    RuleProps,
 } from 'react-querybuilder';
 
 import { ReportExecuteForm } from '../../ReportRunPage';
@@ -28,7 +32,7 @@ import { RemoveButton } from '././RemoveButton.tsx';
 import { validateRule } from './validator.ts';
 import { AddButton } from './AddButton.tsx';
 import { ALL_OPERATORS, LIST_OPERATORS, NULL_OPERATORS, OPERATOR_MAP } from './operators.ts';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { ValidationErrorBanner } from 'design-system/errors/ValidationError.tsx';
 import { AlertMessage } from 'design-system/message/index.ts';
 import classNames from 'classnames';
@@ -247,11 +251,25 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
         defaultValue: filter.defaultValue ? advancedFilterConfigToQuery(filter.defaultValue, columns) : EMPTY_QUERY,
         rules: { validate: (values) => validateAdvancedFilter(columns, values) },
     });
+    const [errorIds, setErrorIds] = useState<string[]>([]);
 
     const fields = columns.filter((c) => c.isFilterable).map(translateColumnToField);
 
+    // only validate when the form validates
+    useEffect(() => {
+        if (value) {
+            setErrorIds(
+                Object.entries(validator(value))
+                    .filter(([_k, v]) => !v.valid)
+                    .map(([k, _v]) => k)
+            );
+        } else {
+            setErrorIds([]);
+        }
+    }, [error]);
+
     return (
-        <div className={classNames(styles.layout, { [styles.validate]: !!error?.message })}>
+        <div className={classNames(styles.layout)}>
             {filter.exceptionMessage && (
                 <AlertMessage type="warning" title="Saved filter has an error and can't be applied">
                     <p>
@@ -277,7 +295,7 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
                     <QueryBuilder
                         fields={fields}
                         query={value}
-                        validator={validator}
+                        context={{ errorIds }}
                         onQueryChange={onChange}
                         addRuleToNewGroups={true}
                         autoSelectField={false}
@@ -292,6 +310,8 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
                             addRuleAction: AddButton,
                             removeGroupAction: RemoveButton,
                             removeRuleAction: RemoveButton,
+                            ruleGroup: RuleGroupWithErrors,
+                            rule: RuleWithErrors,
                         }}
                     />
                 </QueryBuilderDnD>
@@ -318,6 +338,22 @@ const PreviewWhere = ({ query }: { query?: QbRuleGroup }) => {
                         : fallbackExpression}
                 </p>
             </div>
+        </div>
+    );
+};
+
+const RuleGroupWithErrors = (props: RuleGroupProps) => {
+    return (
+        <div className={classNames({ [styles.invalid]: props?.context?.errorIds?.includes(props.id) })}>
+            <DefaultRuleGroup {...props} />
+        </div>
+    );
+};
+
+const RuleWithErrors = (props: RuleProps) => {
+    return (
+        <div className={classNames({ [styles.invalid]: props?.context?.errorIds?.includes(props.id) })}>
+            <DefaultRule {...props} />
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
@@ -5,7 +5,6 @@ import QueryBuilder, {
     formatQuery,
     isRuleType,
     joinWith,
-    QueryValidator,
     RuleGroupProps,
     RuleGroupType,
     splitBy,
@@ -196,21 +195,21 @@ const addColNameAndTypeToRules = (columns: ReportColumn[], value: QbRuleGroup): 
 
 const validateAdvancedFilter = (columns: ReportColumn[], value?: QbRuleGroup) => {
     if (!value) return true;
-    const updatedRuleGroup = addColNameAndTypeToRules(columns, value);
 
     return (
-        Object.values(validator(updatedRuleGroup))
+        Object.values(validator(columns, value))
             .filter((v) => !v.valid)
-            .reduce((acc, cur) => `${acc}\n${cur.reasons[0]}`, '') || true
+            .reduce((acc, cur) => `${acc}\n${cur?.reasons?.[0]}`, '') || true
     );
 };
 
 // tighten the default type so it's just the object version
 type ValidationResultMap = Record<string, ValidationResult>;
 
-const validator: QueryValidator = (q) => {
+const validator = (columns: ReportColumn[], q: QbRuleGroup): ValidationResultMap => {
+    const updatedRuleGroup = addColNameAndTypeToRules(columns, q);
     const result: ValidationResultMap = {};
-    q.rules.forEach((r) => validateRule(r as QbQuery, result));
+    updatedRuleGroup.rules.forEach((r) => validateRule(r, result));
     return result;
 };
 
@@ -252,20 +251,16 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
         defaultValue: filter.defaultValue ? advancedFilterConfigToQuery(filter.defaultValue, columns) : EMPTY_QUERY,
         rules: { validate: (values) => validateAdvancedFilter(columns, values) },
     });
-    const [errorIds, setErrorIds] = useState<string[]>([]);
+    const [validationMap, setValidationMap] = useState<ValidationResultMap>({});
 
     const fields = columns.filter((c) => c.isFilterable).map(translateColumnToField);
 
     // only validate when the form validates
     useEffect(() => {
         if (value) {
-            setErrorIds(
-                Object.entries(validator(value))
-                    .filter(([_k, v]) => !v.valid)
-                    .map(([k, _v]) => k)
-            );
+            setValidationMap(validator(columns, value));
         } else {
-            setErrorIds([]);
+            setValidationMap({});
         }
     }, [error]);
 
@@ -296,7 +291,7 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
                     <QueryBuilder
                         fields={fields}
                         query={value}
-                        context={{ errorIds }}
+                        context={{ validationMap }}
                         onQueryChange={onChange}
                         addRuleToNewGroups={true}
                         autoSelectField={false}
@@ -348,7 +343,11 @@ const PreviewWhere = ({ query }: { query?: QbRuleGroup }) => {
 
 const RuleGroupWithErrors = (props: RuleGroupProps) => {
     return (
-        <div className={classNames({ [styles.invalid]: props?.context?.errorIds?.includes(props.id) })}>
+        <div
+            className={classNames({
+                [styles.invalid]: props.id && props?.context?.validationMap?.[props.id]?.valid === false,
+            })}
+        >
             <DefaultRuleGroup {...props} />
         </div>
     );
@@ -356,7 +355,11 @@ const RuleGroupWithErrors = (props: RuleGroupProps) => {
 
 const RuleWithErrors = (props: RuleProps) => {
     return (
-        <div className={classNames({ [styles.invalid]: props?.context?.errorIds?.includes(props.id) })}>
+        <div
+            className={classNames({
+                [styles.invalid]: props.id && props?.context?.validationMap?.[props.id]?.valid === false,
+            })}
+        >
             <DefaultRule {...props} />
         </div>
     );

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/advanced-filter.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/advanced-filter.module.scss
@@ -66,7 +66,7 @@ $error-border-width: 4px;
         }
 
         // no border on outermost rule group
-        .queryBuilder > .ruleGroup {
+        .queryBuilder > div > .ruleGroup {
             border: none;
             padding: 0;
         }

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/advanced-filter.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/advanced-filter.module.scss
@@ -21,15 +21,13 @@ $error-border-width: 4px;
 }
 
 .layout {
-    &.validate {
-        :global(.queryBuilder-invalid) {
-            &:global(.rule) {
-                @include highlight(colors.$error-dark);
-            }
-            &:global(.ruleGroup) {
-                border-width: $error-border-width;
-                border-color: colors.$error-dark;
-            }
+    .invalid {
+        :global(.rule) {
+            @include highlight(colors.$error-dark);
+        }
+        :global(.ruleGroup) {
+            border-width: $error-border-width;
+            border-color: colors.$error-dark;
         }
     }
 

--- a/apps/modernization-ui/src/apps/report/run/filters/utils/rangeValidator.ts
+++ b/apps/modernization-ui/src/apps/report/run/filters/utils/rangeValidator.ts
@@ -2,7 +2,7 @@ import { getYear, isValid, parse } from 'date-fns';
 
 const formats = ['MM/dd/yyyy', 'MM/yyyy', 'yyyy'];
 
-export const validateDateRange = (value, field) => {
+export const validateDateRange = (value: string[], field: string) => {
     if (rangeValuesMissing(value)) return getRangeValErrorMsg(field, false);
 
     const fromDate = new Date(value[0]!); // can't be undefined because of above checks
@@ -21,7 +21,7 @@ export const validateDateRange = (value, field) => {
     return;
 };
 
-export const validateNumericRange = (value, field) => {
+export const validateNumericRange = (value: string[], field: string) => {
     if (rangeValuesMissing(value)) return getRangeValErrorMsg(field, false);
 
     const fromNum = parseFloat(value[0]); // can't be undefined because of above checks
@@ -48,11 +48,11 @@ export const getBeforeErrorMsg = (field: string, isDate: boolean) => {
     return `From ${typeMsg} must be before To ${typeMsg} for ${field}.`;
 };
 
-export const rangeValuesMissing = (value) => {
+export const rangeValuesMissing = (value: string[]) => {
     return (!!value[0] && !value[1]) || (!value[0] && !!value[1]) || value[0] === '' || value[1] === '';
 };
 
-const isNumberFormat = (val) => {
+const isNumberFormat = (val: unknown) => {
     if (typeof val === 'string') {
         return !!val.match(/^-?\d+(\.\d+)?$/);
     }

--- a/apps/modernization-ui/src/apps/report/run/modals/SaveAsReportModal.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/modals/SaveAsReportModal.spec.tsx
@@ -51,15 +51,16 @@ describe('SaveAsReportModal', () => {
 
         const nameInput = await findByLabelText('Name');
         await user.type(nameInput, 'Test report');
+        await user.click(saveAsNewButton);
         expect(queryByText('The Name is required.')).toBeNull();
 
         const descInput = await findByLabelText('Description');
         await user.type(descInput, 'Test report description');
+        await user.click(saveAsNewButton);
         expect(queryByText('The Description is required.')).toBeNull();
 
         const sectionInput = await findByLabelText('Section name');
         await user.selectOptions(sectionInput, '1000');
-        expect(queryByText('The Section name is required.')).toBeNull();
 
         const privateRadio = getByRole('radio', { name: 'Private' });
         const publicRadio = getByRole('radio', { name: 'Public' });

--- a/apps/modernization-ui/src/apps/report/run/modals/SaveAsReportModal.tsx
+++ b/apps/modernization-ui/src/apps/report/run/modals/SaveAsReportModal.tsx
@@ -57,6 +57,8 @@ export const SaveAsReportModal = ({ saveAsReportModalRef, saving, onSaveAs }: Sa
             sectionCode: undefined,
             group: reportGroupOptions[0],
         },
+        mode: 'onSubmit',
+        reValidateMode: 'onSubmit',
     });
 
     const handleOnSaveAs = ({ reportTitle, sectionCode, group, description }: SaveAsForm) => {

--- a/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
+++ b/apps/modernization-ui/src/design-system/entry/multi-value/RepeatingBlock.tsx
@@ -41,6 +41,7 @@ type RepeatingBlockProps<V extends FieldValues> = {
     isValid?: (isValid: boolean) => void;
     formRenderer?: (entry?: V, sizing?: Sizing) => ReactNode;
     itemName?: string;
+    reValidateMode?: 'onBlur' | 'onSubmit' | 'onChange';
 } & Pick<CardProps, 'id' | 'title' | 'collapsible' | 'disabled'>;
 
 const RepeatingBlock = <V extends FieldValues>({
@@ -62,10 +63,11 @@ const RepeatingBlock = <V extends FieldValues>({
     isValid,
     formRenderer,
     viewRenderer,
+    reValidateMode = 'onBlur',
 }: RepeatingBlockProps<V>) => {
     const form = useForm<V>({
         mode: 'onSubmit',
-        reValidateMode: 'onBlur',
+        reValidateMode,
         defaultValues: resolveDefaultValues(defaultValues),
     });
 


### PR DESCRIPTION
## Description

Instead of revalidating on change, revalidate on submit. 

Note:
* To make this work for the advanced filter widget, needed to move the validation handling out of the automated check as that was running constantly
* Needed to add a prop to the repeating block filter to make this configurable

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-869

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
