### PR TITLE
fix: update line-height in AlertMessage content

### DIFF
--- a/apps/modernization-ui/src/design-system/message/alert/alert-message.module.scss
+++ b/apps/modernization-ui/src/design-system/message/alert/alert-message.module.scss
@@ -7,10 +7,6 @@
     border-left-style: solid;
     border-left-width: 8px;
 
-    h1 {
-        overflow: unset;
-    }
-
     &:focus {
         outline: none !important;
     }
@@ -48,7 +44,7 @@
         font-size: 0.875rem;
         font-style: normal;
         font-weight: 400;
-        line-height: 1.3125rem;
+        line-height: 1.1;
     }
 
     .closeButton {

--- a/apps/modernization-ui/src/design-system/message/alert/alert-message.module.scss
+++ b/apps/modernization-ui/src/design-system/message/alert/alert-message.module.scss
@@ -7,6 +7,10 @@
     border-left-style: solid;
     border-left-width: 8px;
 
+    h1 {
+        overflow: unset;
+    }
+
     &:focus {
         outline: none !important;
     }


### PR DESCRIPTION
## Description
fix `<h1>` headings getting cut off a bit in the `AlertMessage` component

**BEFORE**

<img width="1508" height="180" alt="Screenshot 2026-07-30 at 13 32 58" src="https://github.com/user-attachments/assets/a864d761-876f-42d7-965e-8cae16c6f0ba" />

**AFTER**
<img width="1505" height="191" alt="Screenshot 2026-07-30 at 13 33 29" src="https://github.com/user-attachments/assets/a6f9efc5-8097-4417-b8d1-113111004cfc" />


## Tickets

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
