### PR TITLE
[APP-870] Fix oversized report validation error alert

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportConfigurationPage.tsx
@@ -188,7 +188,7 @@ const ReportConfigurationPage = ({
                     </aside>
                     <div className={layoutStyles.columnContent}>
                         {!!sectionErrors.length && (
-                            <ValidationErrorBanner level={2}>
+                            <ValidationErrorBanner level={2} className={layoutStyles.alertMessage}>
                                 {sectionErrors.map(({ id, title, getValidationMessages }) => (
                                     <ValidationErrorSection id={id} key={id} title={title}>
                                         {getValidationMessages(errors, config)!.map((message, i) => (

--- a/apps/modernization-ui/src/design-system/errors/ValidationError.tsx
+++ b/apps/modernization-ui/src/design-system/errors/ValidationError.tsx
@@ -2,14 +2,22 @@ import { HeadingLevel } from 'components/heading';
 import { AlertMessage } from 'design-system/message';
 import { ReactNode } from 'react';
 
-const ValidationErrorBanner = ({ level, children }: { level: HeadingLevel; children: ReactNode }) => (
-    <AlertMessage type="error" title="Fix the following errors:" level={level}>
+const ValidationErrorBanner = ({
+    level,
+    children,
+    className,
+}: {
+    level: HeadingLevel;
+    children: ReactNode;
+    className?: string;
+}) => (
+    <AlertMessage type="error" title="Fix the following errors:" level={level} className={className}>
         {children}
     </AlertMessage>
 );
 
 const ValidationErrorSection = ({ id, title, children }: { id: string; title: string; children: ReactNode }) => (
-    <div className="usa-prose">
+    <div>
         <p>
             For <a href={`#${id}`}>{title}</a>,
         </p>


### PR DESCRIPTION
## Description

Before:
<img width="1189" height="862" alt="image" src="https://github.com/user-attachments/assets/d40e28cd-cb8f-40d0-ad5b-75461518c55d" />

After:
<img width="1189" height="734" alt="image" src="https://github.com/user-attachments/assets/7e1c0c23-ba3d-4be9-a139-4b3b277775ad" />


## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-870)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
