### PR TITLE
[APP-871] fix: clearing multi-select elided advanced filter validation

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -2914,6 +2914,12 @@ describe('report run page', () => {
 
             expect(queryByText('Enter a value for Condition Code.')).toBeNull();
 
+            await user.click(dropDown);
+            await user.click(getByText('Select all'));
+            await user.click(getByText('Deselect all'));
+
+            expect(await findAllByText('Enter a value for Condition Code.')).toHaveLength(2);
+
             // dates between
             await user.selectOptions(fieldSelect, 'DATE_OF_BIRTH');
             expect(opSelect).toHaveValue('~');

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/validator.ts
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/validator.ts
@@ -64,6 +64,10 @@ export const validateRule = (rule: QbQuery, result: ValidationResultMap) => {
                 if (type === 'DATETIME') {
                     if (!isDateFormat(value)) setInvalid(id, getInvalidDateErrorMsg(label, value));
                 }
+            } else if (Array.isArray(value)) {
+                if (value.length === 0) {
+                    setInvalid(id, getMissingValErrorMsg(label, false));
+                }
             }
         }
     } else if (isQbRuleGroupType(rule)) {


### PR DESCRIPTION
## Description

After populating, a multi select is populated as an array (vs undefined/null), but our validation did not check for empty arrays

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-871

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
