### PR TITLE
BRDG-25: Add script to remove remaining SAS reports from system

### DIFF
--- a/apps/modernization-api/src/main/resources/db/report/execution/06_ODSE_Drop_Sas_Report_Libraries.sql
+++ b/apps/modernization-api/src/main/resources/db/report/execution/06_ODSE_Drop_Sas_Report_Libraries.sql
@@ -1,0 +1,52 @@
+/**
+* Remove all reports that use a Report_Library row with the `runner` column set to `sas`.
+* This includes removal of the impacted reports' filter values, filter validation rows,
+* report filters, sort columns, and display columns before removing the reports and
+* their Report_Library rows.
+*/
+USE [NBS_ODSE]
+
+-- Drop impacted filter values
+DELETE fv FROM dbo.Filter_Value fv
+    LEFT JOIN dbo.Report_Filter rf ON fv.report_filter_uid = rf.report_filter_uid
+    LEFT JOIN dbo.Report r ON rf.report_uid = r.report_uid
+        AND rf.data_source_uid = r.data_source_uid
+    LEFT JOIN dbo.Report_Library rl ON r.library_uid = rl.library_uid
+        WHERE rl.runner = 'sas';
+
+-- Drop impacted report filter validation rows
+DELETE rfv FROM dbo.Report_Filter_Validation rfv
+    LEFT JOIN dbo.Report_Filter rf ON rfv.report_filter_uid = rf.report_filter_uid
+    LEFT JOIN dbo.Report r ON rf.report_uid = r.report_uid
+        AND rf.data_source_uid = r.data_source_uid
+    LEFT JOIN dbo.Report_Library rl ON r.library_uid = rl.library_uid
+        WHERE rl.runner = 'sas';
+
+-- Drop impacted report filters
+DELETE rf FROM dbo.Report_Filter rf
+    LEFT JOIN dbo.Report r ON rf.report_uid = r.report_uid
+        AND rf.data_source_uid = r.data_source_uid
+    LEFT JOIN dbo.Report_Library rl ON r.library_uid = rl.library_uid
+        WHERE rl.runner = 'sas';
+
+-- Drop impacted report sort columns
+DELETE rsc FROM dbo.Report_Sort_Column rsc
+    LEFT JOIN dbo.Report r ON rsc.report_uid = r.report_uid
+        AND rsc.data_source_uid = r.data_source_uid
+    LEFT JOIN dbo.Report_Library rl ON r.library_uid = rl.library_uid
+        WHERE rl.runner = 'sas';
+
+-- Drop impacted display columns
+DELETE dc FROM dbo.Display_Column dc
+    LEFT JOIN dbo.Report r ON dc.report_uid = r.report_uid
+        AND dc.data_source_uid = r.data_source_uid
+    LEFT JOIN dbo.Report_Library rl ON r.library_uid = rl.library_uid
+        WHERE rl.runner = 'sas';
+
+-- Drop impacted reports
+DELETE r FROM dbo.Report r
+    LEFT JOIN dbo.Report_Library rl ON r.library_uid = rl.library_uid
+        WHERE rl.runner = 'sas';
+
+-- Finally, drop SAS report libraries
+DELETE rl FROM dbo.Report_Library rl WHERE rl.runner = 'sas';


### PR DESCRIPTION
## Description

This PR adds a SQL script to remove all remaining SAS-based reports (and all related report data) from NBS, to be run at STLT's leisure.  I've gone ahead and slotted it alongside the other report-execution SQL migrations for now, while actually omitting it from the changelog so it's not run automatically.  I'm not convinced this is a great place to store it, though - curious if anyone else has thoughts on where this might reside?

## Tickets

* [Jira Ticket](https://cdc-nbs.atlassian.net/browse/BRDG-25)

## Checklist before requesting a review
- [ ] PR focuses on a single story
- [ ] Code has been fully tested to meet acceptance criteria
- [ ] PR is reasonably small and reviewable (Generally less than 10 files and 500 changed lines)
- [ ] All new functions/classes/components reasonably small
- [ ] Functions/classes/components focused on one responsibility
- [ ] Code easy to understand and modify (clarity over concise/clever)
- [ ] PRs containing TypeScript follow the [Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)
- [ ] PR does not contain hardcoded values (Uses constants)
- [ ] All code is covered by unit or feature tests
