### PR TITLE
[APP-890] fix: handle ordering by computed clause

### DIFF
--- a/apps/report-execution/src/libraries/nbs_custom.py
+++ b/apps/report-execution/src/libraries/nbs_custom.py
@@ -15,7 +15,12 @@ def execute(
     * Lifted the size check to a global check and refined the env var names
     * Date formatting still needs to be figured out
     """
-    query = subset_query + ' ORDER BY ' + sort_by if sort_by else subset_query
+    # the order by has the alias, so we need to order after selecting
+    query = (
+        f'WITH subset as ({subset_query}) SELECT * FROM subset ORDER BY ' + sort_by
+        if sort_by
+        else subset_query
+    )
     content = trx.query(query)
 
     return ReportResult(content=content)

--- a/apps/report-execution/tests/integration/libraries/nbs_custom.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_custom.py
@@ -79,6 +79,33 @@ class TestIntegrationNbsCustomLibrary:
             'EVENT_DATE',
         ]
 
+    def test_execute_report_string_sort(self, snapshot):
+        report_spec = ReportSpec.model_validate(
+            {
+                'is_export': True,
+                'is_builtin': True,
+                'library_name': 'nbs_custom',
+                'subset_query': """
+                        SELECT PROGRAM_JURISDICTION_OID,
+                               PATIENT_LOCAL_ID as [Patient Local Id],
+                               EVENT_DATE
+                        FROM rdb.dbo.DM_INV_STD
+                """,
+                'sort_by': 'UPPER([Patient Local Id])',
+            }
+        )
+
+        result = execute_report(report_spec)
+
+        data = result.content.data
+        assert len(data) == 500
+        assert len(data[0]) == len(result.content.columns)
+        assert result.content.columns == [
+            'PROGRAM_JURISDICTION_OID',
+            'PATIENT_LOCAL_ID',
+            'EVENT_DATE',
+        ]
+
     def test_execute_report_no_data(self, snapshot):
         report_spec = ReportSpec.model_validate(
             {

--- a/apps/report-execution/tests/integration/libraries/nbs_custom.py
+++ b/apps/report-execution/tests/integration/libraries/nbs_custom.py
@@ -102,7 +102,7 @@ class TestIntegrationNbsCustomLibrary:
         assert len(data[0]) == len(result.content.columns)
         assert result.content.columns == [
             'PROGRAM_JURISDICTION_OID',
-            'PATIENT_LOCAL_ID',
+            'Patient Local Id',
             'EVENT_DATE',
         ]
 


### PR DESCRIPTION
## Description

When we order by strings, we upper them, and that was throwing things off for sql as the computation needs the "raw" column name and not the "alias" column name.

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-890

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
