### PR TITLE
APP-942: Fix Sonar code smell (Use java.time.Month enum over int)

### DIFF
--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/AdvancedFilterConfigurationMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/AdvancedFilterConfigurationMapperTest.java
@@ -11,6 +11,7 @@ import gov.cdc.nbs.entity.odse.ReportFilter;
 import gov.cdc.nbs.entity.odse.ReportId;
 import gov.cdc.nbs.report.models.AdvancedFilterConfiguration;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class AdvancedFilterConfigurationMapperTest {
           .displayable('Y')
           .filterable('N')
           .statusCd('A')
-          .statusTime(LocalDateTime.of(2024, 3, 31, 12, 0))
+          .statusTime(LocalDateTime.of(2024, Month.MARCH, 31, 12, 0))
           .build();
   FilterCode filterCode =
       FilterCode.builder()

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/BasicFilterConfigurationMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/BasicFilterConfigurationMapperTest.java
@@ -14,6 +14,7 @@ import gov.cdc.nbs.entity.odse.ReportId;
 import gov.cdc.nbs.report.ReportConstants;
 import gov.cdc.nbs.report.models.BasicFilterConfiguration;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +36,7 @@ class BasicFilterConfigurationMapperTest {
           .displayable('Y')
           .filterable('N')
           .statusCd('A')
-          .statusTime(LocalDateTime.of(2024, 3, 31, 12, 0))
+          .statusTime(LocalDateTime.of(2024, Month.MARCH, 31, 12, 0))
           .build();
   FilterCode filterCode =
       FilterCode.builder()

--- a/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/ReportColumnMapperTest.java
+++ b/apps/modernization-api/src/test/java/gov/cdc/nbs/report/mappers/ReportColumnMapperTest.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.entity.odse.DataSourceCodeset;
 import gov.cdc.nbs.entity.odse.DataSourceColumn;
 import gov.cdc.nbs.report.models.ReportColumn;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +28,7 @@ class ReportColumnMapperTest {
             .displayable('Y')
             .filterable('N')
             .statusCd('A')
-            .statusTime(LocalDateTime.of(2024, 3, 31, 12, 0))
+            .statusTime(LocalDateTime.of(2024, Month.MARCH, 31, 12, 0))
             .codesets(
                 List.of(
                     DataSourceCodeset.builder()
@@ -67,7 +68,7 @@ class ReportColumnMapperTest {
             .descTxt("Some description")
             .codesets(List.of())
             .statusCd('A')
-            .statusTime(LocalDateTime.of(2024, 3, 31, 12, 0))
+            .statusTime(LocalDateTime.of(2024, Month.MARCH, 31, 12, 0))
             .build();
 
     ReportColumn mapped = ReportColumnMapper.fromDataSourceColumn(dbColumn);

--- a/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/summary/download/PageSummaryCsvCreatorTest.java
+++ b/apps/question-bank/src/test/java/gov/cdc/nbs/questionbank/page/summary/download/PageSummaryCsvCreatorTest.java
@@ -7,6 +7,7 @@ import gov.cdc.nbs.questionbank.page.summary.search.PageSummary.EventType;
 import gov.cdc.nbs.questionbank.question.model.ConditionSummary;
 import java.io.ByteArrayInputStream;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +22,7 @@ class PageSummaryCsvCreatorTest {
 
   @Test
   void should_create_csv() {
-    LocalDate date = LocalDate.of(2023, 12, 9);
+    LocalDate date = LocalDate.of(2023, Month.DECEMBER, 9);
     // Given page summaries
     Page<PageSummary> summaries =
         new PageImpl<>(

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/entity/odse/PersonTest.java
@@ -1609,7 +1609,7 @@ class PersonTest {
         new PatientCommand.UpdateBirth(
             121L,
             LocalDate.parse("2023-06-01"),
-            LocalDate.of(1949, 10, 15),
+            LocalDate.of(1949, Month.OCTOBER, 15),
             Gender.U.value(),
             Indicator.NO.getId(),
             null,
@@ -1646,7 +1646,7 @@ class PersonTest {
         new PatientCommand.UpdateBirth(
             1049L,
             LocalDate.parse("2023-06-01"),
-            LocalDate.of(1949, 10, 15),
+            LocalDate.of(1949, Month.OCTOBER, 15),
             Gender.U.value(),
             Indicator.YES.getId(),
             17,

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/PatientSignatureTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/PatientSignatureTest.java
@@ -588,7 +588,7 @@ class PatientSignatureTest {
         new PatientCommand.UpdateBirth(
             967L,
             LocalDate.of(2023, Month.JUNE, 1),
-            LocalDate.of(1949, 10, 15),
+            LocalDate.of(1949, Month.OCTOBER, 15),
             Gender.U.value(),
             Indicator.NO.getId(),
             17,
@@ -606,7 +606,7 @@ class PatientSignatureTest {
         new PatientCommand.UpdateBirth(
             967L,
             LocalDate.of(2023, Month.JUNE, 1),
-            LocalDate.of(1949, 10, 15),
+            LocalDate.of(1949, Month.OCTOBER, 15),
             Gender.U.value(),
             Indicator.NO.getId(),
             17,
@@ -629,7 +629,7 @@ class PatientSignatureTest {
             new PatientCommand.UpdateBirth(
                 967L,
                 LocalDate.now(),
-                LocalDate.of(1949, 10, 15),
+                LocalDate.of(1949, Month.OCTOBER, 15),
                 Gender.U.value(),
                 Indicator.NO.getId(),
                 17,
@@ -657,7 +657,7 @@ class PatientSignatureTest {
             new PatientCommand.UpdateBirth(
                 967L,
                 LocalDate.of(2023, Month.JUNE, 1),
-                LocalDate.of(1949, 10, 15),
+                LocalDate.of(1949, Month.OCTOBER, 15),
                 Gender.F.value(),
                 Indicator.NO.getId(),
                 17,
@@ -671,7 +671,7 @@ class PatientSignatureTest {
             new PatientCommand.UpdateBirth(
                 967L,
                 LocalDate.of(2023, Month.JUNE, 1),
-                LocalDate.of(1949, 10, 15),
+                LocalDate.of(1949, Month.OCTOBER, 15),
                 Gender.U.value(),
                 Indicator.YES.getId(),
                 17,
@@ -685,7 +685,7 @@ class PatientSignatureTest {
             new PatientCommand.UpdateBirth(
                 967L,
                 LocalDate.of(2023, Month.JUNE, 1),
-                LocalDate.of(1949, 10, 15),
+                LocalDate.of(1949, Month.OCTOBER, 15),
                 Gender.U.value(),
                 Indicator.NO.getId(),
                 151,
@@ -709,7 +709,7 @@ class PatientSignatureTest {
         new PatientCommand.UpdateBirth(
             967L,
             LocalDate.of(2023, Month.JUNE, 1),
-            LocalDate.of(1949, 10, 15),
+            LocalDate.of(1949, Month.OCTOBER, 15),
             Gender.U.value(),
             Indicator.NO.getId(),
             17,

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/demographic/PatientSexBirthTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/demographic/PatientSexBirthTest.java
@@ -8,7 +8,6 @@ import gov.cdc.nbs.patient.PatientCommand;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
-
 import org.junit.jupiter.api.Test;
 
 class PatientSexBirthTest {

--- a/libs/database-entities/src/test/java/gov/cdc/nbs/patient/demographic/PatientSexBirthTest.java
+++ b/libs/database-entities/src/test/java/gov/cdc/nbs/patient/demographic/PatientSexBirthTest.java
@@ -7,6 +7,8 @@ import gov.cdc.nbs.message.enums.Indicator;
 import gov.cdc.nbs.patient.PatientCommand;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
+
 import org.junit.jupiter.api.Test;
 
 class PatientSexBirthTest {
@@ -101,7 +103,7 @@ class PatientSexBirthTest {
         new PatientCommand.UpdateBirth(
             121L,
             LocalDate.parse("2023-06-01"),
-            LocalDate.of(1949, 10, 15),
+            LocalDate.of(1949, Month.OCTOBER, 15),
             null,
             null,
             null,


### PR DESCRIPTION
## Description
Per Sonar, use `java.time.Month` enums over int literals when creating dates.

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-942)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
