### PR TITLE
fix: allow `esc` to cancel confirmation modal unless disabled

### DIFF
--- a/apps/modernization-ui/src/apps/page-builder/components/DeleteQuestion/DeleteQuestion.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/components/DeleteQuestion/DeleteQuestion.tsx
@@ -29,9 +29,6 @@ const DeleteQuestion = ({ onDelete, isStaticElement }: CommonProps) => {
                     handleDeleteQuetions();
                     deleteModalRef.current?.toggleModal();
                 }}
-                onCancel={() => {
-                    deleteModalRef.current?.toggleModal();
-                }}
             />
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/Question.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/question/Question.tsx
@@ -57,9 +57,6 @@ export const Question = ({
                             modal.current?.toggleModal();
                         }}
                         cancelText="Cancel"
-                        onCancel={() => {
-                            modal.current?.toggleModal();
-                        }}
                     />
                 )}
                 <QuestionContent

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/Section.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/Section.tsx
@@ -250,9 +250,6 @@ export const Section = ({
                     deleteSubsection();
                     deleteSubsectionModalRef.current?.toggleModal();
                 }}
-                onCancel={() => {
-                    deleteSubsectionModalRef.current?.toggleModal();
-                }}
             />
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/Sections.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/section/Sections.tsx
@@ -118,9 +118,6 @@ export const Sections = ({
                     deleteSection();
                     deleteSectionModalRef.current?.toggleModal();
                 }}
-                onCancel={() => {
-                    deleteSectionModalRef.current?.toggleModal();
-                }}
             />
         </div>
     );

--- a/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/edit/subsection/SubsectionHeader.tsx
@@ -166,9 +166,6 @@ export const SubsectionHeader = ({
                     handleUngroup();
                     ungroupSubsectionModalRef.current?.toggleModal();
                 }}
-                onCancel={() => {
-                    ungroupSubsectionModalRef.current?.toggleModal();
-                }}
             />
             <ModalComponent
                 modalRef={addStaticElementModalRef}

--- a/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/page/management/preview/PreviewPage.tsx
@@ -229,9 +229,6 @@ const PreviewPageContent = () => {
                 onConfirm={() => {
                     handleDeleteDraft();
                 }}
-                onCancel={() => {
-                    deleteDraftRef.current?.toggleModal();
-                }}
             />
             {!isPublishing ? (
                 <ModalComponent

--- a/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Edit/EditBusinessRules.tsx
+++ b/apps/modernization-ui/src/apps/page-builder/pages/BusinessRulesLibrary/Edit/EditBusinessRules.tsx
@@ -193,7 +193,6 @@ export const EditBusinessRule = () => {
                 detail="Once deleted, this business rule will be permanently removed from the system and will no longer be associated with the page."
                 confirmText="Yes, delete"
                 onConfirm={onDelete}
-                onCancel={() => deleteWarningModal.current?.toggleModal(undefined, false)}
             />
             <div className={styles.breadCrumb}>
                 <Breadcrumb start="../">Business rules</Breadcrumb>

--- a/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
@@ -226,9 +226,6 @@ const DataSourceEditCard = ({
                     setDataSource(dataSource);
                     confirmDataSourceRef.current?.toggleModal();
                 }}
-                onCancel={() => {
-                    confirmDataSourceRef.current?.toggleModal();
-                }}
             />
         </DataSourceCard>
     );

--- a/apps/modernization-ui/src/apps/report/management/configuration/ViewReportConfiguration.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/ViewReportConfiguration.tsx
@@ -66,9 +66,6 @@ const ViewReportConfiguration = () => {
                         })
                         .finally(() => setDeleting(false));
                 }}
-                onCancel={() => {
-                    confirmDeleteRef.current?.toggleModal();
-                }}
             />
         </ReportLayout>
     );

--- a/apps/modernization-ui/src/apps/report/run/modals/SaveAsReportModal.tsx
+++ b/apps/modernization-ui/src/apps/report/run/modals/SaveAsReportModal.tsx
@@ -72,6 +72,7 @@ export const SaveAsReportModal = ({ saveAsReportModalRef, saving, onSaveAs }: Sa
 
     return (
         <ModalComponent
+            forceAction={saving}
             id="save-report-modal"
             className={styles.layout}
             modalRef={saveAsReportModalRef}

--- a/apps/modernization-ui/src/confirmation/ConfirmationModal.tsx
+++ b/apps/modernization-ui/src/confirmation/ConfirmationModal.tsx
@@ -1,5 +1,14 @@
 import { ReactNode, RefObject } from 'react';
-import { Button, ButtonGroup, Icon, Modal, ModalFooter, ModalHeading, ModalRef } from '@trussworks/react-uswds';
+import {
+    Button,
+    ButtonGroup,
+    Icon,
+    Modal,
+    ModalFooter,
+    ModalHeading,
+    ModalRef,
+    ModalToggleButton,
+} from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import style from './confirmationModal.module.scss';
 
@@ -13,7 +22,6 @@ type Props = {
     confirmText?: string;
     onConfirm: () => void;
     cancelText?: string;
-    onCancel: () => void;
     confirmBtnClassName?: string;
     disabled?: boolean;
 };
@@ -28,13 +36,13 @@ export const ConfirmationModal = ({
     confirmText = 'Confirm',
     onConfirm,
     cancelText = 'Cancel',
-    onCancel,
     confirmBtnClassName,
     disabled = false,
 }: Props) => {
     return (
         <Modal
-            forceAction
+            // allow escape to cancel unless interaction is disabled
+            forceAction={disabled}
             ref={modal}
             id={id}
             aria-labelledby="confirmation-heading"
@@ -55,9 +63,9 @@ export const ConfirmationModal = ({
             </div>
             <ModalFooter id="confirmation-footer">
                 <ButtonGroup className={classNames(style.actionButtonGroup)}>
-                    <Button type="button" onClick={onCancel} outline data-testid="cancel-btn" disabled={disabled}>
+                    <ModalToggleButton modalRef={modal} outline data-testid="cancel-btn" disabled={disabled}>
                         {cancelText}
-                    </Button>
+                    </ModalToggleButton>
                     <Button
                         type="button"
                         onClick={onConfirm}


### PR DESCRIPTION
## Description

Per 508 review, allow esc to cancel the confirmation modals. When the modal's interaction is disabled (such as when saving/deleting), don't allow esc to do anything as the user could end up in a weird state
