### PR TITLE
bump 'io.netty:netty-bom' to '4.2.16.Final' to fix vulns

### DIFF
--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     // APP-795: security-patched BOMs above Spring Boot's managed versions.
     // netty-bom aligns every netty module (handler, codec-*, resolver-dns, transport-native-*,
     // codec-classes-quic) at once, superseding the earlier per-artifact 4.2.13.Final pins.
-    implementation platform('io.netty:netty-bom:4.2.15.Final')          // CVE-2026-44249/44892/44894/45416/45536/45673/45674/47244/47691/48043/48748/50009/50010/50020/50560
+    implementation platform('io.netty:netty-bom:4.2.16.Final')          // CVE-2026-44249/44892/44894/45416/45536/45673/45674/47244/47691/48043/48748/50009/50010/50020/50560
     implementation platform('com.fasterxml.jackson:jackson-bom:2.21.5') // CVE-2026-54515
 
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux:4.3.5'

--- a/apps/nbs-gateway/build.gradle
+++ b/apps/nbs-gateway/build.gradle
@@ -39,10 +39,12 @@ dependencies {
 
     implementation platform(SpringBootPlugin.BOM_COORDINATES)
 
-    // APP-795: security-patched BOMs above Spring Boot's managed versions.
-    // netty-bom aligns every netty module (handler, codec-*, resolver-dns, transport-native-*,
-    // codec-classes-quic) at once, superseding the earlier per-artifact 4.2.13.Final pins.
-    implementation platform('io.netty:netty-bom:4.2.16.Final')          // CVE-2026-44249/44892/44894/45416/45536/45673/45674/47244/47691/48043/48748/50009/50010/50020/50560
+    // Security-patched BOMs above Spring Boot's managed versions. 'netty-bom' aligns every netty module (e.g. handler,
+    // codec-*, resolver-dns, transport-native-*, codec-classes-quic) at once in order to resolve vulnerabilities.
+    // previous related CVEs: CVE-2026-44249/44892/44894/45416/45536/45673/45674/47244/47691/48043/48748/50009/50010/50020/50560
+    // latest related CVEs: CVE-2026-47838/55831/55833/56745/56746/56816/59898/59899/59900/59901/59921, GHSA-mfg7-5gfp-c4w3
+    implementation platform('io.netty:netty-bom:4.2.16.Final')
+
     implementation platform('com.fasterxml.jackson:jackson-bom:2.21.5') // CVE-2026-54515
 
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux:4.3.5'
@@ -57,7 +59,6 @@ dependencies {
             because("CVE-2025-58056")
             because("CVE-2025-55163")
         }
-        // netty-* pins (CVE-2026-42577/42582/42587/42579) folded into the netty-bom 4.2.15.Final above.
         implementation("org.bouncycastle:bcprov-jdk18on:1.84") {
             because("CVE-2026-5598")
         }


### PR DESCRIPTION
## Description

Bumps `io.netty:netty-bom` to `4.2.16.Final` in `nbs-gateway` to fix known vulnerabilities.

There are at least 4 vulnerability alerts related to this specific version update.  The full list of high vulnerability alerts involving `netty` can be found here:

https://github.com/CDCgov/NEDSS-Modernization/security/code-scanning?query=netty+is%3Aopen+branch%3Amain+severity%3Ahigh+sort%3Acreated-desc

This PR will likely fix all the highlighted vulnerabilities for `nbs-gateway` found in this Harbor screenshot:

<img width="1363" height="699" alt="asdf" src="https://github.com/user-attachments/assets/e6453536-936b-4548-a186-7d6bfa012d95" />
