### PR TITLE
fix: make filter requiredness validation reactive

### DIFF
--- a/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
@@ -164,7 +164,7 @@ describe('add report configuration page', () => {
         vi.mocked(generated.ReportControllerService.createReport).mockResolvedValue({ reportUid: 1, dataSourceUid: 2 });
         const navigate = vi.fn();
         vi.mocked(useNavigate).mockReturnValue(navigate);
-        const { getByRole, findByRole, findAllByText, findByLabelText } = renderWithRouter();
+        const { getByRole, queryByRole, findByRole, findAllByText, findByLabelText } = renderWithRouter();
 
         expect(getByRole('status')).toHaveTextContent('Loading');
 
@@ -202,13 +202,15 @@ describe('add report configuration page', () => {
         // should add to table and form reset
         expect(await findByRole('cell', { name: 'My filter' })).toBeVisible();
         expect(await findByLabelText('Filter')).toHaveValue('');
-        // add another filter and then change it
+        // add another filter partially and then change it to something that doesn't use those fields
         await user.selectOptions(await findByLabelText('Filter'), '1');
+        await user.selectOptions(await findByLabelText('Selection type'), 'Multi-select filter');
         await user.click(await findByRole('button', { name: 'Add filter' }));
         expect(await findAllByText(/The Associated column is required./)).toHaveLength(2);
         await user.selectOptions(await findByLabelText('Filter'), '7');
         await user.click(await findByRole('button', { name: 'Add filter' }));
         expect(await findByRole('cell', { name: 'Where Clause Builder' })).toBeVisible();
+        expect(queryByRole('cell', { name: 'Multi-select filter' })).toBeNull();
         expect(await findByLabelText('Filter')).toHaveValue('');
 
         await user.click(await findByRole('button', { name: 'Submit' }));

--- a/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
@@ -202,6 +202,12 @@ describe('add report configuration page', () => {
         // should add to table and form reset
         expect(await findByRole('cell', { name: 'My filter' })).toBeVisible();
         expect(await findByLabelText('Filter')).toHaveValue('');
+        // add another filter and then change it
+        await user.selectOptions(await findByLabelText('Filter'), '1');
+        await user.selectOptions(await findByLabelText('Filter'), '7');
+        await user.click(await findByRole('button', { name: 'Add filter' }));
+        expect(await findByRole('cell', { name: 'Where Clause Builder' })).toBeVisible();
+        expect(await findByLabelText('Filter')).toHaveValue('');
 
         await user.click(await findByRole('button', { name: 'Submit' }));
 

--- a/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/AddReportConfiguration.spec.tsx
@@ -164,7 +164,7 @@ describe('add report configuration page', () => {
         vi.mocked(generated.ReportControllerService.createReport).mockResolvedValue({ reportUid: 1, dataSourceUid: 2 });
         const navigate = vi.fn();
         vi.mocked(useNavigate).mockReturnValue(navigate);
-        const { getByRole, findByRole, findByLabelText } = renderWithRouter();
+        const { getByRole, findByRole, findAllByText, findByLabelText } = renderWithRouter();
 
         expect(getByRole('status')).toHaveTextContent('Loading');
 
@@ -204,6 +204,8 @@ describe('add report configuration page', () => {
         expect(await findByLabelText('Filter')).toHaveValue('');
         // add another filter and then change it
         await user.selectOptions(await findByLabelText('Filter'), '1');
+        await user.click(await findByRole('button', { name: 'Add filter' }));
+        expect(await findAllByText(/The Associated column is required./)).toHaveLength(2);
         await user.selectOptions(await findByLabelText('Filter'), '7');
         await user.click(await findByRole('button', { name: 'Add filter' }));
         expect(await findByRole('cell', { name: 'Where Clause Builder' })).toBeVisible();

--- a/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
-import { Controller, FieldError, useWatch } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
 
 import { Shown } from 'conditional-render';
 import { RepeatingBlock } from 'design-system/entry/multi-value';
@@ -25,7 +25,7 @@ const SELECT_OPTIONS: EnumSelectable<BasicFilterConfiguration.selectType>[] = [
 
 export interface FilterConfig {
     id?: number;
-    filter: Selectable;
+    filter: Selectable | null;
     selectType: EnumSelectable<BasicFilterConfiguration.selectType> | null;
     associatedColumn: Selectable | null;
     isRequired: boolean;
@@ -33,7 +33,7 @@ export interface FilterConfig {
 
 const EMPTY_FILTER_CONFIG: Partial<FilterConfig> = {
     id: undefined,
-    filter: undefined,
+    filter: null,
     selectType: null,
     associatedColumn: null,
     isRequired: false,
@@ -42,7 +42,7 @@ const EMPTY_FILTER_CONFIG: Partial<FilterConfig> = {
 type FilterColumn = NamedColumn<FilterConfig, string> & HasValueFunction<FilterConfig, string>;
 
 const filterColumns: FilterColumn[] = [
-    { id: 'filter', name: 'Filter', value: (v) => v.filter.name },
+    { id: 'filter', name: 'Filter', value: (v) => v.filter?.name },
     { id: 'type', name: 'Selection type', value: (v) => v.selectType?.name },
     {
         id: 'column',
@@ -216,17 +216,15 @@ const FilterConfigForm = ({
     // parent report config form
 
     const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
-    const needsSelectType = SELECTABLE_FILTER_IDS.has(filterVal?.value);
-    const needsColumnAndRequired = COLUMN_REQUIRED_FILTER_IDS.has(filterVal?.value);
+    const needsSelectType = !!filterVal && SELECTABLE_FILTER_IDS.has(filterVal.value);
+    const needsColumnAndRequired = !!filterVal && COLUMN_REQUIRED_FILTER_IDS.has(filterVal.value);
 
     return (
         <section>
-            <Controller
+            <Controller<FilterConfig, 'filter'>
                 name="filter"
                 rules={validateRequiredRule('Filter')}
-                // ignoring the ref as it does not pass down well and isn't critical
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
+                render={({ field: { name, value, onChange }, fieldState: { error } }) => (
                     <SingleSelect
                         id={`filter-${name}`}
                         label="Filter"
@@ -237,24 +235,37 @@ const FilterConfigForm = ({
                         error={error?.message}
                         required={true}
                         sizing={SIZING}
-                        {...remaining}
+                        value={value}
+                        onChange={onChange}
                     />
                 )}
             />
-            <Controller
+            <Controller<FilterConfig, 'selectType'>
                 name="selectType"
                 // use function instead of boolean to make sure it reacts to changing filter
                 rules={{
                     validate: (val) =>
                         !needsSelectType || val ? true : validateRequiredRule('Selection type').required.message,
                 }}
-                // ignoring the ref as it does not pass down well and isn't critical
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
-                    <SelectTypeField name={name} error={error} {...remaining} />
+                render={({ field: { name, value, onChange }, fieldState: { error } }) => (
+                    <ConditionalField shown={needsSelectType} reset={() => onChange(null)}>
+                        <SingleSelect
+                            id={`filter-${name}`}
+                            label="Selection type"
+                            helperText="Allow one or multiple selections"
+                            name={name}
+                            options={SELECT_OPTIONS}
+                            orientation="horizontal"
+                            error={error?.message}
+                            required={true}
+                            sizing={SIZING}
+                            value={value}
+                            onChange={onChange}
+                        />
+                    </ConditionalField>
                 )}
             />
-            <Controller
+            <Controller<FilterConfig, 'associatedColumn'>
                 name="associatedColumn"
                 // use function instead of boolean to make sure it reacts to changing filter
                 rules={{
@@ -263,134 +274,51 @@ const FilterConfigForm = ({
                             ? true
                             : validateRequiredRule('Associated column').required.message,
                 }}
-                // ignoring the ref as it does not pass down well and isn't critical
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
-                    <AssociatedColumnField name={name} error={error} columnOptions={columnOptions} {...remaining} />
+                render={({ field: { name, value, onChange }, fieldState: { error } }) => (
+                    <ConditionalField shown={needsColumnAndRequired} reset={() => onChange(null)}>
+                        <SingleSelect
+                            id={`filter-${name}`}
+                            label="Associated column"
+                            name={name}
+                            options={columnOptions}
+                            orientation="horizontal"
+                            error={error?.message}
+                            required={true}
+                            sizing={SIZING}
+                            value={value}
+                            onChange={onChange}
+                        />
+                    </ConditionalField>
                 )}
             />
-            <Controller
+            <Controller<FilterConfig, 'isRequired'>
                 name="isRequired"
-                // ignoring the ref as it does not pass down well and isn't critical
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
-                    <RequiredToggleField name={name} error={error} {...remaining} />
+                render={({ field: { name, value, onChange }, fieldState: { error } }) => (
+                    <ConditionalField shown={needsColumnAndRequired} reset={() => onChange(false)}>
+                        <ToggleField
+                            id={`filter-${name}`}
+                            orientation="horizontal"
+                            sizing={SIZING}
+                            label="Required as basic filter?"
+                            className="height-full"
+                            error={error?.message}
+                            value={value}
+                            onChange={onChange}
+                        />
+                    </ConditionalField>
                 )}
             />
         </section>
     );
 };
 
-const SelectTypeField = ({
-    name,
-    error,
-    value,
-    onChange,
-}: {
-    name: string;
-    error?: FieldError;
-    value: Selectable | null;
-    onChange: (v: Selectable | null) => void;
-}) => {
-    const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
-    const needsSelectType = SELECTABLE_FILTER_IDS.has(filterVal?.value);
-
+const ConditionalField = ({ reset, shown, children }: { reset: () => void; shown: boolean; children: ReactNode }) => {
     // reset when showability changes
     useEffect(() => {
-        if (!needsSelectType) onChange(null);
-    }, [needsSelectType]);
+        if (!shown) reset();
+    }, [shown]);
 
-    return (
-        <Shown when={needsSelectType}>
-            <SingleSelect
-                id={`filter-${name}`}
-                label="Selection type"
-                helperText="Allow one or multiple selections"
-                name={name}
-                options={SELECT_OPTIONS}
-                orientation="horizontal"
-                error={error?.message}
-                required={true}
-                sizing={SIZING}
-                value={value}
-                onChange={onChange}
-            />
-        </Shown>
-    );
-};
-
-const AssociatedColumnField = ({
-    name,
-    error,
-    value,
-    onChange,
-    columnOptions,
-}: {
-    name: string;
-    error?: FieldError;
-    value: Selectable | null;
-    onChange: (v: Selectable | null) => void;
-    columnOptions: Selectable[];
-}) => {
-    const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
-    const needsColumnAndRequired = COLUMN_REQUIRED_FILTER_IDS.has(filterVal?.value);
-
-    // reset when showability changes
-    useEffect(() => {
-        if (!needsColumnAndRequired) onChange(null);
-    }, [needsColumnAndRequired]);
-
-    return (
-        <Shown when={needsColumnAndRequired}>
-            <SingleSelect
-                id={`filter-${name}`}
-                label="Associated column"
-                name={name}
-                options={columnOptions}
-                orientation="horizontal"
-                error={error?.message}
-                required={true}
-                sizing={SIZING}
-                value={value}
-                onChange={onChange}
-            />
-        </Shown>
-    );
-};
-
-const RequiredToggleField = ({
-    name,
-    error,
-    value,
-    onChange,
-}: {
-    name: string;
-    error?: FieldError;
-    value: boolean;
-    onChange: (v: boolean) => void;
-}) => {
-    const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
-    const needsColumnAndRequired = COLUMN_REQUIRED_FILTER_IDS.has(filterVal?.value);
-
-    // reset when showability changes
-    useEffect(() => {
-        if (!needsColumnAndRequired) onChange(false);
-    }, [needsColumnAndRequired]);
-
-    return (
-        <Shown when={needsColumnAndRequired}>
-            <ToggleField
-                id={`filter-${name}`}
-                orientation="horizontal"
-                sizing={SIZING}
-                label="Required as basic filter?"
-                className="height-full"
-                error={error?.message}
-                value={value}
-                onChange={onChange}
-            />
-        </Shown>
-    );
+    return <Shown when={shown}>{children}</Shown>;
 };
 
 export { FilterRepeatingBlock };

--- a/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
@@ -295,7 +295,7 @@ const SelectTypeField = ({
 
     // reset when showability changes
     useEffect(() => {
-        onChange(null);
+        if (!needsSelectType) onChange(null);
     }, [needsSelectType]);
 
     return (
@@ -335,7 +335,7 @@ const AssociatedColumnField = ({
 
     // reset when showability changes
     useEffect(() => {
-        onChange(null);
+        if (!needsColumnAndRequired) onChange(null);
     }, [needsColumnAndRequired]);
 
     return (
@@ -372,7 +372,7 @@ const RequiredToggleField = ({
 
     // reset when showability changes
     useEffect(() => {
-        onChange(false);
+        if (!needsColumnAndRequired) onChange(false);
     }, [needsColumnAndRequired]);
 
     return (

--- a/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Controller, useWatch } from 'react-hook-form';
+import { Controller, FieldError, useWatch } from 'react-hook-form';
 
 import { Shown } from 'conditional-render';
 import { RepeatingBlock } from 'design-system/entry/multi-value';
@@ -249,20 +249,7 @@ const FilterConfigForm = ({
                 // ignoring the ref as it does not pass down well and isn't critical
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
-                    <Shown when={needsSelectType}>
-                        <SingleSelect
-                            id={`filter-${name}`}
-                            label="Selection type"
-                            helperText="Allow one or multiple selections"
-                            name={name}
-                            options={SELECT_OPTIONS}
-                            orientation="horizontal"
-                            error={error?.message}
-                            required={true}
-                            sizing={SIZING}
-                            {...remaining}
-                        />
-                    </Shown>
+                    <SelectTypeField name={name} error={error} {...remaining} />
                 )}
             />
             <Controller
@@ -277,19 +264,7 @@ const FilterConfigForm = ({
                 // ignoring the ref as it does not pass down well and isn't critical
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
-                    <Shown when={needsColumnAndRequired}>
-                        <SingleSelect
-                            id={`filter-${name}`}
-                            label="Associated column"
-                            name={name}
-                            options={columnOptions}
-                            orientation="horizontal"
-                            error={error?.message}
-                            required={true}
-                            sizing={SIZING}
-                            {...remaining}
-                        />
-                    </Shown>
+                    <AssociatedColumnField name={name} error={error} columnOptions={columnOptions} {...remaining} />
                 )}
             />
             <Controller
@@ -297,20 +272,122 @@ const FilterConfigForm = ({
                 // ignoring the ref as it does not pass down well and isn't critical
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
-                    <Shown when={needsColumnAndRequired}>
-                        <ToggleField
-                            id={`filter-${name}`}
-                            orientation="horizontal"
-                            sizing={SIZING}
-                            label="Required as basic filter?"
-                            className="height-full"
-                            error={error?.message}
-                            {...remaining}
-                        />
-                    </Shown>
+                    <RequiredToggleField name={name} error={error} {...remaining} />
                 )}
             />
         </section>
+    );
+};
+
+const SelectTypeField = ({
+    name,
+    error,
+    value,
+    onChange,
+}: {
+    name: string;
+    error?: FieldError;
+    value?: Selectable | null;
+    onChange: (v: Selectable | null) => void;
+}) => {
+    const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
+    const needsSelectType = SELECTABLE_FILTER_IDS.has(filterVal?.value);
+
+    // reset when showability changes
+    useEffect(() => {
+        onChange(null);
+    }, [needsSelectType]);
+
+    return (
+        <Shown when={needsSelectType}>
+            <SingleSelect
+                id={`filter-${name}`}
+                label="Selection type"
+                helperText="Allow one or multiple selections"
+                name={name}
+                options={SELECT_OPTIONS}
+                orientation="horizontal"
+                error={error?.message}
+                required={true}
+                sizing={SIZING}
+                value={value}
+                onChange={onChange}
+            />
+        </Shown>
+    );
+};
+
+const AssociatedColumnField = ({
+    name,
+    error,
+    value,
+    onChange,
+    columnOptions,
+}: {
+    name: string;
+    error?: FieldError;
+    value?: Selectable | null;
+    onChange: (v: Selectable | null) => void;
+    columnOptions: Selectable[];
+}) => {
+    const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
+    const needsColumnAndRequired = COLUMN_REQUIRED_FILTER_IDS.has(filterVal?.value);
+
+    // reset when showability changes
+    useEffect(() => {
+        onChange(null);
+    }, [needsColumnAndRequired]);
+
+    return (
+        <Shown when={needsColumnAndRequired}>
+            <SingleSelect
+                id={`filter-${name}`}
+                label="Associated column"
+                name={name}
+                options={columnOptions}
+                orientation="horizontal"
+                error={error?.message}
+                required={true}
+                sizing={SIZING}
+                value={value}
+                onChange={onChange}
+            />
+        </Shown>
+    );
+};
+
+const RequiredToggleField = ({
+    name,
+    error,
+    value,
+    onChange,
+}: {
+    name: string;
+    error?: FieldError;
+    value?: boolean;
+    onChange: (v: boolean) => void;
+}) => {
+    const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
+    const needsColumnAndRequired = COLUMN_REQUIRED_FILTER_IDS.has(filterVal?.value);
+
+    // reset when showability changes
+    useEffect(() => {
+        onChange(false);
+    }, [needsColumnAndRequired]);
+
+    return (
+        <Shown when={needsColumnAndRequired}>
+            <ToggleField
+                id={`filter-${name}`}
+                orientation="horizontal"
+                sizing={SIZING}
+                label="Required as basic filter?"
+                className="height-full"
+                error={error?.message}
+                value={value}
+                onChange={onChange}
+            />
+        </Shown>
     );
 };
 

--- a/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
@@ -26,16 +26,16 @@ const SELECT_OPTIONS: EnumSelectable<BasicFilterConfiguration.selectType>[] = [
 export interface FilterConfig {
     id?: number;
     filter: Selectable;
-    selectType?: EnumSelectable<BasicFilterConfiguration.selectType>;
-    associatedColumn?: Selectable;
+    selectType: EnumSelectable<BasicFilterConfiguration.selectType> | null;
+    associatedColumn: Selectable | null;
     isRequired: boolean;
 }
 
 const EMPTY_FILTER_CONFIG: Partial<FilterConfig> = {
     id: undefined,
     filter: undefined,
-    selectType: undefined,
-    associatedColumn: undefined,
+    selectType: null,
+    associatedColumn: null,
     isRequired: false,
 };
 
@@ -72,8 +72,8 @@ const FilterRepeatingBlock = ({
         config?.basicFilters.map((f) => ({
             id: f.reportFilterUid,
             filter: filterOptions.find(({ value }) => parseInt(value) === f.filterType.id)!,
-            selectType: SELECT_OPTIONS.find(({ value }) => value === f.selectType),
-            associatedColumn: columnOptions.find(({ value }) => value === f.reportColumnUid?.toString()),
+            selectType: SELECT_OPTIONS.find(({ value }) => value === f.selectType) ?? null,
+            associatedColumn: columnOptions.find(({ value }) => value === f.reportColumnUid?.toString()) ?? null,
             isRequired: f.isRequired,
         })) ?? [];
 
@@ -82,6 +82,8 @@ const FilterRepeatingBlock = ({
             id: config.advancedFilter.reportFilterUid,
             filter: filterOptions.find(({ value }) => value === '7')!,
             isRequired: false,
+            selectType: null,
+            associatedColumn: null,
         });
     }
 
@@ -287,7 +289,7 @@ const SelectTypeField = ({
 }: {
     name: string;
     error?: FieldError;
-    value?: Selectable | null;
+    value: Selectable | null;
     onChange: (v: Selectable | null) => void;
 }) => {
     const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });
@@ -326,7 +328,7 @@ const AssociatedColumnField = ({
 }: {
     name: string;
     error?: FieldError;
-    value?: Selectable | null;
+    value: Selectable | null;
     onChange: (v: Selectable | null) => void;
     columnOptions: Selectable[];
 }) => {
@@ -364,7 +366,7 @@ const RequiredToggleField = ({
 }: {
     name: string;
     error?: FieldError;
-    value?: boolean;
+    value: boolean;
     onChange: (v: boolean) => void;
 }) => {
     const filterVal = useWatch<FilterConfig, 'filter'>({ name: 'filter' });

--- a/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/FilterRepeatingBlock.tsx
@@ -241,7 +241,11 @@ const FilterConfigForm = ({
             />
             <Controller
                 name="selectType"
-                rules={needsSelectType ? validateRequiredRule('Selection type') : undefined}
+                // use function instead of boolean to make sure it reacts to changing filter
+                rules={{
+                    validate: (val) =>
+                        !needsSelectType || val ? true : validateRequiredRule('Selection type').required.message,
+                }}
                 // ignoring the ref as it does not pass down well and isn't critical
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (
@@ -263,7 +267,13 @@ const FilterConfigForm = ({
             />
             <Controller
                 name="associatedColumn"
-                rules={needsColumnAndRequired ? validateRequiredRule('Associated column') : undefined}
+                // use function instead of boolean to make sure it reacts to changing filter
+                rules={{
+                    validate: (val) =>
+                        !needsColumnAndRequired || val
+                            ? true
+                            : validateRequiredRule('Associated column').required.message,
+                }}
                 // ignoring the ref as it does not pass down well and isn't critical
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 render={({ field: { ref, name, ...remaining }, fieldState: { error } }) => (

--- a/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
+++ b/apps/modernization-ui/src/apps/report/management/configuration/ReportConfigurationContent.tsx
@@ -51,7 +51,7 @@ const formToRequest = (data: ConfigForm): AdminReportRequest => {
         sectionCode: data.sectionCode.value,
         filterRequests: data.filterRequests.map((fc) => ({
             id: fc.id,
-            filterCodeUid: parseInt(fc.filter.value),
+            filterCodeUid: parseInt(fc.filter!.value),
             selectType: fc.selectType?.value,
             columnUid: fc.associatedColumn?.value ? parseInt(fc.associatedColumn.value) : undefined,
             isRequired: fc.isRequired,


### PR DESCRIPTION
## Description

When changing from a filter with other required fields to one without one, the requiredness was sticking. Make the validation function based instead of spec based to make sure it runs on the most current state of the world
