### PR TITLE
[APP-910] fix: advanced filter dnd

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportRunPage.spec.tsx
@@ -2784,6 +2784,13 @@ describe('report run page', () => {
             defaultValue: undefined,
         };
 
+        beforeEach(() => {
+            // Spy on console.error and force it to throw an error
+            vi.spyOn(console, 'error').mockImplementation((message) => {
+                throw new Error(`Test failed due to console.error: ${message}`);
+            });
+        });
+
         it('renders the empty filter builder when no default value', async () => {
             const mockApi = vi.mocked(useLoaderData).mockReturnValue({ ...MOCK_CONFIG, advancedFilter: MOCK_FILTER });
             const mockResultApi = vi

--- a/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
+++ b/apps/modernization-ui/src/apps/report/run/filters/advanced/AdvancedFilter.tsx
@@ -12,7 +12,6 @@ import QueryBuilder, {
     RuleGroup as DefaultRuleGroup,
     Rule as DefaultRule,
     RuleProps,
-    FullField,
 } from 'react-querybuilder';
 
 import { ReportExecuteForm } from '../../ReportRunPage';
@@ -32,7 +31,7 @@ import { RemoveButton } from '././RemoveButton.tsx';
 import { validateRule } from './validator.ts';
 import { AddButton } from './AddButton.tsx';
 import { ALL_OPERATORS, LIST_OPERATORS, NULL_OPERATORS, OPERATOR_MAP } from './operators.ts';
-import { ComponentType, ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { ValidationErrorBanner } from 'design-system/errors/ValidationError.tsx';
 import { AlertMessage } from 'design-system/message/index.ts';
 import classNames from 'classnames';
@@ -290,7 +289,15 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
                 </ValidationErrorBanner>
             )}
             <KeyboardDnDProvider>
-                <QueryBuilderDnD dnd={pragmaticDndAdapter} updateWhileDragging={false}>
+                <QueryBuilderDnD
+                    dnd={pragmaticDndAdapter}
+                    updateWhileDragging={false}
+                    // DnD needs these set earlier so that it can handle the context passing
+                    controlElements={{
+                        ruleGroup: RuleGroupWithErrors,
+                        rule: RuleWithErrors,
+                    }}
+                >
                     <QueryBuilder
                         fields={fields}
                         query={value}
@@ -309,11 +316,6 @@ const AdvancedFilter = ({ filter, columns }: { filter: AdvancedFilterConfigurati
                             addRuleAction: AddButton,
                             removeGroupAction: RemoveButton,
                             removeRuleAction: RemoveButton,
-                            // KLUDGE: This is using the literal default component, but ts is very unhappy
-                            ruleGroup: RuleGroupWithErrors as unknown as ComponentType<
-                                RuleGroupProps<ValueSetMetadata & FullField, string>
-                            >,
-                            rule: RuleWithErrors,
                         }}
                     />
                 </QueryBuilderDnD>


### PR DESCRIPTION
## Description

The advanced filter drag and drop broke when the error handling was added as it turns out the query builder dnd has special handling for rules and rule groups and this over-rode it. Move the passing of those control elements to the dnd provider directly to make things happy again.

https://cdc-nbs.atlassian.net/browse/APP-910