### PR TITLE
fix: use same capitalization of `Reports` on result page

### DIFF
--- a/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ReportResultPage.tsx
@@ -87,7 +87,7 @@ const ReportResultPage = ({
         <ReportLayout
             title={config.title}
             startHref={NBS_MANAGE_REPORT_PAGE}
-            startPage="reports"
+            startPage="Reports"
             actions={
                 <>
                     <Permitted permission={PERMISSION_GROUP_MAP[config.group].selectFilterCriteria}>


### PR DESCRIPTION
## Description

Noticed while doing screenshot for docs that the capitalization on the result page didn't match the configuration page
