### PR TITLE
[APP-868][APP-867] fix: more dense/consistent sizing

### DIFF
--- a/apps/modernization-ui/src/apps/landing/SignIn/signIn.module.scss
+++ b/apps/modernization-ui/src/apps/landing/SignIn/signIn.module.scss
@@ -31,7 +31,7 @@
     margin-top: 1rem;
 
     button {
-        font-size: 14px;
+        font-size: 0.875rem;
         padding: 0;
         text-decoration: none;
     }

--- a/apps/modernization-ui/src/apps/page-builder/components/FilterModal/filter.scss
+++ b/apps/modernization-ui/src/apps/page-builder/components/FilterModal/filter.scss
@@ -3,7 +3,7 @@
 .search-desc {
     color: var(--base-base, #71767a);
     font-family: Public Sans;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-style: normal;
     font-weight: 400;
     margin-bottom: 0;

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.scss
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/BusinessRulesLibrary.scss
@@ -178,7 +178,7 @@
 .search-desc {
     color: var(--base-base, #71767a);
     font-family: Public Sans;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-style: normal;
     font-weight: 400;
     margin-bottom: 0;

--- a/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
@@ -319,7 +319,7 @@ const Row = ({
             )}
         />
     ) : (
-        <ValueField label={label} helperText={helperText}>
+        <ValueField label={label} helperText={helperText} sizing={SIZING}>
             <Option option={option} />
         </ValueField>
     );

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
@@ -96,7 +96,7 @@ const ResultDataPage = ({
                 <Card id="report-criteria" title="Report criteria">
                     <ValueField sizing={SIZING} label="Base SQL query">
                         {/* The uswds text-pre-line forces a sans font instead of respecting mono */}
-                        <span style={{ whiteSpace: 'pre-line' }} className="font-mono-sm">
+                        <span style={{ whiteSpace: 'pre-line' }} className="font-mono-xs">
                             {styledQuery}
                         </span>
                     </ValueField>

--- a/apps/modernization-ui/src/apps/report/run/columns/ColumnSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/columns/ColumnSelector.tsx
@@ -13,6 +13,7 @@ import { LiveSearch } from 'components/Search/LiveSearch';
 import styles from './column-selector.module.scss';
 import { toSelectable } from './utils';
 import { ValidationErrorBanner } from 'design-system/errors/ValidationError';
+import { SIZING } from 'apps/report/constants';
 
 const ColumnSelector = ({ columns, defaultColumns }: { columns: ReportColumn[]; defaultColumns?: number[] }) => {
     const {
@@ -81,6 +82,7 @@ const ColumnSelector = ({ columns, defaultColumns }: { columns: ReportColumn[]; 
                                 label={selectWord + (searchText ? ' search results' : ' all')}
                                 selected={false}
                                 onChange={handleSelectAll}
+                                sizing={SIZING}
                             />
                             {availableOptions.map((o) => (
                                 <Checkbox
@@ -89,6 +91,7 @@ const ColumnSelector = ({ columns, defaultColumns }: { columns: ReportColumn[]; 
                                     label={o.name}
                                     selected={value?.includes(o.value)}
                                     onChange={handleOnAvailableChange(o)}
+                                    sizing={SIZING}
                                 />
                             ))}
                         </div>
@@ -98,7 +101,12 @@ const ColumnSelector = ({ columns, defaultColumns }: { columns: ReportColumn[]; 
                         title="Selected columns"
                         collapsible={false}
                         actions={
-                            <Button disabled={noneSelected} onClick={() => onChange([])}>
+                            <Button
+                                destructive={true}
+                                secondary={true}
+                                disabled={noneSelected}
+                                onClick={() => onChange([])}
+                            >
                                 Clear selections
                             </Button>
                         }

--- a/apps/modernization-ui/src/apps/report/run/columns/ColumnSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/columns/ColumnSelector.tsx
@@ -106,10 +106,12 @@ const ColumnSelector = ({ columns, defaultColumns }: { columns: ReportColumn[]; 
                                 destructive={true}
                                 secondary={true}
                                 disabled={noneSelected}
-                                onClick={() => onChange([])}>
+                                onClick={() => onChange([])}
+                            >
                                 Clear selections
                             </Button>
-                        }>
+                        }
+                    >
                         <div className={styles.card}>
                             {noneSelected ? (
                                 <p className={styles.center}>Select a column from "Available columns"</p>
@@ -156,11 +158,13 @@ const SelectedColumnsList = ({
                                         <div
                                             className={styles.option}
                                             ref={draggable.innerRef}
-                                            {...draggable.draggableProps}>
+                                            {...draggable.draggableProps}
+                                        >
                                             <span
                                                 className={styles.handle}
                                                 aria-label={`Drag handle for ${optionName}`}
-                                                {...draggable.dragHandleProps}>
+                                                {...draggable.dragHandleProps}
+                                            >
                                                 <Icon name="drag" />
                                             </span>
                                             <span className={styles.label}>{optionName}</span>

--- a/apps/modernization-ui/src/apps/report/run/columns/ColumnSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/columns/ColumnSelector.tsx
@@ -102,15 +102,14 @@ const ColumnSelector = ({ columns, defaultColumns }: { columns: ReportColumn[]; 
                         collapsible={false}
                         actions={
                             <Button
+                                sizing="small"
                                 destructive={true}
                                 secondary={true}
                                 disabled={noneSelected}
-                                onClick={() => onChange([])}
-                            >
+                                onClick={() => onChange([])}>
                                 Clear selections
                             </Button>
-                        }
-                    >
+                        }>
                         <div className={styles.card}>
                             {noneSelected ? (
                                 <p className={styles.center}>Select a column from "Available columns"</p>
@@ -157,13 +156,11 @@ const SelectedColumnsList = ({
                                         <div
                                             className={styles.option}
                                             ref={draggable.innerRef}
-                                            {...draggable.draggableProps}
-                                        >
+                                            {...draggable.draggableProps}>
                                             <span
                                                 className={styles.handle}
                                                 aria-label={`Drag handle for ${optionName}`}
-                                                {...draggable.dragHandleProps}
-                                            >
+                                                {...draggable.dragHandleProps}>
                                                 <Icon name="drag" />
                                             </span>
                                             <span className={styles.label}>{optionName}</span>

--- a/apps/modernization-ui/src/apps/report/run/columns/column-selector.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/columns/column-selector.module.scss
@@ -1,6 +1,7 @@
 @use 'styles/borders';
 @use 'styles/buttons';
 @use 'styles/colors';
+@use 'styles/components';
 
 .layout {
     background-color: colors.$base-lightest;
@@ -20,7 +21,7 @@
         .search {
             background-color: colors.$primary-lightest;
             width: 100%;
-            padding: 1rem;
+            padding: 0.5rem 1rem;
             height: fit-content;
             position: sticky;
             top: 0;
@@ -45,12 +46,13 @@
                 border-left-style: solid;
                 border-left-color: colors.$clear;
 
-                padding: 0.25rem 1.5rem;
+                padding: 0 1.5rem;
                 gap: 2rem;
                 // keeps the checkbox and dnd options about the same height
-                min-height: 3rem;
+                min-height: 2.1rem;
 
                 @extend %thin-bottom;
+                @extend %medium;
 
                 display: flex;
                 flex-direction: row;

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AddButton.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AddButton.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
 import { ActionProps } from 'react-querybuilder';
 import { Button } from '../../../../../design-system/button';
 
 const AddButton = (props: ActionProps) => {
     return (
         <Button
-            type={'button'}
+            type="button"
             onClick={(e) => props.handleOnClick(e)}
             secondary={props.className === 'ruleGroup-addGroup'}
+            sizing="small"
         >
             {props.title}
         </Button>

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AddButton.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AddButton.tsx
@@ -1,5 +1,5 @@
 import { ActionProps } from 'react-querybuilder';
-import { Button } from '../../../../../design-system/button';
+import { Button } from 'design-system/button';
 
 const AddButton = (props: ActionProps) => {
     return (

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
@@ -308,7 +308,7 @@ const PreviewWhere = ({ query }: { query?: QbRuleGroup }) => {
         <div className="padding-205 border-top border-base-lighter">
             <h3 className="margin-top-1 margin-bottom-2">Preview of WHERE Clause</h3>
             <div className="bg-base-lightest padding-105">
-                <p className="font-mono-md">
+                <p className="font-mono-xs">
                     {query
                         ? formatQuery(query, {
                               format: 'sql',

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/RemoveButton.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/RemoveButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ActionProps } from 'react-querybuilder';
 import { Button } from '../../../../../design-system/button';
 
@@ -11,7 +10,7 @@ const RemoveButton = (props: ActionProps) => {
             tertiary
             destructive
             sizing="small"
-            aria-label={props.title}
+            aria-label={props.title!}
             onClick={(e) => props.handleOnClick(e)}
         />
     );

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/RemoveButton.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/RemoveButton.tsx
@@ -1,5 +1,5 @@
 import { ActionProps } from 'react-querybuilder';
-import { Button } from '../../../../../design-system/button';
+import { Button } from 'design-system/button';
 
 const RemoveButton = (props: ActionProps) => {
     return (

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueInput.tsx
@@ -7,6 +7,7 @@ import { DateBetweenCriteria } from 'design-system/date/criteria';
 import { NumberBetweenCriteria } from 'design-system/input/range/NumberRangeField.tsx';
 import { BETWEEN_OPERATOR } from './operators.ts';
 import { ReactComponentLike } from 'prop-types';
+import { SIZING } from 'apps/report/constants.ts';
 
 const RANGE_COMPONENTS: Record<string, ReactComponentLike> = {
     date: DatePickerRange,
@@ -75,6 +76,7 @@ const ValueInput = (props: ValueEditorProps<FullField>) => {
                 name={labelName}
                 onChange={isBetween ? handleBetweenOnChange : handleSingleOnChange}
                 required
+                sizing={SIZING}
             />
         </div>
     );

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueSingleSelector.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/ValueSingleSelector.tsx
@@ -2,6 +2,7 @@ import { useId } from 'react';
 import { FullOption, ValueSelectorProps } from 'react-querybuilder';
 import { SingleSelect } from 'design-system/select';
 import { Selectable } from 'options';
+import { SIZING } from 'apps/report/constants';
 
 const ValueSingleSelector = (props: ValueSelectorProps<FullOption>) => {
     const id = useId();
@@ -34,6 +35,7 @@ const ValueSingleSelector = (props: ValueSelectorProps<FullOption>) => {
                 placeholder=""
                 name={title}
                 options={availableOptions}
+                sizing={SIZING}
             />
         </span>
     );

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/advanced-filter.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/advanced-filter.module.scss
@@ -57,10 +57,6 @@ $error-border-width: 4px;
             button {
                 margin: 0 0.5rem;
             }
-
-            .trash-icon {
-                margin-bottom: 0.25rem;
-            }
         }
 
         .ruleGroup {

--- a/apps/modernization-ui/src/components/Table/table.module.scss
+++ b/apps/modernization-ui/src/components/Table/table.module.scss
@@ -5,13 +5,13 @@
     table {
         border-width: 0;
         margin: 0;
-        font-size: 14px;
+        font-size: 0.875rem;
         table-layout: fixed;
 
         thead {
             th {
                 div {
-                    font-size: 14px !important;
+                    font-size: 0.875rem !important;
                     display: flex;
                     justify-content: space-between;
                     border: none;

--- a/apps/modernization-ui/src/design-system/checkbox/checkbox.module.scss
+++ b/apps/modernization-ui/src/design-system/checkbox/checkbox.module.scss
@@ -5,6 +5,7 @@ $border-size: 2px;
 
 .checkbox {
     --checkbox-size: 1.125rem;
+    @extend %medium;
 
     box-sizing: border-box;
 

--- a/apps/modernization-ui/src/design-system/errors/ValidationError.tsx
+++ b/apps/modernization-ui/src/design-system/errors/ValidationError.tsx
@@ -9,12 +9,12 @@ const ValidationErrorBanner = ({ level, children }: { level: HeadingLevel; child
 );
 
 const ValidationErrorSection = ({ id, title, children }: { id: string; title: string; children: ReactNode }) => (
-    <div className="usa-prose">
+    <>
         <p>
             For <a href={`#${id}`}>{title}</a>,
         </p>
         <ul>{children}</ul>
-    </div>
+    </>
 );
 
 // Generates an error message that will contain a link to the section if an id is provided

--- a/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
+++ b/apps/modernization-ui/src/design-system/field/horizontal-field.module.scss
@@ -4,6 +4,7 @@
 
 .horizontal {
     --label-area-width: 13rem;
+    @extend %medium;
 
     padding: 0.5rem 1.5rem;
     align-items: flex-start;

--- a/apps/modernization-ui/src/design-system/table/data-table.module.scss
+++ b/apps/modernization-ui/src/design-system/table/data-table.module.scss
@@ -8,7 +8,7 @@
     table {
         border-collapse: separate;
         margin: 0;
-        font-size: 14px;
+        font-size: 0.875rem;
 
         &:global(.usa-table) {
             width: auto;


### PR DESCRIPTION
## Description

Make sizing more consistently "medium" / denser all over

<img width="1456" height="1083" alt="image" src="https://github.com/user-attachments/assets/011b73a7-b326-49f3-9f03-fd7631789bf0" />
<img width="1464" height="962" alt="image" src="https://github.com/user-attachments/assets/890d481f-f1f1-443d-bac0-e18efe0202bb" />
<img width="1450" height="1092" alt="image" src="https://github.com/user-attachments/assets/71a67b83-6f96-41a4-9000-9dc950b7bb16" />


Notes:
* Including making the in-widget buttons on the run page "small" (medium is the default and a bit roomy)
* Rage changed hardcoded 14px in the app to 0.875rem for a11y reasons


## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-868
* https://cdc-nbs.atlassian.net/browse/APP-867

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
