### PR TITLE
Lab Report - HTTP 400 fix 

### DIFF
--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandler.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandler.java
@@ -24,7 +24,8 @@ class IllegalURICharacterChannelHandler extends ChannelInboundHandlerAdapter {
     entry("`", "%60"),
     entry("<", "%3C"),
     entry(">", "%3E"),
-    entry("\"", "%22")
+    entry("\"", "%22"),
+    entry("'", "%27")
   );
 
   @Override

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandler.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandler.java
@@ -1,26 +1,46 @@
 package gov.cdc.nbs.gateway.classic;
 
+import java.util.Map;
+import static java.util.Map.entry;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 
 /**
- * A {@link io.netty.channel.ChannelHandler} that will encode the pipe ({@code |}) character to the
- * safer {@code %7C} value on the uri of the request. The pipe character is considered unsafe to be
- * included in URIs.
+ * A {@link io.netty.channel.ChannelHandler} that will encode special characters to the
+ * safe values on the uri of the request. 
  */
 class IllegalURICharacterChannelHandler extends ChannelInboundHandlerAdapter {
 
-  private static final String PIPE = "|";
-  private static final String PIPE_ENCODED = "%7C";
+  private static final Map<String, String> ENCODING_MAP = Map.ofEntries(
+    entry(" ", "%20"),
+    entry("{", "%7B"),
+    entry("}", "%7D"),
+    entry("[", "%5B"),
+    entry("]", "%5D"),
+    entry("|", "%7C"),
+    entry("\\", "%5C"),
+    entry("^", "%5E"),
+    entry("`", "%60"),
+    entry("<", "%3C"),
+    entry(">", "%3E"),
+    entry("\"", "%22")
+  );
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
     if (msg instanceof DefaultHttpRequest request) {
-      //  alter the uri to encode pipe characters.
-      request.setUri(request.uri().replace(PIPE, PIPE_ENCODED));
+      // alter the uri to encode special characters sent by NBS 6.
+      request.setUri(encodeUri(request.uri()));
     }
 
     super.channelRead(ctx, msg);
+  }
+
+  String encodeUri(String uri) {
+    for (Map.Entry<String, String> entry : ENCODING_MAP.entrySet()) {
+      uri = uri.replace(entry.getKey(), entry.getValue());
+    }
+    return uri;
   }
 }

--- a/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandler.java
+++ b/apps/nbs-gateway/src/main/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandler.java
@@ -1,32 +1,34 @@
 package gov.cdc.nbs.gateway.classic;
 
-import java.util.Map;
 import static java.util.Map.entry;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import java.util.Map;
 
 /**
- * A {@link io.netty.channel.ChannelHandler} that will encode special characters to the
- * safe values on the uri of the request. 
+ * A {@link io.netty.channel.ChannelHandler} that will encode special characters to the safe values
+ * on the uri of the request.
  */
 class IllegalURICharacterChannelHandler extends ChannelInboundHandlerAdapter {
 
-  private static final Map<String, String> ENCODING_MAP = Map.ofEntries(
-    entry(" ", "%20"),
-    entry("{", "%7B"),
-    entry("}", "%7D"),
-    entry("[", "%5B"),
-    entry("]", "%5D"),
-    entry("|", "%7C"),
-    entry("\\", "%5C"),
-    entry("^", "%5E"),
-    entry("`", "%60"),
-    entry("<", "%3C"),
-    entry(">", "%3E"),
-    entry("\"", "%22"),
-    entry("'", "%27")
-  );
+  private static final Map<String, String> ENCODING_MAP =
+      Map.ofEntries(
+          entry(" ", "%20"),
+          entry("{", "%7B"),
+          entry("}", "%7D"),
+          entry("[", "%5B"),
+          entry("]", "%5D"),
+          entry("|", "%7C"),
+          entry("\\", "%5C"),
+          entry("^", "%5E"),
+          entry("`", "%60"),
+          entry("<", "%3C"),
+          entry(">", "%3E"),
+          entry("\"", "%22"),
+          entry("'", "%27"),
+          entry("#", "%23"));
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
@@ -38,7 +40,7 @@ class IllegalURICharacterChannelHandler extends ChannelInboundHandlerAdapter {
     super.channelRead(ctx, msg);
   }
 
-  String encodeUri(String uri) {
+  private String encodeUri(String uri) {
     for (Map.Entry<String, String> entry : ENCODING_MAP.entrySet()) {
       uri = uri.replace(entry.getKey(), entry.getValue());
     }

--- a/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandlerTest.java
+++ b/apps/nbs-gateway/src/test/java/gov/cdc/nbs/gateway/classic/IllegalURICharacterChannelHandlerTest.java
@@ -1,0 +1,70 @@
+package gov.cdc.nbs.gateway.classic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IllegalURICharacterChannelHandlerTest {
+
+  @Mock private ChannelHandlerContext context;
+
+  private final IllegalURICharacterChannelHandler handler = new IllegalURICharacterChannelHandler();
+
+  private final ArgumentCaptor<DefaultHttpRequest> captor =
+      ArgumentCaptor.forClass(DefaultHttpRequest.class);
+
+  @Test
+  void verify_uri_is_encoded() throws Exception {
+    // given a request that contains disallowed characters
+    String uri = " {}[]|\\^`<>\"'#";
+    DefaultHttpRequest request = createRequest(uri);
+
+    when(context.fireChannelRead(captor.capture())).thenReturn(context);
+
+    // when the request is handled
+    handler.channelRead(context, request);
+
+    // then the disallowed characters are encoded
+    DefaultHttpRequest actual = captor.getValue();
+    assertThat(actual.uri()).isEqualTo("%20%7B%7D%5B%5D%7C%5C%5E%60%3C%3E%22%27%23");
+  }
+
+  @Test
+  void verify_uri_can_be_decoded() throws Exception {
+    // given a request that contains disallowed characters
+    String uri = " {}[]|\\^`<>\"'#";
+    DefaultHttpRequest request = createRequest(uri);
+
+    when(context.fireChannelRead(captor.capture())).thenReturn(context);
+
+    // when the request is handled
+    handler.channelRead(context, request);
+
+    // then encoded characters can be decoded
+    String actual = URLDecoder.decode(captor.getValue().uri(), StandardCharsets.UTF_8);
+
+    assertThat(actual).isEqualTo(uri);
+  }
+
+  private DefaultHttpRequest createRequest(String uri) {
+    return new DefaultHttpRequest(
+        HttpVersion.HTTP_1_0,
+        HttpMethod.GET,
+        uri,
+        DefaultHttpHeadersFactory.headersFactory().newEmptyHeaders(),
+        false);
+  }
+}


### PR DESCRIPTION
## Description

During my investigation into the http 400 status errors observed when manually creating a Lab Report, I implemented a quick fix and wanted to push this up as a starting point since it appears to resolve the issue locally. Its possible we might also just be able to use a `URLEncoder` to encode the URL, but I am concerned that this will lead to a "double encoding" as some characters are already encoded by NBS 6. 

## Tickets
[NBS-Central-18504](https://nbscentral.cdc.gov/issues/18504)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [x] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [x] All new functions/classes/components reasonably small
- [x] Functions/classes/components focused on one responsibility
- [x] Code easy to understand and modify (clarity over concise/clever)
- [x] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [x] All code is covered by unit or feature tests
