### PR TITLE
(fix): Remove extra whitespace from Report column sections

### DIFF
--- a/apps/modernization-ui/src/apps/report/layout/layout.module.scss
+++ b/apps/modernization-ui/src/apps/report/layout/layout.module.scss
@@ -6,6 +6,7 @@
     grid-template-columns: 1fr;
     gap: 1rem;
     padding: 1rem;
+    align-content: start;
 }
 
 $header-height: 6rem;


### PR DESCRIPTION
## Description

Filters were expanding to use far more height than they should - this fixes that
