### PR TITLE
override 'js-yaml' to version '4.3.0' to fix vulnerability

### DIFF
--- a/apps/modernization-ui/package-lock.json
+++ b/apps/modernization-ui/package-lock.json
@@ -10805,9 +10805,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {

--- a/apps/modernization-ui/package.json
+++ b/apps/modernization-ui/package.json
@@ -37,7 +37,8 @@
         "typescript": "6.0.3",
         "prop-types": "^15.8.1",
         "nth-check": "^2.0.1 ",
-        "postcss": "^8.4.31"
+        "postcss": "^8.4.31",
+        "js-yaml": "4.3.0"
     },
     "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
## Description

This PR overrides the transitive dependency `js-yaml` to version `4.3.0` which fixes the vulnerability without having to update any parent packages.

Vulnerability reports:
- https://github.com/CDCgov/NEDSS-Modernization/security/dependabot/312
- https://github.com/CDCgov/NEDSS-Modernization/security/dependabot/316