### PR TITLE
fix: handle empty date ranges

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -468,10 +468,7 @@ public class WhereClauseService {
     String colType = column.sourceTypeCode();
     List<String> formattedValues = new ArrayList<>();
 
-    if (!values.isEmpty()) {
-      if (values.stream().allMatch(String::isEmpty)) {
-        return "";
-      }
+    if (!values.isEmpty() && !values.stream().allMatch(String::isEmpty)) {
       if (colType.equals("DATE") || colType.equals("DATETIME")) {
         formattedValues = fieldFormatter.convertToSQLFromDateRange(values);
       } else {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -469,6 +469,9 @@ public class WhereClauseService {
     List<String> formattedValues = new ArrayList<>();
 
     if (!values.isEmpty()) {
+      if (values.stream().allMatch(String::isBlank)) {
+        return "";
+      }
       if (colType.equals("DATE") || colType.equals("DATETIME")) {
         formattedValues = fieldFormatter.convertToSQLFromDateRange(values);
       } else {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/report/WhereClauseService.java
@@ -469,7 +469,7 @@ public class WhereClauseService {
     List<String> formattedValues = new ArrayList<>();
 
     if (!values.isEmpty()) {
-      if (values.stream().allMatch(String::isBlank)) {
+      if (values.stream().allMatch(String::isEmpty)) {
         return "";
       }
       if (colType.equals("DATE") || colType.equals("DATETIME")) {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
@@ -352,6 +352,26 @@ class WhereClauseServiceTest {
   }
 
   @Test
+  void should_handle_empty_or_null_time_range_values() {
+    Long filterUid = 200L;
+    Long columnUid = 5L;
+    FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
+
+    BasicFilterConfiguration config =
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, false, filterType);
+
+    ReportColumn reportColumn = mockReportColumn(columnUid, "DATE", "date_column");
+    ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
+
+    List<BasicFilterRequest> request =
+        List.of(new BasicFilterRequest(filterUid, List.of("", ""), false));
+
+    String whereFragment = whereClauseService.buildBasicWhereFragment(reportConfig, request);
+
+    assertThat(whereFragment).isEqualTo("");
+  }
+
+  @Test
   void should_handle_time_range_values_with_includeNulls() {
     Long filterUid = 200L;
     Long columnUid = 5L;

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/WhereClauseServiceTest.java
@@ -352,7 +352,7 @@ class WhereClauseServiceTest {
   }
 
   @Test
-  void should_handle_empty_or_null_time_range_values() {
+  void should_handle_empty_string_time_range_values() {
     Long filterUid = 200L;
     Long columnUid = 5L;
     FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
@@ -368,7 +368,7 @@ class WhereClauseServiceTest {
 
     String whereFragment = whereClauseService.buildBasicWhereFragment(reportConfig, request);
 
-    assertThat(whereFragment).isEqualTo("");
+    assertThat(whereFragment).isEmpty();
   }
 
   @Test
@@ -406,6 +406,26 @@ class WhereClauseServiceTest {
     ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
 
     List<BasicFilterRequest> request = List.of(new BasicFilterRequest(filterUid, List.of(), true));
+
+    String whereFragment = whereClauseService.buildBasicWhereFragment(reportConfig, request);
+
+    assertThat(whereFragment).isEqualTo("([date_column] IS NULL)");
+  }
+
+  @Test
+  void should_handle_empty_string_time_range_values_with_includeNulls() {
+    Long filterUid = 200L;
+    Long columnUid = 5L;
+    FilterType filterType = createFilterType("BAS_TIM_RANGE", "");
+
+    BasicFilterConfiguration config =
+        createBasicFilterConfiguration(List.of(), filterUid, columnUid, true, filterType);
+
+    ReportColumn reportColumn = mockReportColumn(columnUid, "DATE", "date_column");
+    ReportConfiguration reportConfig = createReportConfig(List.of(config), List.of(reportColumn));
+
+    List<BasicFilterRequest> request =
+        List.of(new BasicFilterRequest(filterUid, List.of("", ""), true));
 
     String whereFragment = whereClauseService.buildBasicWhereFragment(reportConfig, request);
 


### PR DESCRIPTION
## Description
- Fixes a bug in the basic filter with a date range that is not required, a date is entered and then cleared -> resulted in a 422 error
- With this fix, the report should run

A good report to test with is `/report/10066731/22/run` (Case Lab Line Listing)

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-888)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
