### PR TITLE
APP-434: Disable Apollo's dev mode in production (i.e. on build)

### DIFF
--- a/apps/modernization-ui/vite.config.mts
+++ b/apps/modernization-ui/vite.config.mts
@@ -13,6 +13,10 @@ export default defineConfig(({ mode }) => {
 
     return {
         appType: 'spa',
+        define: {
+            //  Disable Apollo development mode checks/warnings in production
+            "globalThis.__DEV__": JSON.stringify(mode !== 'production'),
+        },
         plugins: [react(), tsconfigPaths()],
         publicDir: 'public',
         // Only needed for scss imports

--- a/apps/modernization-ui/vite.config.mts
+++ b/apps/modernization-ui/vite.config.mts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
         appType: 'spa',
         define: {
             //  Disable Apollo development mode checks/warnings in production
-            "globalThis.__DEV__": JSON.stringify(mode !== 'production'),
+            'globalThis.__DEV__': JSON.stringify(mode !== 'production'),
         },
         plugins: [react(), tsconfigPaths()],
         publicDir: 'public',


### PR DESCRIPTION
## Description

This PR disables the Apollo Client's "development mode" when in production (i.e. when Vite's `mode` parameter is set to `production`, which happens by default on build.

- https://www.apollographql.com/docs/react/development-testing/reducing-bundle-size#turning-off-development-mode
- https://vite.dev/guide/env-and-mode#modes

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-434)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
