### PR TITLE
override version for 'js-yaml' to '4.3.0' to fix vulnerability in cypress tests

### DIFF
--- a/testing/regression/package-lock.json
+++ b/testing/regression/package-lock.json
@@ -1818,9 +1818,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1838,9 +1835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1858,9 +1852,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1878,9 +1869,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1898,9 +1886,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1918,9 +1903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5926,9 +5908,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/testing/regression/package.json
+++ b/testing/regression/package.json
@@ -35,6 +35,9 @@
     "react-dom": "^19.2.5",
     "vite": "^8.0.16"
   },
+  "overrides" : {
+    "js-yaml": "4.3.0"
+  },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": false,
     "stepDefinitions": "./cypress/step_definitions/**/*.{js,ts}",


### PR DESCRIPTION
## Description

This PR is for the cypress testing found at `testing/regression`.

Sets `js-yaml` to version `4.3.0` in overrides to fix transitive dependency without changing versions of parent packages.

Vulnerability: https://github.com/CDCgov/NEDSS-Modernization/security/dependabot/316