### PR TITLE
docs: fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@
   directs incoming requests to the appropriate backend services (such as Modernization UI, Modernization API, and
   Question bank), enabling seamless integration between both the modernized and pre-existing frontend, and multiple
   backend services.
-- [Report Execution API](apps/report-execution/README.md) - A Python-based FastAPI server that facilitates the
-- management and execution of various reports, both standard and custom. To be used as the eventual replacement for
-- SAS-based reports.
+- [Report Execution API](apps/report-execution/README.md) - A Python-based FastAPI server that facilitates the management
+  and execution of various reports, both standard and custom. To be used as the eventual replacement for SAS-based reports.
 
 ### Libraries
 


### PR DESCRIPTION
The report execution API got split into a few list items - consolidate
