### PR TITLE
feat: add base hover tooltip for report titles

### DIFF
--- a/apps/modernization-ui/src/apps/report/layout/ReportHeader.tsx
+++ b/apps/modernization-ui/src/apps/report/layout/ReportHeader.tsx
@@ -18,7 +18,9 @@ export const ReportHeader = ({ title, subtitle, actions, startHref, startPage }:
         <div className={styles.header}>
             <div className={styles.left}>
                 <span className={styles.title}>
-                    <Heading level={1} title={title}>{title}</Heading>
+                    <Heading level={1} title={title}>
+                        {title}
+                    </Heading>
                     {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
                 </span>
                 {startHref && startPage && <BackToNbs6Link start={startHref}>Back to {startPage}</BackToNbs6Link>}

--- a/apps/modernization-ui/src/apps/report/layout/ReportHeader.tsx
+++ b/apps/modernization-ui/src/apps/report/layout/ReportHeader.tsx
@@ -18,7 +18,7 @@ export const ReportHeader = ({ title, subtitle, actions, startHref, startPage }:
         <div className={styles.header}>
             <div className={styles.left}>
                 <span className={styles.title}>
-                    <Heading level={1}>{title}</Heading>
+                    <Heading level={1} title={title}>{title}</Heading>
                     {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
                 </span>
                 {startHref && startPage && <BackToNbs6Link start={startHref}>Back to {startPage}</BackToNbs6Link>}


### PR DESCRIPTION
## Description

Titles are sometimes long, add a `title` prop so we get the native browser tooltip on hover (note, this will also show when not cut off and the user hovers on the title)

<img width="831" height="104" alt="image" src="https://github.com/user-attachments/assets/cb258806-b222-4d65-b0ea-ee2dfd1e456b" />

