### PR TITLE
[APP-935] fix: address sonar smell - service not using service tag

### DIFF
--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/delete/PatientDeletionService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/delete/PatientDeletionService.java
@@ -5,9 +5,9 @@ import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.PatientException;
 import gov.cdc.nbs.patient.PatientService;
 import gov.cdc.nbs.patient.RequestContext;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientDeletionService {
 
   private final PatientAssociationCountFinder finder;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientAddressEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientAddressEditService.java
@@ -12,9 +12,9 @@ import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
 import gov.cdc.nbs.patient.demographics.address.AddressDemographic;
 import java.util.Collection;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientAddressEditService {
 
   private static long identifiedBy(final PostalEntityLocatorParticipation participation) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientEditService.java
@@ -17,9 +17,9 @@ import gov.cdc.nbs.patient.PatientException;
 import gov.cdc.nbs.patient.PatientService;
 import gov.cdc.nbs.patient.RequestContext;
 import gov.cdc.nbs.patient.demographic.AddressIdentifierGenerator;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientEditService {
 
   private final PatientService service;

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientEthnicityEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientEthnicityEditService.java
@@ -11,9 +11,9 @@ import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.RequestContext;
 import gov.cdc.nbs.patient.demographics.ethnicity.EthnicityDemographic;
 import java.util.function.Function;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientEthnicityEditService {
 
   private final ChangeResolver<PersonEthnicGroup, String, String> resolver =

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientIdentificationEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientIdentificationEditService.java
@@ -11,9 +11,9 @@ import gov.cdc.nbs.patient.RequestContext;
 import gov.cdc.nbs.patient.demographics.identification.IdentificationDemographic;
 import java.util.Collection;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientIdentificationEditService {
 
   private static long identifiedBy(final IdentificationDemographic demographic) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientNameEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientNameEditService.java
@@ -14,9 +14,9 @@ import gov.cdc.nbs.patient.demographic.name.SoundexResolver;
 import gov.cdc.nbs.patient.demographics.name.NameDemographic;
 import java.util.Collection;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientNameEditService {
   private final SoundexResolver soundexResolver;
 

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientPhoneEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientPhoneEditService.java
@@ -12,9 +12,9 @@ import gov.cdc.nbs.patient.demographic.phone.PhoneIdentifierGenerator;
 import gov.cdc.nbs.patient.demographics.phone.PhoneDemographic;
 import java.util.Collection;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientPhoneEditService {
 
   private static long identifiedBy(final TeleEntityLocatorParticipation participation) {

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientRaceEditService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/file/edit/PatientRaceEditService.java
@@ -10,9 +10,9 @@ import gov.cdc.nbs.patient.PatientCommand;
 import gov.cdc.nbs.patient.RequestContext;
 import gov.cdc.nbs.patient.demographics.race.RaceDemographic;
 import java.util.Collection;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 class PatientRaceEditService {
 
   private static final ChangeResolver<PatientRace, RaceDemographic, String> resolver =

--- a/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
+++ b/apps/modernization-api/src/main/java/gov/cdc/nbs/patient/profile/create/PatientCreationService.java
@@ -28,10 +28,10 @@ import gov.cdc.nbs.patient.identifier.PatientIdentifier;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.Collection;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component
+@Service
 class PatientCreationService {
 
   private final SoundexResolver soudexResolver;

--- a/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageService.java
+++ b/apps/question-bank/src/main/java/gov/cdc/nbs/questionbank/page/PageService.java
@@ -4,10 +4,10 @@ import gov.cdc.nbs.questionbank.entity.WaTemplate;
 import gov.cdc.nbs.questionbank.page.exception.PageNotFoundException;
 import jakarta.persistence.EntityManager;
 import java.util.function.Consumer;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component
+@Service
 public class PageService {
 
   private final EntityManager entityManager;

--- a/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientService.java
+++ b/libs/database-entities/src/main/java/gov/cdc/nbs/patient/PatientService.java
@@ -3,10 +3,10 @@ package gov.cdc.nbs.patient;
 import gov.cdc.nbs.entity.odse.Person;
 import jakarta.persistence.EntityManager;
 import java.util.function.Consumer;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component
+@Service
 public class PatientService {
 
   private final EntityManager entityManager;


### PR DESCRIPTION
## Description

Address the medium sonar smell for files named `Service` but using the `@Component` annotation instead of the `@Service` annotation (they do the same thing under the hood, so it's just a question of readability/intended semantics)

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-935

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
