### PR TITLE
[APP-895] fix: have dead pages 404

### DIFF
--- a/apps/modernization-ui/src/routes/AppRoutes.tsx
+++ b/apps/modernization-ui/src/routes/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router';
+import { createBrowserRouter, RouteObject, RouterProvider } from 'react-router';
 import { initializationLoader, ProtectedLayout } from 'authorization';
 
 import { RedirectHome } from './RedirectHome';
@@ -16,8 +16,9 @@ import { Expired } from 'apps/landing/Expired/Expired';
 import { routing as patientFileRouting } from 'apps/patient/file/PatientFileRouting';
 import { PageProvider } from 'page';
 import { LoadingBlock } from 'libs/loading/block';
+import { ErrorPage } from 'pages/error/ErrorPage';
 
-const routing = [
+const routing: RouteObject[] = [
     welcomeRouting,
     logoutRouting,
     {
@@ -33,6 +34,7 @@ const routing = [
         element: <ProtectedLayout />,
         loader: initializationLoader,
         HydrateFallback: LoadingBlock,
+        ErrorBoundary: ErrorPage,
         children: [
             { index: true, element: <RedirectHome /> },
             ...searchRouting,
@@ -44,7 +46,6 @@ const routing = [
             ...reportRouting,
         ],
     },
-    { path: '*', element: <Navigate to={'/'} /> },
     { path: 'expired', element: <Expired /> },
 ];
 

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/report/ReportAdminRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/report/ReportAdminRouteLocatorConfiguration.java
@@ -28,6 +28,10 @@ import org.springframework.context.annotation.Configuration;
  *   <li>Request is a GET
  *   <li>Path equal to {@code /nbs/NewReport.do
  * </ul>
+ * <ul>
+ *   <li>Request is a GET
+ *   <li>Path equal to {@code /nbs/EditReport.do} or {@code /nbs/NewReportFilter.do} or {@code /nbs/EditReportFilter.do}
+ * </ul>
  */
 @Configuration
 @ConditionalOnProperty(
@@ -76,6 +80,9 @@ class ReportAdminRouteLocatorConfiguration {
                                 .setPath("/nbs/redirect/report/management/configuration/add")
                                 .filters(defaults))
                     .uri(service.uri()))
+
+        // route unused report routes to mod so they will 404 instead of kind of work, kind of not
+        // in NBS 6
         .route(
             "report-config-old-unused",
             route ->
@@ -83,7 +90,7 @@ class ReportAdminRouteLocatorConfiguration {
                     .order(RouteOrdering.MODERNIZED_SERVICE.order())
                     .path(
                         "/nbs/EditReport.do", "/nbs/EditReportFilter.do", "/nbs/NewReportFilter.do")
-                    .filters(filter -> filter.setStatus(404).filters(defaults))
+                    .filters(filter -> filter.filters(defaults))
                     .uri(service.uri()))
         .build();
   }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/report/ReportAdminRouteLocatorConfiguration.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/report/ReportAdminRouteLocatorConfiguration.java
@@ -76,6 +76,15 @@ class ReportAdminRouteLocatorConfiguration {
                                 .setPath("/nbs/redirect/report/management/configuration/add")
                                 .filters(defaults))
                     .uri(service.uri()))
+        .route(
+            "report-config-old-unused",
+            route ->
+                route
+                    .order(RouteOrdering.MODERNIZED_SERVICE.order())
+                    .path(
+                        "/nbs/EditReport.do", "/nbs/EditReportFilter.do", "/nbs/NewReportFilter.do")
+                    .filters(filter -> filter.setStatus(404).filters(defaults))
+                    .uri(service.uri()))
         .build();
   }
 }

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/report/ReportAdminRouteLocatorConfigurationTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/report/ReportAdminRouteLocatorConfigurationTest.java
@@ -1,7 +1,9 @@
 package gov.cdc.nbs.gateway.report;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
@@ -38,38 +40,101 @@ class ReportAdminRouteLocatorConfigurationTest {
   @Test
   void should_route_modernization_ui_for_view() {
     modApi.stubFor(
-        get(urlPathMatching("/nbs/redirect/report/management/configuration/2/1")).willReturn(ok()));
+        post(urlPathMatching("/nbs/redirect/report/management/configuration/2/1"))
+            .willReturn(ok()));
 
     webClient
         .post()
-        .uri(builder -> builder.path("/nbs/ViewReport.do?report_uid=2&data_source_uid=1").build())
+        .uri(
+            builder ->
+                builder.path("/nbs/ViewReport.do").query("report_uid=2&data_source_uid=1").build())
         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
         .exchange()
-        .expectStatus();
+        .expectStatus()
+        .isOk();
   }
 
   @Test
   void should_not_route_to_modernization_view_when_missing_params() {
-    classic.stubFor(get("/nbs/ViewReport.do").willReturn(ok()));
+    classic.stubFor(post(urlPathMatching("/nbs/ViewReport.do.*")).willReturn(ok()));
 
     webClient
         .post()
-        .uri(builder -> builder.path("/nbs/ViewReport.do?data_source_uid=1").build())
+        .uri(
+            builder ->
+                builder.path("/nbs/ViewReport.do").queryParam("data_source_uid", "1").build())
         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
         .exchange()
-        .expectStatus();
+        .expectStatus()
+        .isOk();
   }
 
   @Test
   void should_route_modernization_ui_for_add() {
     modApi.stubFor(
-        get(urlPathMatching("/nbs/redirect/report/management/configuration/add")).willReturn(ok()));
+        post(urlPathMatching("/nbs/redirect/report/management/configuration/add"))
+            .willReturn(ok()));
 
     webClient
         .post()
         .uri(builder -> builder.path("/nbs/NewReport.do").build())
         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
         .exchange()
-        .expectStatus();
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void should_route_modernization_404_ui_for_edit() {
+    modApi.stubFor(get(urlPathMatching("/nbs/EditReport.do")).willReturn(notFound()));
+    classic.stubFor(get(urlPathMatching("/nbs/EditReport.do")).willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(builder -> builder.path("/nbs/EditReport.do").build())
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void should_route_modernization_404_ui_for_new_filter() {
+    modApi.stubFor(get(urlPathMatching("/nbs/NewReportFilter.do")).willReturn(notFound()));
+    classic.stubFor(get(urlPathMatching("/nbs/NewReportFilter.do")).willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(builder -> builder.path("/nbs/NewReportFilter.do").build())
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void should_route_modernization_404_ui_for_edit_filter() {
+    modApi.stubFor(get(urlPathMatching("/nbs/EditReportFilter.do")).willReturn(notFound()));
+    classic.stubFor(get(urlPathMatching("/nbs/EditReportFilter.do")).willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(builder -> builder.path("/nbs/EditReportFilter.do").build())
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void should_route_modernization_404_ui_for_edit_filter_with_params() {
+    modApi.stubFor(get(urlPathMatching("/nbs/EditReportFilter.do")).willReturn(notFound()));
+    classic.stubFor(get(urlPathMatching("/nbs/EditReportFilter.do")).willReturn(ok()));
+
+    webClient
+        .get()
+        .uri(
+            builder ->
+                builder.path("/nbs/EditReportFilter.do").queryParam("filter_uid", "1").build())
+        .exchange()
+        .expectStatus()
+        .isNotFound();
   }
 }

--- a/testing/regression/cypress/e2e/features/reports/admin.feature
+++ b/testing/regression/cypress/e2e/features/reports/admin.feature
@@ -205,4 +205,15 @@ Feature: Manage report configuration
         When I click the "Cancel" button
         Then I should see the report list
 
+    Scenario Outline: Old path <path> 404's
+        When I navigate to "<path>" path
+        Then I should see a "heading" labelled "Not Found"
+
+        Examples:
+            | path |
+            | /nbs/EditReport.do |
+            | /nbs/NewReportFilter.do |
+            | /nbs/EditReportFilter.do |
+            | /nbs/EditReportFilter.do?filter_uid=123 |
+
         

--- a/testing/regression/cypress/step_definitions/generic.steps.js
+++ b/testing/regression/cypress/step_definitions/generic.steps.js
@@ -1,5 +1,9 @@
 import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
+When('I navigate to {string} path', (url) => {
+    cy.visit(url);
+})
+
 When('I click on the {string} link', (name) => {
     cy.contains('a', name).click();
 });


### PR DESCRIPTION
## Description

Redirect un-used NBS 6 report admin paths to mod so they will 404 instead of kind of work, kind of not.

Notes:
* This changes the local dev behavior where things generally/agressively redirect to search instead of 404

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-895

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
