### PR TITLE
[APP-986] fix: result page no data iterating

### DIFF
--- a/apps/modernization-ui/src/apps/deduplication/configuration/import/ImportConfigurationModal.spec.tsx
+++ b/apps/modernization-ui/src/apps/deduplication/configuration/import/ImportConfigurationModal.spec.tsx
@@ -103,8 +103,8 @@ describe('ImportConfigurationModal', () => {
         expect(importButton).toHaveTextContent('Import');
 
         await user.click(importButton);
-
-        expect(onImport).toHaveBeenCalledTimes(1);
+        // call happens in promise, can take a moment to settle
+        waitFor(() => expect(onImport).toHaveBeenCalledTimes(1));
         expect(onImport).toHaveBeenCalledWith('test.json', algorithmExport);
     });
 

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.spec.tsx
@@ -1,4 +1,5 @@
 import { getByText, queryByRole, render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { LoaderFunctionArgs, useLoaderData } from 'react-router';
 
 import { ReportExecutionResult } from 'generated';
@@ -15,7 +16,7 @@ vi.mock('react-router', async () => {
 });
 
 describe('ResultDataPage', () => {
-    it('renders bare bones report result', () => {
+    it('renders bare bones report result', async () => {
         const result: ReportExecutionResult = {
             result: {
                 content: 'a,b,c',
@@ -25,7 +26,7 @@ describe('ResultDataPage', () => {
         };
 
         vi.mocked(useLoaderData).mockReturnValue({ result, title: 'My report', dataSourceName: 'nbs_db.My_Table' });
-        const { getByRole, getByText } = render(<ResultDataPage />);
+        const { getByRole, getByText, container } = render(<ResultDataPage />);
 
         expect(getByRole('table')).toBeVisible();
         expect(getByRole('cell', { name: 'No data found.' })).toBeVisible();
@@ -38,9 +39,11 @@ describe('ResultDataPage', () => {
             'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]'
         );
         expect(getByText('(0 rows)')).toBeVisible();
+
+        expect(await axe(container)).toHaveNoViolations();
     });
 
-    it('renders full report result', () => {
+    it('renders full report result', async () => {
         const result: ReportExecutionResult = {
             result: {
                 content: 'a,b,c\n1,2,3',
@@ -67,13 +70,17 @@ describe('ResultDataPage', () => {
             'SELECT * FROM [NBS_ODSE].[dbo].[PHC_Demographic]'
         );
         expect(getByText(container, '(1 row)')).toBeVisible();
+
+        expect(await axe(container)).toHaveNoViolations();
     });
 
-    it('renders warning when no result', () => {
+    it('renders warning when no result', async () => {
         vi.mocked(useLoaderData).mockReturnValue(null);
-        const { getByRole } = render(<ResultDataPage />);
+        const { getByRole, container } = render(<ResultDataPage />);
 
         expect(getByRole('heading', { name: 'No result found' })).toBeVisible();
+
+        expect(await axe(container)).toHaveNoViolations();
     });
 
     describe('loadReportResult', () => {

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
@@ -141,7 +141,7 @@ const ResultDataPage = () => {
                     )}
                 </Card>
 
-                <Card id="report-criteria" title="Report criteria">
+                <Card id="report-criteria" title="Report criteria" collapsible={true} open={false}>
                     <ValueField sizing={SIZING} label="Base SQL query">
                         {/* The uswds text-pre-line forces a sans font instead of respecting mono */}
                         <span style={{ whiteSpace: 'pre-line' }} className="font-mono-xs">

--- a/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
+++ b/apps/modernization-ui/src/apps/report/run/ResultDataPage.tsx
@@ -105,24 +105,40 @@ const ResultDataPage = () => {
                         </ul>
                     </AlertMessage>
                 )}
-                <Card id="report-details" title="Report details">
+
+                <Card id="report-details" title="Report details" collapsible={true} open={false}>
                     <ValueField sizing={SIZING} label="Data source">
                         {dataSourceName}
+                    </ValueField>
+                    <ValueField sizing={SIZING} label="Report run date">
+                        {formattedTime}
                     </ValueField>
                     <ValueField sizing={SIZING} label="Description">
                         {descriptionHtml && (
                             <div dangerouslySetInnerHTML={{ __html: descriptionHtml }} className="text-wrap" />
                         )}
                     </ValueField>
-                    <ValueField sizing={SIZING} label="Report run date">
-                        {formattedTime}
+                </Card>
+
+                <Card id="report-criteria" title="Report criteria" collapsible={true} open={false}>
+                    <ValueField sizing={SIZING} label="Base SQL query">
+                        {/* The uswds text-pre-line forces a sans font instead of respecting mono */}
+                        <span style={{ whiteSpace: 'pre-line' }} className="font-mono-xs">
+                            {styledQuery}
+                        </span>
                     </ValueField>
                 </Card>
+
                 <Card
                     id="report-result"
                     title="Report result"
                     flair={`(${data.length} row${data.length === 1 ? '' : 's'})`}
                 >
+                    {data.length === 0 && (
+                        <AlertMessage type="information">
+                            <p className="font-sans-md margin-0 margin-top-1">No results match your criteria.</p>
+                        </AlertMessage>
+                    )}
                     {meta.fields && (
                         // set tab-index to ensure there's a focusable item on the page/enable keyboard scroll
                         <section className="overflow-auto" tabIndex={0}>
@@ -139,15 +155,6 @@ const ResultDataPage = () => {
                             />
                         </section>
                     )}
-                </Card>
-
-                <Card id="report-criteria" title="Report criteria" collapsible={true} open={false}>
-                    <ValueField sizing={SIZING} label="Base SQL query">
-                        {/* The uswds text-pre-line forces a sans font instead of respecting mono */}
-                        <span style={{ whiteSpace: 'pre-line' }} className="font-mono-xs">
-                            {styledQuery}
-                        </span>
-                    </ValueField>
                 </Card>
             </div>
         </ReportLayout>

--- a/apps/modernization-ui/src/design-system/card/collapsible.module.scss
+++ b/apps/modernization-ui/src/design-system/card/collapsible.module.scss
@@ -1,11 +1,11 @@
 @mixin expanded($property) {
-    transition-duration: 0.3s;
+    transition-duration: 0.1s;
     transition-property: #{$property};
     transition-timing-function: ease-out;
 }
 
 @mixin collapsed($property) {
-    transition-duration: 0.3s;
+    transition-duration: 0.1s;
     transition-property: #{$property};
     transition-timing-function: ease-in;
 }


### PR DESCRIPTION
## Description

Minor tweaks to the report result page to make it more user friendly (especially when no data)

<img width="2428" height="2056" alt="image" src="https://github.com/user-attachments/assets/606d9973-d467-4acf-8ff8-59fdf61a1d5c" />

## Tickets

* https://cdc-nbs.atlassian.net/browse/APP-986

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
