### PR TITLE
feat: conditional permission check for navbar if dedupe feature flag enabled

### DIFF
--- a/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
@@ -7,6 +7,8 @@ import { permissions } from 'libs/permission';
 let mockPermissions: string[] = [];
 const mockAllowFn = vi.fn((permission: string) => mockPermissions.includes(permission));
 
+let mockFeatures: any = { deduplication: { enabled: false } };
+
 vi.mock('page', () => ({
     usePage: vi.fn(),
 }));
@@ -22,8 +24,15 @@ vi.mock('../../libs/permission/usePermissions', () => ({
     }),
 }));
 
-const renderNavBarWithPermissions = (permissions: string[]) => {
+vi.mock('../../feature', () => ({
+    FeatureToggle: ({ guard, fallback, children }: any) => {
+        return guard(mockFeatures) ? children : fallback;
+    },
+}));
+
+const renderNavBarWithPermissions = (permissions: string[], featuresConfig = mockFeatures) => {
     mockPermissions = permissions;
+    mockFeatures = featuresConfig;
     return render(<NavBar />);
 };
 
@@ -39,9 +48,34 @@ describe('NavBar component tests', () => {
     });
 
     describe('System Management section', () => {
-        it('should display System Management with appropriate permission', () => {
-            const { getByText } = renderNavBarWithPermissions(['ADMINISTRATE-SYSTEM']);
-            expect(getByText('System Management')).toBeInTheDocument();
+        const basePermissions = ['ADMINISTRATE-SYSTEM'];
+
+        describe('When deduplication is disabled', () => {
+            const config = { deduplication: { enabled: false } };
+
+            it('should display System Management with permissions', () => {
+                const { getByText } = renderNavBarWithPermissions(basePermissions, config);
+                expect(getByText('System Management')).toBeInTheDocument();
+            });
+
+            it('should not display System Management with only MERGE-PATIENT permission', () => {
+                const { queryByText } = renderNavBarWithPermissions(['MERGE-PATIENT'], config);
+                expect(queryByText('System Management')).not.toBeInTheDocument();
+            });
+        });
+
+        describe('When deduplication is enabled', () => {
+            const config = { deduplication: { enabled: true } };
+
+            it('should display System Management with permissions', () => {
+                const { getByText } = renderNavBarWithPermissions([...basePermissions, 'MERGE-PATIENT'], config);
+                expect(getByText('System Management')).toBeInTheDocument();
+            });
+
+            it('should display System Management with only MERGE-PATIENT permission', () => {
+                const { getByText } = renderNavBarWithPermissions(['MERGE-PATIENT'], config);
+                expect(getByText('System Management')).toBeInTheDocument();
+            });
         });
     });
 

--- a/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.spec.tsx
@@ -24,7 +24,7 @@ vi.mock('../../libs/permission/usePermissions', () => ({
     }),
 }));
 
-vi.mock('../../feature', () => ({
+vi.mock('feature', () => ({
     FeatureToggle: ({ guard, fallback, children }: any) => {
         return guard(mockFeatures) ? children : fallback;
     },

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -2,9 +2,9 @@ import { permitsAny, Permitted, permissions, permitsAll } from 'libs/permission'
 import { usePage } from 'page';
 import { useUser } from 'user';
 import { FeatureToggle } from 'feature';
+import { NavBarLink } from './NavBarLink';
 
 import styles from './NavBar.module.scss';
-import { NavLink } from './NavLink.tsx';
 
 const BASE_SYS_MGMT_PERMISSIONS = [
     'EPILINKADMIN-SYSTEM',
@@ -37,7 +37,7 @@ export const NavBar = () => {
                             <table role="presentation">
                                 <tbody>
                                     <tr>
-                                        <NavLink url="/nbs/HomePage.do?method=loadHomePage" name="Home" />
+                                        <NavBarLink url="/nbs/HomePage.do?method=loadHomePage" name="Home" />
                                         <Permitted
                                             permission={permitsAny(
                                                 permissions.morbidityReport.add,
@@ -49,14 +49,14 @@ export const NavBar = () => {
                                                 permissions.organization.manage
                                             )}
                                         >
-                                            <NavLink
+                                            <NavBarLink
                                                 url="/nbs/LoadNavbar.do?ContextAction=DataEntry"
                                                 name="Data Entry"
                                                 includeSeparator={true}
                                             />
                                         </Permitted>
                                         <Permitted permission={permitsAll(permissions.patient.merge)}>
-                                            <NavLink
+                                            <NavBarLink
                                                 url="/nbs/LoadNavbar1.do?ContextAction=MergePerson"
                                                 name="Merge Patients"
                                                 includeSeparator={true}
@@ -64,7 +64,7 @@ export const NavBar = () => {
                                         </Permitted>
 
                                         <Permitted permission={permitsAll(permissions.investigation.view)}>
-                                            <NavLink
+                                            <NavBarLink
                                                 url="/nbs/LoadNavbar.do?ContextAction=GlobalInvestigations&initLoad=true"
                                                 name="Open Investigations"
                                                 includeSeparator={true}
@@ -79,7 +79,7 @@ export const NavBar = () => {
                                                 permissions.reports.reportingFacility.view
                                             )}
                                         >
-                                            <NavLink
+                                            <NavBarLink
                                                 url="/nbs/nfc?ObjectType=7&amp;OperationType=116"
                                                 name="Reports"
                                                 includeSeparator={true}
@@ -90,7 +90,7 @@ export const NavBar = () => {
                                             guard={(features) => features?.deduplication?.enabled}
                                             fallback={
                                                 <Permitted permission={permitsAny(...BASE_SYS_MGMT_PERMISSIONS)}>
-                                                    <NavLink
+                                                    <NavBarLink
                                                         url="/nbs/SystemAdmin.do"
                                                         name="System Management"
                                                         includeSeparator={true}
@@ -99,7 +99,7 @@ export const NavBar = () => {
                                             }
                                         >
                                             <Permitted permission={permitsAny(...DEDUPE_FEATURE_SYS_MGMT_PERMISSIONS)}>
-                                                <NavLink
+                                                <NavBarLink
                                                     url="/nbs/SystemAdmin.do"
                                                     name="System Management"
                                                     includeSeparator={true}

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -47,7 +47,8 @@ export const NavBar = () => {
                                                 permissions.place.manage,
                                                 permissions.provider.manage,
                                                 permissions.organization.manage
-                                            )}>
+                                            )}
+                                        >
                                             <NavLink
                                                 url="/nbs/LoadNavbar.do?ContextAction=DataEntry"
                                                 name="Data Entry"
@@ -76,7 +77,8 @@ export const NavBar = () => {
                                                 permissions.reports.public.view,
                                                 permissions.reports.private.view,
                                                 permissions.reports.reportingFacility.view
-                                            )}>
+                                            )}
+                                        >
                                             <NavLink
                                                 url="/nbs/nfc?ObjectType=7&amp;OperationType=116"
                                                 name="Reports"
@@ -94,7 +96,8 @@ export const NavBar = () => {
                                                         includeSeparator={true}
                                                     />
                                                 </Permitted>
-                                            }>
+                                            }
+                                        >
                                             <Permitted permission={permitsAny(...DEDUPE_FEATURE_SYS_MGMT_PERMISSIONS)}>
                                                 <NavLink
                                                     url="/nbs/SystemAdmin.do"

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import { permitsAny, Permitted, permissions, permitsAll } from 'libs/permission';
 import { usePage } from 'page';
 import { useUser } from 'user';
 import { FeatureToggle } from 'feature';
 
 import styles from './NavBar.module.scss';
+import { NavLink } from './NavLink.tsx';
 
-const baseSystemManagementPermissions = [
+const BASE_SYS_MGMT_PERMISSIONS = [
     'EPILINKADMIN-SYSTEM',
     'VIEWELRACTIVITY-OBSERVATIONLABREPORT',
     'SRTADMIN-SYSTEM',
@@ -18,7 +18,7 @@ const baseSystemManagementPermissions = [
     'ADMINISTRATE-SECURITY',
 ];
 
-const mergePatientFeaturePermissions = [...baseSystemManagementPermissions, 'MERGE-PATIENT'];
+const DEDUPE_FEATURE_SYS_MGMT_PERMISSIONS = [...BASE_SYS_MGMT_PERMISSIONS, 'MERGE-PATIENT'];
 
 export const NavBar = () => {
     const {
@@ -27,13 +27,6 @@ export const NavBar = () => {
     } = useUser();
 
     const { title } = usePage();
-
-    const SystemManagementLink: React.ReactNode = (
-        <td className={styles.navLink}>
-            <span> | </span>
-            <a href={`/nbs/SystemAdmin.do`}>System Management</a>
-        </td>
-    );
 
     return (
         <nav className={styles.navbar} aria-label="main menu">
@@ -44,10 +37,7 @@ export const NavBar = () => {
                             <table role="presentation">
                                 <tbody>
                                     <tr>
-                                        <td className={styles.navLink}>
-                                            <a href={`/nbs/HomePage.do?method=loadHomePage`}>Home</a>
-                                        </td>
-
+                                        <NavLink url="/nbs/HomePage.do?method=loadHomePage" name="Home" />
                                         <Permitted
                                             permission={permitsAny(
                                                 permissions.morbidityReport.add,
@@ -57,37 +47,27 @@ export const NavBar = () => {
                                                 permissions.place.manage,
                                                 permissions.provider.manage,
                                                 permissions.organization.manage
-                                            )}
-                                        >
-                                            <td>
-                                                <span> | </span>
-                                            </td>
-                                            <td className={styles.navLink}>
-                                                <a href={`/nbs/LoadNavbar.do?ContextAction=DataEntry`}>Data Entry</a>
-                                            </td>
+                                            )}>
+                                            <NavLink
+                                                url="/nbs/LoadNavbar.do?ContextAction=DataEntry"
+                                                name="Data Entry"
+                                                includeSeparator={true}
+                                            />
                                         </Permitted>
                                         <Permitted permission={permitsAll(permissions.patient.merge)}>
-                                            <td>
-                                                <span> | </span>
-                                            </td>
-                                            <td className={styles.navLink}>
-                                                <a href={`/nbs/LoadNavbar1.do?ContextAction=MergePerson`}>
-                                                    Merge Patients
-                                                </a>
-                                            </td>
+                                            <NavLink
+                                                url="/nbs/LoadNavbar1.do?ContextAction=MergePerson"
+                                                name="Merge Patients"
+                                                includeSeparator={true}
+                                            />
                                         </Permitted>
 
                                         <Permitted permission={permitsAll(permissions.investigation.view)}>
-                                            <td>
-                                                <span> | </span>
-                                            </td>
-                                            <td className={styles.navLink}>
-                                                <a
-                                                    href={`/nbs/LoadNavbar.do?ContextAction=GlobalInvestigations&initLoad=true`}
-                                                >
-                                                    Open Investigations
-                                                </a>
-                                            </td>
+                                            <NavLink
+                                                url="/nbs/LoadNavbar.do?ContextAction=GlobalInvestigations&initLoad=true"
+                                                name="Open Investigations"
+                                                includeSeparator={true}
+                                            />
                                         </Permitted>
 
                                         <Permitted
@@ -96,26 +76,31 @@ export const NavBar = () => {
                                                 permissions.reports.public.view,
                                                 permissions.reports.private.view,
                                                 permissions.reports.reportingFacility.view
-                                            )}
-                                        >
-                                            <td>
-                                                <span> | </span>
-                                            </td>
-                                            <td className={styles.navLink}>
-                                                <a href={`/nbs/nfc?ObjectType=7&amp;OperationType=116`}>Reports</a>
-                                            </td>
+                                            )}>
+                                            <NavLink
+                                                url="/nbs/nfc?ObjectType=7&amp;OperationType=116"
+                                                name="Reports"
+                                                includeSeparator={true}
+                                            />
                                         </Permitted>
 
                                         <FeatureToggle
                                             guard={(features) => features?.deduplication?.enabled}
                                             fallback={
-                                                <Permitted permission={permitsAny(...baseSystemManagementPermissions)}>
-                                                    {SystemManagementLink}
+                                                <Permitted permission={permitsAny(...BASE_SYS_MGMT_PERMISSIONS)}>
+                                                    <NavLink
+                                                        url="/nbs/SystemAdmin.do"
+                                                        name="System Management"
+                                                        includeSeparator={true}
+                                                    />
                                                 </Permitted>
-                                            }
-                                        >
-                                            <Permitted permission={permitsAny(...mergePatientFeaturePermissions)}>
-                                                {SystemManagementLink}
+                                            }>
+                                            <Permitted permission={permitsAny(...DEDUPE_FEATURE_SYS_MGMT_PERMISSIONS)}>
+                                                <NavLink
+                                                    url="/nbs/SystemAdmin.do"
+                                                    name="System Management"
+                                                    includeSeparator={true}
+                                                />
                                             </Permitted>
                                         </FeatureToggle>
                                     </tr>

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { permitsAny, Permitted, permissions, permitsAll } from 'libs/permission';
 import { usePage } from 'page';
 import { useUser } from 'user';
+import { FeatureToggle } from 'feature';
 
 import styles from './NavBar.module.scss';
-import { FeatureToggle } from '../../feature';
 
 const baseSystemManagementPermissions = [
     'EPILINKADMIN-SYSTEM',

--- a/apps/modernization-ui/src/shared/header/NavBar.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBar.tsx
@@ -1,8 +1,24 @@
+import React from 'react';
 import { permitsAny, Permitted, permissions, permitsAll } from 'libs/permission';
 import { usePage } from 'page';
 import { useUser } from 'user';
 
 import styles from './NavBar.module.scss';
+import { FeatureToggle } from '../../feature';
+
+const baseSystemManagementPermissions = [
+    'EPILINKADMIN-SYSTEM',
+    'VIEWELRACTIVITY-OBSERVATIONLABREPORT',
+    'SRTADMIN-SYSTEM',
+    'VIEWPHCRACTIVITY-CASEREPORTING',
+    'IMPORTEXPORTADMIN-SYSTEM',
+    'REPORTADMIN-SYSTEM',
+    'ALERTADMIN-SYSTEM',
+    'ADMINISTRATE-SYSTEM',
+    'ADMINISTRATE-SECURITY',
+];
+
+const mergePatientFeaturePermissions = [...baseSystemManagementPermissions, 'MERGE-PATIENT'];
 
 export const NavBar = () => {
     const {
@@ -11,6 +27,13 @@ export const NavBar = () => {
     } = useUser();
 
     const { title } = usePage();
+
+    const SystemManagementLink: React.ReactNode = (
+        <td className={styles.navLink}>
+            <span> | </span>
+            <a href={`/nbs/SystemAdmin.do`}>System Management</a>
+        </td>
+    );
 
     return (
         <nav className={styles.navbar} aria-label="main menu">
@@ -83,25 +106,18 @@ export const NavBar = () => {
                                             </td>
                                         </Permitted>
 
-                                        <Permitted
-                                            permission={permitsAny(
-                                                'EPILINKADMIN-SYSTEM',
-                                                'VIEWELRACTIVITY-OBSERVATIONLABREPORT',
-                                                'SRTADMIN-SYSTEM',
-                                                'VIEWPHCRACTIVITY-CASEREPORTING',
-                                                'IMPORTEXPORTADMIN-SYSTEM',
-                                                'REPORTADMIN-SYSTEM',
-                                                'ALERTADMIN-SYSTEM',
-                                                'ADMINISTRATE-SYSTEM',
-                                                'ADMINISTRATE-SECURITY',
-                                                'MERGE-PATIENT'
-                                            )}
+                                        <FeatureToggle
+                                            guard={(features) => features?.deduplication?.enabled}
+                                            fallback={
+                                                <Permitted permission={permitsAny(...baseSystemManagementPermissions)}>
+                                                    {SystemManagementLink}
+                                                </Permitted>
+                                            }
                                         >
-                                            <td className={styles.navLink}>
-                                                <span> | </span>
-                                                <a href={`/nbs/SystemAdmin.do`}>System Management</a>
-                                            </td>
-                                        </Permitted>
+                                            <Permitted permission={permitsAny(...mergePatientFeaturePermissions)}>
+                                                {SystemManagementLink}
+                                            </Permitted>
+                                        </FeatureToggle>
                                     </tr>
                                 </tbody>
                             </table>

--- a/apps/modernization-ui/src/shared/header/NavBarLink.tsx
+++ b/apps/modernization-ui/src/shared/header/NavBarLink.tsx
@@ -6,7 +6,7 @@ type NavLinkProps = {
     includeSeparator?: boolean;
 };
 
-export const NavLink = ({ url, name, includeSeparator = false }: NavLinkProps) => {
+export const NavBarLink = ({ url, name, includeSeparator = false }: NavLinkProps) => {
     return (
         <td className={styles.navLink}>
             {includeSeparator && <span> | </span>}

--- a/apps/modernization-ui/src/shared/header/NavLink.tsx
+++ b/apps/modernization-ui/src/shared/header/NavLink.tsx
@@ -1,5 +1,3 @@
-import React, { ReactNode } from 'react';
-
 import styles from './NavBar.module.scss';
 
 type NavLinkProps = {

--- a/apps/modernization-ui/src/shared/header/NavLink.tsx
+++ b/apps/modernization-ui/src/shared/header/NavLink.tsx
@@ -9,8 +9,8 @@ type NavLinkProps = {
 export const NavLink = ({ url, name, includeSeparator = false }: NavLinkProps) => {
     return (
         <td className={styles.navLink}>
-            {includeSeparator && <span> | </span> }
-            <a href={url}>{ name }</a>
+            {includeSeparator && <span> | </span>}
+            <a href={url}>{name}</a>
         </td>
     );
 };

--- a/apps/modernization-ui/src/shared/header/NavLink.tsx
+++ b/apps/modernization-ui/src/shared/header/NavLink.tsx
@@ -1,0 +1,18 @@
+import React, { ReactNode } from 'react';
+
+import styles from './NavBar.module.scss';
+
+type NavLinkProps = {
+    url: string;
+    name: string;
+    includeSeparator?: boolean;
+};
+
+export const NavLink = ({ url, name, includeSeparator = false }: NavLinkProps) => {
+    return (
+        <td className={styles.navLink}>
+            {includeSeparator && <span> | </span> }
+            <a href={url}>{ name }</a>
+        </td>
+    );
+};


### PR DESCRIPTION
## Description

- Fixes a bug where the "System Management" tab was erroneously appearing on NBS 7 pages if a user had the `MERGE-PATIENT` permission leading to a confusing user experience
  - Example:
     - Prerequisite: A user with no system management related permissions but has the `MERGE-PATIENT` permission (locally this is our `state` user)
      1. On the home page notice the "System Management" tab is not visible in the navbar
      2. Go to report run page for any Report, now you can see the "System Management" tab in the navbar
- This fix now conditionally checks for the `MERGE-PATIENT` permission to display that tab if that feature has been enabled
- To toggle this locally, update [this value](https://github.com/CDCgov/NEDSS-Modernization/blob/45435091777d4dbe6934d3785115cf2c2f6680bc/docker-compose.yml#L27)

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-886)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests