### PR TITLE
fix: on-this-page stickiness, card consistency

### DIFF
--- a/apps/modernization-ui/src/apps/report/layout/ReportLayout.tsx
+++ b/apps/modernization-ui/src/apps/report/layout/ReportLayout.tsx
@@ -18,7 +18,7 @@ const ReportLayout = ({ noSkipLink = false, children, ...headerProps }: ReportRu
             <header id={headerId}>
                 <ReportHeader {...headerProps} />
             </header>
-            <main className="overflow-x-auto">{children}</main>
+            <main>{children}</main>
         </div>
     );
 };

--- a/apps/modernization-ui/src/apps/report/layout/layout.module.scss
+++ b/apps/modernization-ui/src/apps/report/layout/layout.module.scss
@@ -71,7 +71,7 @@ $header-height: 6rem;
     .left {
         display: grid;
         grid-template-columns: auto auto;
-        align-content: start;
+        justify-content: start;
         align-items: end;
         gap: 1rem;
     }

--- a/apps/modernization-ui/src/apps/report/layout/layout.module.scss
+++ b/apps/modernization-ui/src/apps/report/layout/layout.module.scss
@@ -55,7 +55,8 @@ $header-height: 6rem;
 }
 
 .header {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto;
     justify-content: space-between;
     align-items: flex-start;
 
@@ -68,10 +69,18 @@ $header-height: 6rem;
     background-color: colors.$base-white;
 
     .left {
-        display: flex;
-        flex-direction: row;
-        gap: 1rem;
+        display: grid;
+        grid-template-columns: auto auto;
+        align-content: start;
         align-items: end;
+        gap: 1rem;
+    }
+
+    // it will cut off with ellipsis, need the height to stay relatively stable
+    // so the logic for the "on this page" aside offset is reasonable
+    .title {
+        overflow: hidden;
+        white-space: nowrap;
     }
 
     .subtitle {
@@ -81,8 +90,6 @@ $header-height: 6rem;
     }
 
     .actions {
-        flex-shrink: 0;
-
         display: flex;
         align-items: center;
         gap: 0.5rem;

--- a/apps/modernization-ui/src/apps/report/layout/layout.module.scss
+++ b/apps/modernization-ui/src/apps/report/layout/layout.module.scss
@@ -2,8 +2,8 @@
 @use 'styles/colors';
 
 .columnContent {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 1rem;
     padding: 1rem;
 }
@@ -28,6 +28,17 @@ $header-height: 6rem;
         display: grid;
         grid-template-columns: 1fr auto;
         grid-template-areas: 'main aside';
+
+        // overflow ruins sticky-ness of aside
+        &:not(:has(aside)) {
+            overflow-x: auto;
+        }
+
+        // assumes that a div will be a primary sibling of the aside
+        // in the layout (<main><aside /><div /></main>
+        &:has(aside) > div {
+            overflow-x: auto;
+        }
 
         h2 {
             scroll-margin-top: $header-height;

--- a/apps/modernization-ui/src/apps/report/run/columns/column-selector.module.scss
+++ b/apps/modernization-ui/src/apps/report/run/columns/column-selector.module.scss
@@ -47,22 +47,20 @@
                 border-left-color: colors.$clear;
 
                 padding: 0 1.5rem;
-                gap: 2rem;
                 // keeps the checkbox and dnd options about the same height
                 min-height: 2.1rem;
 
                 @extend %thin-bottom;
                 @extend %medium;
 
-                display: flex;
-                flex-direction: row;
+                display: grid;
+                grid-template-columns: auto 1fr auto;
                 align-items: center;
                 gap: 0.5rem;
 
                 .label {
                     color: colors.$base-darkest;
                     line-height: 125%;
-                    flex: 1 1 0%;
                 }
 
                 button {

--- a/apps/modernization-ui/src/components/heading/heading.module.scss
+++ b/apps/modernization-ui/src/components/heading/heading.module.scss
@@ -1,3 +1,6 @@
 .heading {
     margin: 0;
+    // so if a call site chooses to no wrap, it will cut off gracefuly
+    text-overflow: ellipsis;
+    overflow: hidden;
 }


### PR DESCRIPTION
## Description

#3470 did fix page overflow, but lost the stickiness of the aside. This PR fixes that and also makes sure the cards all take up the full column width and also don't let their contents overflow

Testing notes:
* open any report and note the "On this page" side nav is sticky
* ensure when the screen shrinks, the main content is scrollable (all screens)
* check the cards are all the same size (full width)