### PR TITLE
[APP-885] fix: add number of rows as flair on result page

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
@@ -13,7 +13,7 @@ describe('ResultDataPage', () => {
             timestamp: '2026-06-17T19:11:35.595501658',
         };
 
-        const { getByRole } = render(
+        const { getByRole, getByText } = render(
             <ResultDataPage result={result} title="My report" dataSourceName="nbs_db.My_Table" />
         );
 
@@ -27,6 +27,7 @@ describe('ResultDataPage', () => {
         expect(getByRole('definition', { name: 'Base SQL query' })).toHaveTextContent(
             'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]'
         );
+        expect(getByText('(0 rows)')).toBeVisible();
     });
 
     it('renders full report result', () => {
@@ -41,7 +42,7 @@ describe('ResultDataPage', () => {
             timestamp: '2026-06-17T19:11:35.595501658',
         };
 
-        const { getByRole } = render(
+        const { getByRole, container } = render(
             <ResultDataPage result={result} title="My report" dataSourceName="nbs_db.My_Table" />
         );
 
@@ -57,5 +58,6 @@ describe('ResultDataPage', () => {
         expect(getByRole('definition', { name: 'Base SQL query' })).toHaveTextContent(
             'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]'
         );
+        expect(getByText(container, '(1 row)')).toBeVisible();
     });
 });

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
@@ -75,7 +75,11 @@ const ResultDataPage = ({
                         {formattedTime}
                     </ValueField>
                 </Card>
-                <Card id="report-result" title="Report result">
+                <Card
+                    id="report-result"
+                    title="Report result"
+                    flair={`(${data.length} row${data.length === 1 ? '' : 's'})`}
+                >
                     {meta.fields && (
                         <section className="overflow-auto">
                             <DataTable


### PR DESCRIPTION
## Description

The row count was in the design, but not in the implementation. When 0 rows and very wide table, the "No data found." message was way off screen creating a bad vibe

<img width="4002" height="338" alt="image" src="https://github.com/user-attachments/assets/a1b4bcf7-be18-4f40-861e-a1f99797e5be" />
<img width="2720" height="366" alt="image" src="https://github.com/user-attachments/assets/f7b1c902-1793-4e10-80ae-8b296cc74753" />
<img width="4016" height="724" alt="image" src="https://github.com/user-attachments/assets/3e433321-f710-4382-8d41-6ab0b96e2bac" />


## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-885

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
