### PR TITLE
build: allow disabling of secure cookie usage

### DIFF
--- a/apps/modernization-api/src/main/resources/application-development.yml
+++ b/apps/modernization-api/src/main/resources/application-development.yml
@@ -29,6 +29,8 @@ logging:
 nbs:
   primary-language: English
   security:
+    # doesn't play nicely with safari for local dev
+    tokenCookieSecure: false
     oidc:
       enabled: false
   report:

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/NBSToken.java
@@ -9,7 +9,7 @@ public record NBSToken(String value) {
   private static final String NBS_TOKEN_NAME = "nbs_token";
 
   public void apply(final SecurityProperties properties, final HttpServletResponse response) {
-    Cookie cookie = asCookie();
+    Cookie cookie = asCookie(properties.getTokenCookieSecure());
     cookie.setMaxAge(properties.getTokenExpirationSeconds());
     response.addCookie(cookie);
   }
@@ -27,10 +27,10 @@ public record NBSToken(String value) {
   }
 
   @SuppressWarnings({"squid:S3330"})
-  private Cookie asCookie() {
+  private Cookie asCookie(boolean secure) {
     Cookie cookie = new Cookie(NBS_TOKEN_NAME, value());
     cookie.setPath("/");
-    cookie.setSecure(true);
+    cookie.setSecure(secure);
     return cookie;
   }
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SecurityProperties.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SecurityProperties.java
@@ -5,8 +5,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "nbs.security")
 public record SecurityProperties(
-    String tokenSecret, String tokenIssuer, long tokenExpirationMillis) {
+    String tokenSecret, String tokenIssuer, long tokenExpirationMillis, Boolean tokenCookieSecure) {
   public int getTokenExpirationSeconds() {
     return Math.toIntExact(TimeUnit.MILLISECONDS.toSeconds(tokenExpirationMillis));
+  }
+
+  public boolean getTokenCookieSecure() {
+    return tokenCookieSecure != false; // null is truthy
   }
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SecurityProperties.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SecurityProperties.java
@@ -11,6 +11,6 @@ public record SecurityProperties(
   }
 
   public boolean getTokenCookieSecure() {
-    return tokenCookieSecure != false; // null is truthy
+    return tokenCookieSecure == null || tokenCookieSecure == true;
   }
 }

--- a/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SecurityProperties.java
+++ b/libs/authentication/src/main/java/gov/cdc/nbs/authentication/SecurityProperties.java
@@ -11,6 +11,6 @@ public record SecurityProperties(
   }
 
   public boolean getTokenCookieSecure() {
-    return tokenCookieSecure == null || tokenCookieSecure == true;
+    return tokenCookieSecure == null || tokenCookieSecure;
   }
 }

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSTokenTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSTokenTest.java
@@ -1,0 +1,59 @@
+package gov.cdc.nbs.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class NBSTokenTest {
+
+  @Test
+  void should_apply_token_with_security_when_null() {
+    SecurityProperties properties = new SecurityProperties("secret", "test-issuer", 10000, null);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    NBSToken token = new NBSToken("token");
+    token.apply(properties, response);
+
+    ArgumentCaptor<Cookie> captor = ArgumentCaptor.forClass(Cookie.class);
+    verify(response).addCookie(captor.capture());
+    Cookie cookie = captor.getValue();
+
+    assertTrue(cookie.getSecure());
+  }
+
+  @Test
+  void should_apply_token_with_security_when_true() {
+    SecurityProperties properties = new SecurityProperties("secret", "test-issuer", 10000, true);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    NBSToken token = new NBSToken("token");
+    token.apply(properties, response);
+
+    ArgumentCaptor<Cookie> captor = ArgumentCaptor.forClass(Cookie.class);
+    verify(response).addCookie(captor.capture());
+    Cookie cookie = captor.getValue();
+
+    assertTrue(cookie.getSecure());
+  }
+
+  @Test
+  void should_apply_token_without_security_when_false() {
+    SecurityProperties properties = new SecurityProperties("secret", "test-issuer", 10000, false);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    NBSToken token = new NBSToken("token");
+    token.apply(properties, response);
+
+    ArgumentCaptor<Cookie> captor = ArgumentCaptor.forClass(Cookie.class);
+    verify(response).addCookie(captor.capture());
+    Cookie cookie = captor.getValue();
+
+    assertFalse(cookie.getSecure());
+  }
+}

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSTokenTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/NBSTokenTest.java
@@ -10,7 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-public class NBSTokenTest {
+class NBSTokenTest {
 
   @Test
   void should_apply_token_with_security_when_null() {

--- a/libs/authentication/src/test/java/gov/cdc/nbs/authentication/TokenCreatorTest.java
+++ b/libs/authentication/src/test/java/gov/cdc/nbs/authentication/TokenCreatorTest.java
@@ -20,7 +20,7 @@ class TokenCreatorTest {
 
     Clock clock = Clock.fixed(Instant.parse("2020-03-03T10:15:30.00Z"), ZoneOffset.UTC);
 
-    SecurityProperties properties = new SecurityProperties("secret", "test-issuer", 10000);
+    SecurityProperties properties = new SecurityProperties("secret", "test-issuer", 10000, null);
 
     Algorithm algorithm = mock(Algorithm.class);
 


### PR DESCRIPTION
## Description

Turns out NBS 7 just doesn't work at all on safari in local development because https isn't used and per-spec, secure cookies only work on https (even though other browsers are more forgiving)
