### PR TITLE
[APP-873] fix: un-require fielda and combinator in advanced filter widget

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueSingleSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueSingleSelector.tsx
@@ -30,7 +30,7 @@ const ValueSingleSelector = (props: ValueSelectorProps<FullOption>) => {
                 value={currentSelection}
                 onChange={handleOnChange}
                 orientation="vertical"
-                required
+                required={props.className === 'rule-operators'}
                 placeholder=""
                 name={title}
                 options={availableOptions}


### PR DESCRIPTION
## Description

Only mark the logic and value fields as required as the combinator is not un-selectable and the un-filled field alone is considered empty and therefore fine

slack thread on design: https://skylight-hq.slack.com/archives/C0ANQHL66JX/p1784581795259109

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-873

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
