### PR TITLE
[APP-935] fix: sonar smell - extract mock to local variable and avoid complicated regex

### DIFF
--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimpleSearchRedirectSteps.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/search/redirect/simple/SimpleSearchRedirectSteps.java
@@ -14,16 +14,12 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import java.time.LocalDate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.JsonPathResultMatchers;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 public class SimpleSearchRedirectSteps {
-
-  private static final Pattern ENCRYPTED_LOCATION = Pattern.compile(".*/(.+)");
 
   private final SimpleSearchRedirectRequester requester;
   private final Active<ResultActions> response;
@@ -84,13 +80,10 @@ public class SimpleSearchRedirectSteps {
     String location = result.andReturn().getResponse().getRedirectedUrl();
 
     if (location != null) {
-      Matcher matcher = ENCRYPTED_LOCATION.matcher(location);
+      String[] parts = location.split("/");
+      String encrypted = parts[parts.length - 1];
 
-      if (matcher.find()) {
-        String encrypted = matcher.group(1);
-
-        this.decrypted.active(this.decryptionRequester.request(encrypted));
-      }
+      this.decrypted.active(this.decryptionRequester.request(encrypted));
     }
   }
 

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/template/TemplateImporterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/template/TemplateImporterTest.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.questionbank.template;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import gov.cdc.nbs.questionbank.template.exception.TemplateImportException;
@@ -40,13 +41,13 @@ class TemplateImporterTest {
   @SuppressWarnings("unchecked")
   void should_import_template() {
     // Given a template to import
-    MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    Resource mockResource = Mockito.mock(Resource.class);
+    MultipartFile mockFile = mock(MultipartFile.class);
+    Resource mockResource = mock(Resource.class);
     when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
-    ResponseEntity<String> response = Mockito.mock(ResponseEntity.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    ResponseEntity<String> response = mock(ResponseEntity.class);
     when(response.getHeaders()).thenReturn(headers);
     when(headers.getFirst("Location")).thenReturn(SUCESS_LOCATION);
     when(restTemplate.exchange(Mockito.any(), eq(String.class))).thenReturn(response);
@@ -64,13 +65,13 @@ class TemplateImporterTest {
   @SuppressWarnings("unchecked")
   void should_fail_already_exists() {
     // Given a template to import that already exists
-    MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    Resource mockResource = Mockito.mock(Resource.class);
+    MultipartFile mockFile = mock(MultipartFile.class);
+    Resource mockResource = mock(Resource.class);
     when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
-    ResponseEntity<String> response = Mockito.mock(ResponseEntity.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    ResponseEntity<String> response = mock(ResponseEntity.class);
     when(response.getHeaders()).thenReturn(headers);
     when(headers.getFirst("Location")).thenReturn(EXISTS_LOCATION);
     when(restTemplate.exchange(Mockito.any(), eq(String.class))).thenReturn(response);
@@ -84,13 +85,13 @@ class TemplateImporterTest {
   @SuppressWarnings("unchecked")
   void should_fail_bad_file() {
     // Given a template to import that already exists
-    MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    Resource mockResource = Mockito.mock(Resource.class);
+    MultipartFile mockFile = mock(MultipartFile.class);
+    Resource mockResource = mock(Resource.class);
     when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
-    ResponseEntity<String> response = Mockito.mock(ResponseEntity.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    ResponseEntity<String> response = mock(ResponseEntity.class);
     when(response.getHeaders()).thenReturn(headers);
     when(headers.getFirst("Location")).thenReturn(BAD_FILE_LOCATION);
     when(restTemplate.exchange(Mockito.any(), eq(String.class))).thenReturn(response);
@@ -104,13 +105,13 @@ class TemplateImporterTest {
   @SuppressWarnings("unchecked")
   void should_fail_null_location() {
     // Given a template to import that already exists
-    MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    Resource mockResource = Mockito.mock(Resource.class);
+    MultipartFile mockFile = mock(MultipartFile.class);
+    Resource mockResource = mock(Resource.class);
     when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
-    ResponseEntity<String> response = Mockito.mock(ResponseEntity.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    ResponseEntity<String> response = mock(ResponseEntity.class);
     when(response.getHeaders()).thenReturn(headers);
     when(headers.getFirst("Location")).thenReturn(null);
     when(restTemplate.exchange(Mockito.any(), eq(String.class))).thenReturn(response);
@@ -124,13 +125,13 @@ class TemplateImporterTest {
   @SuppressWarnings("unchecked")
   void should_fail_bad_id() {
     // Given a template to import that already exists
-    MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    Resource mockResource = Mockito.mock(Resource.class);
+    MultipartFile mockFile = mock(MultipartFile.class);
+    Resource mockResource = mock(Resource.class);
     when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
-    ResponseEntity<String> response = Mockito.mock(ResponseEntity.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    ResponseEntity<String> response = mock(ResponseEntity.class);
     when(response.getHeaders()).thenReturn(headers);
     when(headers.getFirst("Location"))
         .thenReturn("srcTemplateNm=AARBOVIRAL_1_3_INV_NBS_5_4&src=Import&templateUid=abcD");

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/template/TemplateImporterTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/template/TemplateImporterTest.java
@@ -41,7 +41,8 @@ class TemplateImporterTest {
   void should_import_template() {
     // Given a template to import
     MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    when(mockFile.getResource()).thenReturn(Mockito.mock(Resource.class));
+    Resource mockResource = Mockito.mock(Resource.class);
+    when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -64,7 +65,8 @@ class TemplateImporterTest {
   void should_fail_already_exists() {
     // Given a template to import that already exists
     MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    when(mockFile.getResource()).thenReturn(Mockito.mock(Resource.class));
+    Resource mockResource = Mockito.mock(Resource.class);
+    when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -83,7 +85,8 @@ class TemplateImporterTest {
   void should_fail_bad_file() {
     // Given a template to import that already exists
     MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    when(mockFile.getResource()).thenReturn(Mockito.mock(Resource.class));
+    Resource mockResource = Mockito.mock(Resource.class);
+    when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -102,7 +105,8 @@ class TemplateImporterTest {
   void should_fail_null_location() {
     // Given a template to import that already exists
     MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    when(mockFile.getResource()).thenReturn(Mockito.mock(Resource.class));
+    Resource mockResource = Mockito.mock(Resource.class);
+    when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -121,7 +125,8 @@ class TemplateImporterTest {
   void should_fail_bad_id() {
     // Given a template to import that already exists
     MultipartFile mockFile = Mockito.mock(MultipartFile.class);
-    when(mockFile.getResource()).thenReturn(Mockito.mock(Resource.class));
+    Resource mockResource = Mockito.mock(Resource.class);
+    when(mockFile.getResource()).thenReturn(mockResource);
 
     // and a working Classic endpoint
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);


### PR DESCRIPTION
## Description

Address sonar smells to not create a mock inline inside another mock's when, and to not use over-complicated regex

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-935

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
