### PR TITLE
(chore): Pivot CODEOWNERS from phoenix to bridge, at least temporarily

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,13 +2,4 @@
 # For details on the format, and condfiguration of this file see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # default for the repo
-* @CDCgov/nbs-phoenix
-
-# api + ui squad
-/apps/ @CDCgov/nbs-phoenix-app-squad
-/libs/ @CDCgov/nbs-phoenix-app-squad
-
-# library squad
-/apps/report-execution/ @CDCgov/nbs-phoenix-library-squad
-/apps/modernization-api/src/main/resources/db/ @CDCgov/nbs-phoenix-library-squad
-
+* @CDCgov/nbs-bridge


### PR DESCRIPTION
## Description

This PR just updates the CODEOWNERS from `nbs-phoenix` to `nbs-bridge`, at least for the time being.  It also removes the CODEOWNERS split across API/UI and report execution work, now that the SAS removal project has been completed.

## Tickets

N/A

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
