### PR TITLE
[APP-778] fix: manually expand long list params

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/events/investigation/association/AssociatedInvestigationFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/events/investigation/association/AssociatedInvestigationFinder.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.patient.events.investigation.association;
 import com.google.common.collect.Multimap;
 import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
 import gov.cdc.nbs.sql.MultiMapResultSetExtractor;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -64,9 +65,8 @@ public class AssociatedInvestigationFinder {
   Map<Long, Collection<AssociatedInvestigation>> execute(
       final Collection<Long> sources, final PermissionScope scope) {
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, "any", scope.any()))
         .param("sources", sources)
-        .param("any", scope.any())
         .query(extractor)
         .asMap();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/BasePatientFIleContactFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/contact/BasePatientFIleContactFinder.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Multimap;
 import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
 import gov.cdc.nbs.patient.events.investigation.association.AssociatedInvestigationRowMapper;
 import gov.cdc.nbs.sql.MultiMapResultSetExtractor;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -44,10 +45,12 @@ class BasePatientFIleContactFinder implements PatientFileContactFinder {
       final long patient, PermissionScope scope, final PermissionScope associatedScope) {
     if (scope.allowed()) {
       return this.client
-          .sql(query)
+          .sql(
+              ParamUtils.replaceListParam(
+                  ParamUtils.replaceListParam(query, "any", scope.any()),
+                  "associated",
+                  resolveAssociated(associatedScope)))
           .param("patient", patient)
-          .param("any", scope.any())
-          .param("associated", resolveAssociated(associatedScope))
           .query(extractor)
           .asMap()
           .entrySet()

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/document/PatientFileDocumentFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/document/PatientFileDocumentFinder.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.patient.file.events.document;
 
 import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.List;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -64,9 +65,8 @@ class PatientFileDocumentFinder {
 
   List<PatientFileDocument> find(final long patient, final PermissionScope scope) {
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, "any", scope.any()))
         .param("patient", patient)
-        .param("any", scope.any())
         .query(this.mapper)
         .list();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/investigation/PatientInvestigationsFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/investigation/PatientInvestigationsFinder.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.patient.file.events.investigation;
 
 import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
 import gov.cdc.nbs.demographics.name.DisplayableSimpleNameRowMapper;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.List;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
@@ -120,9 +121,8 @@ class PatientInvestigationsFinder {
 
   List<PatientInvestigation> findAll(final long patient, final PermissionScope scope) {
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, "any", scope.any()))
         .param("patient", patient)
-        .param("any", scope.any())
         .param("status", null)
         .query(this.mapper)
         .list();
@@ -130,9 +130,8 @@ class PatientInvestigationsFinder {
 
   List<PatientInvestigation> findOpen(final long patient, final PermissionScope scope) {
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, "any", scope.any()))
         .param("patient", patient)
-        .param("any", scope.any())
         .param("status", OPEN_STATUS)
         .query(this.mapper)
         .list();

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/laboratory/PatientLabReportsFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/laboratory/PatientLabReportsFinder.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.patient.file.events.report.laboratory;
 
 import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -135,9 +136,8 @@ class PatientLabReportsFinder {
       return Collections.emptyList();
     }
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, "any", scope.any()))
         .param("patient", patient)
-        .param("any", scope.any())
         .query(this.mapper)
         .list();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/morbidity/PatientMorbidityReportFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/events/report/morbidity/PatientMorbidityReportFinder.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.patient.file.events.report.morbidity;
 
 import gov.cdc.nbs.authorization.permission.scope.PermissionScope;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -113,9 +114,8 @@ class PatientMorbidityReportFinder {
       return Collections.emptyList();
     }
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, "any", scope.any()))
         .param("patient", patient)
-        .param("any", scope.any())
         .query(this.mapper)
         .list();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/CaseReportRequiringReviewFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/CaseReportRequiringReviewFinder.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.patient.file.summary.drr;
 
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.List;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -67,9 +68,8 @@ class CaseReportRequiringReviewFinder {
 
   List<DocumentRequiringReview> find(final DocumentsRequiringReviewCriteria criteria) {
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, ANY_PARAMETER, criteria.documentScope().any()))
         .param(PATIENT_PARAMETER, criteria.patient())
-        .param(ANY_PARAMETER, criteria.documentScope().any())
         .query(this.mapper)
         .list();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/laboratory/LaboratoryReportRequiringReviewFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/laboratory/LaboratoryReportRequiringReviewFinder.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.patient.file.summary.drr.laboratory;
 
 import gov.cdc.nbs.patient.file.summary.drr.DocumentRequiringReview;
 import gov.cdc.nbs.patient.file.summary.drr.DocumentsRequiringReviewCriteria;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.List;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -120,9 +121,8 @@ class LaboratoryReportRequiringReviewFinder {
 
   List<DocumentRequiringReview> find(final DocumentsRequiringReviewCriteria criteria) {
     return this.client
-        .sql(QUERY)
+        .sql(ParamUtils.replaceListParam(QUERY, ANY_PARAMETER, criteria.labReportScope().any()))
         .param(PATIENT_PARAMETER, criteria.patient())
-        .param(ANY_PARAMETER, criteria.labReportScope().any())
         .query(this.mapper)
         .list();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/morbidity/MorbidityReportRequiringReviewFinder.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/summary/drr/morbidity/MorbidityReportRequiringReviewFinder.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.patient.file.summary.drr.morbidity;
 
 import gov.cdc.nbs.patient.file.summary.drr.DocumentRequiringReview;
 import gov.cdc.nbs.patient.file.summary.drr.DocumentsRequiringReviewCriteria;
+import gov.cdc.nbs.sql.ParamUtils;
 import java.util.List;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -90,9 +91,10 @@ class MorbidityReportRequiringReviewFinder {
 
   List<DocumentRequiringReview> find(final DocumentsRequiringReviewCriteria criteria) {
     return this.client
-        .sql(QUERY)
+        .sql(
+            ParamUtils.replaceListParam(
+                QUERY, ANY_PARAMETER, criteria.morbidityReportScope().any()))
         .param(PATIENT_PARAMETER, criteria.patient())
-        .param(ANY_PARAMETER, criteria.morbidityReportScope().any())
         .query(this.mapper)
         .list();
   }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/ParamUtils.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/ParamUtils.java
@@ -1,0 +1,23 @@
+package gov.cdc.nbs.sql;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class ParamUtils {
+
+  /*
+   * Replace a named query parameter of the style `blah IN (:param)` with the contents directly.
+   *
+   * We elide the standard parameter replacement here as it creates a ? for every item in a list
+   * and with potentially large lists this can exceed the max parameters a query allows.
+   */
+  public static String replaceListParam(String query, String param, Collection<Long> ints) {
+    return query.replace(":" + param, toSqlInContents(ints));
+  }
+
+  // For 'IN' queries we want to replace the param with pre-formatted content instead of expanding
+  // every item into a `?` placeholder and then having SQL server inject it
+  public static String toSqlInContents(Collection<Long> ints) {
+    return ints.stream().map(String::valueOf).collect(Collectors.joining(", "));
+  }
+}

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/ParamUtils.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/ParamUtils.java
@@ -3,7 +3,7 @@ package gov.cdc.nbs.sql;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-public class ParamUtils {
+public final class ParamUtils {
 
   /*
    * Replace a named query parameter of the style `blah IN (:param)` with the contents directly.
@@ -21,4 +21,6 @@ public class ParamUtils {
     if (ints == null) return "";
     return ints.stream().map(String::valueOf).collect(Collectors.joining(", "));
   }
+
+  private ParamUtils() {}
 }

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/ParamUtils.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/sql/ParamUtils.java
@@ -18,6 +18,7 @@ public class ParamUtils {
   // For 'IN' queries we want to replace the param with pre-formatted content instead of expanding
   // every item into a `?` placeholder and then having SQL server inject it
   public static String toSqlInContents(Collection<Long> ints) {
+    if (ints == null) return "";
     return ints.stream().map(String::valueOf).collect(Collectors.joining(", "));
   }
 }

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/sql/ParamUtilsTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/sql/ParamUtilsTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class ParamUtilsTest {
+class ParamUtilsTest {
 
   @Test
   void replaceListParam_replaces_handles_null_collection() {

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/sql/ParamUtilsTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/sql/ParamUtilsTest.java
@@ -1,0 +1,38 @@
+package gov.cdc.nbs.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ParamUtilsTest {
+
+  @Test
+  void replaceListParam_replaces_handles_null_collection() {
+    String result = ParamUtils.replaceListParam("blah in (:param)", "param", null);
+
+    assertThat(result).isEqualTo("blah in ()");
+  }
+
+  @Test
+  void replaceListParam_replaces_handles_empty_collection() {
+    String result = ParamUtils.replaceListParam("blah in (:param)", "param", List.of());
+
+    assertThat(result).isEqualTo("blah in ()");
+  }
+
+  @Test
+  void replaceListParam_replaces_handles_one_len_collection() {
+    String result = ParamUtils.replaceListParam("blah in (:param)", "param", List.of(1L));
+
+    assertThat(result).isEqualTo("blah in (1)");
+  }
+
+  @Test
+  void replaceListParam_replaces_handles_multi_len_collection() {
+    String result =
+        ParamUtils.replaceListParam("blah in (:param)", "param", List.of(1L, 100000L, 999999999L));
+
+    assertThat(result).isEqualTo("blah in (1, 100000, 999999999)");
+  }
+}


### PR DESCRIPTION
## Description

Change permissions check param interpolation to use direct interpolation instead of the query param.

The issue: When a user has a loooooot of permissions (such as in large jurisdictions with many counties and program areas), this can cause a query to exceed the maximum number of query parameters allowed in a prepared statement

The solution: Instead of using query param expansion, directly replace and interpolate these query fragments

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-778

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
