### PR TITLE
build: update minimal node version to match jsdoc requirements

### DIFF
--- a/apps/modernization-ui/package-lock.json
+++ b/apps/modernization-ui/package-lock.json
@@ -18531,7 +18531,7 @@
             "version": "8.21.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
             "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/apps/modernization-ui/package.json
+++ b/apps/modernization-ui/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "engines": {
-        "node": ">v22.0.0"
+        "node": ">v22.22.2"
     },
     "dependencies": {
         "@apollo/client": "^3.11.8",


### PR DESCRIPTION
## Description

After updating #3625 I saw some warnings when installing about supported engines, so updated the node engine version for the package to be in compliance