### PR TITLE
ci: enforce no warnings, make any an error

### DIFF
--- a/apps/modernization-ui/eslint.config.mjs
+++ b/apps/modernization-ui/eslint.config.mjs
@@ -49,7 +49,6 @@ export default defineConfig([
                 'error',
                 { caughtErrors: 'none', destructuredArrayIgnorePattern: '^_' },
             ],
-            '@typescript-eslint/no-explicit-any': 'warn',
             'react/react-in-jsx-scope': 'off',
             'react/no-unescaped-entities': 'off',
             'react-hooks/rules-of-hooks': 'off',

--- a/apps/modernization-ui/package.json
+++ b/apps/modernization-ui/package.json
@@ -99,7 +99,7 @@
         "test:coveragePatient": "vitest --coverage --include=src/apps/patient/**/*.{js,jsx,ts,tsx}",
         "test:coveragePageBuilder": "vitest --coverage --include=src/apps/page-builder/**/*.{js,jsx,ts,tsx}",
         "test:coverageSearch": "vitest --coverage --include=src/apps/search/**/*.{js,jsx,ts,tsx}",
-        "lint": "eslint .",
+        "lint": "eslint . --max-warnings=0",
         "lint:fix": "eslint --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",


### PR DESCRIPTION
## Description

Fail CI on warnings, make using `any` an error (had downgraded it to warning in a prior life as there were too many to fail CI on)
