### PR TITLE
build: make pandas a dev dependency

### DIFF
--- a/apps/report-execution/pyproject.toml
+++ b/apps/report-execution/pyproject.toml
@@ -7,12 +7,12 @@ requires-python = ">=3.14"
 dependencies = [
     "fastapi[standard]==0.141.1",
     "mssql-python==1.13.0",
-    "pandas>=3.0.1",
     "pydantic>=2.13.0,<3.0.0",
 ]
 
 [dependency-groups]
 dev = [
+    "pandas>=3.0.1",
     "pyrefly>=1.2.0",
     "pytest>=9.1.1,<10.0.0",
     "pytest-mock>=3.15.1",

--- a/apps/report-execution/uv.lock
+++ b/apps/report-execution/uv.lock
@@ -944,12 +944,12 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "mssql-python" },
-    { name = "pandas" },
     { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "pandas" },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-mock" },
@@ -966,12 +966,12 @@ dev = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "==0.141.1" },
     { name = "mssql-python", specifier = "==1.13.0" },
-    { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic", specifier = ">=2.13.0,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pandas", specifier = ">=3.0.1" },
     { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },


### PR DESCRIPTION
## Description

Pandas is now only used in tests. Should we make it a dev dependency?

Pros:
* We don't use it in prod, so don't carry it around

Cons:
* If custom libraries want it, it's not there - is it worth keeping for its base data munging capabilities as part of the contract with custom libraries?