### PR TITLE
[APP-940] fix: add --ignore-scripts to npm installs

### DIFF
--- a/.github/workflows/verify-modernization-ui.yaml
+++ b/.github/workflows/verify-modernization-ui.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./apps/modernization-ui
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Lint
         working-directory: ./apps/modernization-ui

--- a/apps/modernization-api/Dockerfile
+++ b/apps/modernization-api/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/modernization-ui
 COPY apps/modernization-ui/package.json package.json
 COPY apps/modernization-ui/package-lock.json package-lock.json
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Copy required sources
 COPY apps/modernization-ui .

--- a/apps/modernization-api/README.md
+++ b/apps/modernization-api/README.md
@@ -68,7 +68,7 @@ Note: Containers do not need to be running to execute tests, but the images must
 
 ```shell
 # Install dependencies
-cd apps/modernization-ui && npm ci
+cd apps/modernization-ui && npm ci --ignore-scripts
 
 # Build the API (from root)
 ./gradlew :modernization-api:buildDependents

--- a/apps/modernization-ui/Dockerfile
+++ b/apps/modernization-ui/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/modernization-ui
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Copy required sources
 COPY . .

--- a/testing/regression/README.md
+++ b/testing/regression/README.md
@@ -39,7 +39,7 @@ cd testing/regression
 ### 2. Install Project Dependencies
 
 ```bash
-npm ci
+npm ci --ignore-scripts
 ```
 
 ### 3. Create and Configure `cypress.env.json`


### PR DESCRIPTION
## Description

Per sonar, run npm install with `--ignore-scripts` to avoid certain supply chain attack vectors

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-940

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
