### PR TITLE
[APP-835] Clean up unused fields in report spec and report result

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportSpecBuilder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportSpecBuilder.java
@@ -124,7 +124,6 @@ public class ReportSpecBuilder {
         isBuiltin,
         reportTitle,
         libraryName,
-        dataSourceName,
         subsetQuery,
         columnMap,
         orderbyCriteria,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportSpecBuilder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportSpecBuilder.java
@@ -122,7 +122,6 @@ public class ReportSpecBuilder {
     return new ReportSpec(
         isExport,
         isBuiltin,
-        reportTitle,
         libraryName,
         subsetQuery,
         columnMap,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportSpecBuilder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/ReportSpecBuilder.java
@@ -89,7 +89,6 @@ public class ReportSpecBuilder {
 
     boolean isExport = reportExecRequest.isExport();
     boolean isBuiltin = reportLibrary.isBuiltin();
-    String reportTitle = reportConfig.title();
     String libraryName = reportConfig.library().name();
     String dataSourceName =
         dataSourceNameUtils.buildDataSourceName(reportConfig.dataSource().name());

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/LibraryExecutionResult.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/LibraryExecutionResult.java
@@ -1,15 +1,9 @@
 package gov.cdc.nbs.report.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /** Model returned from the report-execution service when a library is invoked */
 public record LibraryExecutionResult(
-    @Schema(
-            requiredMode = Schema.RequiredMode.REQUIRED,
-            allowableValues = {"table"})
-        @JsonProperty("content_type")
-        String contentType,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String content,
     String subheader,
     String description) {}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/LibraryExecutionResult.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/LibraryExecutionResult.java
@@ -11,6 +11,5 @@ public record LibraryExecutionResult(
         @JsonProperty("content_type")
         String contentType,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String content,
-    String header,
     String subheader,
     String description) {}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/LibraryExecutionResult.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/LibraryExecutionResult.java
@@ -1,9 +1,10 @@
 package gov.cdc.nbs.report.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /** Model returned from the report-execution service when a library is invoked */
 public record LibraryExecutionResult(
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String content,
-    String subheader,
+    @JsonProperty("context_header") String contextHeader,
     String description) {}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/ReportSpec.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/ReportSpec.java
@@ -8,7 +8,6 @@ public record ReportSpec(
     @JsonProperty(value = "is_builtin", required = true) boolean isBuiltin,
     @JsonProperty(value = "report_title", required = true) String reportTitle,
     @JsonProperty(value = "library_name", required = true) String libraryName,
-    @JsonProperty(value = "data_source_name", required = true) String dataSourceName,
     @JsonProperty(value = "subset_query", required = true) String subsetQuery,
     @JsonProperty(value = "column_map") List<List<String>> columnMap,
     @JsonProperty(value = "sort_by") String sortBy,

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/ReportSpec.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/models/ReportSpec.java
@@ -6,7 +6,6 @@ import java.util.List;
 public record ReportSpec(
     @JsonProperty(value = "is_export", required = true) boolean isExport,
     @JsonProperty(value = "is_builtin", required = true) boolean isBuiltin,
-    @JsonProperty(value = "report_title", required = true) String reportTitle,
     @JsonProperty(value = "library_name", required = true) String libraryName,
     @JsonProperty(value = "subset_query", required = true) String subsetQuery,
     @JsonProperty(value = "column_map") List<List<String>> columnMap,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportControllerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportControllerTest.java
@@ -801,7 +801,6 @@ class ReportControllerTest {
         new LibraryExecutionResult(
             "table",
             "report_uid,data_source_uid,add_reason_cd,add_time,add_user_uid,desc_txt,effective_from_time,effective_to_time,report_title,report_type_codestatus_time",
-            "result header",
             "result subheader",
             "result description"),
         "SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]",

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportControllerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportControllerTest.java
@@ -800,7 +800,7 @@ class ReportControllerTest {
     return new ReportExecutionResult(
         new LibraryExecutionResult(
             "report_uid,data_source_uid,add_reason_cd,add_time,add_user_uid,desc_txt,effective_from_time,effective_to_time,report_title,report_type_codestatus_time",
-            "result subheader",
+            "result context header",
             "result description"),
         "SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]",
         LocalDateTime.of(2025, Month.MAY, 5, 12, 23));

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportControllerTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportControllerTest.java
@@ -799,7 +799,6 @@ class ReportControllerTest {
   private ReportExecutionResult getReportExecutionResponse() {
     return new ReportExecutionResult(
         new LibraryExecutionResult(
-            "table",
             "report_uid,data_source_uid,add_reason_cd,add_time,add_user_uid,desc_txt,effective_from_time,effective_to_time,report_title,report_type_codestatus_time",
             "result subheader",
             "result description"),

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
@@ -114,7 +114,6 @@ class ReportExecutionServiceClientTest {
   private ReportExecutionResult getReportExecutionResponse() {
     return new ReportExecutionResult(
         new LibraryExecutionResult(
-            "table",
             "report_uid,data_source _uid,add_reason_cd,add_time,add_user_uid,desc_txt,effective_from_time,effective_to_time,report_title,report_type_codestatus_time",
             "result subheader",
             "result description"),

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
@@ -62,7 +62,6 @@ class ReportExecutionServiceClientTest {
             true,
             "Test Report",
             "nbs_custom",
-            "[NBS_ODSE].[dbo].[PHCDemographic]",
             "SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]",
             null,
             null,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
@@ -116,7 +116,6 @@ class ReportExecutionServiceClientTest {
         new LibraryExecutionResult(
             "table",
             "report_uid,data_source _uid,add_reason_cd,add_time,add_user_uid,desc_txt,effective_from_time,effective_to_time,report_title,report_type_codestatus_time",
-            "result header",
             "result subheader",
             "result description"),
         "SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]",

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
@@ -115,7 +115,7 @@ class ReportExecutionServiceClientTest {
     return new ReportExecutionResult(
         new LibraryExecutionResult(
             "report_uid,data_source _uid,add_reason_cd,add_time,add_user_uid,desc_txt,effective_from_time,effective_to_time,report_title,report_type_codestatus_time",
-            "result subheader",
+            "result context header",
             "result description"),
         "SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]",
         LocalDateTime.of(2025, Month.MAY, 5, 12, 23));

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportExecutionServiceClientTest.java
@@ -60,7 +60,6 @@ class ReportExecutionServiceClientTest {
         new ReportSpec(
             true,
             true,
-            "Test Report",
             "nbs_custom",
             "SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]",
             null,

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportSpecBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportSpecBuilderTest.java
@@ -156,7 +156,6 @@ class ReportSpecBuilderTest {
 
     assertThat(reportSpec.isBuiltin()).isEqualTo(reportConfig.library().isBuiltin());
     assertThat(reportSpec.isExport()).isEqualTo(request.isExport());
-    assertThat(reportSpec.reportTitle()).isEqualTo(reportConfig.title());
     assertThat(reportSpec.libraryName()).isEqualTo(reportConfig.library().name());
 
     assertThat(reportSpec.subsetQuery())

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportSpecBuilderTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/ReportSpecBuilderTest.java
@@ -158,7 +158,6 @@ class ReportSpecBuilderTest {
     assertThat(reportSpec.isExport()).isEqualTo(request.isExport());
     assertThat(reportSpec.reportTitle()).isEqualTo(reportConfig.title());
     assertThat(reportSpec.libraryName()).isEqualTo(reportConfig.library().name());
-    assertThat(reportSpec.dataSourceName()).isEqualTo("[NBS_ODSE].[dbo].[NBS_configuration]");
 
     assertThat(reportSpec.subsetQuery())
         .isEqualTo(

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/models/ReportSpecTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/models/ReportSpecTest.java
@@ -15,7 +15,6 @@ class ReportSpecTest {
         new ReportSpec(
             true,
             true,
-            "Test Report",
             "nbs_custom",
             "SELECT * FROM [NBS_ODSE].[dbo].[NBS_configuration]",
             null,
@@ -25,7 +24,6 @@ class ReportSpecTest {
 
     assertThat(reportSpec.isBuiltin()).isTrue();
     assertThat(reportSpec.isExport()).isTrue();
-    assertThat(reportSpec.reportTitle()).isEqualTo("Test Report");
     assertThat(reportSpec.libraryName()).isEqualTo("nbs_custom");
     assertThat(reportSpec.subsetQuery())
         .isEqualTo("SELECT * FROM [NBS_ODSE].[dbo].[NBS_configuration]");

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/models/ReportSpecTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/models/ReportSpecTest.java
@@ -17,7 +17,6 @@ class ReportSpecTest {
             true,
             "Test Report",
             "nbs_custom",
-            "nbs_rdb.investigation",
             "SELECT * FROM [NBS_ODSE].[dbo].[NBS_configuration]",
             null,
             "UPPER([Column Title]) ASC",
@@ -28,7 +27,6 @@ class ReportSpecTest {
     assertThat(reportSpec.isExport()).isTrue();
     assertThat(reportSpec.reportTitle()).isEqualTo("Test Report");
     assertThat(reportSpec.libraryName()).isEqualTo("nbs_custom");
-    assertThat(reportSpec.dataSourceName()).isEqualTo("nbs_rdb.investigation");
     assertThat(reportSpec.subsetQuery())
         .isEqualTo("SELECT * FROM [NBS_ODSE].[dbo].[NBS_configuration]");
     assertThat(reportSpec.sortBy()).isEqualTo("UPPER([Column Title]) ASC");

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -188,7 +188,6 @@ const MOCK_BASIC_FILTER = {
 
 const MOCK_RESULT: generated.ReportExecutionResult = {
     result: {
-        header: 'Title',
         content: 'I am the result',
     },
     query: 'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]',

--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -188,7 +188,6 @@ const MOCK_BASIC_FILTER = {
 
 const MOCK_RESULT: generated.ReportExecutionResult = {
     result: {
-        content_type: generated.LibraryExecutionResult.content_type.TABLE,
         header: 'Title',
         content: 'I am the result',
     },

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
@@ -1,12 +1,11 @@
 import { getByText, queryByRole, render } from '@testing-library/react';
-import { LibraryExecutionResult, ReportExecutionResult } from 'generated';
+import { ReportExecutionResult } from 'generated';
 import { ResultDataPage } from './ResultDataPage';
 
 describe('ResultDataPage', () => {
     it('renders bare bones report result', () => {
         const result: ReportExecutionResult = {
             result: {
-                content_type: LibraryExecutionResult.content_type.TABLE,
                 content: 'a,b,c',
             },
             query: 'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]',
@@ -32,7 +31,6 @@ describe('ResultDataPage', () => {
     it('renders full report result', () => {
         const result: ReportExecutionResult = {
             result: {
-                content_type: LibraryExecutionResult.content_type.TABLE,
                 content: 'a,b,c\n1,2,3',
                 context_header: 'Georgia | Pertussis, Measles',
                 description: '**bold text**\n\n* a list item',

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
@@ -34,7 +34,7 @@ describe('ResultDataPage', () => {
             result: {
                 content_type: LibraryExecutionResult.content_type.TABLE,
                 content: 'a,b,c\n1,2,3',
-                subheader: 'Georgia | Pertussis, Measles',
+                context_header: 'Georgia | Pertussis, Measles',
                 description: '**bold text**\n\n* a list item',
             },
             query: 'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]',

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
@@ -26,7 +26,7 @@ const ResultDataPage = ({
     result: {
         query,
         timestamp,
-        result: { subheader, description, content },
+        result: { context_header, description, content },
     },
     title,
     dataSourceName,
@@ -51,7 +51,7 @@ const ResultDataPage = ({
         .replace(' ORDER BY ', '\nORDER BY ');
 
     return (
-        <ReportLayout title={title} subtitle={subheader} noSkipLink={true}>
+        <ReportLayout title={title} subtitle={context_header} noSkipLink={true}>
             <div className={layoutStyes.columnContent}>
                 {(errors?.length ?? 0) > 0 && (
                     <AlertMessage type="error" title="There were errors parsing the result:">

--- a/apps/modernization-ui/src/generated/index.ts
+++ b/apps/modernization-ui/src/generated/index.ts
@@ -41,7 +41,7 @@ export type { GenderDemographic } from './models/GenderDemographic';
 export type { GeneralInformationDemographic } from './models/GeneralInformationDemographic';
 export type { IdentificationDemographic } from './models/IdentificationDemographic';
 export type { Library } from './models/Library';
-export { LibraryExecutionResult } from './models/LibraryExecutionResult';
+export type { LibraryExecutionResult } from './models/LibraryExecutionResult';
 export type { LoginRequest } from './models/LoginRequest';
 export type { LoginResponse } from './models/LoginResponse';
 export type { Me } from './models/Me';

--- a/apps/modernization-ui/src/generated/models/LibraryExecutionResult.ts
+++ b/apps/modernization-ui/src/generated/models/LibraryExecutionResult.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 export type LibraryExecutionResult = {
     content: string;
-    subheader?: string;
+    context_header?: string;
     description?: string;
 };
 

--- a/apps/modernization-ui/src/generated/models/LibraryExecutionResult.ts
+++ b/apps/modernization-ui/src/generated/models/LibraryExecutionResult.ts
@@ -5,7 +5,6 @@
 export type LibraryExecutionResult = {
     content_type: LibraryExecutionResult.content_type;
     content: string;
-    header?: string;
     subheader?: string;
     description?: string;
 };

--- a/apps/modernization-ui/src/generated/models/LibraryExecutionResult.ts
+++ b/apps/modernization-ui/src/generated/models/LibraryExecutionResult.ts
@@ -3,14 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 export type LibraryExecutionResult = {
-    content_type: LibraryExecutionResult.content_type;
     content: string;
     subheader?: string;
     description?: string;
 };
-export namespace LibraryExecutionResult {
-    export enum content_type {
-        TABLE = 'table',
-    }
-}
 

--- a/apps/report-execution/src/execute_report.py
+++ b/apps/report-execution/src/execute_report.py
@@ -8,7 +8,7 @@ from .config import load_report_configurations
 from .db_transaction import check_row_limits, db_transaction
 
 
-def execute_report(report_spec: models.ReportSpec):
+def execute_report(report_spec: models.ReportSpec) -> models.ReportResult:
     """Execute a report spec by validating inputs, loading library, handling DB
     connection and transaction,and validating/processing results.
     """
@@ -22,7 +22,7 @@ def execute_report(report_spec: models.ReportSpec):
     with db_transaction(conn_string, report_spec.is_export) as trx:
         load_report_configurations(trx)
 
-        result = library.execute(
+        result: models.ReportResult = library.execute(
             trx,
             subset_query=report_spec.subset_query,
             data_source_name=report_spec.data_source_name,
@@ -33,10 +33,6 @@ def execute_report(report_spec: models.ReportSpec):
         )
 
     check_valid_result(result, report_spec)
-
-    # Most libraries won't have a specific header, so the report title is used
-    if result.header is None:
-        result.header = report_spec.report_title
 
     return result
 

--- a/apps/report-execution/src/execute_report.py
+++ b/apps/report-execution/src/execute_report.py
@@ -25,7 +25,6 @@ def execute_report(report_spec: models.ReportSpec) -> models.ReportResult:
         result: models.ReportResult = library.execute(
             trx,
             subset_query=report_spec.subset_query,
-            data_source_name=report_spec.data_source_name,
             sort_by=report_spec.sort_by,
             days_value=report_spec.days_value,
             column_map=report_spec.column_map,

--- a/apps/report-execution/src/libraries/nbs_custom.py
+++ b/apps/report-execution/src/libraries/nbs_custom.py
@@ -19,4 +19,4 @@ def execute(
     query = subset_query + ' ORDER BY ' + sort_by if sort_by else subset_query
     content = trx.query(query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/nbs_custom.py
+++ b/apps/report-execution/src/libraries/nbs_custom.py
@@ -5,7 +5,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     sort_by: str | None,
     **kwargs,
 ):

--- a/apps/report-execution/src/libraries/nbs_custom.py
+++ b/apps/report-execution/src/libraries/nbs_custom.py
@@ -19,6 +19,4 @@ def execute(
     query = subset_query + ' ORDER BY ' + sort_by if sort_by else subset_query
     content = trx.query(query)
 
-    header = f'Custom Report For Table: {data_source_name}'
-
-    return ReportResult(content_type='table', content=content, header=header)
+    return ReportResult(content_type='table', content=content)

--- a/apps/report-execution/src/libraries/nbs_sr_02.py
+++ b/apps/report-execution/src/libraries/nbs_sr_02.py
@@ -52,7 +52,6 @@ def execute(
 """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=content,
         subheader=subheader,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_02.py
+++ b/apps/report-execution/src/libraries/nbs_sr_02.py
@@ -1,6 +1,6 @@
 from src.db_transaction import Transaction
 from src.models import ReportResult
-from src.utils import gen_subheader
+from src.utils import gen_context_header
 
 
 def execute(
@@ -31,9 +31,9 @@ def execute(
         """
     )
 
-    # Get the unique state(s) in the data set for subheader display
+    # Get the unique state(s) in the data set for context_header display
     state_list = content.get_unique_column('State')
-    subheader = gen_subheader(states=state_list)
+    context_header = gen_context_header(states=state_list)
 
     description = """
 **<u>Report content</u>**
@@ -53,6 +53,6 @@ def execute(
 
     return ReportResult(
         content=content,
-        subheader=subheader,
+        context_header=context_header,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_02.py
+++ b/apps/report-execution/src/libraries/nbs_sr_02.py
@@ -6,7 +6,6 @@ from src.utils import gen_context_header
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 02: Cases of Reportable Diseases by County for Selected Time

--- a/apps/report-execution/src/libraries/nbs_sr_05.py
+++ b/apps/report-execution/src/libraries/nbs_sr_05.py
@@ -7,7 +7,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 05: Cases of Reportable Diseases for a specific state.

--- a/apps/report-execution/src/libraries/nbs_sr_05.py
+++ b/apps/report-execution/src/libraries/nbs_sr_05.py
@@ -181,7 +181,6 @@ def execute(
 """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=content,
         subheader=None,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_05.py
+++ b/apps/report-execution/src/libraries/nbs_sr_05.py
@@ -23,9 +23,9 @@ def execute(
     * Matched "export format"
     * Run doesn't include the Year and Cases columns
     * Run has columns in different order
-    * Use pipe separator instead of new line for subheader
+    * Use pipe separator instead of new line for context_header
     * Remove "by county" from the description since this isn't by county
-    * Removed state functionality from the subheader
+    * Removed state functionality from the context_header
     * Negative precentages are displayed with parentheses to match SAS
       output (e.g. -0.12 gets displayed as (12%)).  The SAS script uses
       the `percent9.0` format, meaning the result is always 9 characters
@@ -182,6 +182,6 @@ def execute(
 
     return ReportResult(
         content=content,
-        subheader=None,
+        context_header=None,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_07.py
+++ b/apps/report-execution/src/libraries/nbs_sr_07.py
@@ -64,7 +64,6 @@ def execute(
     """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=modified_table,
         subheader=nbs_sr_05_report_result.subheader,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_07.py
+++ b/apps/report-execution/src/libraries/nbs_sr_07.py
@@ -23,7 +23,7 @@ def execute(
     * Matched "export format"
     * Remove references to "Bar Graph" since export is a table
     * Use results of nbs_sr_05.py for the following:
-    * - subheader
+    * - context_header
     * - content (data is modified to fit expected table format of nbs_sr_07.py)
     """
     nbs_sr_05_report_result = execute_nbs_sr_05(
@@ -65,6 +65,6 @@ def execute(
 
     return ReportResult(
         content=modified_table,
-        subheader=nbs_sr_05_report_result.subheader,
+        context_header=nbs_sr_05_report_result.context_header,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_07.py
+++ b/apps/report-execution/src/libraries/nbs_sr_07.py
@@ -8,7 +8,6 @@ from src.models import ReportResult, Table
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 07: Cases of Selected Diseases vs. 5-Year Median for a
@@ -27,7 +26,7 @@ def execute(
     * - content (data is modified to fit expected table format of nbs_sr_07.py)
     """
     nbs_sr_05_report_result = execute_nbs_sr_05(
-        trx, subset_query, data_source_name, **kwargs
+        trx, subset_query, **kwargs
     )
     nbs_sr_05_report_result_rows = nbs_sr_05_report_result.content.data
 

--- a/apps/report-execution/src/libraries/nbs_sr_07.py
+++ b/apps/report-execution/src/libraries/nbs_sr_07.py
@@ -25,9 +25,7 @@ def execute(
     * - context_header
     * - content (data is modified to fit expected table format of nbs_sr_07.py)
     """
-    nbs_sr_05_report_result = execute_nbs_sr_05(
-        trx, subset_query, **kwargs
-    )
+    nbs_sr_05_report_result = execute_nbs_sr_05(trx, subset_query, **kwargs)
     nbs_sr_05_report_result_rows = nbs_sr_05_report_result.content.data
 
     modified_rows = list(

--- a/apps/report-execution/src/libraries/nbs_sr_08.py
+++ b/apps/report-execution/src/libraries/nbs_sr_08.py
@@ -1,6 +1,6 @@
 from src.db_transaction import Transaction
 from src.models import ReportResult
-from src.utils import gen_subheader
+from src.utils import gen_context_header
 
 
 def execute(
@@ -35,9 +35,9 @@ def execute(
         ORDER BY state, county;
         """
     )
-    # Get the unique state(s) in the data set for subheader display
+    # Get the unique state(s) in the data set for context_header display
     state_list = content.get_unique_column('State')
-    subheader = gen_subheader(states=state_list)
+    context_header = gen_context_header(states=state_list)
 
     description = """
 **<u>Report content</u>**
@@ -57,6 +57,6 @@ def execute(
 
     return ReportResult(
         content=content,
-        subheader=subheader,
+        context_header=context_header,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_08.py
+++ b/apps/report-execution/src/libraries/nbs_sr_08.py
@@ -56,7 +56,6 @@ def execute(
 """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=content,
         subheader=subheader,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_08.py
+++ b/apps/report-execution/src/libraries/nbs_sr_08.py
@@ -6,7 +6,6 @@ from src.utils import gen_context_header
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 08: Report of Disease Cases Over Selected Time Period.

--- a/apps/report-execution/src/libraries/nbs_sr_09.py
+++ b/apps/report-execution/src/libraries/nbs_sr_09.py
@@ -6,7 +6,6 @@ from src.utils import gen_context_header
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 09: Monthly Cases by Disease and County for Selected State

--- a/apps/report-execution/src/libraries/nbs_sr_09.py
+++ b/apps/report-execution/src/libraries/nbs_sr_09.py
@@ -85,7 +85,6 @@ def execute(
 """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=content,
         subheader=subheader,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_09.py
+++ b/apps/report-execution/src/libraries/nbs_sr_09.py
@@ -1,6 +1,6 @@
 from src.db_transaction import Transaction
 from src.models import ReportResult
-from src.utils import gen_subheader
+from src.utils import gen_context_header
 
 
 def execute(
@@ -62,7 +62,7 @@ def execute(
     )
 
     state_list = content.get_unique_column('State')
-    subheader = gen_subheader(states=state_list)
+    context_header = gen_context_header(states=state_list)
 
     description = """
 **<u>Report content</u>**
@@ -86,6 +86,6 @@ def execute(
 
     return ReportResult(
         content=content,
-        subheader=subheader,
+        context_header=context_header,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_11.py
+++ b/apps/report-execution/src/libraries/nbs_sr_11.py
@@ -58,7 +58,6 @@ selected by the user
 """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=content,
         subheader=subheader,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_11.py
+++ b/apps/report-execution/src/libraries/nbs_sr_11.py
@@ -6,7 +6,6 @@ from src.utils import gen_context_header
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 11: Cases of Selected Diseases By Year Over Time.

--- a/apps/report-execution/src/libraries/nbs_sr_11.py
+++ b/apps/report-execution/src/libraries/nbs_sr_11.py
@@ -1,6 +1,6 @@
 from src.db_transaction import Transaction
 from src.models import ReportResult
-from src.utils import gen_subheader
+from src.utils import gen_context_header
 
 
 def execute(
@@ -33,7 +33,7 @@ def execute(
 
     state_list = content.get_unique_column('State')
     condition_list = content.get_unique_column('Condition')
-    subheader = gen_subheader(
+    context_header = gen_context_header(
         states=state_list,
         diseases=condition_list,
     )
@@ -59,6 +59,6 @@ selected by the user
 
     return ReportResult(
         content=content,
-        subheader=subheader,
+        context_header=context_header,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_13.py
+++ b/apps/report-execution/src/libraries/nbs_sr_13.py
@@ -52,6 +52,6 @@ def execute(
 
     return ReportResult(
         content=content,
-        subheader=None,
+        context_header=None,
         description=description,
     )

--- a/apps/report-execution/src/libraries/nbs_sr_13.py
+++ b/apps/report-execution/src/libraries/nbs_sr_13.py
@@ -51,7 +51,6 @@ def execute(
 """  # noqa: E501
 
     return ReportResult(
-        content_type='table',
         content=content,
         subheader=None,
         description=description,

--- a/apps/report-execution/src/libraries/nbs_sr_13.py
+++ b/apps/report-execution/src/libraries/nbs_sr_13.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Standard Report 13: Counts of Selected Diseases By Case Status.

--- a/apps/report-execution/src/libraries/nbs_sr_18.py
+++ b/apps/report-execution/src/libraries/nbs_sr_18.py
@@ -5,7 +5,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """SR18: TB Case Verification Report. Computes statistics about TB cases.

--- a/apps/report-execution/src/libraries/nbs_sr_18.py
+++ b/apps/report-execution/src/libraries/nbs_sr_18.py
@@ -30,4 +30,4 @@ def execute(
 
     content = trx.query(query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/nbs_sr_19.py
+++ b/apps/report-execution/src/libraries/nbs_sr_19.py
@@ -93,4 +93,4 @@ def execute(
 
     content = trx.query(query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/nbs_sr_19.py
+++ b/apps/report-execution/src/libraries/nbs_sr_19.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     library_params: dict,
     **kwargs,
 ):

--- a/apps/report-execution/src/libraries/nbs_sr_20.py
+++ b/apps/report-execution/src/libraries/nbs_sr_20.py
@@ -25,4 +25,4 @@ def execute(
         columns=['monthYear', 'sasdate', 'counted_cases'], data=modified_rows
     )
 
-    return ReportResult(content_type='table', content=modified_table)
+    return ReportResult(content=modified_table)

--- a/apps/report-execution/src/libraries/nbs_sr_20.py
+++ b/apps/report-execution/src/libraries/nbs_sr_20.py
@@ -6,12 +6,11 @@ from src.models import ReportResult, Table
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """Wrapper report leveraging SR19 core engine with a modified column layout."""
     nbs_sr_19_report_result = execute_nbs_sr_19(
-        trx, subset_query, data_source_name, **kwargs
+        trx, subset_query, **kwargs
     )
     nbs_sr_19_report_result_rows = nbs_sr_19_report_result.content.data
 

--- a/apps/report-execution/src/libraries/nbs_sr_20.py
+++ b/apps/report-execution/src/libraries/nbs_sr_20.py
@@ -9,9 +9,7 @@ def execute(
     **kwargs,
 ):
     """Wrapper report leveraging SR19 core engine with a modified column layout."""
-    nbs_sr_19_report_result = execute_nbs_sr_19(
-        trx, subset_query, **kwargs
-    )
+    nbs_sr_19_report_result = execute_nbs_sr_19(trx, subset_query, **kwargs)
     nbs_sr_19_report_result_rows = nbs_sr_19_report_result.content.data
 
     # Mapping:

--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -36,7 +36,6 @@ from src.models import ReportResult, Table
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     library_params: dict,
     **kwargs,
 ):

--- a/apps/report-execution/src/libraries/pa_01.py
+++ b/apps/report-execution/src/libraries/pa_01.py
@@ -127,7 +127,7 @@ def execute(
             data=[],
         )
 
-        return ReportResult(content_type='table', content=content)
+        return ReportResult(content=content)
 
     # run queries
     tables: dict[str, Table] = {}
@@ -197,7 +197,7 @@ def execute(
         data=output_rows,
     )
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)
 
 
 def _get_workers(case_interview_rows: Table) -> list[Pa01Worker]:

--- a/apps/report-execution/src/libraries/pa_03.py
+++ b/apps/report-execution/src/libraries/pa_03.py
@@ -305,4 +305,4 @@ def execute(
         data=rows,
     )
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/pa_03.py
+++ b/apps/report-execution/src/libraries/pa_03.py
@@ -96,7 +96,6 @@ def _ratio(numerator: int, denominator: int) -> float | None:
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """PA03 STD Program Report: Internet Partner Services Report.

--- a/apps/report-execution/src/libraries/pa_05.py
+++ b/apps/report-execution/src/libraries/pa_05.py
@@ -7,7 +7,6 @@ from src.models import ReportResult, Table
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """PA05 Worker Interview Activity Report.

--- a/apps/report-execution/src/libraries/pa_05.py
+++ b/apps/report-execution/src/libraries/pa_05.py
@@ -70,4 +70,4 @@ def execute(
         data=rows,
     )
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
@@ -118,9 +118,8 @@ def execute(
 
     content = trx.query(full_query)
 
-    header = 'Potential Duplicate Investigations'
     subheader = f'Duplicate Investigations Time Frame: {days_value} Days'
 
     return ReportResult(
-        content_type='table', content=content, header=header, subheader=subheader
+        content_type='table', content=content, subheader=subheader
     )

--- a/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
@@ -14,7 +14,6 @@ REQUIRED_COL_NAMES = [col['name'] for col in REQUIRED_COLS]
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     days_value: None | int,
     column_map: list[list[str]],
     sort_by: str | None,

--- a/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
@@ -121,5 +121,5 @@ def execute(
     subheader = f'Duplicate Investigations Time Frame: {days_value} Days'
 
     return ReportResult(
-        content_type='table', content=content, subheader=subheader
+        content=content, subheader=subheader
     )

--- a/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
@@ -120,6 +120,4 @@ def execute(
 
     subheader = f'Duplicate Investigations Time Frame: {days_value} Days'
 
-    return ReportResult(
-        content=content, subheader=subheader
-    )
+    return ReportResult(content=content, subheader=subheader)

--- a/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/src/libraries/potntl_dup_inv_sum.py
@@ -118,6 +118,6 @@ def execute(
 
     content = trx.query(full_query)
 
-    subheader = f'Duplicate Investigations Time Frame: {days_value} Days'
+    context_header = f'Duplicate Investigations Time Frame: {days_value} Days'
 
-    return ReportResult(content=content, subheader=subheader)
+    return ReportResult(content=content, context_header=context_header)

--- a/apps/report-execution/src/libraries/qa_01.py
+++ b/apps/report-execution/src/libraries/qa_01.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """QA01 STD Program Report: Interview Record Listing.

--- a/apps/report-execution/src/libraries/qa_01.py
+++ b/apps/report-execution/src/libraries/qa_01.py
@@ -58,4 +58,4 @@ def execute(
 
     content = trx.query(sql_query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/qa_03.py
+++ b/apps/report-execution/src/libraries/qa_03.py
@@ -57,4 +57,4 @@ def execute(
 
     content = trx.query(sql_query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/qa_03.py
+++ b/apps/report-execution/src/libraries/qa_03.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """QA03 STD Program Report: Case Listing Report.

--- a/apps/report-execution/src/libraries/qa_04.py
+++ b/apps/report-execution/src/libraries/qa_04.py
@@ -60,4 +60,4 @@ def execute(
         CONFIRMATION_DT;
     """
     content = trx.query(full_query)
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/qa_04.py
+++ b/apps/report-execution/src/libraries/qa_04.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """QA04 Cases Missing Lab and/or Treatment.

--- a/apps/report-execution/src/libraries/qa_05.py
+++ b/apps/report-execution/src/libraries/qa_05.py
@@ -108,6 +108,5 @@ def execute(
     )
 
     return ReportResult(
-        content_type='table',
         content=content,
     )

--- a/apps/report-execution/src/libraries/qa_05.py
+++ b/apps/report-execution/src/libraries/qa_05.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """QA Report 05: Number of Records Entered by User ID.

--- a/apps/report-execution/src/libraries/qa_06.py
+++ b/apps/report-execution/src/libraries/qa_06.py
@@ -116,4 +116,4 @@ def execute(
 
     content = trx.query(query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/qa_06.py
+++ b/apps/report-execution/src/libraries/qa_06.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """QA Report 06: Patients with Multiple Cases. This report generates a list,

--- a/apps/report-execution/src/libraries/qa_07.py
+++ b/apps/report-execution/src/libraries/qa_07.py
@@ -189,4 +189,4 @@ def execute(
     ORDER BY f.PATIENT_NAME, f.DIAGNOSIS, f.FL_FUP_EXAM_DT, f.INVESTIGATION_KEY
     """
     content = trx.query(sql)
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/libraries/qa_07.py
+++ b/apps/report-execution/src/libraries/qa_07.py
@@ -7,7 +7,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     library_params: dict,
     **kwargs,
 ):

--- a/apps/report-execution/src/libraries/qa_10.py
+++ b/apps/report-execution/src/libraries/qa_10.py
@@ -6,7 +6,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """QA10 STD Program Report: Interviews - Pregnant/Recent Birth Report.

--- a/apps/report-execution/src/libraries/qa_10.py
+++ b/apps/report-execution/src/libraries/qa_10.py
@@ -63,4 +63,4 @@ def execute(
 
     content = trx.query(sql_query)
 
-    return ReportResult(content_type='table', content=content)
+    return ReportResult(content=content)

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, Json, PlainSerializer

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -118,6 +118,5 @@ class ReportResult(BaseModel):
 
     content_type: Literal['table']
     content: Annotated[Table, PlainSerializer(serialize_table)]
-    header: str | None = None
     subheader: str | None = None
     description: str | None = None

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -117,5 +117,5 @@ class ReportResult(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     content: Annotated[Table, PlainSerializer(serialize_table)]
-    subheader: str | None = None
+    context_header: str | None = None
     description: str | None = None

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -14,7 +14,6 @@ class ReportSpec(BaseModel):
     is_builtin: bool
     report_title: str = Field(min_length=1)
     library_name: str = Field(min_length=1)
-    data_source_name: str = Field(min_length=1)
     subset_query: str = Field(min_length=1)
     sort_by: str | None = None
     days_value: int | None = None  # Specific to potntl_dup_inv_sum

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -116,7 +116,6 @@ class ReportResult(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    content_type: Literal['table']
     content: Annotated[Table, PlainSerializer(serialize_table)]
     subheader: str | None = None
     description: str | None = None

--- a/apps/report-execution/src/models.py
+++ b/apps/report-execution/src/models.py
@@ -12,7 +12,6 @@ class ReportSpec(BaseModel):
 
     is_export: bool
     is_builtin: bool
-    report_title: str = Field(min_length=1)
     library_name: str = Field(min_length=1)
     subset_query: str = Field(min_length=1)
     sort_by: str | None = None

--- a/apps/report-execution/src/utils.py
+++ b/apps/report-execution/src/utils.py
@@ -55,11 +55,11 @@ def parse_date(date_str: str, date_format: str) -> datetime | None:
             return None
 
 
-def gen_subheader(
+def gen_context_header(
     states: list[str | None] | None = None,
     diseases: list[str] | None = None,
 ) -> str:
-    """Generate a subheader for reports from various optional components.
+    """Generate a context_header for reports from various optional components.
 
     Note: Caller is responsible for sorting/deduplicating states and diseases.
 
@@ -68,7 +68,7 @@ def gen_subheader(
         diseases: Optional list of disease strings (already sorted and deduplicated)
 
     Returns:
-        Formatted subheader string
+        Formatted context_header string
     """
     parts = []
 

--- a/apps/report-execution/tests/execute_report.py
+++ b/apps/report-execution/tests/execute_report.py
@@ -21,7 +21,6 @@ class TestExecuteReport:
         )
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Custom Report For Table: random_db_table_0'
         assert result.subheader is None
         assert result.description is None
         assert result.content.columns == ['id', 'name']
@@ -63,7 +62,6 @@ class TestExecuteReport:
         )
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Custom Report For Table: random_db_table_0'
         assert result.content.columns == ['id', 'name']
         assert len(result.content.data) == 4
 

--- a/apps/report-execution/tests/execute_report.py
+++ b/apps/report-execution/tests/execute_report.py
@@ -20,7 +20,6 @@ class TestExecuteReport:
             }
         )
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.subheader is None
         assert result.description is None
         assert result.content.columns == ['id', 'name']
@@ -61,7 +60,6 @@ class TestExecuteReport:
             }
         )
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.content.columns == ['id', 'name']
         assert len(result.content.data) == 4
 

--- a/apps/report-execution/tests/execute_report.py
+++ b/apps/report-execution/tests/execute_report.py
@@ -13,7 +13,6 @@ class TestExecuteReport:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'Test Report',
                 'library_name': 'nbs_custom',
                 'subset_query': 'SELECT * FROM test',
             }
@@ -31,7 +30,6 @@ class TestExecuteReport:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'Test Report',
                 'library_name': 'missing_library',
                 'subset_query': 'SELECT * FROM test',
             }
@@ -50,7 +48,6 @@ class TestExecuteReport:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'Test Report with Params',
                 'library_name': 'nbs_custom',
                 'subset_query': 'SELECT * FROM test',
                 'library_params': '{"report_days": 30}',
@@ -67,7 +64,6 @@ class TestExecuteReport:
                 {
                     'is_export': True,
                     'is_builtin': True,
-                    'report_title': 'Invalid Params',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM test',
                     'library_params': 'not a json object',

--- a/apps/report-execution/tests/execute_report.py
+++ b/apps/report-execution/tests/execute_report.py
@@ -15,7 +15,6 @@ class TestExecuteReport:
                 'is_builtin': True,
                 'report_title': 'Test Report',
                 'library_name': 'nbs_custom',
-                'data_source_name': 'random_db_table_0',
                 'subset_query': 'SELECT * FROM test',
             }
         )
@@ -34,7 +33,6 @@ class TestExecuteReport:
                 'is_builtin': True,
                 'report_title': 'Test Report',
                 'library_name': 'missing_library',
-                'data_source_name': 'random_db_table_0',
                 'subset_query': 'SELECT * FROM test',
             }
         )
@@ -54,7 +52,6 @@ class TestExecuteReport:
                 'is_builtin': True,
                 'report_title': 'Test Report with Params',
                 'library_name': 'nbs_custom',
-                'data_source_name': 'random_db_table_0',
                 'subset_query': 'SELECT * FROM test',
                 'library_params': '{"report_days": 30}',
             }
@@ -72,7 +69,6 @@ class TestExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Invalid Params',
                     'library_name': 'nbs_custom',
-                    'data_source_name': 'random_db_table_0',
                     'subset_query': 'SELECT * FROM test',
                     'library_params': 'not a json object',
                 }

--- a/apps/report-execution/tests/execute_report.py
+++ b/apps/report-execution/tests/execute_report.py
@@ -20,7 +20,7 @@ class TestExecuteReport:
             }
         )
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
         assert result.content.columns == ['id', 'name']
 

--- a/apps/report-execution/tests/integration/assets/custom_library.py
+++ b/apps/report-execution/tests/integration/assets/custom_library.py
@@ -5,7 +5,6 @@ from src.models import ReportResult
 def execute(
     trx: Transaction,
     subset_query: str,
-    data_source_name: str,
     **kwargs,
 ):
     """This is a stub custom library just to start to get the interface hooked up."""

--- a/apps/report-execution/tests/integration/assets/custom_library.py
+++ b/apps/report-execution/tests/integration/assets/custom_library.py
@@ -12,5 +12,5 @@ def execute(
     content = trx.query(subset_query)
 
     return ReportResult(
-        content_type='table', content=content, description='Custom pass through query'
+        content=content, description='Custom pass through query'
     )

--- a/apps/report-execution/tests/integration/assets/custom_library.py
+++ b/apps/report-execution/tests/integration/assets/custom_library.py
@@ -11,6 +11,4 @@ def execute(
     """This is a stub custom library just to start to get the interface hooked up."""
     content = trx.query(subset_query)
 
-    return ReportResult(
-        content=content, description='Custom pass through query'
-    )
+    return ReportResult(content=content, description='Custom pass through query')

--- a/apps/report-execution/tests/integration/execute_report.py
+++ b/apps/report-execution/tests/integration/execute_report.py
@@ -45,10 +45,6 @@ class TestIntegrationExecuteReport:
         )
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert (
-            result.header
-            == 'Custom Report For Table: [NBS_ODSE].[dbo].[Filter_operator]'
-        )
         assert result.content.columns == [
             'filter_operator_uid',
             'filter_operator_code',
@@ -342,7 +338,6 @@ class TestIntegrationExecuteReport:
             def execute_method(self, trx, subset_query, data_source_name, **kwargs):
                 return {
                     'content_type': 'table',
-                    'header': 'Custom Report: [NBS_ODSE].[dbo].[Filter_operator]',
                     'content': {
                         'columns': ['filter_operator_uid', 'filter_operator_code'],
                     },
@@ -387,7 +382,6 @@ class TestIntegrationExecuteReport:
             def execute_method(self, trx, subset_query, data_source_name, **kwargs):
                 return {
                     'content_type': 'table',
-                    'header': 'Custom Report: [NBS_ODSE].[dbo].[Filter_operator]',
                     'content': {
                         'data': [
                             (1, 'Code1'),

--- a/apps/report-execution/tests/integration/execute_report.py
+++ b/apps/report-execution/tests/integration/execute_report.py
@@ -38,7 +38,6 @@ class TestIntegrationExecuteReport:
                 'report_title': 'Test Report',
                 'library_name': 'nbs_custom',
                 # Filter operator is used here as it is a stable, small table
-                'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 'sort_by': 'UPPER([filter_operator_code]) ASC',
             }
@@ -66,7 +65,6 @@ class TestIntegrationExecuteReport:
                 'report_title': 'Test Report',
                 'library_name': 'nbs_custom',
                 # Filter operator is used here as it is a stable, small table
-                'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                 'subset_query': 'SELECT *; FROM [NBS_ODSE].[dbo].[Filter_operator]',
             }
         )
@@ -93,7 +91,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )
@@ -128,7 +125,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )
@@ -165,7 +161,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )
@@ -206,7 +201,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )
@@ -231,7 +225,6 @@ class TestIntegrationExecuteReport:
             'is_builtin',
             'report_title',
             'library_name',
-            'data_source_name',
             'subset_query',
         ],
     )
@@ -241,7 +234,6 @@ class TestIntegrationExecuteReport:
             'is_builtin': True,
             'report_title': 'Test Report',
             'library_name': 'nbs_custom',
-            'data_source_name': '[NBS_ODSE].[dbo].[Filter_code]',
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',
         }
         invalid_spec.pop(missing_prop)
@@ -268,7 +260,6 @@ class TestIntegrationExecuteReport:
         [
             'report_title',
             'library_name',
-            'data_source_name',
             'subset_query',
         ],
     )
@@ -278,7 +269,6 @@ class TestIntegrationExecuteReport:
             'is_builtin': True,
             'report_title': 'Test Report',
             'library_name': 'nbs_custom',
-            'data_source_name': '[NBS_ODSE].[dbo].[Filter_code]',
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',
         }
         invalid_spec.pop(empty_string_prop)
@@ -303,7 +293,7 @@ class TestIntegrationExecuteReport:
 
     def test_execute_report_missing_result(self, monkeypatch):
         def get_lib_returning_none(library_name: str, is_builtin: bool, **kwargs):
-            def execute_method(self, trx, subset_query, data_source_name, **kwargs):
+            def execute_method(self, trx, subset_query, **kwargs):
                 return None
 
             mock_library = type(
@@ -321,7 +311,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )
@@ -334,7 +323,7 @@ class TestIntegrationExecuteReport:
 
     def test_execute_report_result_missing_content_data(self, monkeypatch):
         def get_lib_without_data(library_name: str, is_builtin: bool):
-            def execute_method(self, trx, subset_query, data_source_name, **kwargs):
+            def execute_method(self, trx, subset_query, **kwargs):
                 return {
                     'content': {
                         'columns': ['filter_operator_uid', 'filter_operator_code'],
@@ -356,7 +345,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )
@@ -377,7 +365,7 @@ class TestIntegrationExecuteReport:
 
     def test_execute_report_result_missing_content_columns(self, monkeypatch):
         def get_lib_without_columns(library_name: str, is_builtin: bool):
-            def execute_method(self, trx, subset_query, data_source_name, **kwargs):
+            def execute_method(self, trx, subset_query, **kwargs):
                 return {
                     'content': {
                         'data': [
@@ -402,7 +390,6 @@ class TestIntegrationExecuteReport:
                     'is_builtin': True,
                     'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
-                    'data_source_name': '[NBS_ODSE].[dbo].[Filter_operator]',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
             )

--- a/apps/report-execution/tests/integration/execute_report.py
+++ b/apps/report-execution/tests/integration/execute_report.py
@@ -44,7 +44,6 @@ class TestIntegrationExecuteReport:
             }
         )
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.content.columns == [
             'filter_operator_uid',
             'filter_operator_code',
@@ -337,7 +336,6 @@ class TestIntegrationExecuteReport:
         def get_lib_without_data(library_name: str, is_builtin: bool):
             def execute_method(self, trx, subset_query, data_source_name, **kwargs):
                 return {
-                    'content_type': 'table',
                     'content': {
                         'columns': ['filter_operator_uid', 'filter_operator_code'],
                     },
@@ -381,7 +379,6 @@ class TestIntegrationExecuteReport:
         def get_lib_without_columns(library_name: str, is_builtin: bool):
             def execute_method(self, trx, subset_query, data_source_name, **kwargs):
                 return {
-                    'content_type': 'table',
                     'content': {
                         'data': [
                             (1, 'Code1'),

--- a/apps/report-execution/tests/integration/execute_report.py
+++ b/apps/report-execution/tests/integration/execute_report.py
@@ -35,7 +35,6 @@ class TestIntegrationExecuteReport:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'Test Report',
                 'library_name': 'nbs_custom',
                 # Filter operator is used here as it is a stable, small table
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
@@ -62,7 +61,6 @@ class TestIntegrationExecuteReport:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'Test Report',
                 'library_name': 'nbs_custom',
                 # Filter operator is used here as it is a stable, small table
                 'subset_query': 'SELECT *; FROM [NBS_ODSE].[dbo].[Filter_operator]',
@@ -89,7 +87,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': False,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
@@ -123,7 +120,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': True,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
@@ -159,7 +155,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': False,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
@@ -199,7 +194,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': False,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
@@ -223,7 +217,6 @@ class TestIntegrationExecuteReport:
         [
             'is_export',
             'is_builtin',
-            'report_title',
             'library_name',
             'subset_query',
         ],
@@ -232,7 +225,6 @@ class TestIntegrationExecuteReport:
         invalid_spec = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'Test Report',
             'library_name': 'nbs_custom',
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',
         }
@@ -258,7 +250,6 @@ class TestIntegrationExecuteReport:
     @pytest.mark.parametrize(
         'empty_string_prop',
         [
-            'report_title',
             'library_name',
             'subset_query',
         ],
@@ -267,7 +258,6 @@ class TestIntegrationExecuteReport:
         invalid_spec = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'Test Report',
             'library_name': 'nbs_custom',
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',
         }
@@ -309,7 +299,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': False,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
@@ -343,7 +332,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': False,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }
@@ -388,7 +376,6 @@ class TestIntegrationExecuteReport:
                 {
                     'is_export': False,
                     'is_builtin': True,
-                    'report_title': 'Test Report',
                     'library_name': 'nbs_custom',
                     'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_operator]',
                 }

--- a/apps/report-execution/tests/integration/libraries/custom_library.py
+++ b/apps/report-execution/tests/integration/libraries/custom_library.py
@@ -16,7 +16,6 @@ class TestCustomLibrary:
             'report_title': 'Test Report',
             'library_name': 'custom_library',
             # Filter code is used here as it is a stable, small table
-            'data_source_name': '[NBS_ODSE].[dbo].[Filter_code]',
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',
         }
 

--- a/apps/report-execution/tests/integration/libraries/custom_library.py
+++ b/apps/report-execution/tests/integration/libraries/custom_library.py
@@ -13,7 +13,6 @@ class TestCustomLibrary:
         report_spec = {
             'is_export': True,
             'is_builtin': False,
-            'report_title': 'Test Report',
             'library_name': 'custom_library',
             # Filter code is used here as it is a stable, small table
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',

--- a/apps/report-execution/tests/integration/libraries/nbs_custom.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_custom.py
@@ -20,7 +20,6 @@ class TestIntegrationNbsCustomLibrary:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_custom',
                 'subset_query': """
                         SELECT PROGRAM_JURISDICTION_OID,
@@ -58,7 +57,6 @@ class TestIntegrationNbsCustomLibrary:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_custom',
                 'subset_query': """
                         SELECT PROGRAM_JURISDICTION_OID,
@@ -86,7 +84,6 @@ class TestIntegrationNbsCustomLibrary:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_custom',
                 'subset_query': """
                         SELECT PROGRAM_JURISDICTION_OID,

--- a/apps/report-execution/tests/integration/libraries/nbs_custom.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_custom.py
@@ -35,7 +35,6 @@ class TestIntegrationNbsCustomLibrary:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 500
@@ -74,7 +73,6 @@ class TestIntegrationNbsCustomLibrary:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 500
@@ -104,7 +102,6 @@ class TestIntegrationNbsCustomLibrary:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) == 0
         assert result.content.columns == [

--- a/apps/report-execution/tests/integration/libraries/nbs_custom.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_custom.py
@@ -22,7 +22,6 @@ class TestIntegrationNbsCustomLibrary:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_custom',
-                'data_source_name': '[NBS_RDB].[dbo].[DM_INV_STD]',
                 'subset_query': """
                         SELECT PROGRAM_JURISDICTION_OID,
                                PATIENT_LOCAL_ID,
@@ -61,7 +60,6 @@ class TestIntegrationNbsCustomLibrary:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_custom',
-                'data_source_name': '[NBS_RDB].[dbo].[DM_INV_STD]',
                 'subset_query': """
                         SELECT PROGRAM_JURISDICTION_OID,
                                PATIENT_LOCAL_ID,
@@ -90,7 +88,6 @@ class TestIntegrationNbsCustomLibrary:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_custom',
-                'data_source_name': '[NBS_RDB].[dbo].[DM_INV_STD]',
                 'subset_query': """
                         SELECT PROGRAM_JURISDICTION_OID,
                                PATIENT_LOCAL_ID,

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
@@ -92,10 +92,6 @@ class TestIntegrationNbsSr02Library:
         )
 
         result = execute_report(report_spec)
-        assert (
-            result.header
-            == 'SR2: Counts of Reportable Diseases by County for Selected Time Frame'
-        )
         assert result.subheader == 'Georgia'
         assert len(result.description) > 100
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
@@ -25,7 +25,6 @@ class TestIntegrationNbsSr02Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 25  # two combinations with no data, zeros not filled
@@ -64,7 +63,6 @@ class TestIntegrationNbsSr02Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -94,7 +92,6 @@ class TestIntegrationNbsSr02Library:
         result = execute_report(report_spec)
         assert result.subheader == 'Georgia'
         assert len(result.description) > 100
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'State'
         assert result.content.columns[1] == 'County'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
@@ -68,7 +68,7 @@ class TestIntegrationNbsSr02Library:
         assert len(data) == 0
         assert len(result.content.columns) == 4
 
-        assert result.subheader == ''
+        assert result.context_header == ''
 
     def test_execute_report_check_metadata_one_state(self):
         """Check the metadata and column names are correct."""
@@ -90,8 +90,8 @@ class TestIntegrationNbsSr02Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Georgia'
-        assert len(result.description) > 100
+        assert result.context_header == 'Georgia'
+        assert result.description is not None and len(result.description) > 100
 
         assert result.content.columns[0] == 'State'
         assert result.content.columns[1] == 'County'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
@@ -17,7 +17,6 @@ class TestIntegrationNbsSr02Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 2',
                 'library_name': 'nbs_sr_02',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -51,7 +50,6 @@ class TestIntegrationNbsSr02Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 2',
                 'library_name': 'nbs_sr_02',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
@@ -74,10 +72,6 @@ class TestIntegrationNbsSr02Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': (
-                    'SR2: Counts of Reportable Diseases by County for Selected '
-                    'Time Frame'
-                ),
                 'library_name': 'nbs_sr_02',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_02.py
@@ -19,7 +19,6 @@ class TestIntegrationNbsSr02Library:
                 'is_builtin': True,
                 'report_title': 'SR 2',
                 'library_name': 'nbs_sr_02',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -54,7 +53,6 @@ class TestIntegrationNbsSr02Library:
                 'is_builtin': True,
                 'report_title': 'SR 2',
                 'library_name': 'nbs_sr_02',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
                     "WHERE state = 'Rhode Island'"
@@ -81,7 +79,6 @@ class TestIntegrationNbsSr02Library:
                     'Time Frame'
                 ),
                 'library_name': 'nbs_sr_02',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     " WHERE state_cd = '13'"

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
@@ -213,7 +213,6 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'SR5: Cases of Reportable Diseases by State'
         assert len(result.description) > 100
         assert result.content_type == 'table'
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
@@ -37,7 +37,6 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 3
@@ -80,7 +79,6 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) >= 1
         assert len(result.content.data[0]) == len(result.content.columns)
@@ -118,7 +116,6 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) >= 1
         assert len(result.content.data[0]) == len(result.content.columns)
@@ -156,7 +153,6 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) >= 1
         assert len(result.content.data[0]) == len(result.content.columns)
@@ -194,7 +190,6 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) == 0
         assert len(result.content.columns) == 8
@@ -214,7 +209,6 @@ class TestIntegrationNbsSr05Library:
 
         result = execute_report(report_spec)
         assert len(result.description) > 100
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'Percent Change 2024 vs 5 Year Median'
         assert result.content.columns[1] == 'Cumulative for 2023 to Date'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
@@ -29,7 +29,6 @@ class TestIntegrationNbsSr05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -67,7 +66,6 @@ class TestIntegrationNbsSr05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
@@ -103,7 +101,6 @@ class TestIntegrationNbsSr05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
@@ -139,7 +136,6 @@ class TestIntegrationNbsSr05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
@@ -176,7 +172,6 @@ class TestIntegrationNbsSr05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] WHERE 1 = 0'
@@ -195,7 +190,6 @@ class TestIntegrationNbsSr05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR5: Cases of Reportable Diseases by State',
                 'library_name': 'nbs_sr_05',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
@@ -208,7 +208,7 @@ class TestIntegrationNbsSr05Library:
         )
 
         result = execute_report(report_spec)
-        assert len(result.description) > 100
+        assert result.description is not None and len(result.description) > 100
 
         assert result.content.columns[0] == 'Percent Change 2024 vs 5 Year Median'
         assert result.content.columns[1] == 'Cumulative for 2023 to Date'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_05.py
@@ -31,7 +31,6 @@ class TestIntegrationNbsSr05Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -70,7 +69,6 @@ class TestIntegrationNbsSr05Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     'WHERE YEAR(event_date) < (2024 - 5)'
@@ -107,7 +105,6 @@ class TestIntegrationNbsSr05Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     'WHERE YEAR(event_date) < 2024'
@@ -144,7 +141,6 @@ class TestIntegrationNbsSr05Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     'WHERE YEAR(event_date) = 2024'
@@ -182,7 +178,6 @@ class TestIntegrationNbsSr05Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_05',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] WHERE 1 = 0'
                 ),
@@ -202,7 +197,6 @@ class TestIntegrationNbsSr05Library:
                 'is_builtin': True,
                 'report_title': 'SR5: Cases of Reportable Diseases by State',
                 'library_name': 'nbs_sr_05',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
@@ -68,11 +68,6 @@ class TestIntegrationNbsSr07Library:
         )
 
         result = execute_report(report_spec)
-        assert (
-            result.header
-            == 'SR7: Cases of Selected Diseases vs. 5-Year Median for Selected '
-            'Time Period'
-        )
         assert len(result.description) > 100
         assert result.content_type == 'table'
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
@@ -31,7 +31,6 @@ class TestIntegrationNbsSr07Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 6
@@ -69,7 +68,6 @@ class TestIntegrationNbsSr07Library:
 
         result = execute_report(report_spec)
         assert len(result.description) > 100
-        assert result.content_type == 'table'
 
         assert result.content.columns == ['Disease', 'type', 'Number of Cases']
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
@@ -23,7 +23,6 @@ class TestIntegrationNbsSr07Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR7',
                 'library_name': 'nbs_sr_07',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -55,10 +54,6 @@ class TestIntegrationNbsSr07Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': (
-                    'SR7: Cases of Selected Diseases vs. 5-Year Median for Selected '
-                    'Time Period'
-                ),
                 'library_name': 'nbs_sr_07',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -74,7 +69,6 @@ class TestIntegrationNbsSr07Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR7',
                 'library_name': 'nbs_sr_07',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] WHERE 1 = 2'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
@@ -67,7 +67,7 @@ class TestIntegrationNbsSr07Library:
         )
 
         result = execute_report(report_spec)
-        assert len(result.description) > 100
+        assert result.description is not None and len(result.description) > 100
 
         assert result.content.columns == ['Disease', 'type', 'Number of Cases']
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_07.py
@@ -25,7 +25,6 @@ class TestIntegrationNbsSr07Library:
                 'is_builtin': True,
                 'report_title': 'SR7',
                 'library_name': 'nbs_sr_07',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -61,7 +60,6 @@ class TestIntegrationNbsSr07Library:
                     'Time Period'
                 ),
                 'library_name': 'nbs_sr_07',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -78,7 +76,6 @@ class TestIntegrationNbsSr07Library:
                 'is_builtin': True,
                 'report_title': 'SR7',
                 'library_name': 'nbs_sr_07',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] WHERE 1 = 2'
                 ),

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
@@ -23,7 +23,6 @@ class TestIntegrationNbsSr08Library:
                     'SR8: Report of Disease Cases Over Selected Time Period'
                 ),
                 'library_name': 'nbs_sr_08',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -64,7 +63,6 @@ class TestIntegrationNbsSr08Library:
                     'SR8: Report of Disease Cases Over Selected Time Period'
                 ),
                 'library_name': 'nbs_sr_08',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
                     "WHERE state = 'Rhode Island'"
@@ -90,7 +88,6 @@ class TestIntegrationNbsSr08Library:
                     'SR8: Report of Disease Cases Over Selected Time Period'
                 ),
                 'library_name': 'nbs_sr_08',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     " WHERE state_cd = '13'"

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
@@ -101,7 +101,6 @@ class TestIntegrationNbsSr08Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'SR8: Report of Disease Cases Over Selected Time Period'
         assert result.subheader == 'Georgia'
         assert len(result.description) > 100
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
@@ -78,7 +78,7 @@ class TestIntegrationNbsSr08Library:
         assert len(data) == 0
         assert len(result.content.columns) == 7
 
-        assert result.subheader == ''
+        assert result.context_header == ''
 
     def test_execute_report_check_metadata_one_state(self):
         """Check the metadata and column names are correct."""
@@ -99,8 +99,8 @@ class TestIntegrationNbsSr08Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Georgia'
-        assert len(result.description) > 100
+        assert result.context_header == 'Georgia'
+        assert result.description is not None and len(result.description) > 100
 
         assert result.content.columns[0] == 'State Code'
         assert result.content.columns[1] == 'State'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
@@ -19,9 +19,6 @@ class TestIntegrationNbsSr08Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': (
-                    'SR8: Report of Disease Cases Over Selected Time Period'
-                ),
                 'library_name': 'nbs_sr_08',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -59,9 +56,6 @@ class TestIntegrationNbsSr08Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': (
-                    'SR8: Report of Disease Cases Over Selected Time Period'
-                ),
                 'library_name': 'nbs_sr_08',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
@@ -84,9 +78,6 @@ class TestIntegrationNbsSr08Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': (
-                    'SR8: Report of Disease Cases Over Selected Time Period'
-                ),
                 'library_name': 'nbs_sr_08',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_08.py
@@ -29,7 +29,6 @@ class TestIntegrationNbsSr08Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 897
@@ -74,7 +73,6 @@ class TestIntegrationNbsSr08Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -103,7 +101,6 @@ class TestIntegrationNbsSr08Library:
         result = execute_report(report_spec)
         assert result.subheader == 'Georgia'
         assert len(result.description) > 100
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'State Code'
         assert result.content.columns[1] == 'State'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
@@ -32,7 +32,6 @@ class TestIntegrationNbsSr09Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) > 0
@@ -95,7 +94,6 @@ class TestIntegrationNbsSr09Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert len(result.content.data) >= 0
 
     def test_execute_report_empty_subset(self):
@@ -114,7 +112,6 @@ class TestIntegrationNbsSr09Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         # Should return empty dataset but with correct column structure
         assert len(result.content.data) == 0
@@ -174,8 +171,6 @@ class TestIntegrationNbsSr09Library:
         assert 'Report content' in result.description
         assert 'Cases' in result.description
         assert 'Event Date:' in result.description
-
-        assert result.content_type == 'table'
 
     def test_execute_report_month_ordering(self):
         """Verify months are ordered correctly for a single state/county/disease."""

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
@@ -166,14 +166,7 @@ class TestIntegrationNbsSr09Library:
 
         result = execute_report(report_spec)
 
-        # Check header
-        assert (
-            result.header
-            == 'SR9: Monthly Cases of Selected Disease by County and State'
-        )
-
         # Check subheader contains expected elements
-
         assert 'Georgia' in result.subheader and 'Tennessee' in result.subheader
 
         # Check description contains required sections

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
@@ -26,7 +26,6 @@ class TestIntegrationNbsSr09Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -84,7 +83,6 @@ class TestIntegrationNbsSr09Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     "WHERE state = 'Georgia' "
@@ -104,7 +102,6 @@ class TestIntegrationNbsSr09Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] WHERE 1 = 0'
                 ),
@@ -126,7 +123,6 @@ class TestIntegrationNbsSr09Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -156,7 +152,6 @@ class TestIntegrationNbsSr09Library:
                     'SR9: Monthly Cases of Selected Disease by County and State'
                 ),
                 'library_name': 'nbs_sr_09',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -184,7 +179,6 @@ class TestIntegrationNbsSr09Library:
                 'is_builtin': True,
                 'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     "WHERE state = 'Georgia' "

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
@@ -163,10 +163,14 @@ class TestIntegrationNbsSr09Library:
 
         result = execute_report(report_spec)
 
-        # Check subheader contains expected elements
-        assert 'Georgia' in result.subheader and 'Tennessee' in result.subheader
+        # Check context_header contains expected elements
+        assert result.context_header is not None
+        assert (
+            'Georgia' in result.context_header and 'Tennessee' in result.context_header
+        )
 
         # Check description contains required sections
+        assert result.description is not None
         assert len(result.description) > 100
         assert 'Report content' in result.description
         assert 'Cases' in result.description

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_09.py
@@ -24,7 +24,6 @@ class TestIntegrationNbsSr09Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -81,7 +80,6 @@ class TestIntegrationNbsSr09Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
@@ -100,7 +98,6 @@ class TestIntegrationNbsSr09Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] WHERE 1 = 0'
@@ -121,7 +118,6 @@ class TestIntegrationNbsSr09Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -148,9 +144,6 @@ class TestIntegrationNbsSr09Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': (
-                    'SR9: Monthly Cases of Selected Disease by County and State'
-                ),
                 'library_name': 'nbs_sr_09',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -177,7 +170,6 @@ class TestIntegrationNbsSr09Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'NBS Custom',
                 'library_name': 'nbs_sr_09',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
@@ -25,7 +25,6 @@ class TestIntegrationNbsSr11Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 144
@@ -61,7 +60,6 @@ class TestIntegrationNbsSr11Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -88,7 +86,6 @@ class TestIntegrationNbsSr11Library:
         assert result.subheader == 'Georgia | Measles, Pertussis'
 
         assert len(result.description) > 100
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'State Code'
         assert result.content.columns[1] == 'State'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
@@ -19,7 +19,6 @@ class TestIntegrationNbsSr11Library:
                 'is_builtin': True,
                 'report_title': 'SR 11',
                 'library_name': 'nbs_sr_11',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -51,7 +50,6 @@ class TestIntegrationNbsSr11Library:
                 'is_builtin': True,
                 'report_title': 'SR 11',
                 'library_name': 'nbs_sr_11',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
                     "WHERE state = 'Rhode Island'"
@@ -73,7 +71,6 @@ class TestIntegrationNbsSr11Library:
                 'is_builtin': True,
                 'report_title': 'SR11: Cases of Selected Diseases By Year Over Time',
                 'library_name': 'nbs_sr_11',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
                     "WHERE state = 'Georgia' "

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
@@ -83,9 +83,9 @@ class TestIntegrationNbsSr11Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Georgia | Measles, Pertussis'
+        assert result.context_header == 'Georgia | Measles, Pertussis'
 
-        assert len(result.description) > 100
+        assert result.description is not None and len(result.description) > 100
 
         assert result.content.columns[0] == 'State Code'
         assert result.content.columns[1] == 'State'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
@@ -85,7 +85,6 @@ class TestIntegrationNbsSr11Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'SR11: Cases of Selected Diseases By Year Over Time'
         assert result.subheader == 'Georgia | Measles, Pertussis'
 
         assert len(result.description) > 100

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_11.py
@@ -17,7 +17,6 @@ class TestIntegrationNbsSr11Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 11',
                 'library_name': 'nbs_sr_11',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -48,7 +47,6 @@ class TestIntegrationNbsSr11Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 11',
                 'library_name': 'nbs_sr_11',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
@@ -69,7 +67,6 @@ class TestIntegrationNbsSr11Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR11: Cases of Selected Diseases By Year Over Time',
                 'library_name': 'nbs_sr_11',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
@@ -21,7 +21,6 @@ class TestIntegrationNbsSr13Library:
                 'is_builtin': True,
                 'report_title': 'SR 13',
                 'library_name': 'nbs_sr_13',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
         )
@@ -49,7 +48,6 @@ class TestIntegrationNbsSr13Library:
                 'is_builtin': True,
                 'report_title': 'SR 3',
                 'library_name': 'nbs_sr_13',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
                     "WHERE state = 'Rhode Island'"
@@ -70,7 +68,6 @@ class TestIntegrationNbsSr13Library:
                 'is_builtin': True,
                 'report_title': 'SR13: Counts of Selected Diseases By Case Status',
                 'library_name': 'nbs_sr_13',
-                'data_source_name': '[NBS_ODSE].[dbo].[PHCDemographic]',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '
                     " WHERE state_cd = '13'"

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
@@ -81,7 +81,6 @@ class TestIntegrationNbsSr13Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'SR13: Counts of Selected Diseases By Case Status'
         assert len(result.description) > 100
         assert result.content_type == 'table'
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
@@ -27,7 +27,6 @@ class TestIntegrationNbsSr13Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 6  # two combinations with no data, zeros not filled
@@ -59,7 +58,6 @@ class TestIntegrationNbsSr13Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) == 0
         assert result.content.columns == ['Case Count', 'Condition', 'Case Status']
@@ -82,6 +80,5 @@ class TestIntegrationNbsSr13Library:
 
         result = execute_report(report_spec)
         assert len(result.description) > 100
-        assert result.content_type == 'table'
 
         assert result.content.columns == ['Case Count', 'Condition', 'Case Status']

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
@@ -19,7 +19,6 @@ class TestIntegrationNbsSr13Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 13',
                 'library_name': 'nbs_sr_13',
                 'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]',
             }
@@ -46,7 +45,6 @@ class TestIntegrationNbsSr13Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 3',
                 'library_name': 'nbs_sr_13',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic]'
@@ -66,7 +64,6 @@ class TestIntegrationNbsSr13Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR13: Counts of Selected Diseases By Case Status',
                 'library_name': 'nbs_sr_13',
                 'subset_query': (
                     'SELECT * FROM [NBS_ODSE].[dbo].[PHCDemographic] '

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_13.py
@@ -79,6 +79,6 @@ class TestIntegrationNbsSr13Library:
         )
 
         result = execute_report(report_spec)
-        assert len(result.description) > 100
+        assert result.description is not None and len(result.description) > 100
 
         assert result.content.columns == ['Case Count', 'Condition', 'Case Status']

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_18.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_18.py
@@ -25,7 +25,6 @@ class TestIntegrationNbsSr18Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_18.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_18.py
@@ -19,7 +19,6 @@ class TestIntegrationNbsSr18Library:
                 'is_builtin': True,
                 'report_title': 'SR 18',
                 'library_name': 'nbs_sr_18',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
             }
         )
@@ -49,7 +48,6 @@ class TestIntegrationNbsSr18Library:
                 'is_builtin': True,
                 'report_title': 'SR 18',
                 'library_name': 'nbs_sr_18',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART] WHERE 1 = 2',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_18.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_18.py
@@ -17,7 +17,6 @@ class TestIntegrationNbsSr18Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 18',
                 'library_name': 'nbs_sr_18',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
             }
@@ -46,7 +45,6 @@ class TestIntegrationNbsSr18Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 18',
                 'library_name': 'nbs_sr_18',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART] WHERE 1 = 2',
             }

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_19.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_19.py
@@ -27,7 +27,6 @@ class TestIntegrationNbsSr19Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
 
@@ -65,7 +64,6 @@ class TestIntegrationNbsSr19Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_19.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_19.py
@@ -20,7 +20,6 @@ class TestIntegrationNbsSr19Library:
                 'is_builtin': True,
                 'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "COUNT_DATE"}',
             }
@@ -57,7 +56,6 @@ class TestIntegrationNbsSr19Library:
                 'is_builtin': True,
                 'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "DATE_REPORTED"}',
             }
@@ -94,7 +92,6 @@ class TestIntegrationNbsSr19Library:
                 'is_builtin': True,
                 'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART] WHERE 1 = 2',
                 'library_params': '{"date_column": "COUNT_DATE"}',
             }
@@ -120,7 +117,6 @@ class TestIntegrationNbsSr19Library:
                 'is_builtin': True,
                 'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{}',
             }
@@ -140,7 +136,6 @@ class TestIntegrationNbsSr19Library:
                 'is_builtin': True,
                 'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '"not_a_dict"',
             }
@@ -172,7 +167,6 @@ class TestIntegrationNbsSr19Library:
                 'is_builtin': True,
                 'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': status_query,
                 'library_params': '{"date_column": "COUNT_DATE"}',
             }

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_19.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_19.py
@@ -18,7 +18,6 @@ class TestIntegrationNbsSr19Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "COUNT_DATE"}',
@@ -54,7 +53,6 @@ class TestIntegrationNbsSr19Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "DATE_REPORTED"}',
@@ -90,7 +88,6 @@ class TestIntegrationNbsSr19Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART] WHERE 1 = 2',
                 'library_params': '{"date_column": "COUNT_DATE"}',
@@ -115,7 +112,6 @@ class TestIntegrationNbsSr19Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{}',
@@ -134,7 +130,6 @@ class TestIntegrationNbsSr19Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '"not_a_dict"',
@@ -165,7 +160,6 @@ class TestIntegrationNbsSr19Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 19',
                 'library_name': 'nbs_sr_19',
                 'subset_query': status_query,
                 'library_params': '{"date_column": "COUNT_DATE"}',

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_20.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_20.py
@@ -27,7 +27,6 @@ class TestIntegrationNbsSr20Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
 
@@ -61,7 +60,6 @@ class TestIntegrationNbsSr20Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
 

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_20.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_20.py
@@ -20,7 +20,6 @@ class TestIntegrationNbsSr20Library:
                 'is_builtin': True,
                 'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "COUNT_DATE"}',
             }
@@ -53,7 +52,6 @@ class TestIntegrationNbsSr20Library:
                 'is_builtin': True,
                 'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "DATE_REPORTED"}',
             }
@@ -86,7 +84,6 @@ class TestIntegrationNbsSr20Library:
                 'is_builtin': True,
                 'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART] WHERE 1 = 2',
                 'library_params': '{"date_column": "COUNT_DATE"}',
             }
@@ -110,7 +107,6 @@ class TestIntegrationNbsSr20Library:
                 'is_builtin': True,
                 'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{}',
             }
@@ -130,7 +126,6 @@ class TestIntegrationNbsSr20Library:
                 'is_builtin': True,
                 'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '"not_a_dict"',
             }
@@ -162,7 +157,6 @@ class TestIntegrationNbsSr20Library:
                 'is_builtin': True,
                 'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
-                'data_source_name': '[RDB].[dbo].[TB_DATAMART]',
                 'subset_query': status_query,
                 'library_params': '{"date_column": "COUNT_DATE"}',
             }

--- a/apps/report-execution/tests/integration/libraries/nbs_sr_20.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_sr_20.py
@@ -18,7 +18,6 @@ class TestIntegrationNbsSr20Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "COUNT_DATE"}',
@@ -50,7 +49,6 @@ class TestIntegrationNbsSr20Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{"date_column": "DATE_REPORTED"}',
@@ -82,7 +80,6 @@ class TestIntegrationNbsSr20Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART] WHERE 1 = 2',
                 'library_params': '{"date_column": "COUNT_DATE"}',
@@ -105,7 +102,6 @@ class TestIntegrationNbsSr20Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '{}',
@@ -124,7 +120,6 @@ class TestIntegrationNbsSr20Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[TB_DATAMART]',
                 'library_params': '"not_a_dict"',
@@ -155,7 +150,6 @@ class TestIntegrationNbsSr20Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'SR 20',
                 'library_name': 'nbs_sr_20',
                 'subset_query': status_query,
                 'library_params': '{"date_column": "COUNT_DATE"}',

--- a/apps/report-execution/tests/integration/libraries/pa_01.py
+++ b/apps/report-execution/tests/integration/libraries/pa_01.py
@@ -16,9 +16,6 @@ class TestIntegrationPa01Library:
         base = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': (
-                'PA01 Case Management Report (Interview Assign Date) - HIV'
-            ),
             'library_name': 'pa_01',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             'library_params': '{"report_variant": "HIV"}',
@@ -105,7 +102,6 @@ class TestIntegrationPa01Library:
     def test_execute_report_check_data_std(self, snapshot):
         report_spec = self.create_spec(
             library_params='{"report_variant": "STD"}',
-            report_title='PA01 Case Management Report (Interview Assign Date) - STD',
         )
 
         result = execute_report(report_spec)
@@ -141,7 +137,6 @@ class TestIntegrationPa01Library:
         report_spec = self.create_spec(
             subset_query='SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2',
             library_params='{"report_variant": "STD"}',
-            report_title='PA01 Case Management Report (Interview Assign Date) - STD',
         )
 
         result = execute_report(report_spec)

--- a/apps/report-execution/tests/integration/libraries/pa_01.py
+++ b/apps/report-execution/tests/integration/libraries/pa_01.py
@@ -20,7 +20,6 @@ class TestIntegrationPa01Library:
                 'PA01 Case Management Report (Interview Assign Date) - HIV'
             ),
             'library_name': 'pa_01',
-            'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             'library_params': '{"report_variant": "HIV"}',
         }

--- a/apps/report-execution/tests/integration/libraries/pa_03.py
+++ b/apps/report-execution/tests/integration/libraries/pa_03.py
@@ -227,7 +227,7 @@ class TestIntegrationPa03Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
 
         assert result.content.columns[0] == 'Category 1'

--- a/apps/report-execution/tests/integration/libraries/pa_03.py
+++ b/apps/report-execution/tests/integration/libraries/pa_03.py
@@ -25,7 +25,6 @@ class TestIntegrationPa03Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 36
@@ -199,7 +198,6 @@ class TestIntegrationPa03Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 36
@@ -231,7 +229,6 @@ class TestIntegrationPa03Library:
         result = execute_report(report_spec)
         assert result.subheader is None
         assert result.description is None
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'Category 1'
         assert result.content.columns[1] == 'Category 2'

--- a/apps/report-execution/tests/integration/libraries/pa_03.py
+++ b/apps/report-execution/tests/integration/libraries/pa_03.py
@@ -229,7 +229,6 @@ class TestIntegrationPa03Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'PA03'
         assert result.subheader is None
         assert result.description is None
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/pa_03.py
+++ b/apps/report-execution/tests/integration/libraries/pa_03.py
@@ -19,7 +19,6 @@ class TestIntegrationPa03Library:
                 'is_builtin': True,
                 'report_title': 'PA03',
                 'library_name': 'pa_03',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -190,7 +189,6 @@ class TestIntegrationPa03Library:
                 'is_builtin': True,
                 'report_title': 'PA03',
                 'library_name': 'pa_03',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
                 ),
@@ -221,7 +219,6 @@ class TestIntegrationPa03Library:
                 'is_builtin': True,
                 'report_title': 'PA03',
                 'library_name': 'pa_03',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/pa_03.py
+++ b/apps/report-execution/tests/integration/libraries/pa_03.py
@@ -17,7 +17,6 @@ class TestIntegrationPa03Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'PA03',
                 'library_name': 'pa_03',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -187,7 +186,6 @@ class TestIntegrationPa03Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'PA03',
                 'library_name': 'pa_03',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
@@ -217,7 +215,6 @@ class TestIntegrationPa03Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'PA03',
                 'library_name': 'pa_03',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }

--- a/apps/report-execution/tests/integration/libraries/pa_05.py
+++ b/apps/report-execution/tests/integration/libraries/pa_05.py
@@ -17,7 +17,6 @@ class TestIntegrationPa05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'PA05',
                 'library_name': 'pa_05',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -65,7 +64,6 @@ class TestIntegrationPa05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'PA05',
                 'library_name': 'pa_05',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
@@ -100,7 +98,6 @@ class TestIntegrationPa05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'PA05',
                 'library_name': 'pa_05',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }

--- a/apps/report-execution/tests/integration/libraries/pa_05.py
+++ b/apps/report-execution/tests/integration/libraries/pa_05.py
@@ -25,7 +25,6 @@ class TestIntegrationPa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(result.content.columns) == 7
@@ -77,7 +76,6 @@ class TestIntegrationPa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 23
@@ -114,7 +112,6 @@ class TestIntegrationPa05Library:
         result = execute_report(report_spec)
         assert result.subheader is None
         assert result.description is None
-        assert result.content_type == 'table'
         assert result.content.columns == [
             'Worker',
             'Category 1',

--- a/apps/report-execution/tests/integration/libraries/pa_05.py
+++ b/apps/report-execution/tests/integration/libraries/pa_05.py
@@ -112,7 +112,6 @@ class TestIntegrationPa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'PA05'
         assert result.subheader is None
         assert result.description is None
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/pa_05.py
+++ b/apps/report-execution/tests/integration/libraries/pa_05.py
@@ -110,7 +110,7 @@ class TestIntegrationPa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
         assert result.content.columns == [
             'Worker',

--- a/apps/report-execution/tests/integration/libraries/pa_05.py
+++ b/apps/report-execution/tests/integration/libraries/pa_05.py
@@ -19,7 +19,6 @@ class TestIntegrationPa05Library:
                 'is_builtin': True,
                 'report_title': 'PA05',
                 'library_name': 'pa_05',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -68,7 +67,6 @@ class TestIntegrationPa05Library:
                 'is_builtin': True,
                 'report_title': 'PA05',
                 'library_name': 'pa_05',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
                 ),
@@ -104,7 +102,6 @@ class TestIntegrationPa05Library:
                 'is_builtin': True,
                 'report_title': 'PA05',
                 'library_name': 'pa_05',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
@@ -59,7 +59,6 @@ class TestIntegrationNbsSrDupInvLibrary:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Potential Duplicate Investigations'
         assert 'Duplicate Investigations Time Frame: 3650 Days' in result.subheader
         assert result.subheader is not None
 
@@ -75,7 +74,6 @@ class TestIntegrationNbsSrDupInvLibrary:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Potential Duplicate Investigations'
 
         data = result.content.data
         assert len(data) >= 0
@@ -94,7 +92,6 @@ class TestIntegrationNbsSrDupInvLibrary:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Potential Duplicate Investigations'
 
         data = result.content.data
         assert len(data) >= 0
@@ -113,7 +110,6 @@ class TestIntegrationNbsSrDupInvLibrary:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Potential Duplicate Investigations'
 
         data = result.content.data
         assert len(data) >= 0
@@ -130,7 +126,6 @@ class TestIntegrationNbsSrDupInvLibrary:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'Potential Duplicate Investigations'
         assert result.subheader == 'Duplicate Investigations Time Frame: 365 Days'
 
         data = result.content
@@ -180,7 +175,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=365)
 
         result = execute_report(report_spec)
-        assert result.header == 'Potential Duplicate Investigations'
         assert result.subheader == 'Duplicate Investigations Time Frame: 365 Days'
         assert result.content_type == 'table'
 

--- a/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
@@ -36,7 +36,6 @@ class TestIntegrationNbsSrDupInvLibrary:
             'version': 1,
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'Potential Duplicate Investigations',
             'library_name': 'potntl_dup_inv_sum',
             'subset_query': '',
             'days_value': None,

--- a/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
@@ -38,7 +38,6 @@ class TestIntegrationNbsSrDupInvLibrary:
             'is_builtin': True,
             'report_title': 'Potential Duplicate Investigations',
             'library_name': 'potntl_dup_inv_sum',
-            'data_source_name': '[RDB].[dbo].[INV_SUMM_DATAMART]',
             'subset_query': '',
             'days_value': None,
             'column_map': self.default_column_map,

--- a/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
@@ -58,7 +58,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec()
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert 'Duplicate Investigations Time Frame: 3650 Days' in result.subheader
         assert result.subheader is not None
 
@@ -73,7 +72,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(sort_by='UPPER([Disease Code]) ASC')
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) >= 0
@@ -91,7 +89,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(sort_by='UPPER([Investigation Local Id]) ASC')
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) >= 0
@@ -109,7 +106,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(sort_by='[Event Date] ASC')
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) >= 0
@@ -125,7 +121,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=365)
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.subheader == 'Duplicate Investigations Time Frame: 365 Days'
 
         data = result.content
@@ -137,7 +132,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=3650)
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.subheader == 'Duplicate Investigations Time Frame: 3650 Days'
 
         # Should return more results than the 30-day test
@@ -154,7 +148,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=-3650)
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.subheader == 'Duplicate Investigations Time Frame: -3650 Days'
 
         # Based on current implementation, this should not return any results.
@@ -167,7 +160,6 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec.subset_query += ' WHERE 1 = 0'
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert len(result.content.data) == 0
 
     def test_execute_report_check_metadata(self):
@@ -176,7 +168,6 @@ class TestIntegrationNbsSrDupInvLibrary:
 
         result = execute_report(report_spec)
         assert result.subheader == 'Duplicate Investigations Time Frame: 365 Days'
-        assert result.content_type == 'table'
 
     def test_execute_report_verify_no_single_events(self):
         """Verify that patients with only one event are filtered out."""

--- a/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
+++ b/apps/report-execution/tests/integration/libraries/potntl_dup_inv_sum.py
@@ -58,8 +58,12 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec()
 
         result = execute_report(report_spec)
-        assert 'Duplicate Investigations Time Frame: 3650 Days' in result.subheader
-        assert result.subheader is not None
+        assert (
+            result.context_header is not None
+            and 'Duplicate Investigations Time Frame: 3650 Days'
+            in result.context_header
+        )
+        assert result.context_header is not None
 
         data = result.content
         assert len(data.data) >= 0
@@ -121,7 +125,7 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=365)
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Duplicate Investigations Time Frame: 365 Days'
+        assert result.context_header == 'Duplicate Investigations Time Frame: 365 Days'
 
         data = result.content
         assert len(data.data) >= 0
@@ -132,7 +136,7 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=3650)
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Duplicate Investigations Time Frame: 3650 Days'
+        assert result.context_header == 'Duplicate Investigations Time Frame: 3650 Days'
 
         # Should return more results than the 30-day test
         spec_30 = self.create_spec(days_value=30)
@@ -148,7 +152,9 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=-3650)
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Duplicate Investigations Time Frame: -3650 Days'
+        assert (
+            result.context_header == 'Duplicate Investigations Time Frame: -3650 Days'
+        )
 
         # Based on current implementation, this should not return any results.
         assert len(result.content.data) == 0
@@ -167,7 +173,7 @@ class TestIntegrationNbsSrDupInvLibrary:
         report_spec = self.create_spec(days_value=365)
 
         result = execute_report(report_spec)
-        assert result.subheader == 'Duplicate Investigations Time Frame: 365 Days'
+        assert result.context_header == 'Duplicate Investigations Time Frame: 365 Days'
 
     def test_execute_report_verify_no_single_events(self):
         """Verify that patients with only one event are filtered out."""

--- a/apps/report-execution/tests/integration/libraries/qa_01.py
+++ b/apps/report-execution/tests/integration/libraries/qa_01.py
@@ -30,7 +30,6 @@ class TestIntegrationNbsQa01Library:
         report_spec = self.create_spec()
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 534
@@ -60,7 +59,6 @@ class TestIntegrationNbsQa01Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -92,6 +90,5 @@ class TestIntegrationNbsQa01Library:
         report_spec = self.create_spec(report_title='QA01 Interview Record List')
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert result.content.columns == expected_columns

--- a/apps/report-execution/tests/integration/libraries/qa_01.py
+++ b/apps/report-execution/tests/integration/libraries/qa_01.py
@@ -18,7 +18,6 @@ class TestIntegrationNbsQa01Library:
         base = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'QA 01',
             'library_name': 'qa_01',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
         }
@@ -86,7 +85,7 @@ class TestIntegrationNbsQa01Library:
             'age',
         ]
 
-        report_spec = self.create_spec(report_title='QA01 Interview Record List')
+        report_spec = self.create_spec()
 
         result = execute_report(report_spec)
 

--- a/apps/report-execution/tests/integration/libraries/qa_01.py
+++ b/apps/report-execution/tests/integration/libraries/qa_01.py
@@ -92,7 +92,6 @@ class TestIntegrationNbsQa01Library:
         report_spec = self.create_spec(report_title='QA01 Interview Record List')
 
         result = execute_report(report_spec)
-        assert result.header == 'QA01 Interview Record List'
         assert result.content_type == 'table'
 
         assert result.content.columns == expected_columns

--- a/apps/report-execution/tests/integration/libraries/qa_01.py
+++ b/apps/report-execution/tests/integration/libraries/qa_01.py
@@ -20,7 +20,6 @@ class TestIntegrationNbsQa01Library:
             'is_builtin': True,
             'report_title': 'QA 01',
             'library_name': 'qa_01',
-            'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
         }
         base.update(overrides)

--- a/apps/report-execution/tests/integration/libraries/qa_03.py
+++ b/apps/report-execution/tests/integration/libraries/qa_03.py
@@ -85,7 +85,6 @@ class TestIntegrationNbsQa03Library:
         report_spec = self.create_spec(report_title='QA03 Interview Record List')
 
         result = execute_report(report_spec)
-        assert result.header == 'QA03 Interview Record List'
         assert result.content_type == 'table'
 
         assert result.content.columns == expected_columns

--- a/apps/report-execution/tests/integration/libraries/qa_03.py
+++ b/apps/report-execution/tests/integration/libraries/qa_03.py
@@ -34,7 +34,6 @@ class TestIntegrationNbsQa03Library:
         report_spec = self.create_spec()
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) > 500
@@ -61,7 +60,6 @@ class TestIntegrationNbsQa03Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -85,6 +83,5 @@ class TestIntegrationNbsQa03Library:
         report_spec = self.create_spec(report_title='QA03 Interview Record List')
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert result.content.columns == expected_columns

--- a/apps/report-execution/tests/integration/libraries/qa_03.py
+++ b/apps/report-execution/tests/integration/libraries/qa_03.py
@@ -20,7 +20,6 @@ class TestIntegrationNbsQa03Library:
         base = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'QA 03',
             'library_name': 'qa_03',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
         }
@@ -79,7 +78,7 @@ class TestIntegrationNbsQa03Library:
             'PATIENTID',
         ]
 
-        report_spec = self.create_spec(report_title='QA03 Interview Record List')
+        report_spec = self.create_spec()
 
         result = execute_report(report_spec)
 

--- a/apps/report-execution/tests/integration/libraries/qa_03.py
+++ b/apps/report-execution/tests/integration/libraries/qa_03.py
@@ -22,7 +22,6 @@ class TestIntegrationNbsQa03Library:
             'is_builtin': True,
             'report_title': 'QA 03',
             'library_name': 'qa_03',
-            'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
         }
         base.update(overrides)

--- a/apps/report-execution/tests/integration/libraries/qa_04.py
+++ b/apps/report-execution/tests/integration/libraries/qa_04.py
@@ -78,7 +78,7 @@ class TestIntegrationQa04Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
 
     def test_execute_report_error_explanations(self):

--- a/apps/report-execution/tests/integration/libraries/qa_04.py
+++ b/apps/report-execution/tests/integration/libraries/qa_04.py
@@ -28,7 +28,6 @@ class TestIntegrationQa04Library:
 
         result = execute_report(report_spec)
 
-        assert result.content_type == 'table'
         data = result.content
         assert len(data.data) > 0
         assert len(data.data[0]) == len(data.columns) if data.data else True
@@ -61,7 +60,6 @@ class TestIntegrationQa04Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         data = result.content
         assert data.data == []
 
@@ -80,7 +78,6 @@ class TestIntegrationQa04Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
         assert result.subheader is None
         assert result.description is None
 

--- a/apps/report-execution/tests/integration/libraries/qa_04.py
+++ b/apps/report-execution/tests/integration/libraries/qa_04.py
@@ -21,7 +21,6 @@ class TestIntegrationQa04Library:
                 'is_builtin': True,
                 'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -52,7 +51,6 @@ class TestIntegrationQa04Library:
                 'is_builtin': True,
                 'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': """
                     SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1=0
                 """,
@@ -72,7 +70,6 @@ class TestIntegrationQa04Library:
                 'is_builtin': True,
                 'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -90,7 +87,6 @@ class TestIntegrationQa04Library:
                 'is_builtin': True,
                 'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -114,7 +110,6 @@ class TestIntegrationQa04Library:
                 'is_builtin': True,
                 'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': """
                     SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]
                     WHERE INV_CASE_STATUS = 'Suspect'
@@ -138,7 +133,6 @@ class TestIntegrationQa04Library:
                 'is_builtin': True,
                 'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/qa_04.py
+++ b/apps/report-execution/tests/integration/libraries/qa_04.py
@@ -19,7 +19,6 @@ class TestIntegrationQa04Library:
                 'version': 1,
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -49,7 +48,6 @@ class TestIntegrationQa04Library:
                 'version': 1,
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
                 'subset_query': """
                     SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1=0
@@ -68,7 +66,6 @@ class TestIntegrationQa04Library:
                 'version': 1,
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -85,7 +82,6 @@ class TestIntegrationQa04Library:
                 'version': 1,
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -108,7 +104,6 @@ class TestIntegrationQa04Library:
                 'version': 1,
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
                 'subset_query': """
                     SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]
@@ -131,7 +126,6 @@ class TestIntegrationQa04Library:
                 'version': 1,
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA04 Cases Missing Lab and/or Treatment',
                 'library_name': 'qa_04',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }

--- a/apps/report-execution/tests/integration/libraries/qa_04.py
+++ b/apps/report-execution/tests/integration/libraries/qa_04.py
@@ -29,7 +29,6 @@ class TestIntegrationQa04Library:
         result = execute_report(report_spec)
 
         assert result.content_type == 'table'
-        assert result.header == 'QA04 Cases Missing Lab and/or Treatment'
         data = result.content
         assert len(data.data) > 0
         assert len(data.data[0]) == len(data.columns) if data.data else True
@@ -63,7 +62,6 @@ class TestIntegrationQa04Library:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'QA04 Cases Missing Lab and/or Treatment'
         data = result.content
         assert data.data == []
 
@@ -83,7 +81,6 @@ class TestIntegrationQa04Library:
 
         result = execute_report(report_spec)
         assert result.content_type == 'table'
-        assert result.header == 'QA04 Cases Missing Lab and/or Treatment'
         assert result.subheader is None
         assert result.description is None
 

--- a/apps/report-execution/tests/integration/libraries/qa_05.py
+++ b/apps/report-execution/tests/integration/libraries/qa_05.py
@@ -19,7 +19,6 @@ class TestIntegrationQa05Library:
                 'is_builtin': True,
                 'report_title': 'QA 5',
                 'library_name': 'qa_05',
-                'data_source_name': '[RDB].[dbo].[V_EVENT_METRIC]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[V_EVENT_METRIC]',
             }
         )
@@ -53,7 +52,6 @@ class TestIntegrationQa05Library:
                 'is_builtin': True,
                 'report_title': 'QA 5',
                 'library_name': 'qa_05',
-                'data_source_name': '[RDB].[dbo].[V_EVENT_METRIC]',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[V_EVENT_METRIC] WHERE 1 = 2'
                 ),
@@ -74,7 +72,6 @@ class TestIntegrationQa05Library:
                 'is_builtin': True,
                 'report_title': 'QA05 Number of Records Entered by User ID',
                 'library_name': 'qa_05',
-                'data_source_name': '[RDB].[dbo].[V_EVENT_METRIC]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[V_EVENT_METRIC]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/qa_05.py
+++ b/apps/report-execution/tests/integration/libraries/qa_05.py
@@ -82,7 +82,6 @@ class TestIntegrationQa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'QA05 Number of Records Entered by User ID'
         assert result.subheader is None
         assert result.description is None
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/qa_05.py
+++ b/apps/report-execution/tests/integration/libraries/qa_05.py
@@ -80,7 +80,7 @@ class TestIntegrationQa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
 
         assert result.content.columns[0] == 'user_qc'

--- a/apps/report-execution/tests/integration/libraries/qa_05.py
+++ b/apps/report-execution/tests/integration/libraries/qa_05.py
@@ -25,7 +25,6 @@ class TestIntegrationQa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 94
@@ -62,7 +61,6 @@ class TestIntegrationQa05Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -84,7 +82,6 @@ class TestIntegrationQa05Library:
         result = execute_report(report_spec)
         assert result.subheader is None
         assert result.description is None
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'user_qc'
         assert result.content.columns[1] == 'OOJ_REFF'

--- a/apps/report-execution/tests/integration/libraries/qa_05.py
+++ b/apps/report-execution/tests/integration/libraries/qa_05.py
@@ -17,7 +17,6 @@ class TestIntegrationQa05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA 5',
                 'library_name': 'qa_05',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[V_EVENT_METRIC]',
             }
@@ -50,7 +49,6 @@ class TestIntegrationQa05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA 5',
                 'library_name': 'qa_05',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[V_EVENT_METRIC] WHERE 1 = 2'
@@ -70,7 +68,6 @@ class TestIntegrationQa05Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA05 Number of Records Entered by User ID',
                 'library_name': 'qa_05',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[V_EVENT_METRIC]',
             }

--- a/apps/report-execution/tests/integration/libraries/qa_06.py
+++ b/apps/report-execution/tests/integration/libraries/qa_06.py
@@ -20,7 +20,6 @@ class TestIntegrationQa06Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA06',
                 'library_name': 'qa_06',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -60,7 +59,6 @@ class TestIntegrationQa06Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA06',
                 'library_name': 'qa_06',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
@@ -79,7 +77,6 @@ class TestIntegrationQa06Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA06',
                 'library_name': 'qa_06',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }

--- a/apps/report-execution/tests/integration/libraries/qa_06.py
+++ b/apps/report-execution/tests/integration/libraries/qa_06.py
@@ -91,7 +91,6 @@ class TestIntegrationQa06Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'QA06'
         assert result.subheader is None
         assert result.description is None
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/qa_06.py
+++ b/apps/report-execution/tests/integration/libraries/qa_06.py
@@ -89,7 +89,7 @@ class TestIntegrationQa06Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
 
         assert result.content.columns[0] == 'PATIENT_NAME'

--- a/apps/report-execution/tests/integration/libraries/qa_06.py
+++ b/apps/report-execution/tests/integration/libraries/qa_06.py
@@ -22,7 +22,6 @@ class TestIntegrationQa06Library:
                 'is_builtin': True,
                 'report_title': 'QA06',
                 'library_name': 'qa_06',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -63,7 +62,6 @@ class TestIntegrationQa06Library:
                 'is_builtin': True,
                 'report_title': 'QA06',
                 'library_name': 'qa_06',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
                 ),
@@ -83,7 +81,6 @@ class TestIntegrationQa06Library:
                 'is_builtin': True,
                 'report_title': 'QA06',
                 'library_name': 'qa_06',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/qa_06.py
+++ b/apps/report-execution/tests/integration/libraries/qa_06.py
@@ -28,7 +28,6 @@ class TestIntegrationQa06Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data[0]) == 13
@@ -72,7 +71,6 @@ class TestIntegrationQa06Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -93,7 +91,6 @@ class TestIntegrationQa06Library:
         result = execute_report(report_spec)
         assert result.subheader is None
         assert result.description is None
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'PATIENT_NAME'
         assert result.content.columns[1] == 'PATIENT_LOCAL_ID'

--- a/apps/report-execution/tests/integration/libraries/qa_07.py
+++ b/apps/report-execution/tests/integration/libraries/qa_07.py
@@ -22,7 +22,6 @@ class TestIntegrationQa07Library:
             'is_builtin': True,
             'report_title': 'QA07',
             'library_name': 'qa_07',
-            'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             'library_params': '{"days_value": 30}',
         }

--- a/apps/report-execution/tests/integration/libraries/qa_07.py
+++ b/apps/report-execution/tests/integration/libraries/qa_07.py
@@ -20,7 +20,6 @@ class TestIntegrationQa07Library:
             'version': 1,
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'QA07',
             'library_name': 'qa_07',
             'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             'library_params': '{"days_value": 30}',

--- a/apps/report-execution/tests/integration/libraries/qa_07.py
+++ b/apps/report-execution/tests/integration/libraries/qa_07.py
@@ -32,7 +32,6 @@ class TestIntegrationQa07Library:
     def test_execute_report_check_data(self, snapshot):
         report_spec = self.create_spec()
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 4
@@ -57,7 +56,6 @@ class TestIntegrationQa07Library:
         """
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         assert len(result.content.data) == 0
 

--- a/apps/report-execution/tests/integration/libraries/qa_10.py
+++ b/apps/report-execution/tests/integration/libraries/qa_10.py
@@ -76,7 +76,6 @@ class TestIntegrationQa10Library:
         )
 
         result = execute_report(report_spec)
-        assert result.header == 'QA10'
         assert result.subheader is None
         assert result.description is None
         assert result.content_type == 'table'

--- a/apps/report-execution/tests/integration/libraries/qa_10.py
+++ b/apps/report-execution/tests/integration/libraries/qa_10.py
@@ -19,7 +19,6 @@ class TestIntegrationQa10Library:
                 'is_builtin': True,
                 'report_title': 'QA10',
                 'library_name': 'qa_10',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )
@@ -47,7 +46,6 @@ class TestIntegrationQa10Library:
                 'is_builtin': True,
                 'report_title': 'QA10',
                 'library_name': 'qa_10',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
                 ),
@@ -68,7 +66,6 @@ class TestIntegrationQa10Library:
                 'is_builtin': True,
                 'report_title': 'QA10',
                 'library_name': 'qa_10',
-                'data_source_name': '[RDB].[dbo].[STD_HIV_DATAMART]',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
         )

--- a/apps/report-execution/tests/integration/libraries/qa_10.py
+++ b/apps/report-execution/tests/integration/libraries/qa_10.py
@@ -74,7 +74,7 @@ class TestIntegrationQa10Library:
         )
 
         result = execute_report(report_spec)
-        assert result.subheader is None
+        assert result.context_header is None
         assert result.description is None
 
         assert result.content.columns[0] == 'INVESTIGATION_KEY'

--- a/apps/report-execution/tests/integration/libraries/qa_10.py
+++ b/apps/report-execution/tests/integration/libraries/qa_10.py
@@ -25,7 +25,6 @@ class TestIntegrationQa10Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 26
@@ -56,7 +55,6 @@ class TestIntegrationQa10Library:
         )
 
         result = execute_report(report_spec)
-        assert result.content_type == 'table'
 
         data = result.content.data
         assert len(data) == 0
@@ -78,7 +76,6 @@ class TestIntegrationQa10Library:
         result = execute_report(report_spec)
         assert result.subheader is None
         assert result.description is None
-        assert result.content_type == 'table'
 
         assert result.content.columns[0] == 'INVESTIGATION_KEY'
         assert result.content.columns[1] == 'PATIENT_NAME'

--- a/apps/report-execution/tests/integration/libraries/qa_10.py
+++ b/apps/report-execution/tests/integration/libraries/qa_10.py
@@ -17,7 +17,6 @@ class TestIntegrationQa10Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA10',
                 'library_name': 'qa_10',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }
@@ -44,7 +43,6 @@ class TestIntegrationQa10Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA10',
                 'library_name': 'qa_10',
                 'subset_query': (
                     'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART] WHERE 1 = 2'
@@ -64,7 +62,6 @@ class TestIntegrationQa10Library:
             {
                 'is_export': True,
                 'is_builtin': True,
-                'report_title': 'QA10',
                 'library_name': 'qa_10',
                 'subset_query': 'SELECT * FROM [RDB].[dbo].[STD_HIV_DATAMART]',
             }

--- a/apps/report-execution/tests/integration/main.py
+++ b/apps/report-execution/tests/integration/main.py
@@ -14,7 +14,6 @@ class TestMainApp:
         report_spec = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'Test Report',
             'library_name': 'nbs_custom',
             # Filter code is used here as it is a stable, small table
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',

--- a/apps/report-execution/tests/integration/main.py
+++ b/apps/report-execution/tests/integration/main.py
@@ -34,7 +34,3 @@ class TestMainApp:
         assert response.status == 200
 
         result = json.loads(response.read())
-        assert (
-            result['header']
-            == 'Custom Report For Table: [NBS_ODSE].[dbo].[Filter_code]'
-        )

--- a/apps/report-execution/tests/integration/main.py
+++ b/apps/report-execution/tests/integration/main.py
@@ -17,7 +17,6 @@ class TestMainApp:
             'report_title': 'Test Report',
             'library_name': 'nbs_custom',
             # Filter code is used here as it is a stable, small table
-            'data_source_name': '[NBS_ODSE].[dbo].[Filter_code]',
             'subset_query': 'SELECT * FROM [NBS_ODSE].[dbo].[Filter_code]',
         }
 

--- a/apps/report-execution/tests/integration/main.py
+++ b/apps/report-execution/tests/integration/main.py
@@ -31,3 +31,29 @@ class TestMainApp:
 
         response = connection.getresponse()
         assert response.status == 200
+
+        result = json.loads(response.read())
+
+        assert result is not None
+
+        for k in ['content', 'context_header', 'description']:
+            assert k in result.keys()
+
+        assert len(result['content']) > 0
+
+        exepected_cols = [
+            'filter_uid',
+            'code_table',
+            'desc_txt',
+            'effective_from_time',
+            'effective_to_time',
+            'filter_code',
+            'filter_code_set_nm',
+            'filter_type',
+            'filter_name',
+            'status_cd',
+            'status_time',
+        ]
+        found_cols = result['content'].split('\r\n')[0].split(',')
+
+        assert found_cols == exepected_cols

--- a/apps/report-execution/tests/integration/main.py
+++ b/apps/report-execution/tests/integration/main.py
@@ -36,7 +36,7 @@ class TestMainApp:
         assert result is not None
 
         for k in ['content', 'context_header', 'description']:
-            assert k in result.keys()
+            assert k in result
 
         assert len(result['content']) > 0
 

--- a/apps/report-execution/tests/integration/main.py
+++ b/apps/report-execution/tests/integration/main.py
@@ -32,5 +32,3 @@ class TestMainApp:
 
         response = connection.getresponse()
         assert response.status == 200
-
-        result = json.loads(response.read())

--- a/apps/report-execution/tests/main.py
+++ b/apps/report-execution/tests/main.py
@@ -40,7 +40,6 @@ class TestReportExecuteEndpoint:
             'is_builtin': True,
             'report_title': 'Test Report',
             'library_name': 'nbs_custom',
-            'data_source_name': 'random_db_table_0',
             'subset_query': 'SELECT * FROM test',
         }
         response = client.post('/report/execute', json=report_spec)
@@ -70,7 +69,6 @@ class TestReportExecuteEndpoint:
             'is_builtin': True,
             'report_title': 'Time-based Report',
             'library_name': 'nbs_custom',
-            'data_source_name': 'random_db_table_1',
             'subset_query': 'SELECT * FROM events WHERE date > ?',
         }
         response = client.post('/report/execute', json=report_spec)
@@ -94,7 +92,6 @@ class TestReportExecuteEndpoint:
             'is_builtin': True,
             'report_title': 'Test Report',
             'library_name': 'nbs_custom',
-            'data_source_name': 'random_db_table_3',
             'subset_query': 'SELECT * FROM test',
         }
         response = client.post('/report/execute', json=invalid_spec)
@@ -108,7 +105,6 @@ class TestReportExecuteEndpoint:
             'is_builtin': True,
             'report_title': 'Test Report',
             'library_name': 'missing_library',
-            'data_source_name': 'random_db_table_3',
             'subset_query': 'SELECT * FROM test',
         }
         response = client.post('/report/execute', json=invalid_spec)

--- a/apps/report-execution/tests/main.py
+++ b/apps/report-execution/tests/main.py
@@ -38,7 +38,6 @@ class TestReportExecuteEndpoint:
         report_spec = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'Test Report',
             'library_name': 'nbs_custom',
             'subset_query': 'SELECT * FROM test',
         }
@@ -67,7 +66,6 @@ class TestReportExecuteEndpoint:
         report_spec = {
             'is_export': False,
             'is_builtin': True,
-            'report_title': 'Time-based Report',
             'library_name': 'nbs_custom',
             'subset_query': 'SELECT * FROM events WHERE date > ?',
         }
@@ -79,7 +77,6 @@ class TestReportExecuteEndpoint:
     def test_execute_report_api_missing_required_fields(self, client):
         """Test that missing required fields return a validation error."""
         incomplete_spec = {
-            'report_title': 'Incomplete Report',
         }
         response = client.post('/report/execute', json=incomplete_spec)
 
@@ -90,7 +87,6 @@ class TestReportExecuteEndpoint:
         invalid_spec = {
             'is_export': 'not_a_boolean',
             'is_builtin': True,
-            'report_title': 'Test Report',
             'library_name': 'nbs_custom',
             'subset_query': 'SELECT * FROM test',
         }
@@ -103,7 +99,6 @@ class TestReportExecuteEndpoint:
         invalid_spec = {
             'is_export': True,
             'is_builtin': True,
-            'report_title': 'Test Report',
             'library_name': 'missing_library',
             'subset_query': 'SELECT * FROM test',
         }

--- a/apps/report-execution/tests/main.py
+++ b/apps/report-execution/tests/main.py
@@ -76,8 +76,7 @@ class TestReportExecuteEndpoint:
 
     def test_execute_report_api_missing_required_fields(self, client):
         """Test that missing required fields return a validation error."""
-        incomplete_spec = {
-        }
+        incomplete_spec = {}
         response = client.post('/report/execute', json=incomplete_spec)
 
         assert response.status_code == 422  # Unprocessable Entity

--- a/apps/report-execution/tests/utils.py
+++ b/apps/report-execution/tests/utils.py
@@ -66,17 +66,17 @@ class TestUtils:
         res = utils.get_str_env_or_default('CSV_DATE_STRFTIME', 'foobar')
         assert res == 'foobar'
 
-    def test_gen_subheader_with_us(self):
-        result = utils.gen_subheader(states=['Georgia', 'Tennessee'])
+    def test_gen_context_header_with_us(self):
+        result = utils.gen_context_header(states=['Georgia', 'Tennessee'])
         assert result == 'Georgia, Tennessee'
 
-    def test_gen_subheader_with_states_and_diseases(self):
-        result = utils.gen_subheader(
+    def test_gen_context_header_with_states_and_diseases(self):
+        result = utils.gen_context_header(
             states=[None, 'Alabama', 'Georgia'],
             diseases=['Measles'],
         )
         assert result == 'N/A, Alabama, Georgia | Measles'
 
-    def test_gen_subheader_no_args(self):
-        result = utils.gen_subheader()
+    def test_gen_context_header_no_args(self):
+        result = utils.gen_context_header()
         assert result == ''


### PR DESCRIPTION
## Description

Clean up unused fields in report spec and report result.

Changes:
- remove `contentType` from library execution result
- remove `header` from library execution result
- rename `subheader` to `contextHeader` in library execution result
- remove `dataSourceName` from report spec
- remove `reportTitle` from report spec
- fix some typing issues in Python test files

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-835)

## Checklist before requesting a review
- [x] PR focuses on a single story
- [x] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [x] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
